### PR TITLE
CODEGEN: compiler calculates path of compile unit as absolute path

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1659,8 +1659,8 @@ internal class CodeGeneratorVisitor(val context: Context) : IrElementVisitorVoid
     //-------------------------------------------------------------------------//
     private fun IrFile.file(): DIFileRef {
         return context.debugInfo.files.getOrPut(this) {
-            val path = this.fileEntry.name.split("/")
-            DICreateFile(context.debugInfo.builder, path.last(), path.dropLast(1).joinToString("/"))!!
+            val path = this.fileEntry.name.toFileAndFolder()
+            DICreateFile(context.debugInfo.builder, path.file, path.folder)!!
         }
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/util/NoJavaUtil.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/util/NoJavaUtil.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.backend.konan.util
+
+class File(val path:String) {
+    private val javaFile = java.io.File(path)
+    val  absoluteFile: File
+        get() = File(javaFile.absolutePath)
+    val name: String
+        get() = javaFile.name
+    val parent: String
+        get() = javaFile.parent
+}


### PR DESCRIPTION
Для дебага с lldb оказывается важным путь в DICompileUnit. это изменение чинит следующий сценарий:
```
> dist/bin/konanc -g backend.native/tests/codegen/lambda/lambda1.kt
JetFile: lambda1.kt
> lldb program.kexe
```