### PR TITLE
Use libunwind on Linux machines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ void setupCompilationFlags() {
     if (isLinux()) {
         ext.targetArgs <<
             ["host": 
-               ["--sysroot=${gccToolchainDir}/${gnuTriplet}/sysroot"],
+               ["--sysroot=${gccToolchainDir}/${gnuTriplet}/sysroot", "-DUSE_LIBUNWIND=1"],
              "raspberrypi":
                ["-target", "armv7-unknown-linux-gnueabihf",
                 "-mfpu=vfp", "-mfloat-abi=hard",

--- a/runtime/src/main/cpp/Exceptions.cpp
+++ b/runtime/src/main/cpp/Exceptions.cpp
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#ifdef USE_LIBUNWIND
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+#else
 #include <execinfo.h>
+#endif
+#include <stdio.h>  // for snprintf
 #include <stdlib.h>
 #include <string.h>
 
@@ -59,9 +64,56 @@ extern "C" {
 // TODO: this implementation is just a hack, e.g. the result is inexact;
 // however it is better to have an inexact stacktrace than not to have any.
 OBJ_GETTER0(GetCurrentStackTrace) {
-  const int maxSize = 32;
-  void* buffer[maxSize];
+  const int maxSize = 64;
+  const int skipFrames = 3;
+#ifdef USE_LIBUNWIND
+  unw_cursor_t cursor;
+  unw_context_t context;
 
+  unw_getcontext(&context);
+  unw_init_local(&cursor, &context);
+
+  // Count number of stacktrace elements.
+  int count = 0;
+  while (unw_step(&cursor) > 0 && count++ < maxSize) {
+    unw_word_t offset, pc;
+    unw_get_reg(&cursor, UNW_REG_IP, &pc);
+    if (pc == 0) {
+      break;
+    }
+  }
+
+  int frameCount = count > skipFrames ? count - skipFrames : 0;
+  ObjHeader* result =
+    AllocArrayInstance(theArrayTypeInfo, frameCount, OBJ_RESULT);
+
+  unw_init_local(&cursor, &context);
+  // Skip few initial frames.
+  count = 0;
+  while (unw_step(&cursor) > 0 && count++ < skipFrames) {
+  }
+
+  ArrayHeader* array = result->array();
+  count = 0;
+  while (unw_step(&cursor) > 0 && count < frameCount) {
+    unw_word_t offset, pc;
+    unw_get_reg(&cursor, UNW_REG_IP, &pc);
+    if (pc == 0) {
+      break;
+    }
+    char symbol[512];
+    char traceLine[512 + 64];
+    if (unw_get_proc_name(&cursor, symbol, sizeof(symbol), &offset) == 0) {
+      snprintf(traceLine, sizeof(traceLine), "%s [+%lx]", symbol, offset);
+    } else {
+      snprintf(traceLine, sizeof(traceLine), " [%lx]", pc);
+    }
+    CreateStringFromCString(
+      traceLine, ArrayAddressOfElementAt(array, count++));
+  }
+  return result;
+#else
+  void* buffer[maxSize];
   int size = backtrace(buffer, maxSize);
   char** symbols = backtrace_symbols(buffer, size);
   RuntimeAssert(symbols != nullptr, "Not enough memory to retrieve the stacktrace");
@@ -74,11 +126,12 @@ OBJ_GETTER0(GetCurrentStackTrace) {
       symbols[index], ArrayAddressOfElementAt(array, index));
   }
   return result;
+#endif
 }
 
 void ThrowException(KRef exception) {
   RuntimeAssert(exception != nullptr && IsInstance(exception, theThrowableTypeInfo),
-                "Throwing something non-throwable");
+		"Throwing something non-throwable");
   throw KotlinException(exception);
 }
 


### PR DESCRIPTION
Backtrace looks like:
Uncaught exception from Kotlin's main: Throwable: UNIX call failed
        at kfun:throwUnixError()Reference [+35]
        at kfun:main$lambda-1#internal [+406]
        at kfun:main$lambda-1$bound-0#internal [+49]
        at kfun:kotlinx.cinterop.memScoped(kotlin.Function1<kotlinx.cinterop.MemScope,GENERIC>)Reference [+4d]
        at kfun:main(kotlin.Array<kotlin.String>) [+f2]
        at Konan_start [+19]
        at Konan_main [+5b]
        at __libc_start_main [+f0]
        at _start [+29]
        at null