### PR TITLE
Fix build on Linux

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -62,57 +62,59 @@ compileCompilerKotlin {
     dependsOn('generateCompilerProto')
 }
 
-String[] linkerOpts1() {
-        def libs = ['-lLLVMX86Disassembler',
-                    '-lLLVMX86AsmParser',
-                    '-lLLVMX86CodeGen',
-                    '-lLLVMSelectionDAG',
-                    '-lLLVMAsmPrinter',
-                    '-lLLVMX86Desc',
-                    '-lLLVMMCDisassembler',
-                    '-lLLVMX86Info',
-                    '-lLLVMX86AsmPrinter',
-                    '-lLLVMX86Utils',
-                    '-lLLVMInterpreter',
-                    '-lLLVMCodeGen',
-                    '-lLLVMScalarOpts',
-                    '-lLLVMInstCombine',
-                    '-lLLVMInstrumentation',
-                    '-lLLVMProfileData',
-                    '-lLLVMTransformUtils',
-                    '-lLLVMBitWriter',
-                    '-lLLVMExecutionEngine',
-                    '-lLLVMTarget',
-                    '-lLLVMAnalysis',
-                    '-lLLVMRuntimeDyld',
-                    '-lLLVMObject',
-                    '-lLLVMMCParser',
-                    '-lLLVMBitReader',
-                    '-lLLVMMC',
-                    '-lLLVMCore',
-                    '-lLLVMSupport']
-    List<String> ldflags = new ArrayList<>()
-    if (isLinux())
-        ldflags.addAll(["-L$llvmDir/lib",
-                "-Wl,-Bstatic", "-Wl,--whole-archive"]
+List<String> llvmLinkerOpts() {
+    // TODO: cannot use llvm-config because it can be inaccessible during project configuration
+    final List<String> libs = [
+            '-lLLVMX86Disassembler',
+            '-lLLVMX86AsmParser',
+            '-lLLVMX86CodeGen',
+            '-lLLVMSelectionDAG',
+            '-lLLVMAsmPrinter',
+            '-lLLVMX86Desc',
+            '-lLLVMMCDisassembler',
+            '-lLLVMX86Info',
+            '-lLLVMX86AsmPrinter',
+            '-lLLVMX86Utils',
+            '-lLLVMInterpreter',
+            '-lLLVMCodeGen',
+            '-lLLVMScalarOpts',
+            '-lLLVMInstCombine',
+            '-lLLVMInstrumentation',
+            '-lLLVMProfileData',
+            '-lLLVMTransformUtils',
+            '-lLLVMBitWriter',
+            '-lLLVMExecutionEngine',
+            '-lLLVMTarget',
+            '-lLLVMAnalysis',
+            '-lLLVMRuntimeDyld',
+            '-lLLVMObject',
+            '-lLLVMMCParser',
+            '-lLLVMBitReader',
+            '-lLLVMMC',
+            '-lLLVMCore',
+            '-lLLVMSupport'
+    ]
+
+    final List<String> res = new ArrayList<>()
+
+    res << "-L$llvmDir/lib"
+
+    if (isLinux()) {
+        res.addAll(["-Wl,-Bstatic", "-Wl,--whole-archive"]
                 + libs
-                + ["-Wl,--no-whole-archive", "-Wl,-Bdynamic",
-                "-L$libffiDir/lib -lffi",
-                "-lrt", "-ldl","-lpthread", "-lz", "-lm"])
-    else
-     ldflags.addAll(["-L$llvmDir/lib", "-lc++"]
-             + libs
-             + ["-L$libffiDir/lib", "-lffi"])
-    ArrayList<String> strldflags = new ArrayList<>()
-    ldflags.forEach{strldflags.add(it.toString())}
-    return strldflags.toArray(new String[0])
+                + ["-Wl,--no-whole-archive", "-Wl,-Bdynamic"])
+    } else {
+        res.addAll(libs)
+    }
+
+    return res
 }
 
 kotlinNativeInterop {
    llvm {
      defFile 'llvm.def'
      compilerOpts "-fPIC", "-I$llvmDir/include"
-     linkerOpts linkerOpts1()
+     linkerOpts llvmLinkerOpts()
    }
 
    hash { // TODO: copy-pasted from ':common:compileHash'

--- a/backend.native/llvm.def
+++ b/backend.native/llvm.def
@@ -8,7 +8,7 @@ compilerOpts = -std=c99 -fPIC \
 
 linker = clang++
 
-linkerOpts = -stdlib=libc++ -fPIC -fvisibility-inlines-hidden \
+linkerOpts = -fPIC -fvisibility-inlines-hidden \
     -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers \
     -pedantic -Wno-long-long -Wcovered-switch-default -Wnon-virtual-dtor -Wdelete-non-virtual-dtor \
     -std=c++11 \
@@ -19,4 +19,5 @@ linkerOpts.osx = \
     -lpthread -lz -lm  -lcurses
 
 linkerOpts.linux=\
-     -Wl,-z,noexecstack
+     -Wl,-z,noexecstack \
+     -lrt -ldl -lpthread -lz -lm

--- a/buildSrc/src/main/groovy/org/jetbrains/kotlin/NativeInteropPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/jetbrains/kotlin/NativeInteropPlugin.groovy
@@ -57,6 +57,10 @@ class NamedNativeInteropConfig implements Named {
     }
 
     void linkerOpts(String... values) {
+        this.linkerOpts(values.toList())
+    }
+
+    void linkerOpts(List<String> values) {
         linkerOpts.addAll(values)
     }
 


### PR DESCRIPTION
Update options according to llvm-config:

* delete "--stdlib=libc++"  (it seems to provoke runtime link errors on Linux)
* remove "-lffi" (it doesn't seem to be required)
* remove "-lc++" on macOS

Also move Linux system libs options to llvm.def (as for macOS)