### PR TITLE
Introduced shims for LLVM StubGenerator.

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
@@ -7,7 +7,8 @@ class StubGenerator(
         val nativeIndex: NativeIndex,
         val pkgName: String,
         val libName: String,
-        val excludedFunctions: Set<String>) {
+        val excludedFunctions: Set<String>,
+        val dumpShims: Boolean) {
 
     /**
      * The names that should not be used for struct classes to prevent name clashes
@@ -583,7 +584,18 @@ class StubGenerator(
                     out(binding.convFree.invoke(externalParamNames[i]))
                 }
             }
+
+            if (dumpShims) {
+                val returnValueRepresentation  = retValBinding.conv("res")
+                out("print(\"\${${returnValueRepresentation}}\\t= \")")
+                out("print(\"${func.name}( \")")
+                val argsRepresentation = paramNames.map{"\${${it}}"}.joinToString(", ")
+                out("print(\"${argsRepresentation}\")")
+                out("println(\")\")")
+            }
+
             out("return " + retValBinding.conv("res"))
+
         }
         out("}")
     }

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -86,6 +86,11 @@ private fun Properties.getSpaceSeparated(name: String): List<String> {
     return this.getProperty(name)?.split(' ') ?: emptyList()
 }
 
+private fun List<String>?.isTrue(): Boolean {
+    // The rightmost wins
+    return this?.last() == "true" ?: false
+}
+
 private fun processLib(ktGenRoot: String,
                        nativeLibsDir: String,
                        llvmInstallPath: String,
@@ -105,6 +110,7 @@ private fun processLib(ktGenRoot: String,
     val additionalHeaders = args["-h"].orEmpty()
     val additionalCompilerOpts = args["-copt"].orEmpty()
     val additionalLinkerOpts = args["-lopt"].orEmpty()
+    val generateShims = args["-shims"].isTrue()
 
     val headerFiles = config.getSpaceSeparated("headers") + additionalHeaders
     val compilerOpts = config.getSpaceSeparated("compilerOpts") + additionalCompilerOpts
@@ -127,7 +133,7 @@ private fun processLib(ktGenRoot: String,
 
     val nativeIndex = buildNativeIndex(headerFiles, compilerOpts)
 
-    val gen = StubGenerator(nativeIndex, outKtPkg, libName, excludedFunctions)
+    val gen = StubGenerator(nativeIndex, outKtPkg, libName, excludedFunctions, generateShims)
 
     outKtFile.parentFile.mkdirs()
     outKtFile.bufferedWriter().use { out ->

--- a/buildSrc/src/main/groovy/org/jetbrains/kotlin/NativeInteropPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/jetbrains/kotlin/NativeInteropPlugin.groovy
@@ -191,6 +191,11 @@ class NamedNativeInteropConfig implements Named {
                 headers.files.each {
                     args "-h:$it"
                 }
+
+                if (project.hasProperty("shims")) {
+                    args  "-shims:$project.ext.shims"
+                }
+
             }
         }
 


### PR DESCRIPTION
Run your gradlew task with -Dshims=true to dump the trace

This is not a complete executable solution yet, but already very useful for llvm api tracing