### PR TITLE
Add includedFunctions property to *.def files

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/InteropConfiguration.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/InteropConfiguration.kt
@@ -25,6 +25,8 @@ class InteropConfiguration(
         val library: NativeLibrary,
         val pkgName: String,
         val excludedFunctions: Set<String>,
+        val includedFunctions: Set<String>,
+        val useIncludedFunctions: Boolean,
         val strictEnums: Set<String>,
         val nonStrictEnums: Set<String>
 )

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
@@ -54,6 +54,12 @@ class StubGenerator(
     val excludedFunctions: Set<String>
         get() = configuration.excludedFunctions
 
+	val includedFunctions: Set<String>
+	    get() = configuration.includedFunctions
+
+    val useIncludedFunctions: Boolean
+        get() = configuration.useIncludedFunctions
+
     val keywords = setOf(
             "as", "break", "class", "continue", "do", "else", "false", "for", "fun", "if", "in",
             "interface", "is", "null", "object", "package", "return", "super", "this", "throw",
@@ -150,7 +156,13 @@ class StubGenerator(
         get() = decl.kotlinName
 
 
-    val functionsToBind = nativeIndex.functions.filter { it.name !in excludedFunctions }
+    val functionsToBind = nativeIndex.functions.filter { 
+       if (useIncludedFunctions) {
+       	  it.name in includedFunctions
+       } else {
+          it.name !in excludedFunctions
+       }
+    }
 
     private val usedFunctionTypes = mutableMapOf<FunctionType, String>()
 

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -317,6 +317,7 @@ private fun processLib(konanHome: String,
         defaultOpts + additionalLinkerOpts 
     val linker = args["-linker"]?.atMostOne() ?: config.getProperty("linker") ?: "clang"
     val excludedFunctions = config.getSpaceSeparated("excludedFunctions").toSet()
+    val includedFunctions = config.getSpaceSeparated("includedFunctions").toSet()
 
     val fqParts = args["-pkg"]?.atMostOne()?.let {
         it.split('.')
@@ -335,6 +336,8 @@ private fun processLib(konanHome: String,
             library = library,
             pkgName = outKtPkg,
             excludedFunctions = excludedFunctions,
+            includedFunctions = includedFunctions,
+            useIncludedFunctions = !includedFunctions.isEmpty(),
             strictEnums = config.getSpaceSeparated("strictEnums").toSet(),
             nonStrictEnums = config.getSpaceSeparated("nonStrictEnums").toSet()
     )


### PR DESCRIPTION
### Why?
This PR allows making smaller cstubs by only including a few functions (instead of excluding a few with `exlcudedFunctions`). This potentially decreases compilation times.

### Example
```
headers = time.h
includedFunctions = ctime time
```
This strips all of the functions from `time.h` except `ctime` and `time`

### Conflicting statements
```
headers = time.h
includedFunctions = a b
excludedFunctions = b c
```
In a situation like this, `includedFunctions` will be used, and `excludedFunctions` will be ignored

### Expansion?
Maybe this idea should be expanded for classes as well? The compiler could note down what classes are necessary (from return and parameter types of functions) and users can include extra classes with `includedClasses`