### PR TITLE
Start a new serializer for each class.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanSerializationUtil.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanSerializationUtil.kt
@@ -160,11 +160,12 @@ internal class KonanSerializationUtil(val context: Context) {
 
         if (skip(classDescriptor)) return
 
-        val classProto = serializer.classProto(classDescriptor).build()     
+        val localSerializer = KonanDescriptorSerializer.create(classDescriptor, serializerExtension)
+        val classProto = localSerializer.classProto(classDescriptor).build()
             ?: error("Class not serialized: $classDescriptor")
 
         builder.addClasses(classProto)
-        val index = serializer.stringTable.getFqNameIndex(classDescriptor)
+        val index = localSerializer.stringTable.getFqNameIndex(classDescriptor)
         builder.addClassName(index)
 
         serializeClasses(packageName, builder, 


### PR DESCRIPTION
#499 remerge
The consequence of that would be the type tables started anew for each class.
Without that the ever growing common global type table is written to each class.
Making the class protobufs bigger and bigger.