### PR TITLE
Supported KProperty2 and KMutableProperty2

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -168,8 +168,10 @@ class ReflectionTypes(module: ModuleDescriptor) {
     val kMutableProperty1: ClassDescriptor by ClassLookup(kotlinReflectScope)
     val kProperty0Impl: ClassDescriptor by ClassLookup(konanInternalScope)
     val kProperty1Impl: ClassDescriptor by ClassLookup(konanInternalScope)
+    val kProperty2Impl: ClassDescriptor by ClassLookup(konanInternalScope)
     val kMutableProperty0Impl: ClassDescriptor by ClassLookup(konanInternalScope)
     val kMutableProperty1Impl: ClassDescriptor by ClassLookup(konanInternalScope)
+    val kMutableProperty2Impl: ClassDescriptor by ClassLookup(konanInternalScope)
     val kLocalDelegatedPropertyImpl: ClassDescriptor by ClassLookup(konanInternalScope)
     val kLocalDelegatedMutablePropertyImpl: ClassDescriptor by ClassLookup(konanInternalScope)
 


### PR DESCRIPTION
Consider this code:
object Delegate {
    operator fun getValue(t: Any?, p: KProperty<*>): String {
        return ""
    }
}

class A {
    val String.ext by Delegate
}

then the type of <p> is KProperty2 (it has 2 receivers).