### PR TITLE
Removed -compile_as_stdlib mode, as it is not needed anymore.

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -196,7 +196,7 @@ targetList.each { target ->
             "-Dkonan.home=${project.parent.file('dist')}",
             "-Djava.library.path=${project.buildDir}/nativelibs"
         args('-output', project(':runtime').file("build/${target}/stdlib.kt.bc"), 
-            '-nolink', '-nostdlib', '-compile_as_stdlib', '-ea',
+            '-nolink', '-nostdlib', '-ea',
             '-target', target,
             '-runtime', project(':runtime').file("build/${target}/runtime.bc"),
             '-properties', project(':backend.native').file('konan.properties'),

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -70,7 +70,6 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
             with(configuration) {
 
                 put(NOSTDLIB, arguments.nostdlib)
-                put(COMPILE_AS_STDLIB, arguments.compileAsStdlib)
                 put(NOLINK, arguments.nolink)
                 put(NOMAIN, arguments.nomain)
                 put(LIBRARY_FILES,

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.java
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.java
@@ -38,9 +38,6 @@ public class K2NativeCompilerArguments extends CommonCompilerArguments {
     @Argument(value = "nostdlib", description = "Don't link with stdlib")
     public boolean nostdlib;
 
-    @Argument(value = "compile_as_stdlib", description = "Compile the module as stdlib")
-    public boolean compileAsStdlib;
-
     @Argument(value = "opt", description = "Enable optimizations during compilation")
     public boolean optimization;
 
@@ -48,46 +45,49 @@ public class K2NativeCompilerArguments extends CommonCompilerArguments {
     @ValueDescription("<target>")
     public String target;
 
-    @Argument(value = "list_targets", description = "List available hardware targets")
+    @Argument(value = "enable_assertions", alias = "ea", description = "Enable runtime assertions in generated code")
+    public boolean enableAssertions;
+
+    // The rest of the options are only interesting for developers.
+    // Make sure to prepend them with double dash.
+
+    @Argument(value = "list_targets", prefix = "--", description = "List available hardware targets")
     public boolean listTargets;
 
-    @Argument(value = "print_ir", description = "Print IR")
+    @Argument(value = "print_ir", prefix = "--", description = "Print IR")
     public boolean printIr;
 
-    @Argument(value = "print_descriptors", description = "Print descriptor tree")
+    @Argument(value = "print_descriptors", prefix = "--", description = "Print descriptor tree")
     public boolean printDescriptors;
 
-    @Argument(value = "print_bitcode", description = "Print llvm bitcode")
+    @Argument(value = "print_bitcode", prefix = "--", description = "Print llvm bitcode")
     public boolean printBitCode;
 
-    @Argument(value = "verify_ir", description = "Verify IR")
+    @Argument(value = "verify_ir", prefix = "--", description = "Verify IR")
     public boolean verifyIr;
 
-    @Argument(value = "verify_descriptors", description = "Verify descriptor tree")
+    @Argument(value = "verify_descriptors", prefix = "--", description = "Verify descriptor tree")
     public boolean verifyDescriptors;
 
-    @Argument(value = "verify_bitcode", description = "Verify llvm bitcode after each method")
+    @Argument(value = "verify_bitcode", prefix = "--", description = "Verify llvm bitcode after each method")
     public boolean verifyBitCode;
 
-    @Argument(value = "enable", description = "Enable backend phase")
+    @Argument(value = "enable", prefix = "--", description = "Enable backend phase")
     @ValueDescription("<Phase>")
     public String[] enablePhases;
 
-    @Argument(value = "disable", description = "Disable backend phase")
+    @Argument(value = "disable", prefix = "--", description = "Disable backend phase")
     @ValueDescription("<Phase>")
     public String[] disablePhases;
 
-    @Argument(value = "verbose", description = "Trace phase execution")
+    @Argument(value = "verbose", prefix = "--", description = "Trace phase execution")
     @ValueDescription("<Phase>")
     public String[] verbosePhases;
 
-    @Argument(value = "list", description = "List all backend phases")
+    @Argument(value = "list", prefix = "--", description = "List all backend phases")
     public boolean listPhases;
 
-    @Argument(value = "time", description = "Report execution time for compiler phases")
+    @Argument(value = "time", prefix = "--", description = "Report execution time for compiler phases")
     public boolean timePhases;
-
-    @Argument(value = "enable_assertions", alias = "ea", description = "Enable runtime assertions in generated code")
-    public boolean enableAssertions;
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -12,8 +12,6 @@ class KonanConfig(val project: Project, val configuration: CompilerConfiguration
 
     internal val distribution = Distribution(configuration)
 
-    internal val compileAsStdlib = configuration.get(KonanConfigKeys.COMPILE_AS_STDLIB) ?: false
-
     internal val libraries: List<String>
         get() {
             val fromCommandLine = configuration.getList(KonanConfigKeys.LIBRARY_FILES)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -23,8 +23,6 @@ class KonanConfigKeys {
                 = CompilerConfigurationKey.create("optimized compilation")
         val NOSTDLIB: CompilerConfigurationKey<Boolean> 
                 = CompilerConfigurationKey.create("don't link with stdlib")
-        val COMPILE_AS_STDLIB: CompilerConfigurationKey<Boolean>
-                = CompilerConfigurationKey.create("compile the module as stdlib")
         val NOLINK: CompilerConfigurationKey<Boolean> 
                 = CompilerConfigurationKey.create("don't link, only produce a bitcode file ")
         val NOMAIN: CompilerConfigurationKey<Boolean> 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
@@ -29,11 +29,7 @@ import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProvid
 
 object TopDownAnalyzerFacadeForKonan {
     fun analyzeFiles(files: Collection<KtFile>, config: KonanConfig): AnalysisResult {
-        val moduleName = if (config.compileAsStdlib) {
-            STDLIB_MODULE_NAME
-        } else {
-            Name.special("<${config.moduleId}>")
-        }
+        val moduleName = Name.special("<${config.moduleId}>") 
 
         val projectContext = ProjectContext(config.project)
         val builtIns = KonanBuiltIns(projectContext.storageManager)
@@ -41,7 +37,6 @@ object TopDownAnalyzerFacadeForKonan {
 
         val module = context.module
         builtIns.builtInsModule = module
-        assert (module.isStdlib() == config.compileAsStdlib)
 
         if (!module.isStdlib()) {
             context.setDependencies(listOf(module) + config.moduleDescriptors)


### PR DESCRIPTION
Moved "compiler hacker" options to use double dash. Like "--verbose linker".