### PR TITLE
Inline: correct containing declaration

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/common/IrElementTransformerVoidWithContext.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/common/IrElementTransformerVoidWithContext.kt
@@ -16,49 +16,157 @@
 
 package org.jetbrains.kotlin.backend.common
 
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.declarations.IrClass
-import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.builders.Scope
+import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
+import org.jetbrains.kotlin.descriptors.*
 
-abstract class IrElementTransformerVoidWithContext(): IrElementTransformerVoid() {
-    private fun <E> MutableList<E>.push(element: E) = this.add(element)
+private fun <E> MutableList<E>.push(element: E) = this.add(element)
 
-    private fun <E> MutableList<E>.pop() = this.removeAt(size - 1)
+private fun <E> MutableList<E>.pop() = this.removeAt(size - 1)
 
-    private fun <E> MutableList<E>.peek(): E? = if (size == 0) null else this[size - 1]
+private fun <E> MutableList<E>.peek(): E? = if (size == 0) null else this[size - 1]
 
-    private val functionsStack = mutableListOf<FunctionDescriptor>()
-    private val functionDeclarationsStack = mutableListOf<IrFunction>()
-    private val classesStack = mutableListOf<ClassDescriptor>()
+internal class ScopeWithIr(val scope: Scope, val irElement: IrElement)
 
-    override final fun visitFunction(declaration: IrFunction): IrStatement {
-        functionsStack.push(declaration.descriptor)
-        functionDeclarationsStack.push(declaration)
-        val result = visitFunctionNew(declaration)
-        functionDeclarationsStack.pop()
-        functionsStack.pop()
+abstract internal class IrElementTransformerVoidWithContext : IrElementTransformerVoid() {
+
+    private val scopeStack = mutableListOf<ScopeWithIr>()
+
+    override final fun visitFile(declaration: IrFile): IrFile {
+        scopeStack.push(ScopeWithIr(Scope(declaration.packageFragmentDescriptor), declaration))
+        val result = visitFileNew(declaration)
+        scopeStack.pop()
         return result
     }
 
     override final fun visitClass(declaration: IrClass): IrStatement {
-        classesStack.push(declaration.descriptor)
+        scopeStack.push(ScopeWithIr(Scope(declaration.descriptor), declaration))
         val result = visitClassNew(declaration)
-        classesStack.pop()
+        scopeStack.pop()
         return result
     }
 
-    protected val currentFunction get() = functionsStack.peek()
-    protected val currentFunctionDeclaration get() = functionDeclarationsStack.peek()
-    protected val currentClass get() = classesStack.peek()
+    override final fun visitProperty(declaration: IrProperty): IrStatement {
+        scopeStack.push(ScopeWithIr(Scope(declaration.descriptor), declaration))
+        val result = visitPropertyNew(declaration)
+        scopeStack.pop()
+        return result
+    }
 
-    open fun visitFunctionNew(declaration: IrFunction) : IrStatement {
+    override final fun visitField(declaration: IrField): IrStatement {
+        val isDelegated = declaration.descriptor.isDelegated
+        if (isDelegated) scopeStack.push(ScopeWithIr(Scope(declaration.descriptor), declaration))
+        val result = visitFieldNew(declaration)
+        if (isDelegated) scopeStack.pop()
+        return result
+    }
+
+    override final fun visitFunction(declaration: IrFunction): IrStatement {
+        scopeStack.push(ScopeWithIr(Scope(declaration.descriptor), declaration))
+        val result = visitFunctionNew(declaration)
+        scopeStack.pop()
+        return result
+    }
+
+    protected val currentFile get() = scopeStack.lastOrNull { it.scope.scopeOwner is PackageFragmentDescriptor }
+    protected val currentClass get() = scopeStack.lastOrNull { it.scope.scopeOwner is ClassDescriptor }
+    protected val currentFunction get() = scopeStack.lastOrNull { it.scope.scopeOwner is FunctionDescriptor }
+    protected val currentProperty get() = scopeStack.lastOrNull { it.scope.scopeOwner is PropertyDescriptor }
+    protected val currentScope get() = scopeStack.peek()
+    protected val parentScope get() = if (scopeStack.size < 2) null else scopeStack[scopeStack.size - 2]
+
+    fun printScopeStack() {
+        scopeStack.forEach { println(it.scope.scopeOwner) }
+    }
+
+    open fun visitFileNew(declaration: IrFile): IrFile {
+        return super.visitFile(declaration)
+    }
+
+    open fun visitClassNew(declaration: IrClass): IrStatement {
+        return super.visitClass(declaration)
+    }
+
+    open fun visitFunctionNew(declaration: IrFunction): IrStatement {
         return super.visitFunction(declaration)
     }
 
-    open fun visitClassNew(declaration: IrClass) : IrStatement {
-        return super.visitClass(declaration)
+    open fun visitPropertyNew(declaration: IrProperty): IrStatement {
+        return super.visitProperty(declaration)
+    }
+
+    open fun visitFieldNew(declaration: IrField): IrStatement {
+        return super.visitField(declaration)
+    }
+}
+
+abstract internal class IrElementVisitorVoidWithContext : IrElementVisitorVoid {
+
+    private val scopeStack = mutableListOf<ScopeWithIr>()
+
+    override final fun visitFile(declaration: IrFile) {
+        scopeStack.push(ScopeWithIr(Scope(declaration.packageFragmentDescriptor), declaration))
+        visitFileNew(declaration)
+        scopeStack.pop()
+    }
+
+    override final fun visitClass(declaration: IrClass) {
+        scopeStack.push(ScopeWithIr(Scope(declaration.descriptor), declaration))
+        visitClassNew(declaration)
+        scopeStack.pop()
+    }
+
+    override final fun visitProperty(declaration: IrProperty) {
+        scopeStack.push(ScopeWithIr(Scope(declaration.descriptor), declaration))
+        visitPropertyNew(declaration)
+        scopeStack.pop()
+    }
+
+    override final fun visitField(declaration: IrField) {
+        val isDelegated = declaration.descriptor.isDelegated
+        if (isDelegated) scopeStack.push(ScopeWithIr(Scope(declaration.descriptor), declaration))
+        visitFieldNew(declaration)
+        if (isDelegated) scopeStack.pop()
+    }
+
+    override final fun visitFunction(declaration: IrFunction) {
+        scopeStack.push(ScopeWithIr(Scope(declaration.descriptor), declaration))
+        visitFunctionNew(declaration)
+        scopeStack.pop()
+    }
+
+    protected val currentFile get() = scopeStack.lastOrNull { it.scope.scopeOwner is PackageFragmentDescriptor }
+    protected val currentClass get() = scopeStack.lastOrNull { it.scope.scopeOwner is ClassDescriptor }
+    protected val currentFunction get() = scopeStack.lastOrNull { it.scope.scopeOwner is FunctionDescriptor }
+    protected val currentProperty get() = scopeStack.lastOrNull { it.scope.scopeOwner is PropertyDescriptor }
+    protected val currentScope get() = scopeStack.peek()
+    protected val parentScope get() = if (scopeStack.size < 2) null else scopeStack[scopeStack.size - 2]
+
+    fun printScopeStack() {
+        scopeStack.forEach { println(it.scope.scopeOwner) }
+    }
+
+    open fun visitFileNew(declaration: IrFile) {
+        super.visitFile(declaration)
+    }
+
+    open fun visitClassNew(declaration: IrClass) {
+        super.visitClass(declaration)
+    }
+
+    open fun visitFunctionNew(declaration: IrFunction) {
+        super.visitFunction(declaration)
+    }
+
+    open fun visitPropertyNew(declaration: IrProperty) {
+        super.visitProperty(declaration)
+    }
+
+    open fun visitFieldNew(declaration: IrField) {
+        super.visitField(declaration)
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FunctionInlining.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FunctionInlining.kt
@@ -297,12 +297,15 @@ internal class FunctionInlining(val context: Context): IrElementTransformerVoidW
                 return@forEach
             }
 
-            val varName = currentScope!!.scope.scopeOwner.name.toString() + "_inline"
-            val newVar = currentScope!!.scope.createTemporaryVariable(argument, varName, false)  // Create new variable and init it with the parameter expression.
-            statements.add(newVar)                                                       // Add initialization of the new variable in statement list.
+            val currentScope = currentScope!!
+            val varName = currentScope.scope.scopeOwner.name.toString() + "_inline"
+            val newVar = currentScope.scope.createTemporaryVariable(argument, varName, false)  // Create new variable and init it with the parameter expression.
+            statements.add(newVar)                                                               // Add initialization of the new variable in statement list.
 
-            val getVal = IrGetValueImpl(0, 0, newVar.descriptor)                            // Create new IR element representing access the new variable.
-            parametersNew[parameter] = getVal                                               // Parameter will be replaced with the new variable.
+            val startOffset = currentScope.irElement.startOffset
+            val endOffset = currentScope.irElement.endOffset
+            val getVal = IrGetValueImpl(startOffset, endOffset, newVar.descriptor)               // Create new IR element representing access the new variable.
+            parametersNew[parameter] = getVal                                                    // Parameter will be replaced with the new variable.
         }
         return EvaluatedParameters(parametersNew, statements)
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InnerClassLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InnerClassLowering.kt
@@ -106,7 +106,7 @@ internal class InnerClassLowering(val context: Context) : ClassLoweringPass {
 
                     if (implicitThisClass == classDescriptor) return expression
 
-                    val constructorDescriptor = currentFunction!! as? ConstructorDescriptor
+                    val constructorDescriptor = currentFunction!!.scope.scopeOwner as? ConstructorDescriptor
 
                     val startOffset = expression.startOffset
                     val endOffset = expression.endOffset


### PR DESCRIPTION
1. Containing declaration can be computed as parent from the IR.

2. Sometimes we need to substitute FunctionDescriptor which is defined
inside an inline function call but nevertheless leaks to the outside:

```
public inline fun <T, R> T.myLet(f: (T) -> R): R = f(this)

interface foo {
    fun bar(): String
}

fun box(): String {
    val baz = "OK".myLet {
        object : foo {
            override fun bar() = it
        }
    }
    return baz.bar()
}```