### PR TITLE
Applied the same name table fallbacks for anonymous objects as other …

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanSerializerExtension.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanSerializerExtension.kt
@@ -35,6 +35,8 @@ import org.jetbrains.kotlin.types.FlexibleType
 internal class KonanSerializerExtension(val context: Context) :
         KotlinSerializerExtensionBase(KonanSerializerProtocol) {
 
+    override val stringTable = KonanStringTable()
+
     private val backingFieldClass = 
         context.builtIns.getKonanInternalClass("HasBackingField").getDefaultType()
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanStringTable.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanStringTable.kt
@@ -1,0 +1,26 @@
+package org.jetbrains.kotlin.backend.konan.serialization
+
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.serialization.StringTableImpl
+import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperClassifiers
+import org.jetbrains.kotlin.resolve.descriptorUtil.module
+
+class KonanStringTable : StringTableImpl() {
+    override fun getFqNameIndexOfLocalAnonymousClass(descriptor: ClassifierDescriptorWithTypeParameters): Int {
+        return if (descriptor.containingDeclaration is CallableMemberDescriptor) {
+            val superClassifiers = descriptor.getAllSuperClassifiers()
+                .mapNotNull { it as ClassifierDescriptorWithTypeParameters }
+                .filter { it != descriptor }
+                .toList()
+            if (superClassifiers.size == 1) {
+                    getFqNameIndex(superClassifiers[0])
+            } else {
+                val superClass = superClassifiers.find { !DescriptorUtils.isInterface(it) }
+                getFqNameIndex(superClass ?: descriptor.module.builtIns.any)
+            }
+        } else {
+            super.getFqNameIndexOfLocalAnonymousClass(descriptor)
+        }
+    }
+}


### PR DESCRIPTION
…backends do.

Note that for such snippet:
```

class Foo {
        private val taq = object {var a = 7}
        val y = 20
}
class Bar {
        val qux = object {var b = 9}
        val x = 10
}

```
the type of taq is `Foo.taq.<no name provided>`, but the type of qux is` kotlin.Any`
```

lazy class Foo
class Foo::this
public constructor Foo() defined in Foo[ClassConstructorDescriptorImpl@45d6ef73]
private final val taq: Foo.taq.<no name provided> defined in Foo[PropertyDescriptorImpl@720653c2]
private final fun <get-taq>(): Foo.taq.<no name provided> defined in Foo[PropertyGetterDescriptorImpl@5cbd159f]
public final val y: kotlin.Int defined in Foo[PropertyDescriptorImpl@6a84bc2a]
public final fun <get-y>(): kotlin.Int defined in Foo[PropertyGetterDescriptorImpl@3b05a99b]
@konan.SymbolName public open external fun equals(other: kotlin.Any?): kotlin.Boolean defined in Foo[DeserializedSimpleFunctionDescriptor@5226e402]
value-parameter other: kotlin.Any? defined in Foo.equals[ValueParameterDescriptorImpl@6df3e44c]
@konan.SymbolName public open external fun hashCode(): kotlin.Int defined in Foo[DeserializedSimpleFunctionDescriptor@189b5fb1]
public open fun quxqux(other: kotlin.Any?): kotlin.Boolean defined in Foo[DeserializedSimpleFunctionDescriptor@1ddd3478]
value-parameter other: kotlin.Any? defined in Foo.quxqux[ValueParameterDescriptorImpl@7ce7e83c]
@konan.SymbolName public open external fun toString(): kotlin.String defined in Foo[DeserializedSimpleFunctionDescriptor@4d33940d]
```
```

lazy class Bar
class Bar::this
public constructor Bar() defined in Bar[ClassConstructorDescriptorImpl@4a05d8ae]
public final val qux: kotlin.Any defined in Bar[PropertyDescriptorImpl@27068a50]
public final fun <get-qux>(): kotlin.Any defined in Bar[PropertyGetterDescriptorImpl@3c904f1e]
public final val x: kotlin.Int defined in Bar[PropertyDescriptorImpl@5b78fdb1]
public final fun <get-x>(): kotlin.Int defined in Bar[PropertyGetterDescriptorImpl@4eb30d44]
@konan.SymbolName public open external fun equals(other: kotlin.Any?): kotlin.Boolean defined in Bar[DeserializedSimpleFunctionDescriptor@43cf6ea3]
value-parameter other: kotlin.Any? defined in Bar.equals[ValueParameterDescriptorImpl@d56aaa6]
@konan.SymbolName public open external fun hashCode(): kotlin.Int defined in Bar[DeserializedSimpleFunctionDescriptor@37c5fc56]
public open fun quxqux(other: kotlin.Any?): kotlin.Boolean defined in Bar[DeserializedSimpleFunctionDescriptor@1c025cb]
value-parameter other: kotlin.Any? defined in Bar.quxqux[ValueParameterDescriptorImpl@6972c30a]
@konan.SymbolName public open external fun toString(): kotlin.String defined in Bar[DeserializedSimpleFunctionDescriptor@50825a02]
```