### PR TITLE
build: Use a property to provide an URL for dependency downloading

### DIFF
--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -37,16 +37,13 @@ abstract class NativeDep extends DefaultTask {
     }
 
     protected final String host = getCurrentHostTarget();
+    String baseUrl = "https://jetbrains.bintray.com/kotlin-native-dependencies"
 
     @Input
     abstract String getFileName()
 
     protected String getUrl() {
         return "$baseUrl/$fileName"
-    }
-
-    protected String getBaseUrl() {
-        return "https://jetbrains.bintray.com/kotlin-native-dependencies"
     }
 
     protected File getBaseOutDir() {


### PR DESCRIPTION
This patch adds baseUrl property to store a dependency downloading
path. The property may be set for each downloading task separately.