### PR TITLE
build: Rename bunlde archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .idea/shelf
 /dependencies/all
 dist
-kotlin-native-*.tgz
+kotlin-native-*.tar.gz
 translator/src/test/kotlin/tests/*/linked
 out
 tmp
@@ -44,9 +44,3 @@ proto/compiler/google/src/google/protobuf/compiler/kotlin/protoc
 
 # translator auto generated artifacts
 kotstd/ll
-
-# directory for manual debug runs
-run-debug/**
-!run-debug/interop
-!run-debug/konanc
-

--- a/build.gradle
+++ b/build.gradle
@@ -263,19 +263,18 @@ task cross_dist {
 
 task bundle(type: Tar) {
     dependsOn('cross_dist')
+    baseName = "kotlin-native-${simpleOsName()}-${project.konanVersion}"
     from("$project.rootDir/dist") {
         include '**'
         exclude 'dependencies'
-        into 'kotlin-native'
+        into baseName
     }
     from(project.rootDir) {
         include 'samples/**'
-        into 'kotlin-native'
+        into baseName
     }
-    baseName = 'kotlin-native'
-    appendix = simpleOsName()
     destinationDir = file('.')
-    extension = 'tgz'
+    extension = 'tar.gz'
     compression = Compression.GZIP
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ remoteRoot=konan_tests
 # Download artifacts of https://teamcity.jetbrains.com/viewType.html?buildTypeId=bt345
 testDataVersion=1009012:id
 kotlinCompilerModule=org.jetbrains.kotlin:kotlin-compiler:1.1-20170310.145051-441
+konanVersion=0.1


### PR DESCRIPTION
This patch renames the bundle to .tar.gz to work with it in
dependecny downloader.
Also it adds a version number in the bundle name.