### PR TITLE
IR: defaults: calculate right `this` receiver parameter for calling o…

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DefaultArgumentStubGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DefaultArgumentStubGenerator.kt
@@ -336,7 +336,7 @@ private fun FunctionDescriptor.generateDefaultsDescription(context: Context): Fu
                 val name = Name.identifier("$name\$default")
 
                 SimpleFunctionDescriptorImpl.create(
-                        /* containingDeclaration = */ if (DescriptorUtils.isOverride(this)) this.overriddenDescriptors.first().containingDeclaration as ClassDescriptor else containingDeclaration,
+                        /* containingDeclaration = */ containingDeclaration,
                         /* annotations           = */ annotations,
                         /* name                  = */ name,
                         /* kind                  = */ CallableMemberDescriptor.Kind.SYNTHESIZED,


### PR DESCRIPTION
…riginal function.

previously in case:
```
fun box(): String {
    val a: A = B(1)
    a.copy(1)
    a.component1()
    return "OK"
}

interface A {
    fun copy(x: Int): A
    fun component1(): Any
}

data class B(val x: Int) : A
```

in stab `B::copy$default` `B::copy` called with `A::this` that behaviour isn't correct, should be `B::this` used.