### PR TITLE
IR: enum prevent loosing IrExpressionBody on lowering of enums

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
@@ -169,7 +169,7 @@ internal class EnumClassLowering(val context: Context) : ClassLoweringPass {
 
             val constructors = mutableSetOf<ClassConstructorDescriptor>()
 
-            descriptor.constructors.forEach { it ->
+            descriptor.constructors.forEach {
                 val loweredEnumConstructor = loweredEnumConstructors[it]!!
                 val (constructorDescriptor, constructor) = createSimpleDelegatingConstructor(defaultClassDescriptor, loweredEnumConstructor)
                 constructors.add(constructorDescriptor)


### PR DESCRIPTION
enumWithTwoDefArgs.kt : passed
enumWithTwoDoubleDefArgs.kt: passed
enum.kt: passed
enumWithOneDefArg.kt: passed