### PR TITLE
IR: don't generate IrReturn for IrDelegationCall in constructor

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DefaultArgumentStubGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DefaultArgumentStubGenerator.kt
@@ -111,7 +111,7 @@ class DefaultArgumentStubGenerator internal constructor(val context: Context): D
                     }
                 }
                 if (functionDescriptor is ClassConstructorDescriptor) {
-                    + irReturn(IrDelegatingConstructorCallImpl(
+                    + IrDelegatingConstructorCallImpl(
                             startOffset = irFunction.startOffset,
                             endOffset   = irFunction.endOffset,
                             descriptor  = functionDescriptor
@@ -122,7 +122,7 @@ class DefaultArgumentStubGenerator internal constructor(val context: Context): D
                         if (functionDescriptor.dispatchReceiverParameter != null) {
                             dispatchReceiver = irThis()
                         }
-                    })
+                    }
                 } else {
                     +irReturn(irCall(functionDescriptor).apply {
                         if (functionDescriptor.dispatchReceiverParameter != null) {


### PR DESCRIPTION
воспроизводиться в external_codegen_blackbox_innerNested_superConstructorCall::deepLocalHierarchy