### PR TITLE
Fix usage of new Kotlin command line arguments API

### DIFF
--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.java
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.java
@@ -17,99 +17,87 @@
 package org.jetbrains.kotlin.cli.bc;
 
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments;
-import org.jetbrains.kotlin.cli.common.arguments.ValueDescription;
-import org.jetbrains.kotlin.cli.common.parser.com.sampullara.cli.Argument;
+import org.jetbrains.kotlin.cli.common.arguments.Argument;
 
 public class K2NativeCompilerArguments extends CommonCompilerArguments {
-    @Argument(value = "output", alias = "o", description = "Output file path")
-    @ValueDescription("<path>")
+    @Argument(value = "-output", shortName = "-o", valueDescription = "<path>", description = "Output file path")
     public String outputFile;
 
-    @Argument(value = "runtime", description = "Override standard \'runtime.bc\' location")
-    @ValueDescription("<path>")
+    @Argument(value = "-runtime", valueDescription = "<path>", description = "Override standard 'runtime.bc' location")
     public String runtimeFile;
 
-    @Argument(value = "properties", description = "Override standard \'konan.properties\' location")
-    @ValueDescription("<path>")
+    @Argument(value = "-properties", valueDescription = "<path>", description = "Override standard 'konan.properties' location")
     public String propertyFile;
 
-    @Argument(value = "library", alias = "l", description = "Link with the library")
-    @ValueDescription("<path>")
+    @Argument(value = "-library", shortName = "-l", valueDescription = "<path>", description = "Link with the library")
     public String[] libraries;
 
-    @Argument(value = "nativelibrary", alias = "nl", description = "Include the native library")
-    @ValueDescription("<path>")
+    @Argument(value = "-nativelibrary", shortName = "-nl", valueDescription = "<path>", description = "Include the native library")
     public String[] nativeLibraries;
 
-    @Argument(value = "nolink", description = "Don't link, just produce a bitcode file")
+    @Argument(value = "-nolink", description = "Don't link, just produce a bitcode file")
     public boolean nolink;
 
-    @Argument(value = "nomain", description = "Assume 'main' entry point to be provided by external libraries")
+    @Argument(value = "-nomain", description = "Assume 'main' entry point to be provided by external libraries")
     public boolean nomain;
 
-    @Argument(value = "linkerArgs", description = "Pass arguments to linker", delimiter = " ")
-    @ValueDescription("<arg>")
+    @Argument(value = "-linkerArgs", valueDescription = "<arg>", description = "Pass arguments to linker", delimiter = " ")
     public String[] linkerArguments;
 
-    @Argument(value = "nostdlib", description = "Don't link with stdlib")
+    @Argument(value = "-nostdlib", description = "Don't link with stdlib")
     public boolean nostdlib;
 
-    @Argument(value = "opt", description = "Enable optimizations during compilation")
+    @Argument(value = "-opt", description = "Enable optimizations during compilation")
     public boolean optimization;
 
-    @Argument(value = "target", description = "Set hardware target")
-    @ValueDescription("<target>")
+    @Argument(value = "-target", valueDescription = "<target>", description = "Set hardware target")
     public String target;
 
-    @Argument(value = "enable_assertions", alias = "ea", description = "Enable runtime assertions in generated code")
+    @Argument(value = "-enable_assertions", shortName = "-ea", description = "Enable runtime assertions in generated code")
     public boolean enableAssertions;
 
     // The rest of the options are only interesting for developers.
     // Make sure to prepend them with double dash.
 
-    @Argument(value = "list_targets", description = "List available hardware targets")
+    @Argument(value = "-list_targets", description = "List available hardware targets")
     public boolean listTargets;
 
-    @Argument(value = "print_ir", prefix = "--", description = "Print IR")
+    @Argument(value = "--print_ir", description = "Print IR")
     public boolean printIr;
 
-    @Argument(value = "print_ir_with_descriptors", prefix = "--", description = "Print IR with descriptors")
+    @Argument(value = "--print_ir_with_descriptors", description = "Print IR with descriptors")
     public boolean printIrWithDescriptors;
 
-    @Argument(value = "print_descriptors", prefix = "--", description = "Print descriptor tree")
+    @Argument(value = "--print_descriptors", description = "Print descriptor tree")
     public boolean printDescriptors;
 
-    @Argument(value = "print_locations", prefix = "--", description = "Print locations")
+    @Argument(value = "--print_locations", description = "Print locations")
     public boolean printLocations;
 
-    @Argument(value = "print_bitcode", prefix = "--", description = "Print llvm bitcode")
+    @Argument(value = "--print_bitcode", description = "Print llvm bitcode")
     public boolean printBitCode;
 
-    @Argument(value = "verify_ir", prefix = "--", description = "Verify IR")
+    @Argument(value = "--verify_ir", description = "Verify IR")
     public boolean verifyIr;
 
-    @Argument(value = "verify_descriptors", prefix = "--", description = "Verify descriptor tree")
+    @Argument(value = "--verify_descriptors", description = "Verify descriptor tree")
     public boolean verifyDescriptors;
 
-    @Argument(value = "verify_bitcode", prefix = "--", description = "Verify llvm bitcode after each method")
+    @Argument(value = "--verify_bitcode", description = "Verify llvm bitcode after each method")
     public boolean verifyBitCode;
 
-    @Argument(value = "enable", prefix = "--", description = "Enable backend phase")
-    @ValueDescription("<Phase>")
+    @Argument(value = "--enable", valueDescription = "<Phase>", description = "Enable backend phase")
     public String[] enablePhases;
 
-    @Argument(value = "disable", prefix = "--", description = "Disable backend phase")
-    @ValueDescription("<Phase>")
+    @Argument(value = "--disable", valueDescription = "<Phase>", description = "Disable backend phase")
     public String[] disablePhases;
 
-    @Argument(value = "verbose", prefix = "--", description = "Trace phase execution")
-    @ValueDescription("<Phase>")
+    @Argument(value = "--verbose", valueDescription = "<Phase>", description = "Trace phase execution")
     public String[] verbosePhases;
 
-    @Argument(value = "list_phases", prefix = "--", description = "List all backend phases")
+    @Argument(value = "--list_phases", description = "List all backend phases")
     public boolean listPhases;
 
-    @Argument(value = "time", prefix = "--", description = "Report execution time for compiler phases")
+    @Argument(value = "--time", description = "Report execution time for compiler phases")
     public boolean timePhases;
 }
-


### PR DESCRIPTION
This will be needed after an update to the new compiler because https://github.com/JetBrains/kotlin/commit/78c0111c6e85b54a2ba4ddd766099dabb4d633bd

~Please do not merge yet. There's `delimiter = " "` used in `linkerArguments`, which is not yet supported in the new API, I'll support it soon~ Fixed now