### PR TITLE
Pkg config issue and wrong workdir of cinterop

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
@@ -1188,7 +1188,7 @@ class StubGenerator(
     private val FunctionDecl.cStubName: String
         get() {
             require(platform == KotlinPlatform.NATIVE)
-            return "kni_" + pkgName.replace('/', '_') + '_' + this.name
+            return "kni_" + pkgName.replace('.', '_') + '_' + this.name
         }
 
     private val FunctionDecl.kotlinExternalName: String

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -354,7 +354,7 @@ private fun processLib(konanHome: String,
         }
     }
 
-    val workDir = defFile?.parentFile ?: File(System.getProperty("java.io.tmpdir"))
+    val workDir = defFile?.absoluteFile?.parentFile ?: File(System.getProperty("java.io.tmpdir"))
 
     if (flavor == KotlinPlatform.JVM) {
 


### PR DESCRIPTION
When I was using cinterop in cmd line, 

```
cinterop -def kotliner.def -o build/kotliner/kotliner.kt.bc
```
 I got a error:

```
/Users/benny/Github/kotlin-native/dist/dependencies/clang-llvm-3.9.0-darwin-macos/bin/clang -Isrc/c -isystem /Users/benny/Github/kotlin-native/dist/dependencies/clang-llvm-3.9.0-darwin-macos/lib/clang/3.9.0/include -B/Users/benny/Github/kotlin-native/dist/dependencies/target-sysroot-1-darwin-macos/usr/bin --sysroot=/Users/benny/Github/kotlin-native/dist/dependencies/target-sysroot-1-darwin-macos -mmacosx-version-min=10.11 -emit-llvm -c build/kotliner/kotliner.kt.bc-build/natives/cstubs.c -o build/kotliner/kotliner.kt.bc-build/natives/cstubs.bc
clang-3.9: error: no such file or directory: 'build/kotliner/kotliner.kt.bc-build/natives/cstubs.c'
clang-3.9: error: no input files
Exception in thread "main" java.lang.Error: Process finished with non-zero exit code: 1
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.runExpectingSuccess(main.kt:112)
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.runCmd(main.kt:158)
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.processLib(main.kt:396)
        at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.main(main.kt:43)
```

It was obviously caused by a wrong "working dir". When I check the code in MainKt.processLib, I found that the workdir was retrieved from defFile passed from the command line and if the defFile was a relative file like File("interop.def") , its parentFile would be null thus making the workdir assigned by a temporary file.