### PR TITLE
Rework interop callbacks

### DIFF
--- a/INTEROP.md
+++ b/INTEROP.md
@@ -275,14 +275,7 @@ methods available:
 ### Callbacks ###
 
 To convert Kotlin function to pointer to C function,
-`staticCFunction(::kotlinFunction)` can be used. Currently `staticCFunction`
-heavily relies on type inference, so the expression `staticCFunction(...)`
-should be either assigned to the variable having proper type explicitly
-specified, or passed to the function, e.g.
-
-```
-glutDisplayFunc(staticCFunction(::display))
-```
+`staticCFunction(::kotlinFunction)` can be used.
 
 Note that some function types are not supported currently. For example,
 it is not possible to get pointer to function that receives or returns structs

--- a/Interop/Indexer/build.gradle
+++ b/Interop/Indexer/build.gradle
@@ -79,7 +79,7 @@ kotlinNativeInterop {
         defFile 'clang.def'
         compilerOpts "-I$llvmDir/include"
         linkerOpts "-L$llvmDir/lib"
-        genTask.args '-keepcstubs:true'
+        genTask.args '-keepcstubs', 'true'
     }
 }
 

--- a/Interop/Indexer/prebuilt/nativeInteropStubs/c/clangstubs.c
+++ b/Interop/Indexer/prebuilt/nativeInteropStubs/c/clangstubs.c
@@ -2,1029 +2,1344 @@
 #include <jni.h>
 #include <clang-c/Index.h>
 
-JNIEXPORT jlong JNICALL Java_clang_externals_asctime (JNIEnv *env, jobject obj, jlong arg0) {
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1asctime (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (asctime((struct tm*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clock (JNIEnv *env, jobject obj) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clock (JNIEnv *jniEnv, jclass jclss) {
     return (jlong) (clock());
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_ctime (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1ctime (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (ctime((time_t*)arg0));
 }
-JNIEXPORT jdouble JNICALL Java_clang_externals_difftime (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT jdouble JNICALL Java_clang_clang_kni_1difftime (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     return (jdouble) (difftime((time_t)arg0, (time_t)arg1));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_getdate (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1getdate (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (getdate((char*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_gmtime (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1gmtime (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (gmtime((time_t*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_localtime (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1localtime (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (localtime((time_t*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_mktime (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1mktime (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (mktime((struct tm*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_strftime (JNIEnv *env, jobject obj, jlong arg0, jlong arg1, jlong arg2, jlong arg3) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1strftime (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1, jlong arg2, jlong arg3) {
     return (jlong) (strftime((char*)arg0, (size_t)arg1, (char*)arg2, (struct tm*)arg3));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_strptime (JNIEnv *env, jobject obj, jlong arg0, jlong arg1, jlong arg2) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1strptime (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1, jlong arg2) {
     return (jlong) (strptime((char*)arg0, (char*)arg1, (struct tm*)arg2));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_time (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1time (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (time((time_t*)arg0));
 }
-JNIEXPORT void JNICALL Java_clang_externals_tzset (JNIEnv *env, jobject obj) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1tzset (JNIEnv *jniEnv, jclass jclss) {
     tzset();
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_asctime_1r (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1asctime_1r (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     return (jlong) (asctime_r((struct tm*)arg0, (char*)arg1));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_ctime_1r (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1ctime_1r (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     return (jlong) (ctime_r((time_t*)arg0, (char*)arg1));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_gmtime_1r (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1gmtime_1r (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     return (jlong) (gmtime_r((time_t*)arg0, (struct tm*)arg1));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_localtime_1r (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1localtime_1r (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     return (jlong) (localtime_r((time_t*)arg0, (struct tm*)arg1));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_posix2time (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1posix2time (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (posix2time((time_t)arg0));
 }
-JNIEXPORT void JNICALL Java_clang_externals_tzsetwall (JNIEnv *env, jobject obj) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1tzsetwall (JNIEnv *jniEnv, jclass jclss) {
     tzsetwall();
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_time2posix (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1time2posix (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (time2posix((time_t)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_timelocal (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1timelocal (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (timelocal((struct tm*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_timegm (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1timegm (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (timegm((struct tm*)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_nanosleep (JNIEnv *env, jobject obj, jlong __rqtp, jlong __rmtp) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1nanosleep (JNIEnv *jniEnv, jclass jclss, jlong __rqtp, jlong __rmtp) {
     return (jint) (nanosleep((struct timespec*)__rqtp, (struct timespec*)__rmtp));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clock_1getres (JNIEnv *env, jobject obj, jint __clock_id, jlong __res) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clock_1getres (JNIEnv *jniEnv, jclass jclss, jint __clock_id, jlong __res) {
     return (jint) (clock_getres((clockid_t)__clock_id, (struct timespec*)__res));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clock_1gettime (JNIEnv *env, jobject obj, jint __clock_id, jlong __tp) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clock_1gettime (JNIEnv *jniEnv, jclass jclss, jint __clock_id, jlong __tp) {
     return (jint) (clock_gettime((clockid_t)__clock_id, (struct timespec*)__tp));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clock_1gettime_1nsec_1np (JNIEnv *env, jobject obj, jint __clock_id) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clock_1gettime_1nsec_1np (JNIEnv *jniEnv, jclass jclss, jint __clock_id) {
     return (jlong) (clock_gettime_nsec_np((clockid_t)__clock_id));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clock_1settime (JNIEnv *env, jobject obj, jint __clock_id, jlong __tp) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clock_1settime (JNIEnv *jniEnv, jclass jclss, jint __clock_id, jlong __tp) {
     return (jint) (clock_settime((clockid_t)__clock_id, (struct timespec*)__tp));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCString (JNIEnv *env, jobject obj, jlong string) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCString (JNIEnv *jniEnv, jclass jclss, jlong string) {
     return (jlong) (clang_getCString(*(CXString*)string));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeString (JNIEnv *env, jobject obj, jlong string) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeString (JNIEnv *jniEnv, jclass jclss, jlong string) {
     clang_disposeString(*(CXString*)string);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeStringSet (JNIEnv *env, jobject obj, jlong set) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeStringSet (JNIEnv *jniEnv, jclass jclss, jlong set) {
     clang_disposeStringSet((CXStringSet*)set);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getBuildSessionTimestamp (JNIEnv *env, jobject obj) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getBuildSessionTimestamp (JNIEnv *jniEnv, jclass jclss) {
     return (jlong) (clang_getBuildSessionTimestamp());
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1VirtualFileOverlay_1create (JNIEnv *env, jobject obj, jint options) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1VirtualFileOverlay_1create (JNIEnv *jniEnv, jclass jclss, jint options) {
     return (jlong) (clang_VirtualFileOverlay_create((unsigned int)options));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1VirtualFileOverlay_1addFileMapping (JNIEnv *env, jobject obj, jlong arg0, jlong virtualPath, jlong realPath) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1VirtualFileOverlay_1addFileMapping (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong virtualPath, jlong realPath) {
     return (jint) (clang_VirtualFileOverlay_addFileMapping((CXVirtualFileOverlay)arg0, (char*)virtualPath, (char*)realPath));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1VirtualFileOverlay_1setCaseSensitivity (JNIEnv *env, jobject obj, jlong arg0, jint caseSensitive) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1VirtualFileOverlay_1setCaseSensitivity (JNIEnv *jniEnv, jclass jclss, jlong arg0, jint caseSensitive) {
     return (jint) (clang_VirtualFileOverlay_setCaseSensitivity((CXVirtualFileOverlay)arg0, (int)caseSensitive));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1VirtualFileOverlay_1writeToBuffer (JNIEnv *env, jobject obj, jlong arg0, jint options, jlong out_buffer_ptr, jlong out_buffer_size) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1VirtualFileOverlay_1writeToBuffer (JNIEnv *jniEnv, jclass jclss, jlong arg0, jint options, jlong out_buffer_ptr, jlong out_buffer_size) {
     return (jint) (clang_VirtualFileOverlay_writeToBuffer((CXVirtualFileOverlay)arg0, (unsigned int)options, (char**)out_buffer_ptr, (unsigned int*)out_buffer_size));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1free (JNIEnv *env, jobject obj, jlong buffer) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1free (JNIEnv *jniEnv, jclass jclss, jlong buffer) {
     clang_free((void*)buffer);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1VirtualFileOverlay_1dispose (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1VirtualFileOverlay_1dispose (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     clang_VirtualFileOverlay_dispose((CXVirtualFileOverlay)arg0);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1ModuleMapDescriptor_1create (JNIEnv *env, jobject obj, jint options) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1ModuleMapDescriptor_1create (JNIEnv *jniEnv, jclass jclss, jint options) {
     return (jlong) (clang_ModuleMapDescriptor_create((unsigned int)options));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1ModuleMapDescriptor_1setFrameworkModuleName (JNIEnv *env, jobject obj, jlong arg0, jlong name) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1ModuleMapDescriptor_1setFrameworkModuleName (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong name) {
     return (jint) (clang_ModuleMapDescriptor_setFrameworkModuleName((CXModuleMapDescriptor)arg0, (char*)name));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1ModuleMapDescriptor_1setUmbrellaHeader (JNIEnv *env, jobject obj, jlong arg0, jlong name) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1ModuleMapDescriptor_1setUmbrellaHeader (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong name) {
     return (jint) (clang_ModuleMapDescriptor_setUmbrellaHeader((CXModuleMapDescriptor)arg0, (char*)name));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1ModuleMapDescriptor_1writeToBuffer (JNIEnv *env, jobject obj, jlong arg0, jint options, jlong out_buffer_ptr, jlong out_buffer_size) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1ModuleMapDescriptor_1writeToBuffer (JNIEnv *jniEnv, jclass jclss, jlong arg0, jint options, jlong out_buffer_ptr, jlong out_buffer_size) {
     return (jint) (clang_ModuleMapDescriptor_writeToBuffer((CXModuleMapDescriptor)arg0, (unsigned int)options, (char**)out_buffer_ptr, (unsigned int*)out_buffer_size));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1ModuleMapDescriptor_1dispose (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1ModuleMapDescriptor_1dispose (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     clang_ModuleMapDescriptor_dispose((CXModuleMapDescriptor)arg0);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1createIndex (JNIEnv *env, jobject obj, jint excludeDeclarationsFromPCH, jint displayDiagnostics) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1createIndex (JNIEnv *jniEnv, jclass jclss, jint excludeDeclarationsFromPCH, jint displayDiagnostics) {
     return (jlong) (clang_createIndex((int)excludeDeclarationsFromPCH, (int)displayDiagnostics));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeIndex (JNIEnv *env, jobject obj, jlong index) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeIndex (JNIEnv *jniEnv, jclass jclss, jlong index) {
     clang_disposeIndex((CXIndex)index);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1CXIndex_1setGlobalOptions (JNIEnv *env, jobject obj, jlong arg0, jint options) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1CXIndex_1setGlobalOptions (JNIEnv *jniEnv, jclass jclss, jlong arg0, jint options) {
     clang_CXIndex_setGlobalOptions((CXIndex)arg0, (unsigned int)options);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXIndex_1getGlobalOptions (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXIndex_1getGlobalOptions (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_CXIndex_getGlobalOptions((CXIndex)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getFileName (JNIEnv *env, jobject obj, jlong SFile, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getFileName (JNIEnv *jniEnv, jclass jclss, jlong SFile, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getFileName((CXFile)SFile);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getFileTime (JNIEnv *env, jobject obj, jlong SFile) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getFileTime (JNIEnv *jniEnv, jclass jclss, jlong SFile) {
     return (jlong) (clang_getFileTime((CXFile)SFile));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getFileUniqueID (JNIEnv *env, jobject obj, jlong file, jlong outID) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getFileUniqueID (JNIEnv *jniEnv, jclass jclss, jlong file, jlong outID) {
     return (jint) (clang_getFileUniqueID((CXFile)file, (CXFileUniqueID*)outID));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isFileMultipleIncludeGuarded (JNIEnv *env, jobject obj, jlong tu, jlong file) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isFileMultipleIncludeGuarded (JNIEnv *jniEnv, jclass jclss, jlong tu, jlong file) {
     return (jint) (clang_isFileMultipleIncludeGuarded((CXTranslationUnit)tu, (CXFile)file));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getFile (JNIEnv *env, jobject obj, jlong tu, jlong file_name) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getFile (JNIEnv *jniEnv, jclass jclss, jlong tu, jlong file_name) {
     return (jlong) (clang_getFile((CXTranslationUnit)tu, (char*)file_name));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1File_1isEqual (JNIEnv *env, jobject obj, jlong file1, jlong file2) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1File_1isEqual (JNIEnv *jniEnv, jclass jclss, jlong file1, jlong file2) {
     return (jint) (clang_File_isEqual((CXFile)file1, (CXFile)file2));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getNullLocation (JNIEnv *env, jobject obj, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getNullLocation (JNIEnv *jniEnv, jclass jclss, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_getNullLocation();
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1equalLocations (JNIEnv *env, jobject obj, jlong loc1, jlong loc2) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1equalLocations (JNIEnv *jniEnv, jclass jclss, jlong loc1, jlong loc2) {
     return (jint) (clang_equalLocations(*(CXSourceLocation*)loc1, *(CXSourceLocation*)loc2));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getLocation (JNIEnv *env, jobject obj, jlong tu, jlong file, jint line, jint column, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getLocation (JNIEnv *jniEnv, jclass jclss, jlong tu, jlong file, jint line, jint column, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_getLocation((CXTranslationUnit)tu, (CXFile)file, (unsigned int)line, (unsigned int)column);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getLocationForOffset (JNIEnv *env, jobject obj, jlong tu, jlong file, jint offset, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getLocationForOffset (JNIEnv *jniEnv, jclass jclss, jlong tu, jlong file, jint offset, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_getLocationForOffset((CXTranslationUnit)tu, (CXFile)file, (unsigned int)offset);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Location_1isInSystemHeader (JNIEnv *env, jobject obj, jlong location) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Location_1isInSystemHeader (JNIEnv *jniEnv, jclass jclss, jlong location) {
     return (jint) (clang_Location_isInSystemHeader(*(CXSourceLocation*)location));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Location_1isFromMainFile (JNIEnv *env, jobject obj, jlong location) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Location_1isFromMainFile (JNIEnv *jniEnv, jclass jclss, jlong location) {
     return (jint) (clang_Location_isFromMainFile(*(CXSourceLocation*)location));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getNullRange (JNIEnv *env, jobject obj, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getNullRange (JNIEnv *jniEnv, jclass jclss, jlong retValPlacement) {
     *(CXSourceRange*)retValPlacement = clang_getNullRange();
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getRange (JNIEnv *env, jobject obj, jlong begin, jlong end, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getRange (JNIEnv *jniEnv, jclass jclss, jlong begin, jlong end, jlong retValPlacement) {
     *(CXSourceRange*)retValPlacement = clang_getRange(*(CXSourceLocation*)begin, *(CXSourceLocation*)end);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1equalRanges (JNIEnv *env, jobject obj, jlong range1, jlong range2) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1equalRanges (JNIEnv *jniEnv, jclass jclss, jlong range1, jlong range2) {
     return (jint) (clang_equalRanges(*(CXSourceRange*)range1, *(CXSourceRange*)range2));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Range_1isNull (JNIEnv *env, jobject obj, jlong range) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Range_1isNull (JNIEnv *jniEnv, jclass jclss, jlong range) {
     return (jint) (clang_Range_isNull(*(CXSourceRange*)range));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1getExpansionLocation (JNIEnv *env, jobject obj, jlong location, jlong file, jlong line, jlong column, jlong offset) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1getExpansionLocation (JNIEnv *jniEnv, jclass jclss, jlong location, jlong file, jlong line, jlong column, jlong offset) {
     clang_getExpansionLocation(*(CXSourceLocation*)location, (CXFile*)file, (unsigned int*)line, (unsigned int*)column, (unsigned int*)offset);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1getPresumedLocation (JNIEnv *env, jobject obj, jlong location, jlong filename, jlong line, jlong column) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1getPresumedLocation (JNIEnv *jniEnv, jclass jclss, jlong location, jlong filename, jlong line, jlong column) {
     clang_getPresumedLocation(*(CXSourceLocation*)location, (CXString*)filename, (unsigned int*)line, (unsigned int*)column);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1getInstantiationLocation (JNIEnv *env, jobject obj, jlong location, jlong file, jlong line, jlong column, jlong offset) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1getInstantiationLocation (JNIEnv *jniEnv, jclass jclss, jlong location, jlong file, jlong line, jlong column, jlong offset) {
     clang_getInstantiationLocation(*(CXSourceLocation*)location, (CXFile*)file, (unsigned int*)line, (unsigned int*)column, (unsigned int*)offset);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1getSpellingLocation (JNIEnv *env, jobject obj, jlong location, jlong file, jlong line, jlong column, jlong offset) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1getSpellingLocation (JNIEnv *jniEnv, jclass jclss, jlong location, jlong file, jlong line, jlong column, jlong offset) {
     clang_getSpellingLocation(*(CXSourceLocation*)location, (CXFile*)file, (unsigned int*)line, (unsigned int*)column, (unsigned int*)offset);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1getFileLocation (JNIEnv *env, jobject obj, jlong location, jlong file, jlong line, jlong column, jlong offset) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1getFileLocation (JNIEnv *jniEnv, jclass jclss, jlong location, jlong file, jlong line, jlong column, jlong offset) {
     clang_getFileLocation(*(CXSourceLocation*)location, (CXFile*)file, (unsigned int*)line, (unsigned int*)column, (unsigned int*)offset);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getRangeStart (JNIEnv *env, jobject obj, jlong range, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getRangeStart (JNIEnv *jniEnv, jclass jclss, jlong range, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_getRangeStart(*(CXSourceRange*)range);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getRangeEnd (JNIEnv *env, jobject obj, jlong range, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getRangeEnd (JNIEnv *jniEnv, jclass jclss, jlong range, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_getRangeEnd(*(CXSourceRange*)range);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getSkippedRanges (JNIEnv *env, jobject obj, jlong tu, jlong file) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getSkippedRanges (JNIEnv *jniEnv, jclass jclss, jlong tu, jlong file) {
     return (jlong) (clang_getSkippedRanges((CXTranslationUnit)tu, (CXFile)file));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeSourceRangeList (JNIEnv *env, jobject obj, jlong ranges) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeSourceRangeList (JNIEnv *jniEnv, jclass jclss, jlong ranges) {
     clang_disposeSourceRangeList((CXSourceRangeList*)ranges);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getNumDiagnosticsInSet (JNIEnv *env, jobject obj, jlong Diags) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getNumDiagnosticsInSet (JNIEnv *jniEnv, jclass jclss, jlong Diags) {
     return (jint) (clang_getNumDiagnosticsInSet((CXDiagnosticSet)Diags));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticInSet (JNIEnv *env, jobject obj, jlong Diags, jint Index) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticInSet (JNIEnv *jniEnv, jclass jclss, jlong Diags, jint Index) {
     return (jlong) (clang_getDiagnosticInSet((CXDiagnosticSet)Diags, (unsigned int)Index));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1loadDiagnostics (JNIEnv *env, jobject obj, jlong file, jlong error, jlong errorString) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1loadDiagnostics (JNIEnv *jniEnv, jclass jclss, jlong file, jlong error, jlong errorString) {
     return (jlong) (clang_loadDiagnostics((char*)file, (enum CXLoadDiag_Error*)error, (CXString*)errorString));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeDiagnosticSet (JNIEnv *env, jobject obj, jlong Diags) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeDiagnosticSet (JNIEnv *jniEnv, jclass jclss, jlong Diags) {
     clang_disposeDiagnosticSet((CXDiagnosticSet)Diags);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getChildDiagnostics (JNIEnv *env, jobject obj, jlong D) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getChildDiagnostics (JNIEnv *jniEnv, jclass jclss, jlong D) {
     return (jlong) (clang_getChildDiagnostics((CXDiagnostic)D));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getNumDiagnostics (JNIEnv *env, jobject obj, jlong Unit) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getNumDiagnostics (JNIEnv *jniEnv, jclass jclss, jlong Unit) {
     return (jint) (clang_getNumDiagnostics((CXTranslationUnit)Unit));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnostic (JNIEnv *env, jobject obj, jlong Unit, jint Index) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnostic (JNIEnv *jniEnv, jclass jclss, jlong Unit, jint Index) {
     return (jlong) (clang_getDiagnostic((CXTranslationUnit)Unit, (unsigned int)Index));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticSetFromTU (JNIEnv *env, jobject obj, jlong Unit) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticSetFromTU (JNIEnv *jniEnv, jclass jclss, jlong Unit) {
     return (jlong) (clang_getDiagnosticSetFromTU((CXTranslationUnit)Unit));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeDiagnostic (JNIEnv *env, jobject obj, jlong Diagnostic) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeDiagnostic (JNIEnv *jniEnv, jclass jclss, jlong Diagnostic) {
     clang_disposeDiagnostic((CXDiagnostic)Diagnostic);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1formatDiagnostic (JNIEnv *env, jobject obj, jlong Diagnostic, jint Options, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1formatDiagnostic (JNIEnv *jniEnv, jclass jclss, jlong Diagnostic, jint Options, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_formatDiagnostic((CXDiagnostic)Diagnostic, (unsigned int)Options);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1defaultDiagnosticDisplayOptions (JNIEnv *env, jobject obj) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1defaultDiagnosticDisplayOptions (JNIEnv *jniEnv, jclass jclss) {
     return (jint) (clang_defaultDiagnosticDisplayOptions());
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getDiagnosticSeverity (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getDiagnosticSeverity (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_getDiagnosticSeverity((CXDiagnostic)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticLocation (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticLocation (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_getDiagnosticLocation((CXDiagnostic)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticSpelling (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticSpelling (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getDiagnosticSpelling((CXDiagnostic)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticOption (JNIEnv *env, jobject obj, jlong Diag, jlong Disable, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticOption (JNIEnv *jniEnv, jclass jclss, jlong Diag, jlong Disable, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getDiagnosticOption((CXDiagnostic)Diag, (CXString*)Disable);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getDiagnosticCategory (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getDiagnosticCategory (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_getDiagnosticCategory((CXDiagnostic)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticCategoryName (JNIEnv *env, jobject obj, jint Category, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticCategoryName (JNIEnv *jniEnv, jclass jclss, jint Category, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getDiagnosticCategoryName((unsigned int)Category);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticCategoryText (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticCategoryText (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getDiagnosticCategoryText((CXDiagnostic)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getDiagnosticNumRanges (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getDiagnosticNumRanges (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_getDiagnosticNumRanges((CXDiagnostic)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticRange (JNIEnv *env, jobject obj, jlong Diagnostic, jint Range, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticRange (JNIEnv *jniEnv, jclass jclss, jlong Diagnostic, jint Range, jlong retValPlacement) {
     *(CXSourceRange*)retValPlacement = clang_getDiagnosticRange((CXDiagnostic)Diagnostic, (unsigned int)Range);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getDiagnosticNumFixIts (JNIEnv *env, jobject obj, jlong Diagnostic) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getDiagnosticNumFixIts (JNIEnv *jniEnv, jclass jclss, jlong Diagnostic) {
     return (jint) (clang_getDiagnosticNumFixIts((CXDiagnostic)Diagnostic));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDiagnosticFixIt (JNIEnv *env, jobject obj, jlong Diagnostic, jint FixIt, jlong ReplacementRange, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDiagnosticFixIt (JNIEnv *jniEnv, jclass jclss, jlong Diagnostic, jint FixIt, jlong ReplacementRange, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getDiagnosticFixIt((CXDiagnostic)Diagnostic, (unsigned int)FixIt, (CXSourceRange*)ReplacementRange);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTranslationUnitSpelling (JNIEnv *env, jobject obj, jlong CTUnit, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTranslationUnitSpelling (JNIEnv *jniEnv, jclass jclss, jlong CTUnit, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getTranslationUnitSpelling((CXTranslationUnit)CTUnit);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1createTranslationUnitFromSourceFile (JNIEnv *env, jobject obj, jlong CIdx, jlong source_filename, jint num_clang_command_line_args, jlong clang_command_line_args, jint num_unsaved_files, jlong unsaved_files) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1createTranslationUnitFromSourceFile (JNIEnv *jniEnv, jclass jclss, jlong CIdx, jlong source_filename, jint num_clang_command_line_args, jlong clang_command_line_args, jint num_unsaved_files, jlong unsaved_files) {
     return (jlong) (clang_createTranslationUnitFromSourceFile((CXIndex)CIdx, (char*)source_filename, (int)num_clang_command_line_args, (char**)clang_command_line_args, (unsigned int)num_unsaved_files, (struct CXUnsavedFile*)unsaved_files));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1createTranslationUnit (JNIEnv *env, jobject obj, jlong CIdx, jlong ast_filename) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1createTranslationUnit (JNIEnv *jniEnv, jclass jclss, jlong CIdx, jlong ast_filename) {
     return (jlong) (clang_createTranslationUnit((CXIndex)CIdx, (char*)ast_filename));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1createTranslationUnit2 (JNIEnv *env, jobject obj, jlong CIdx, jlong ast_filename, jlong out_TU) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1createTranslationUnit2 (JNIEnv *jniEnv, jclass jclss, jlong CIdx, jlong ast_filename, jlong out_TU) {
     return (jint) (clang_createTranslationUnit2((CXIndex)CIdx, (char*)ast_filename, (CXTranslationUnit*)out_TU));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1defaultEditingTranslationUnitOptions (JNIEnv *env, jobject obj) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1defaultEditingTranslationUnitOptions (JNIEnv *jniEnv, jclass jclss) {
     return (jint) (clang_defaultEditingTranslationUnitOptions());
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1parseTranslationUnit (JNIEnv *env, jobject obj, jlong CIdx, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jint options) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1parseTranslationUnit (JNIEnv *jniEnv, jclass jclss, jlong CIdx, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jint options) {
     return (jlong) (clang_parseTranslationUnit((CXIndex)CIdx, (char*)source_filename, (char**)command_line_args, (int)num_command_line_args, (struct CXUnsavedFile*)unsaved_files, (unsigned int)num_unsaved_files, (unsigned int)options));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1parseTranslationUnit2 (JNIEnv *env, jobject obj, jlong CIdx, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jint options, jlong out_TU) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1parseTranslationUnit2 (JNIEnv *jniEnv, jclass jclss, jlong CIdx, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jint options, jlong out_TU) {
     return (jint) (clang_parseTranslationUnit2((CXIndex)CIdx, (char*)source_filename, (char**)command_line_args, (int)num_command_line_args, (struct CXUnsavedFile*)unsaved_files, (unsigned int)num_unsaved_files, (unsigned int)options, (CXTranslationUnit*)out_TU));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1parseTranslationUnit2FullArgv (JNIEnv *env, jobject obj, jlong CIdx, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jint options, jlong out_TU) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1parseTranslationUnit2FullArgv (JNIEnv *jniEnv, jclass jclss, jlong CIdx, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jint options, jlong out_TU) {
     return (jint) (clang_parseTranslationUnit2FullArgv((CXIndex)CIdx, (char*)source_filename, (char**)command_line_args, (int)num_command_line_args, (struct CXUnsavedFile*)unsaved_files, (unsigned int)num_unsaved_files, (unsigned int)options, (CXTranslationUnit*)out_TU));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1defaultSaveOptions (JNIEnv *env, jobject obj, jlong TU) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1defaultSaveOptions (JNIEnv *jniEnv, jclass jclss, jlong TU) {
     return (jint) (clang_defaultSaveOptions((CXTranslationUnit)TU));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1saveTranslationUnit (JNIEnv *env, jobject obj, jlong TU, jlong FileName, jint options) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1saveTranslationUnit (JNIEnv *jniEnv, jclass jclss, jlong TU, jlong FileName, jint options) {
     return (jint) (clang_saveTranslationUnit((CXTranslationUnit)TU, (char*)FileName, (unsigned int)options));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeTranslationUnit (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeTranslationUnit (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     clang_disposeTranslationUnit((CXTranslationUnit)arg0);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1defaultReparseOptions (JNIEnv *env, jobject obj, jlong TU) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1defaultReparseOptions (JNIEnv *jniEnv, jclass jclss, jlong TU) {
     return (jint) (clang_defaultReparseOptions((CXTranslationUnit)TU));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1reparseTranslationUnit (JNIEnv *env, jobject obj, jlong TU, jint num_unsaved_files, jlong unsaved_files, jint options) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1reparseTranslationUnit (JNIEnv *jniEnv, jclass jclss, jlong TU, jint num_unsaved_files, jlong unsaved_files, jint options) {
     return (jint) (clang_reparseTranslationUnit((CXTranslationUnit)TU, (unsigned int)num_unsaved_files, (struct CXUnsavedFile*)unsaved_files, (unsigned int)options));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTUResourceUsageName (JNIEnv *env, jobject obj, jint kind) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTUResourceUsageName (JNIEnv *jniEnv, jclass jclss, jint kind) {
     return (jlong) (clang_getTUResourceUsageName((enum CXTUResourceUsageKind)kind));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCXTUResourceUsage (JNIEnv *env, jobject obj, jlong TU, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCXTUResourceUsage (JNIEnv *jniEnv, jclass jclss, jlong TU, jlong retValPlacement) {
     *(struct CXTUResourceUsage*)retValPlacement = clang_getCXTUResourceUsage((CXTranslationUnit)TU);
     return (jlong) retValPlacement;
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeCXTUResourceUsage (JNIEnv *env, jobject obj, jlong usage) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeCXTUResourceUsage (JNIEnv *jniEnv, jclass jclss, jlong usage) {
     clang_disposeCXTUResourceUsage(*(struct CXTUResourceUsage*)usage);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getNullCursor (JNIEnv *env, jobject obj, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getNullCursor (JNIEnv *jniEnv, jclass jclss, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getNullCursor();
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTranslationUnitCursor (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTranslationUnitCursor (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getTranslationUnitCursor((CXTranslationUnit)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1equalCursors (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1equalCursors (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     return (jint) (clang_equalCursors(*(CXCursor*)arg0, *(CXCursor*)arg1));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isNull (JNIEnv *env, jobject obj, jlong cursor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isNull (JNIEnv *jniEnv, jclass jclss, jlong cursor) {
     return (jint) (clang_Cursor_isNull(*(CXCursor*)cursor));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1hashCursor (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1hashCursor (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_hashCursor(*(CXCursor*)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCursorKind (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCursorKind (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_getCursorKind(*(CXCursor*)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isDeclaration (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isDeclaration (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isDeclaration((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isReference (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isReference (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isReference((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isExpression (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isExpression (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isExpression((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isStatement (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isStatement (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isStatement((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isAttribute (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isAttribute (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isAttribute((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1hasAttrs (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1hasAttrs (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_hasAttrs(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isInvalid (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isInvalid (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isInvalid((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isTranslationUnit (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isTranslationUnit (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isTranslationUnit((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isPreprocessing (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isPreprocessing (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isPreprocessing((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isUnexposed (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isUnexposed (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_isUnexposed((enum CXCursorKind)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCursorLinkage (JNIEnv *env, jobject obj, jlong cursor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCursorLinkage (JNIEnv *jniEnv, jclass jclss, jlong cursor) {
     return (jint) (clang_getCursorLinkage(*(CXCursor*)cursor));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCursorVisibility (JNIEnv *env, jobject obj, jlong cursor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCursorVisibility (JNIEnv *jniEnv, jclass jclss, jlong cursor) {
     return (jint) (clang_getCursorVisibility(*(CXCursor*)cursor));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCursorAvailability (JNIEnv *env, jobject obj, jlong cursor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCursorAvailability (JNIEnv *jniEnv, jclass jclss, jlong cursor) {
     return (jint) (clang_getCursorAvailability(*(CXCursor*)cursor));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCursorPlatformAvailability (JNIEnv *env, jobject obj, jlong cursor, jlong always_deprecated, jlong deprecated_message, jlong always_unavailable, jlong unavailable_message, jlong availability, jint availability_size) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCursorPlatformAvailability (JNIEnv *jniEnv, jclass jclss, jlong cursor, jlong always_deprecated, jlong deprecated_message, jlong always_unavailable, jlong unavailable_message, jlong availability, jint availability_size) {
     return (jint) (clang_getCursorPlatformAvailability(*(CXCursor*)cursor, (int*)always_deprecated, (CXString*)deprecated_message, (int*)always_unavailable, (CXString*)unavailable_message, (struct CXPlatformAvailability*)availability, (int)availability_size));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeCXPlatformAvailability (JNIEnv *env, jobject obj, jlong availability) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeCXPlatformAvailability (JNIEnv *jniEnv, jclass jclss, jlong availability) {
     clang_disposeCXPlatformAvailability((struct CXPlatformAvailability*)availability);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCursorLanguage (JNIEnv *env, jobject obj, jlong cursor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCursorLanguage (JNIEnv *jniEnv, jclass jclss, jlong cursor) {
     return (jint) (clang_getCursorLanguage(*(CXCursor*)cursor));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getTranslationUnit (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getTranslationUnit (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_Cursor_getTranslationUnit(*(CXCursor*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1createCXCursorSet (JNIEnv *env, jobject obj) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1createCXCursorSet (JNIEnv *jniEnv, jclass jclss) {
     return (jlong) (clang_createCXCursorSet());
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeCXCursorSet (JNIEnv *env, jobject obj, jlong cset) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeCXCursorSet (JNIEnv *jniEnv, jclass jclss, jlong cset) {
     clang_disposeCXCursorSet((CXCursorSet)cset);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXCursorSet_1contains (JNIEnv *env, jobject obj, jlong cset, jlong cursor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXCursorSet_1contains (JNIEnv *jniEnv, jclass jclss, jlong cset, jlong cursor) {
     return (jint) (clang_CXCursorSet_contains((CXCursorSet)cset, *(CXCursor*)cursor));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXCursorSet_1insert (JNIEnv *env, jobject obj, jlong cset, jlong cursor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXCursorSet_1insert (JNIEnv *jniEnv, jclass jclss, jlong cset, jlong cursor) {
     return (jint) (clang_CXCursorSet_insert((CXCursorSet)cset, *(CXCursor*)cursor));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorSemanticParent (JNIEnv *env, jobject obj, jlong cursor, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorSemanticParent (JNIEnv *jniEnv, jclass jclss, jlong cursor, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getCursorSemanticParent(*(CXCursor*)cursor);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorLexicalParent (JNIEnv *env, jobject obj, jlong cursor, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorLexicalParent (JNIEnv *jniEnv, jclass jclss, jlong cursor, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getCursorLexicalParent(*(CXCursor*)cursor);
     return (jlong) retValPlacement;
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1getOverriddenCursors (JNIEnv *env, jobject obj, jlong cursor, jlong overridden, jlong num_overridden) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1getOverriddenCursors (JNIEnv *jniEnv, jclass jclss, jlong cursor, jlong overridden, jlong num_overridden) {
     clang_getOverriddenCursors(*(CXCursor*)cursor, (CXCursor**)overridden, (unsigned int*)num_overridden);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeOverriddenCursors (JNIEnv *env, jobject obj, jlong overridden) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeOverriddenCursors (JNIEnv *jniEnv, jclass jclss, jlong overridden) {
     clang_disposeOverriddenCursors((CXCursor*)overridden);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getIncludedFile (JNIEnv *env, jobject obj, jlong cursor) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getIncludedFile (JNIEnv *jniEnv, jclass jclss, jlong cursor) {
     return (jlong) (clang_getIncludedFile(*(CXCursor*)cursor));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursor (JNIEnv *env, jobject obj, jlong arg0, jlong arg1, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursor (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getCursor((CXTranslationUnit)arg0, *(CXSourceLocation*)arg1);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorLocation (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorLocation (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_getCursorLocation(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorExtent (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorExtent (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXSourceRange*)retValPlacement = clang_getCursorExtent(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorType (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorType (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getCursorType(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTypeSpelling (JNIEnv *env, jobject obj, jlong CT, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTypeSpelling (JNIEnv *jniEnv, jclass jclss, jlong CT, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getTypeSpelling(*(CXType*)CT);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTypedefDeclUnderlyingType (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTypedefDeclUnderlyingType (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getTypedefDeclUnderlyingType(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getEnumDeclIntegerType (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getEnumDeclIntegerType (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getEnumDeclIntegerType(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getEnumConstantDeclValue (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getEnumConstantDeclValue (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jlong) (clang_getEnumConstantDeclValue(*(CXCursor*)C));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getEnumConstantDeclUnsignedValue (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getEnumConstantDeclUnsignedValue (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jlong) (clang_getEnumConstantDeclUnsignedValue(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getFieldDeclBitWidth (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getFieldDeclBitWidth (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_getFieldDeclBitWidth(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1getNumArguments (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1getNumArguments (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_getNumArguments(*(CXCursor*)C));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getArgument (JNIEnv *env, jobject obj, jlong C, jint i, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getArgument (JNIEnv *jniEnv, jclass jclss, jlong C, jint i, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_Cursor_getArgument(*(CXCursor*)C, (unsigned int)i);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1getNumTemplateArguments (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1getNumTemplateArguments (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_getNumTemplateArguments(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1getTemplateArgumentKind (JNIEnv *env, jobject obj, jlong C, jint I) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1getTemplateArgumentKind (JNIEnv *jniEnv, jclass jclss, jlong C, jint I) {
     return (jint) (clang_Cursor_getTemplateArgumentKind(*(CXCursor*)C, (unsigned int)I));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getTemplateArgumentType (JNIEnv *env, jobject obj, jlong C, jint I, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getTemplateArgumentType (JNIEnv *jniEnv, jclass jclss, jlong C, jint I, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_Cursor_getTemplateArgumentType(*(CXCursor*)C, (unsigned int)I);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getTemplateArgumentValue (JNIEnv *env, jobject obj, jlong C, jint I) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getTemplateArgumentValue (JNIEnv *jniEnv, jclass jclss, jlong C, jint I) {
     return (jlong) (clang_Cursor_getTemplateArgumentValue(*(CXCursor*)C, (unsigned int)I));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getTemplateArgumentUnsignedValue (JNIEnv *env, jobject obj, jlong C, jint I) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getTemplateArgumentUnsignedValue (JNIEnv *jniEnv, jclass jclss, jlong C, jint I) {
     return (jlong) (clang_Cursor_getTemplateArgumentUnsignedValue(*(CXCursor*)C, (unsigned int)I));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1equalTypes (JNIEnv *env, jobject obj, jlong A, jlong B) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1equalTypes (JNIEnv *jniEnv, jclass jclss, jlong A, jlong B) {
     return (jint) (clang_equalTypes(*(CXType*)A, *(CXType*)B));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCanonicalType (JNIEnv *env, jobject obj, jlong T, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCanonicalType (JNIEnv *jniEnv, jclass jclss, jlong T, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getCanonicalType(*(CXType*)T);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isConstQualifiedType (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isConstQualifiedType (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_isConstQualifiedType(*(CXType*)T));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isMacroFunctionLike (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isMacroFunctionLike (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_isMacroFunctionLike(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isMacroBuiltin (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isMacroBuiltin (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_isMacroBuiltin(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isFunctionInlined (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isFunctionInlined (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_isFunctionInlined(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isVolatileQualifiedType (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isVolatileQualifiedType (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_isVolatileQualifiedType(*(CXType*)T));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isRestrictQualifiedType (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isRestrictQualifiedType (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_isRestrictQualifiedType(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getPointeeType (JNIEnv *env, jobject obj, jlong T, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getPointeeType (JNIEnv *jniEnv, jclass jclss, jlong T, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getPointeeType(*(CXType*)T);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTypeDeclaration (JNIEnv *env, jobject obj, jlong T, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTypeDeclaration (JNIEnv *jniEnv, jclass jclss, jlong T, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getTypeDeclaration(*(CXType*)T);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getDeclObjCTypeEncoding (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getDeclObjCTypeEncoding (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getDeclObjCTypeEncoding(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Type_1getObjCEncoding (JNIEnv *env, jobject obj, jlong type, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Type_1getObjCEncoding (JNIEnv *jniEnv, jclass jclss, jlong type, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_Type_getObjCEncoding(*(CXType*)type);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTypeKindSpelling (JNIEnv *env, jobject obj, jint K, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTypeKindSpelling (JNIEnv *jniEnv, jclass jclss, jint K, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getTypeKindSpelling((enum CXTypeKind)K);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getFunctionTypeCallingConv (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getFunctionTypeCallingConv (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_getFunctionTypeCallingConv(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getResultType (JNIEnv *env, jobject obj, jlong T, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getResultType (JNIEnv *jniEnv, jclass jclss, jlong T, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getResultType(*(CXType*)T);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getNumArgTypes (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getNumArgTypes (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_getNumArgTypes(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getArgType (JNIEnv *env, jobject obj, jlong T, jint i, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getArgType (JNIEnv *jniEnv, jclass jclss, jlong T, jint i, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getArgType(*(CXType*)T, (unsigned int)i);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isFunctionTypeVariadic (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isFunctionTypeVariadic (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_isFunctionTypeVariadic(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorResultType (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorResultType (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getCursorResultType(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isPODType (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isPODType (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_isPODType(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getElementType (JNIEnv *env, jobject obj, jlong T, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getElementType (JNIEnv *jniEnv, jclass jclss, jlong T, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getElementType(*(CXType*)T);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getNumElements (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getNumElements (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jlong) (clang_getNumElements(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getArrayElementType (JNIEnv *env, jobject obj, jlong T, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getArrayElementType (JNIEnv *jniEnv, jclass jclss, jlong T, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getArrayElementType(*(CXType*)T);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getArraySize (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getArraySize (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jlong) (clang_getArraySize(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Type_1getNamedType (JNIEnv *env, jobject obj, jlong T, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Type_1getNamedType (JNIEnv *jniEnv, jclass jclss, jlong T, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_Type_getNamedType(*(CXType*)T);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Type_1getAlignOf (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Type_1getAlignOf (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jlong) (clang_Type_getAlignOf(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Type_1getClassType (JNIEnv *env, jobject obj, jlong T, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Type_1getClassType (JNIEnv *jniEnv, jclass jclss, jlong T, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_Type_getClassType(*(CXType*)T);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Type_1getSizeOf (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Type_1getSizeOf (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jlong) (clang_Type_getSizeOf(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Type_1getOffsetOf (JNIEnv *env, jobject obj, jlong T, jlong S) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Type_1getOffsetOf (JNIEnv *jniEnv, jclass jclss, jlong T, jlong S) {
     return (jlong) (clang_Type_getOffsetOf(*(CXType*)T, (char*)S));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getOffsetOfField (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getOffsetOfField (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jlong) (clang_Cursor_getOffsetOfField(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isAnonymous (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isAnonymous (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_isAnonymous(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Type_1getNumTemplateArguments (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Type_1getNumTemplateArguments (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_Type_getNumTemplateArguments(*(CXType*)T));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Type_1getTemplateArgumentAsType (JNIEnv *env, jobject obj, jlong T, jint i, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Type_1getTemplateArgumentAsType (JNIEnv *jniEnv, jclass jclss, jlong T, jint i, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_Type_getTemplateArgumentAsType(*(CXType*)T, (unsigned int)i);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Type_1getCXXRefQualifier (JNIEnv *env, jobject obj, jlong T) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Type_1getCXXRefQualifier (JNIEnv *jniEnv, jclass jclss, jlong T) {
     return (jint) (clang_Type_getCXXRefQualifier(*(CXType*)T));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isBitField (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isBitField (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_isBitField(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isVirtualBase (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isVirtualBase (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_isVirtualBase(*(CXCursor*)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCXXAccessSpecifier (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCXXAccessSpecifier (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_getCXXAccessSpecifier(*(CXCursor*)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1getStorageClass (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1getStorageClass (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_Cursor_getStorageClass(*(CXCursor*)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getNumOverloadedDecls (JNIEnv *env, jobject obj, jlong cursor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getNumOverloadedDecls (JNIEnv *jniEnv, jclass jclss, jlong cursor) {
     return (jint) (clang_getNumOverloadedDecls(*(CXCursor*)cursor));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getOverloadedDecl (JNIEnv *env, jobject obj, jlong cursor, jint index, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getOverloadedDecl (JNIEnv *jniEnv, jclass jclss, jlong cursor, jint index, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getOverloadedDecl(*(CXCursor*)cursor, (unsigned int)index);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getIBOutletCollectionType (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getIBOutletCollectionType (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_getIBOutletCollectionType(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1visitChildren (JNIEnv *env, jobject obj, jlong parent, jlong visitor, jlong client_data) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1visitChildren (JNIEnv *jniEnv, jclass jclss, jlong parent, jlong visitor, jlong client_data) {
     return (jint) (clang_visitChildren(*(CXCursor*)parent, (CXCursorVisitor)visitor, (CXClientData)client_data));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorUSR (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorUSR (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getCursorUSR(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1constructUSR_1ObjCClass (JNIEnv *env, jobject obj, jlong class_name, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1constructUSR_1ObjCClass (JNIEnv *jniEnv, jclass jclss, jlong class_name, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_constructUSR_ObjCClass((char*)class_name);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1constructUSR_1ObjCCategory (JNIEnv *env, jobject obj, jlong class_name, jlong category_name, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1constructUSR_1ObjCCategory (JNIEnv *jniEnv, jclass jclss, jlong class_name, jlong category_name, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_constructUSR_ObjCCategory((char*)class_name, (char*)category_name);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1constructUSR_1ObjCProtocol (JNIEnv *env, jobject obj, jlong protocol_name, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1constructUSR_1ObjCProtocol (JNIEnv *jniEnv, jclass jclss, jlong protocol_name, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_constructUSR_ObjCProtocol((char*)protocol_name);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1constructUSR_1ObjCIvar (JNIEnv *env, jobject obj, jlong name, jlong classUSR, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1constructUSR_1ObjCIvar (JNIEnv *jniEnv, jclass jclss, jlong name, jlong classUSR, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_constructUSR_ObjCIvar((char*)name, *(CXString*)classUSR);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1constructUSR_1ObjCMethod (JNIEnv *env, jobject obj, jlong name, jint isInstanceMethod, jlong classUSR, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1constructUSR_1ObjCMethod (JNIEnv *jniEnv, jclass jclss, jlong name, jint isInstanceMethod, jlong classUSR, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_constructUSR_ObjCMethod((char*)name, (unsigned int)isInstanceMethod, *(CXString*)classUSR);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1constructUSR_1ObjCProperty (JNIEnv *env, jobject obj, jlong property, jlong classUSR, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1constructUSR_1ObjCProperty (JNIEnv *jniEnv, jclass jclss, jlong property, jlong classUSR, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_constructUSR_ObjCProperty((char*)property, *(CXString*)classUSR);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorSpelling (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorSpelling (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getCursorSpelling(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getSpellingNameRange (JNIEnv *env, jobject obj, jlong arg0, jint pieceIndex, jint options, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getSpellingNameRange (JNIEnv *jniEnv, jclass jclss, jlong arg0, jint pieceIndex, jint options, jlong retValPlacement) {
     *(CXSourceRange*)retValPlacement = clang_Cursor_getSpellingNameRange(*(CXCursor*)arg0, (unsigned int)pieceIndex, (unsigned int)options);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorDisplayName (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorDisplayName (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getCursorDisplayName(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorReferenced (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorReferenced (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getCursorReferenced(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorDefinition (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorDefinition (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getCursorDefinition(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1isCursorDefinition (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1isCursorDefinition (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_isCursorDefinition(*(CXCursor*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCanonicalCursor (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCanonicalCursor (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getCanonicalCursor(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1getObjCSelectorIndex (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1getObjCSelectorIndex (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_Cursor_getObjCSelectorIndex(*(CXCursor*)arg0));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isDynamicCall (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isDynamicCall (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_isDynamicCall(*(CXCursor*)C));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getReceiverType (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getReceiverType (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXType*)retValPlacement = clang_Cursor_getReceiverType(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1getObjCPropertyAttributes (JNIEnv *env, jobject obj, jlong C, jint reserved) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1getObjCPropertyAttributes (JNIEnv *jniEnv, jclass jclss, jlong C, jint reserved) {
     return (jint) (clang_Cursor_getObjCPropertyAttributes(*(CXCursor*)C, (unsigned int)reserved));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1getObjCDeclQualifiers (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1getObjCDeclQualifiers (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_getObjCDeclQualifiers(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isObjCOptional (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isObjCOptional (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_isObjCOptional(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Cursor_1isVariadic (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Cursor_1isVariadic (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_Cursor_isVariadic(*(CXCursor*)C));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getCommentRange (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getCommentRange (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXSourceRange*)retValPlacement = clang_Cursor_getCommentRange(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getRawCommentText (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getRawCommentText (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_Cursor_getRawCommentText(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getBriefCommentText (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getBriefCommentText (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_Cursor_getBriefCommentText(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getMangling (JNIEnv *env, jobject obj, jlong arg0, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getMangling (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_Cursor_getMangling(*(CXCursor*)arg0);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getCXXManglings (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getCXXManglings (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_Cursor_getCXXManglings(*(CXCursor*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1getModule (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1getModule (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jlong) (clang_Cursor_getModule(*(CXCursor*)C));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getModuleForFile (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getModuleForFile (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     return (jlong) (clang_getModuleForFile((CXTranslationUnit)arg0, (CXFile)arg1));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Module_1getASTFile (JNIEnv *env, jobject obj, jlong Module) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Module_1getASTFile (JNIEnv *jniEnv, jclass jclss, jlong Module) {
     return (jlong) (clang_Module_getASTFile((CXModule)Module));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Module_1getParent (JNIEnv *env, jobject obj, jlong Module) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Module_1getParent (JNIEnv *jniEnv, jclass jclss, jlong Module) {
     return (jlong) (clang_Module_getParent((CXModule)Module));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Module_1getName (JNIEnv *env, jobject obj, jlong Module, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Module_1getName (JNIEnv *jniEnv, jclass jclss, jlong Module, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_Module_getName((CXModule)Module);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Module_1getFullName (JNIEnv *env, jobject obj, jlong Module, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Module_1getFullName (JNIEnv *jniEnv, jclass jclss, jlong Module, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_Module_getFullName((CXModule)Module);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Module_1isSystem (JNIEnv *env, jobject obj, jlong Module) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Module_1isSystem (JNIEnv *jniEnv, jclass jclss, jlong Module) {
     return (jint) (clang_Module_isSystem((CXModule)Module));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Module_1getNumTopLevelHeaders (JNIEnv *env, jobject obj, jlong arg0, jlong Module) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Module_1getNumTopLevelHeaders (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong Module) {
     return (jint) (clang_Module_getNumTopLevelHeaders((CXTranslationUnit)arg0, (CXModule)Module));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Module_1getTopLevelHeader (JNIEnv *env, jobject obj, jlong arg0, jlong Module, jint Index) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Module_1getTopLevelHeader (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong Module, jint Index) {
     return (jlong) (clang_Module_getTopLevelHeader((CXTranslationUnit)arg0, (CXModule)Module, (unsigned int)Index));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXConstructor_1isConvertingConstructor (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXConstructor_1isConvertingConstructor (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXConstructor_isConvertingConstructor(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXConstructor_1isCopyConstructor (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXConstructor_1isCopyConstructor (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXConstructor_isCopyConstructor(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXConstructor_1isDefaultConstructor (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXConstructor_1isDefaultConstructor (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXConstructor_isDefaultConstructor(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXConstructor_1isMoveConstructor (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXConstructor_1isMoveConstructor (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXConstructor_isMoveConstructor(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXField_1isMutable (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXField_1isMutable (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXField_isMutable(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXMethod_1isDefaulted (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXMethod_1isDefaulted (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXMethod_isDefaulted(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXMethod_1isPureVirtual (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXMethod_1isPureVirtual (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXMethod_isPureVirtual(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXMethod_1isStatic (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXMethod_1isStatic (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXMethod_isStatic(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXMethod_1isVirtual (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXMethod_1isVirtual (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXMethod_isVirtual(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1CXXMethod_1isConst (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1CXXMethod_1isConst (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_CXXMethod_isConst(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getTemplateCursorKind (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getTemplateCursorKind (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jint) (clang_getTemplateCursorKind(*(CXCursor*)C));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getSpecializedCursorTemplate (JNIEnv *env, jobject obj, jlong C, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getSpecializedCursorTemplate (JNIEnv *jniEnv, jclass jclss, jlong C, jlong retValPlacement) {
     *(CXCursor*)retValPlacement = clang_getSpecializedCursorTemplate(*(CXCursor*)C);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorReferenceNameRange (JNIEnv *env, jobject obj, jlong C, jint NameFlags, jint PieceIndex, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorReferenceNameRange (JNIEnv *jniEnv, jclass jclss, jlong C, jint NameFlags, jint PieceIndex, jlong retValPlacement) {
     *(CXSourceRange*)retValPlacement = clang_getCursorReferenceNameRange(*(CXCursor*)C, (unsigned int)NameFlags, (unsigned int)PieceIndex);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getTokenKind (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getTokenKind (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_getTokenKind(*(CXToken*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTokenSpelling (JNIEnv *env, jobject obj, jlong arg0, jlong arg1, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTokenSpelling (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getTokenSpelling((CXTranslationUnit)arg0, *(CXToken*)arg1);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTokenLocation (JNIEnv *env, jobject obj, jlong arg0, jlong arg1, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTokenLocation (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_getTokenLocation((CXTranslationUnit)arg0, *(CXToken*)arg1);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getTokenExtent (JNIEnv *env, jobject obj, jlong arg0, jlong arg1, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getTokenExtent (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1, jlong retValPlacement) {
     *(CXSourceRange*)retValPlacement = clang_getTokenExtent((CXTranslationUnit)arg0, *(CXToken*)arg1);
     return (jlong) retValPlacement;
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1tokenize (JNIEnv *env, jobject obj, jlong TU, jlong Range, jlong Tokens, jlong NumTokens) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1tokenize (JNIEnv *jniEnv, jclass jclss, jlong TU, jlong Range, jlong Tokens, jlong NumTokens) {
     clang_tokenize((CXTranslationUnit)TU, *(CXSourceRange*)Range, (CXToken**)Tokens, (unsigned int*)NumTokens);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1annotateTokens (JNIEnv *env, jobject obj, jlong TU, jlong Tokens, jint NumTokens, jlong Cursors) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1annotateTokens (JNIEnv *jniEnv, jclass jclss, jlong TU, jlong Tokens, jint NumTokens, jlong Cursors) {
     clang_annotateTokens((CXTranslationUnit)TU, (CXToken*)Tokens, (unsigned int)NumTokens, (CXCursor*)Cursors);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeTokens (JNIEnv *env, jobject obj, jlong TU, jlong Tokens, jint NumTokens) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeTokens (JNIEnv *jniEnv, jclass jclss, jlong TU, jlong Tokens, jint NumTokens) {
     clang_disposeTokens((CXTranslationUnit)TU, (CXToken*)Tokens, (unsigned int)NumTokens);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorKindSpelling (JNIEnv *env, jobject obj, jint Kind, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorKindSpelling (JNIEnv *jniEnv, jclass jclss, jint Kind, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getCursorKindSpelling((enum CXCursorKind)Kind);
     return (jlong) retValPlacement;
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1getDefinitionSpellingAndExtent (JNIEnv *env, jobject obj, jlong arg0, jlong startBuf, jlong endBuf, jlong startLine, jlong startColumn, jlong endLine, jlong endColumn) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1getDefinitionSpellingAndExtent (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong startBuf, jlong endBuf, jlong startLine, jlong startColumn, jlong endLine, jlong endColumn) {
     clang_getDefinitionSpellingAndExtent(*(CXCursor*)arg0, (char**)startBuf, (char**)endBuf, (unsigned int*)startLine, (unsigned int*)startColumn, (unsigned int*)endLine, (unsigned int*)endColumn);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1enableStackTraces (JNIEnv *env, jobject obj) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1enableStackTraces (JNIEnv *jniEnv, jclass jclss) {
     clang_enableStackTraces();
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1executeOnThread (JNIEnv *env, jobject obj, jlong fn, jlong user_data, jint stack_size) {
-    clang_executeOnThread((void (*)(void*))fn, (void*)user_data, (unsigned int)stack_size);
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1executeOnThread (JNIEnv *jniEnv, jclass jclss, jlong fn, jlong user_data, jint stack_size) {
+    clang_executeOnThread((void*)fn, (void*)user_data, (unsigned int)stack_size);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCompletionChunkKind (JNIEnv *env, jobject obj, jlong completion_string, jint chunk_number) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCompletionChunkKind (JNIEnv *jniEnv, jclass jclss, jlong completion_string, jint chunk_number) {
     return (jint) (clang_getCompletionChunkKind((CXCompletionString)completion_string, (unsigned int)chunk_number));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCompletionChunkText (JNIEnv *env, jobject obj, jlong completion_string, jint chunk_number, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCompletionChunkText (JNIEnv *jniEnv, jclass jclss, jlong completion_string, jint chunk_number, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getCompletionChunkText((CXCompletionString)completion_string, (unsigned int)chunk_number);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCompletionChunkCompletionString (JNIEnv *env, jobject obj, jlong completion_string, jint chunk_number) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCompletionChunkCompletionString (JNIEnv *jniEnv, jclass jclss, jlong completion_string, jint chunk_number) {
     return (jlong) (clang_getCompletionChunkCompletionString((CXCompletionString)completion_string, (unsigned int)chunk_number));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getNumCompletionChunks (JNIEnv *env, jobject obj, jlong completion_string) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getNumCompletionChunks (JNIEnv *jniEnv, jclass jclss, jlong completion_string) {
     return (jint) (clang_getNumCompletionChunks((CXCompletionString)completion_string));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCompletionPriority (JNIEnv *env, jobject obj, jlong completion_string) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCompletionPriority (JNIEnv *jniEnv, jclass jclss, jlong completion_string) {
     return (jint) (clang_getCompletionPriority((CXCompletionString)completion_string));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCompletionAvailability (JNIEnv *env, jobject obj, jlong completion_string) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCompletionAvailability (JNIEnv *jniEnv, jclass jclss, jlong completion_string) {
     return (jint) (clang_getCompletionAvailability((CXCompletionString)completion_string));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1getCompletionNumAnnotations (JNIEnv *env, jobject obj, jlong completion_string) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1getCompletionNumAnnotations (JNIEnv *jniEnv, jclass jclss, jlong completion_string) {
     return (jint) (clang_getCompletionNumAnnotations((CXCompletionString)completion_string));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCompletionAnnotation (JNIEnv *env, jobject obj, jlong completion_string, jint annotation_number, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCompletionAnnotation (JNIEnv *jniEnv, jclass jclss, jlong completion_string, jint annotation_number, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getCompletionAnnotation((CXCompletionString)completion_string, (unsigned int)annotation_number);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCompletionParent (JNIEnv *env, jobject obj, jlong completion_string, jlong kind, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCompletionParent (JNIEnv *jniEnv, jclass jclss, jlong completion_string, jlong kind, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getCompletionParent((CXCompletionString)completion_string, (enum CXCursorKind*)kind);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCompletionBriefComment (JNIEnv *env, jobject obj, jlong completion_string, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCompletionBriefComment (JNIEnv *jniEnv, jclass jclss, jlong completion_string, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getCompletionBriefComment((CXCompletionString)completion_string);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getCursorCompletionString (JNIEnv *env, jobject obj, jlong cursor) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getCursorCompletionString (JNIEnv *jniEnv, jclass jclss, jlong cursor) {
     return (jlong) (clang_getCursorCompletionString(*(CXCursor*)cursor));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1defaultCodeCompleteOptions (JNIEnv *env, jobject obj) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1defaultCodeCompleteOptions (JNIEnv *jniEnv, jclass jclss) {
     return (jint) (clang_defaultCodeCompleteOptions());
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1codeCompleteAt (JNIEnv *env, jobject obj, jlong TU, jlong complete_filename, jint complete_line, jint complete_column, jlong unsaved_files, jint num_unsaved_files, jint options) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1codeCompleteAt (JNIEnv *jniEnv, jclass jclss, jlong TU, jlong complete_filename, jint complete_line, jint complete_column, jlong unsaved_files, jint num_unsaved_files, jint options) {
     return (jlong) (clang_codeCompleteAt((CXTranslationUnit)TU, (char*)complete_filename, (unsigned int)complete_line, (unsigned int)complete_column, (struct CXUnsavedFile*)unsaved_files, (unsigned int)num_unsaved_files, (unsigned int)options));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1sortCodeCompletionResults (JNIEnv *env, jobject obj, jlong Results, jint NumResults) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1sortCodeCompletionResults (JNIEnv *jniEnv, jclass jclss, jlong Results, jint NumResults) {
     clang_sortCodeCompletionResults((CXCompletionResult*)Results, (unsigned int)NumResults);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1disposeCodeCompleteResults (JNIEnv *env, jobject obj, jlong Results) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1disposeCodeCompleteResults (JNIEnv *jniEnv, jclass jclss, jlong Results) {
     clang_disposeCodeCompleteResults((CXCodeCompleteResults*)Results);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1codeCompleteGetNumDiagnostics (JNIEnv *env, jobject obj, jlong Results) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1codeCompleteGetNumDiagnostics (JNIEnv *jniEnv, jclass jclss, jlong Results) {
     return (jint) (clang_codeCompleteGetNumDiagnostics((CXCodeCompleteResults*)Results));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1codeCompleteGetDiagnostic (JNIEnv *env, jobject obj, jlong Results, jint Index) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1codeCompleteGetDiagnostic (JNIEnv *jniEnv, jclass jclss, jlong Results, jint Index) {
     return (jlong) (clang_codeCompleteGetDiagnostic((CXCodeCompleteResults*)Results, (unsigned int)Index));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1codeCompleteGetContexts (JNIEnv *env, jobject obj, jlong Results) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1codeCompleteGetContexts (JNIEnv *jniEnv, jclass jclss, jlong Results) {
     return (jlong) (clang_codeCompleteGetContexts((CXCodeCompleteResults*)Results));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1codeCompleteGetContainerKind (JNIEnv *env, jobject obj, jlong Results, jlong IsIncomplete) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1codeCompleteGetContainerKind (JNIEnv *jniEnv, jclass jclss, jlong Results, jlong IsIncomplete) {
     return (jint) (clang_codeCompleteGetContainerKind((CXCodeCompleteResults*)Results, (unsigned int*)IsIncomplete));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1codeCompleteGetContainerUSR (JNIEnv *env, jobject obj, jlong Results, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1codeCompleteGetContainerUSR (JNIEnv *jniEnv, jclass jclss, jlong Results, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_codeCompleteGetContainerUSR((CXCodeCompleteResults*)Results);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1codeCompleteGetObjCSelector (JNIEnv *env, jobject obj, jlong Results, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1codeCompleteGetObjCSelector (JNIEnv *jniEnv, jclass jclss, jlong Results, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_codeCompleteGetObjCSelector((CXCodeCompleteResults*)Results);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getClangVersion (JNIEnv *env, jobject obj, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getClangVersion (JNIEnv *jniEnv, jclass jclss, jlong retValPlacement) {
     *(CXString*)retValPlacement = clang_getClangVersion();
     return (jlong) retValPlacement;
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1toggleCrashRecovery (JNIEnv *env, jobject obj, jint isEnabled) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1toggleCrashRecovery (JNIEnv *jniEnv, jclass jclss, jint isEnabled) {
     clang_toggleCrashRecovery((unsigned int)isEnabled);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1getInclusions (JNIEnv *env, jobject obj, jlong tu, jlong visitor, jlong client_data) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1getInclusions (JNIEnv *jniEnv, jclass jclss, jlong tu, jlong visitor, jlong client_data) {
     clang_getInclusions((CXTranslationUnit)tu, (CXInclusionVisitor)visitor, (CXClientData)client_data);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1Cursor_1Evaluate (JNIEnv *env, jobject obj, jlong C) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1Cursor_1Evaluate (JNIEnv *jniEnv, jclass jclss, jlong C) {
     return (jlong) (clang_Cursor_Evaluate(*(CXCursor*)C));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1EvalResult_1getKind (JNIEnv *env, jobject obj, jlong E) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1EvalResult_1getKind (JNIEnv *jniEnv, jclass jclss, jlong E) {
     return (jint) (clang_EvalResult_getKind((CXEvalResult)E));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1EvalResult_1getAsInt (JNIEnv *env, jobject obj, jlong E) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1EvalResult_1getAsInt (JNIEnv *jniEnv, jclass jclss, jlong E) {
     return (jint) (clang_EvalResult_getAsInt((CXEvalResult)E));
 }
-JNIEXPORT jdouble JNICALL Java_clang_externals_clang_1EvalResult_1getAsDouble (JNIEnv *env, jobject obj, jlong E) {
+
+JNIEXPORT jdouble JNICALL Java_clang_clang_kni_1clang_1EvalResult_1getAsDouble (JNIEnv *jniEnv, jclass jclss, jlong E) {
     return (jdouble) (clang_EvalResult_getAsDouble((CXEvalResult)E));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1EvalResult_1getAsStr (JNIEnv *env, jobject obj, jlong E) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1EvalResult_1getAsStr (JNIEnv *jniEnv, jclass jclss, jlong E) {
     return (jlong) (clang_EvalResult_getAsStr((CXEvalResult)E));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1EvalResult_1dispose (JNIEnv *env, jobject obj, jlong E) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1EvalResult_1dispose (JNIEnv *jniEnv, jclass jclss, jlong E) {
     clang_EvalResult_dispose((CXEvalResult)E);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getRemappings (JNIEnv *env, jobject obj, jlong path) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getRemappings (JNIEnv *jniEnv, jclass jclss, jlong path) {
     return (jlong) (clang_getRemappings((char*)path));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1getRemappingsFromFileList (JNIEnv *env, jobject obj, jlong filePaths, jint numFiles) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1getRemappingsFromFileList (JNIEnv *jniEnv, jclass jclss, jlong filePaths, jint numFiles) {
     return (jlong) (clang_getRemappingsFromFileList((char**)filePaths, (unsigned int)numFiles));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1remap_1getNumFiles (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1remap_1getNumFiles (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jint) (clang_remap_getNumFiles((CXRemapping)arg0));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1remap_1getFilenames (JNIEnv *env, jobject obj, jlong arg0, jint index, jlong original, jlong transformed) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1remap_1getFilenames (JNIEnv *jniEnv, jclass jclss, jlong arg0, jint index, jlong original, jlong transformed) {
     clang_remap_getFilenames((CXRemapping)arg0, (unsigned int)index, (CXString*)original, (CXString*)transformed);
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1remap_1dispose (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1remap_1dispose (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     clang_remap_dispose((CXRemapping)arg0);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1findReferencesInFile (JNIEnv *env, jobject obj, jlong cursor, jlong file, jlong visitor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1findReferencesInFile (JNIEnv *jniEnv, jclass jclss, jlong cursor, jlong file, jlong visitor) {
     return (jint) (clang_findReferencesInFile(*(CXCursor*)cursor, (CXFile)file, *(struct CXCursorAndRangeVisitor*)visitor));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1findIncludesInFile (JNIEnv *env, jobject obj, jlong TU, jlong file, jlong visitor) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1findIncludesInFile (JNIEnv *jniEnv, jclass jclss, jlong TU, jlong file, jlong visitor) {
     return (jint) (clang_findIncludesInFile((CXTranslationUnit)TU, (CXFile)file, *(struct CXCursorAndRangeVisitor*)visitor));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1index_1isEntityObjCContainerKind (JNIEnv *env, jobject obj, jint arg0) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1index_1isEntityObjCContainerKind (JNIEnv *jniEnv, jclass jclss, jint arg0) {
     return (jint) (clang_index_isEntityObjCContainerKind((CXIdxEntityKind)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getObjCContainerDeclInfo (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getObjCContainerDeclInfo (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getObjCContainerDeclInfo((CXIdxDeclInfo*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getObjCInterfaceDeclInfo (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getObjCInterfaceDeclInfo (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getObjCInterfaceDeclInfo((CXIdxDeclInfo*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getObjCCategoryDeclInfo (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getObjCCategoryDeclInfo (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getObjCCategoryDeclInfo((CXIdxDeclInfo*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getObjCProtocolRefListInfo (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getObjCProtocolRefListInfo (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getObjCProtocolRefListInfo((CXIdxDeclInfo*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getObjCPropertyDeclInfo (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getObjCPropertyDeclInfo (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getObjCPropertyDeclInfo((CXIdxDeclInfo*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getIBOutletCollectionAttrInfo (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getIBOutletCollectionAttrInfo (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getIBOutletCollectionAttrInfo((CXIdxAttrInfo*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getCXXClassDeclInfo (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getCXXClassDeclInfo (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getCXXClassDeclInfo((CXIdxDeclInfo*)arg0));
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getClientContainer (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getClientContainer (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getClientContainer((CXIdxContainerInfo*)arg0));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1index_1setClientContainer (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1index_1setClientContainer (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     clang_index_setClientContainer((CXIdxContainerInfo*)arg0, (CXIdxClientContainer)arg1);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1index_1getClientEntity (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1index_1getClientEntity (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     return (jlong) (clang_index_getClientEntity((CXIdxEntityInfo*)arg0));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1index_1setClientEntity (JNIEnv *env, jobject obj, jlong arg0, jlong arg1) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1index_1setClientEntity (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong arg1) {
     clang_index_setClientEntity((CXIdxEntityInfo*)arg0, (CXIdxClientEntity)arg1);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1IndexAction_1create (JNIEnv *env, jobject obj, jlong CIdx) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1IndexAction_1create (JNIEnv *jniEnv, jclass jclss, jlong CIdx) {
     return (jlong) (clang_IndexAction_create((CXIndex)CIdx));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1IndexAction_1dispose (JNIEnv *env, jobject obj, jlong arg0) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1IndexAction_1dispose (JNIEnv *jniEnv, jclass jclss, jlong arg0) {
     clang_IndexAction_dispose((CXIndexAction)arg0);
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1indexSourceFile (JNIEnv *env, jobject obj, jlong arg0, jlong client_data, jlong index_callbacks, jint index_callbacks_size, jint index_options, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jlong out_TU, jint TU_options) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1indexSourceFile (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong client_data, jlong index_callbacks, jint index_callbacks_size, jint index_options, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jlong out_TU, jint TU_options) {
     return (jint) (clang_indexSourceFile((CXIndexAction)arg0, (CXClientData)client_data, (IndexerCallbacks*)index_callbacks, (unsigned int)index_callbacks_size, (unsigned int)index_options, (char*)source_filename, (char**)command_line_args, (int)num_command_line_args, (struct CXUnsavedFile*)unsaved_files, (unsigned int)num_unsaved_files, (CXTranslationUnit*)out_TU, (unsigned int)TU_options));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1indexSourceFileFullArgv (JNIEnv *env, jobject obj, jlong arg0, jlong client_data, jlong index_callbacks, jint index_callbacks_size, jint index_options, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jlong out_TU, jint TU_options) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1indexSourceFileFullArgv (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong client_data, jlong index_callbacks, jint index_callbacks_size, jint index_options, jlong source_filename, jlong command_line_args, jint num_command_line_args, jlong unsaved_files, jint num_unsaved_files, jlong out_TU, jint TU_options) {
     return (jint) (clang_indexSourceFileFullArgv((CXIndexAction)arg0, (CXClientData)client_data, (IndexerCallbacks*)index_callbacks, (unsigned int)index_callbacks_size, (unsigned int)index_options, (char*)source_filename, (char**)command_line_args, (int)num_command_line_args, (struct CXUnsavedFile*)unsaved_files, (unsigned int)num_unsaved_files, (CXTranslationUnit*)out_TU, (unsigned int)TU_options));
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1indexTranslationUnit (JNIEnv *env, jobject obj, jlong arg0, jlong client_data, jlong index_callbacks, jint index_callbacks_size, jint index_options, jlong arg5) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1indexTranslationUnit (JNIEnv *jniEnv, jclass jclss, jlong arg0, jlong client_data, jlong index_callbacks, jint index_callbacks_size, jint index_options, jlong arg5) {
     return (jint) (clang_indexTranslationUnit((CXIndexAction)arg0, (CXClientData)client_data, (IndexerCallbacks*)index_callbacks, (unsigned int)index_callbacks_size, (unsigned int)index_options, (CXTranslationUnit)arg5));
 }
-JNIEXPORT void JNICALL Java_clang_externals_clang_1indexLoc_1getFileLocation (JNIEnv *env, jobject obj, jlong loc, jlong indexFile, jlong file, jlong line, jlong column, jlong offset) {
+
+JNIEXPORT void JNICALL Java_clang_clang_kni_1clang_1indexLoc_1getFileLocation (JNIEnv *jniEnv, jclass jclss, jlong loc, jlong indexFile, jlong file, jlong line, jlong column, jlong offset) {
     clang_indexLoc_getFileLocation(*(CXIdxLoc*)loc, (CXIdxClientFile*)indexFile, (CXFile*)file, (unsigned int*)line, (unsigned int*)column, (unsigned int*)offset);
 }
-JNIEXPORT jlong JNICALL Java_clang_externals_clang_1indexLoc_1getCXSourceLocation (JNIEnv *env, jobject obj, jlong loc, jlong retValPlacement) {
+
+JNIEXPORT jlong JNICALL Java_clang_clang_kni_1clang_1indexLoc_1getCXSourceLocation (JNIEnv *jniEnv, jclass jclss, jlong loc, jlong retValPlacement) {
     *(CXSourceLocation*)retValPlacement = clang_indexLoc_getCXSourceLocation(*(CXIdxLoc*)loc);
     return (jlong) retValPlacement;
 }
-JNIEXPORT jint JNICALL Java_clang_externals_clang_1Type_1visitFields (JNIEnv *env, jobject obj, jlong T, jlong visitor, jlong client_data) {
+
+JNIEXPORT jint JNICALL Java_clang_clang_kni_1clang_1Type_1visitFields (JNIEnv *jniEnv, jclass jclss, jlong T, jlong visitor, jlong client_data) {
     return (jint) (clang_Type_visitFields(*(CXType*)T, (CXFieldVisitor)visitor, (CXClientData)client_data));
 }
+

--- a/Interop/Indexer/prebuilt/nativeInteropStubs/kotlin/clang/clang.kt
+++ b/Interop/Indexer/prebuilt/nativeInteropStubs/kotlin/clang/clang.kt
@@ -4707,37 +4707,37 @@ class IndexerCallbacks(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(64, 8)
     
-    var abortQuery: CPointer<CFunction<(COpaquePointer?, COpaquePointer?) -> Int>>?
-        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?) -> Int>>>(0).value
-        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?) -> Int>>>(0).value = value }
+    var abortQuery: CPointer<CFunction<(CXClientData?, COpaquePointer?) -> Int>>?
+        get() = memberAt<CPointerVar<CFunction<(CXClientData?, COpaquePointer?) -> Int>>>(0).value
+        set(value) { memberAt<CPointerVar<CFunction<(CXClientData?, COpaquePointer?) -> Int>>>(0).value = value }
     
-    var diagnostic: CPointer<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> Unit>>?
-        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> Unit>>>(8).value
-        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> Unit>>>(8).value = value }
+    var diagnostic: CPointer<CFunction<(CXClientData?, CXDiagnosticSet?, COpaquePointer?) -> Unit>>?
+        get() = memberAt<CPointerVar<CFunction<(CXClientData?, CXDiagnosticSet?, COpaquePointer?) -> Unit>>>(8).value
+        set(value) { memberAt<CPointerVar<CFunction<(CXClientData?, CXDiagnosticSet?, COpaquePointer?) -> Unit>>>(8).value = value }
     
-    var enteredMainFile: CPointer<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>?
-        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>>(16).value
-        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>>(16).value = value }
+    var enteredMainFile: CPointer<CFunction<(CXClientData?, CXFile?, COpaquePointer?) -> CXIdxClientFile?>>?
+        get() = memberAt<CPointerVar<CFunction<(CXClientData?, CXFile?, COpaquePointer?) -> CXIdxClientFile?>>>(16).value
+        set(value) { memberAt<CPointerVar<CFunction<(CXClientData?, CXFile?, COpaquePointer?) -> CXIdxClientFile?>>>(16).value = value }
     
-    var ppIncludedFile: CPointer<CFunction<(COpaquePointer?, CPointer<CXIdxIncludedFileInfo>?) -> COpaquePointer?>>?
-        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxIncludedFileInfo>?) -> COpaquePointer?>>>(24).value
-        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxIncludedFileInfo>?) -> COpaquePointer?>>>(24).value = value }
+    var ppIncludedFile: CPointer<CFunction<(CXClientData?, CPointer<CXIdxIncludedFileInfo>?) -> CXIdxClientFile?>>?
+        get() = memberAt<CPointerVar<CFunction<(CXClientData?, CPointer<CXIdxIncludedFileInfo>?) -> CXIdxClientFile?>>>(24).value
+        set(value) { memberAt<CPointerVar<CFunction<(CXClientData?, CPointer<CXIdxIncludedFileInfo>?) -> CXIdxClientFile?>>>(24).value = value }
     
-    var importedASTFile: CPointer<CFunction<(COpaquePointer?, CPointer<CXIdxImportedASTFileInfo>?) -> COpaquePointer?>>?
-        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxImportedASTFileInfo>?) -> COpaquePointer?>>>(32).value
-        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxImportedASTFileInfo>?) -> COpaquePointer?>>>(32).value = value }
+    var importedASTFile: CPointer<CFunction<(CXClientData?, CPointer<CXIdxImportedASTFileInfo>?) -> CXIdxClientASTFile?>>?
+        get() = memberAt<CPointerVar<CFunction<(CXClientData?, CPointer<CXIdxImportedASTFileInfo>?) -> CXIdxClientASTFile?>>>(32).value
+        set(value) { memberAt<CPointerVar<CFunction<(CXClientData?, CPointer<CXIdxImportedASTFileInfo>?) -> CXIdxClientASTFile?>>>(32).value = value }
     
-    var startedTranslationUnit: CPointer<CFunction<(COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>?
-        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>>(40).value
-        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>>(40).value = value }
+    var startedTranslationUnit: CPointer<CFunction<(CXClientData?, COpaquePointer?) -> CXIdxClientContainer?>>?
+        get() = memberAt<CPointerVar<CFunction<(CXClientData?, COpaquePointer?) -> CXIdxClientContainer?>>>(40).value
+        set(value) { memberAt<CPointerVar<CFunction<(CXClientData?, COpaquePointer?) -> CXIdxClientContainer?>>>(40).value = value }
     
-    var indexDeclaration: CPointer<CFunction<(COpaquePointer?, CPointer<CXIdxDeclInfo>?) -> Unit>>?
-        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxDeclInfo>?) -> Unit>>>(48).value
-        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxDeclInfo>?) -> Unit>>>(48).value = value }
+    var indexDeclaration: CPointer<CFunction<(CXClientData?, CPointer<CXIdxDeclInfo>?) -> Unit>>?
+        get() = memberAt<CPointerVar<CFunction<(CXClientData?, CPointer<CXIdxDeclInfo>?) -> Unit>>>(48).value
+        set(value) { memberAt<CPointerVar<CFunction<(CXClientData?, CPointer<CXIdxDeclInfo>?) -> Unit>>>(48).value = value }
     
-    var indexEntityReference: CPointer<CFunction<(COpaquePointer?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>?
-        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>>(56).value
-        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>>(56).value = value }
+    var indexEntityReference: CPointer<CFunction<(CXClientData?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>?
+        get() = memberAt<CPointerVar<CFunction<(CXClientData?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>>(56).value
+        set(value) { memberAt<CPointerVar<CFunction<(CXClientData?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>>(56).value = value }
     
 }
 
@@ -5891,7 +5891,7 @@ typealias CXCursorSetVar = CPointerVarOf<CXCursorSet>
 typealias CXCursorSet = CPointer<CXCursorSetImpl>
 
 typealias CXCursorVisitorVar = CPointerVarOf<CXCursorVisitor>
-typealias CXCursorVisitor = CPointer<CFunction<(CValue<CXCursor>, CValue<CXCursor>, COpaquePointer?) -> CXChildVisitResult>>
+typealias CXCursorVisitor = CPointer<CFunction<(CValue<CXCursor>, CValue<CXCursor>, CXClientData?) -> CXChildVisitResult>>
 
 typealias CXModuleVar = CPointerVarOf<CXModule>
 typealias CXModule = COpaquePointer
@@ -5900,7 +5900,7 @@ typealias CXCompletionStringVar = CPointerVarOf<CXCompletionString>
 typealias CXCompletionString = COpaquePointer
 
 typealias CXInclusionVisitorVar = CPointerVarOf<CXInclusionVisitor>
-typealias CXInclusionVisitor = CPointer<CFunction<(COpaquePointer?, CPointer<CXSourceLocation>?, Int, COpaquePointer?) -> Unit>>
+typealias CXInclusionVisitor = CPointer<CFunction<(CXFile?, CPointer<CXSourceLocation>?, Int, CXClientData?) -> Unit>>
 
 typealias CXEvalResultVar = CPointerVarOf<CXEvalResult>
 typealias CXEvalResult = COpaquePointer
@@ -5924,6 +5924,6 @@ typealias CXIndexActionVar = CPointerVarOf<CXIndexAction>
 typealias CXIndexAction = COpaquePointer
 
 typealias CXFieldVisitorVar = CPointerVarOf<CXFieldVisitor>
-typealias CXFieldVisitor = CPointer<CFunction<(CValue<CXCursor>, COpaquePointer?) -> CXVisitorResult>>
+typealias CXFieldVisitor = CPointer<CFunction<(CValue<CXCursor>, CXClientData?) -> CXVisitorResult>>
 
 private val loadLibrary = System.loadLibrary("clangstubs")

--- a/Interop/Indexer/prebuilt/nativeInteropStubs/kotlin/clang/clang.kt
+++ b/Interop/Indexer/prebuilt/nativeInteropStubs/kotlin/clang/clang.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@file:JvmName("clang")
 @file:Suppress("UNUSED_EXPRESSION", "UNUSED_VARIABLE")
 package clang
 
@@ -22,62 +23,78 @@ import kotlinx.cinterop.*
 fun asctime(arg0: CValuesRef<tm>?): CPointer<ByteVar>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.asctime(_arg0)
+        val res = kni_asctime(_arg0)
         interpretCPointer<ByteVar>(res)
     }
 }
 
+private external fun kni_asctime(arg0: NativePtr): NativePtr
+
 fun clock(): clock_t {
-    val res = externals.clock()
+    val res = kni_clock()
     return res
 }
+
+private external fun kni_clock(): Long
 
 fun ctime(arg0: CValuesRef<time_tVar>?): CPointer<ByteVar>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.ctime(_arg0)
+        val res = kni_ctime(_arg0)
         interpretCPointer<ByteVar>(res)
     }
 }
 
+private external fun kni_ctime(arg0: NativePtr): NativePtr
+
 fun difftime(arg0: time_t, arg1: time_t): Double {
     val _arg0 = arg0
     val _arg1 = arg1
-    val res = externals.difftime(_arg0, _arg1)
+    val res = kni_difftime(_arg0, _arg1)
     return res
 }
+
+private external fun kni_difftime(arg0: Long, arg1: Long): Double
 
 fun getdate(arg0: String?): CPointer<tm>? {
     return memScoped {
         val _arg0 = arg0?.cstr?.getPointer(memScope).rawValue
-        val res = externals.getdate(_arg0)
+        val res = kni_getdate(_arg0)
         interpretCPointer<tm>(res)
     }
 }
+
+private external fun kni_getdate(arg0: NativePtr): NativePtr
 
 fun gmtime(arg0: CValuesRef<time_tVar>?): CPointer<tm>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.gmtime(_arg0)
+        val res = kni_gmtime(_arg0)
         interpretCPointer<tm>(res)
     }
 }
+
+private external fun kni_gmtime(arg0: NativePtr): NativePtr
 
 fun localtime(arg0: CValuesRef<time_tVar>?): CPointer<tm>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.localtime(_arg0)
+        val res = kni_localtime(_arg0)
         interpretCPointer<tm>(res)
     }
 }
 
+private external fun kni_localtime(arg0: NativePtr): NativePtr
+
 fun mktime(arg0: CValuesRef<tm>?): time_t {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.mktime(_arg0)
+        val res = kni_mktime(_arg0)
         res
     }
 }
+
+private external fun kni_mktime(arg0: NativePtr): Long
 
 fun strftime(arg0: CValuesRef<ByteVar>?, arg1: size_t, arg2: String?, arg3: CValuesRef<tm>?): size_t {
     return memScoped {
@@ -85,196 +102,246 @@ fun strftime(arg0: CValuesRef<ByteVar>?, arg1: size_t, arg2: String?, arg3: CVal
         val _arg1 = arg1
         val _arg2 = arg2?.cstr?.getPointer(memScope).rawValue
         val _arg3 = arg3?.getPointer(memScope).rawValue
-        val res = externals.strftime(_arg0, _arg1, _arg2, _arg3)
+        val res = kni_strftime(_arg0, _arg1, _arg2, _arg3)
         res
     }
 }
+
+private external fun kni_strftime(arg0: NativePtr, arg1: Long, arg2: NativePtr, arg3: NativePtr): Long
 
 fun strptime(arg0: String?, arg1: String?, arg2: CValuesRef<tm>?): CPointer<ByteVar>? {
     return memScoped {
         val _arg0 = arg0?.cstr?.getPointer(memScope).rawValue
         val _arg1 = arg1?.cstr?.getPointer(memScope).rawValue
         val _arg2 = arg2?.getPointer(memScope).rawValue
-        val res = externals.strptime(_arg0, _arg1, _arg2)
+        val res = kni_strptime(_arg0, _arg1, _arg2)
         interpretCPointer<ByteVar>(res)
     }
 }
 
+private external fun kni_strptime(arg0: NativePtr, arg1: NativePtr, arg2: NativePtr): NativePtr
+
 fun time(arg0: CValuesRef<time_tVar>?): time_t {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.time(_arg0)
+        val res = kni_time(_arg0)
         res
     }
 }
 
+private external fun kni_time(arg0: NativePtr): Long
+
 fun tzset(): Unit {
-    val res = externals.tzset()
+    val res = kni_tzset()
     return res
 }
+
+private external fun kni_tzset(): Unit
 
 fun asctime_r(arg0: CValuesRef<tm>?, arg1: CValuesRef<ByteVar>?): CPointer<ByteVar>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
         val _arg1 = arg1?.getPointer(memScope).rawValue
-        val res = externals.asctime_r(_arg0, _arg1)
+        val res = kni_asctime_r(_arg0, _arg1)
         interpretCPointer<ByteVar>(res)
     }
 }
+
+private external fun kni_asctime_r(arg0: NativePtr, arg1: NativePtr): NativePtr
 
 fun ctime_r(arg0: CValuesRef<time_tVar>?, arg1: CValuesRef<ByteVar>?): CPointer<ByteVar>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
         val _arg1 = arg1?.getPointer(memScope).rawValue
-        val res = externals.ctime_r(_arg0, _arg1)
+        val res = kni_ctime_r(_arg0, _arg1)
         interpretCPointer<ByteVar>(res)
     }
 }
+
+private external fun kni_ctime_r(arg0: NativePtr, arg1: NativePtr): NativePtr
 
 fun gmtime_r(arg0: CValuesRef<time_tVar>?, arg1: CValuesRef<tm>?): CPointer<tm>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
         val _arg1 = arg1?.getPointer(memScope).rawValue
-        val res = externals.gmtime_r(_arg0, _arg1)
+        val res = kni_gmtime_r(_arg0, _arg1)
         interpretCPointer<tm>(res)
     }
 }
+
+private external fun kni_gmtime_r(arg0: NativePtr, arg1: NativePtr): NativePtr
 
 fun localtime_r(arg0: CValuesRef<time_tVar>?, arg1: CValuesRef<tm>?): CPointer<tm>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
         val _arg1 = arg1?.getPointer(memScope).rawValue
-        val res = externals.localtime_r(_arg0, _arg1)
+        val res = kni_localtime_r(_arg0, _arg1)
         interpretCPointer<tm>(res)
     }
 }
 
+private external fun kni_localtime_r(arg0: NativePtr, arg1: NativePtr): NativePtr
+
 fun posix2time(arg0: time_t): time_t {
     val _arg0 = arg0
-    val res = externals.posix2time(_arg0)
+    val res = kni_posix2time(_arg0)
     return res
 }
 
+private external fun kni_posix2time(arg0: Long): Long
+
 fun tzsetwall(): Unit {
-    val res = externals.tzsetwall()
+    val res = kni_tzsetwall()
     return res
 }
+
+private external fun kni_tzsetwall(): Unit
 
 fun time2posix(arg0: time_t): time_t {
     val _arg0 = arg0
-    val res = externals.time2posix(_arg0)
+    val res = kni_time2posix(_arg0)
     return res
 }
+
+private external fun kni_time2posix(arg0: Long): Long
 
 fun timelocal(arg0: CValuesRef<tm>?): time_t {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.timelocal(_arg0)
+        val res = kni_timelocal(_arg0)
         res
     }
 }
 
+private external fun kni_timelocal(arg0: NativePtr): Long
+
 fun timegm(arg0: CValuesRef<tm>?): time_t {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.timegm(_arg0)
+        val res = kni_timegm(_arg0)
         res
     }
 }
+
+private external fun kni_timegm(arg0: NativePtr): Long
 
 fun nanosleep(__rqtp: CValuesRef<timespec>?, __rmtp: CValuesRef<timespec>?): Int {
     return memScoped {
         val ___rqtp = __rqtp?.getPointer(memScope).rawValue
         val ___rmtp = __rmtp?.getPointer(memScope).rawValue
-        val res = externals.nanosleep(___rqtp, ___rmtp)
+        val res = kni_nanosleep(___rqtp, ___rmtp)
         res
     }
 }
+
+private external fun kni_nanosleep(__rqtp: NativePtr, __rmtp: NativePtr): Int
 
 fun clock_getres(__clock_id: clockid_t, __res: CValuesRef<timespec>?): Int {
     return memScoped {
         val ___clock_id = __clock_id
         val ___res = __res?.getPointer(memScope).rawValue
-        val res = externals.clock_getres(___clock_id, ___res)
+        val res = kni_clock_getres(___clock_id, ___res)
         res
     }
 }
+
+private external fun kni_clock_getres(__clock_id: Int, __res: NativePtr): Int
 
 fun clock_gettime(__clock_id: clockid_t, __tp: CValuesRef<timespec>?): Int {
     return memScoped {
         val ___clock_id = __clock_id
         val ___tp = __tp?.getPointer(memScope).rawValue
-        val res = externals.clock_gettime(___clock_id, ___tp)
+        val res = kni_clock_gettime(___clock_id, ___tp)
         res
     }
 }
 
+private external fun kni_clock_gettime(__clock_id: Int, __tp: NativePtr): Int
+
 fun clock_gettime_nsec_np(__clock_id: clockid_t): __uint64_t {
     val ___clock_id = __clock_id
-    val res = externals.clock_gettime_nsec_np(___clock_id)
+    val res = kni_clock_gettime_nsec_np(___clock_id)
     return res
 }
+
+private external fun kni_clock_gettime_nsec_np(__clock_id: Int): Long
 
 fun clock_settime(__clock_id: clockid_t, __tp: CValuesRef<timespec>?): Int {
     return memScoped {
         val ___clock_id = __clock_id
         val ___tp = __tp?.getPointer(memScope).rawValue
-        val res = externals.clock_settime(___clock_id, ___tp)
+        val res = kni_clock_settime(___clock_id, ___tp)
         res
     }
 }
+
+private external fun kni_clock_settime(__clock_id: Int, __tp: NativePtr): Int
 
 fun clang_getCString(string: CValue<CXString>): CPointer<ByteVar>? {
     return memScoped {
         val _string = string.getPointer(memScope).rawValue
-        val res = externals.clang_getCString(_string)
+        val res = kni_clang_getCString(_string)
         interpretCPointer<ByteVar>(res)
     }
 }
 
+private external fun kni_clang_getCString(string: NativePtr): NativePtr
+
 fun clang_disposeString(string: CValue<CXString>): Unit {
     return memScoped {
         val _string = string.getPointer(memScope).rawValue
-        val res = externals.clang_disposeString(_string)
+        val res = kni_clang_disposeString(_string)
         res
     }
 }
+
+private external fun kni_clang_disposeString(string: NativePtr): Unit
 
 fun clang_disposeStringSet(set: CValuesRef<CXStringSet>?): Unit {
     return memScoped {
         val _set = set?.getPointer(memScope).rawValue
-        val res = externals.clang_disposeStringSet(_set)
+        val res = kni_clang_disposeStringSet(_set)
         res
     }
 }
 
+private external fun kni_clang_disposeStringSet(set: NativePtr): Unit
+
 fun clang_getBuildSessionTimestamp(): Long {
-    val res = externals.clang_getBuildSessionTimestamp()
+    val res = kni_clang_getBuildSessionTimestamp()
     return res
 }
 
+private external fun kni_clang_getBuildSessionTimestamp(): Long
+
 fun clang_VirtualFileOverlay_create(options: Int): CXVirtualFileOverlay? {
     val _options = options
-    val res = externals.clang_VirtualFileOverlay_create(_options)
+    val res = kni_clang_VirtualFileOverlay_create(_options)
     return interpretCPointer<CXVirtualFileOverlayImpl>(res)
 }
+
+private external fun kni_clang_VirtualFileOverlay_create(options: Int): NativePtr
 
 fun clang_VirtualFileOverlay_addFileMapping(arg0: CXVirtualFileOverlay?, virtualPath: String?, realPath: String?): CXErrorCode {
     return memScoped {
         val _arg0 = arg0.rawValue
         val _virtualPath = virtualPath?.cstr?.getPointer(memScope).rawValue
         val _realPath = realPath?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_VirtualFileOverlay_addFileMapping(_arg0, _virtualPath, _realPath)
+        val res = kni_clang_VirtualFileOverlay_addFileMapping(_arg0, _virtualPath, _realPath)
         CXErrorCode.byValue(res)
     }
 }
 
+private external fun kni_clang_VirtualFileOverlay_addFileMapping(arg0: NativePtr, virtualPath: NativePtr, realPath: NativePtr): Int
+
 fun clang_VirtualFileOverlay_setCaseSensitivity(arg0: CXVirtualFileOverlay?, caseSensitive: Int): CXErrorCode {
     val _arg0 = arg0.rawValue
     val _caseSensitive = caseSensitive
-    val res = externals.clang_VirtualFileOverlay_setCaseSensitivity(_arg0, _caseSensitive)
+    val res = kni_clang_VirtualFileOverlay_setCaseSensitivity(_arg0, _caseSensitive)
     return CXErrorCode.byValue(res)
 }
+
+private external fun kni_clang_VirtualFileOverlay_setCaseSensitivity(arg0: NativePtr, caseSensitive: Int): Int
 
 fun clang_VirtualFileOverlay_writeToBuffer(arg0: CXVirtualFileOverlay?, options: Int, out_buffer_ptr: CValuesRef<CPointerVar<ByteVar>>?, out_buffer_size: CValuesRef<IntVar>?): CXErrorCode {
     return memScoped {
@@ -282,46 +349,58 @@ fun clang_VirtualFileOverlay_writeToBuffer(arg0: CXVirtualFileOverlay?, options:
         val _options = options
         val _out_buffer_ptr = out_buffer_ptr?.getPointer(memScope).rawValue
         val _out_buffer_size = out_buffer_size?.getPointer(memScope).rawValue
-        val res = externals.clang_VirtualFileOverlay_writeToBuffer(_arg0, _options, _out_buffer_ptr, _out_buffer_size)
+        val res = kni_clang_VirtualFileOverlay_writeToBuffer(_arg0, _options, _out_buffer_ptr, _out_buffer_size)
         CXErrorCode.byValue(res)
     }
 }
 
+private external fun kni_clang_VirtualFileOverlay_writeToBuffer(arg0: NativePtr, options: Int, out_buffer_ptr: NativePtr, out_buffer_size: NativePtr): Int
+
 fun clang_free(buffer: COpaquePointer?): Unit {
     val _buffer = buffer.rawValue
-    val res = externals.clang_free(_buffer)
+    val res = kni_clang_free(_buffer)
     return res
 }
+
+private external fun kni_clang_free(buffer: NativePtr): Unit
 
 fun clang_VirtualFileOverlay_dispose(arg0: CXVirtualFileOverlay?): Unit {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_VirtualFileOverlay_dispose(_arg0)
+    val res = kni_clang_VirtualFileOverlay_dispose(_arg0)
     return res
 }
 
+private external fun kni_clang_VirtualFileOverlay_dispose(arg0: NativePtr): Unit
+
 fun clang_ModuleMapDescriptor_create(options: Int): CXModuleMapDescriptor? {
     val _options = options
-    val res = externals.clang_ModuleMapDescriptor_create(_options)
+    val res = kni_clang_ModuleMapDescriptor_create(_options)
     return interpretCPointer<CXModuleMapDescriptorImpl>(res)
 }
+
+private external fun kni_clang_ModuleMapDescriptor_create(options: Int): NativePtr
 
 fun clang_ModuleMapDescriptor_setFrameworkModuleName(arg0: CXModuleMapDescriptor?, name: String?): CXErrorCode {
     return memScoped {
         val _arg0 = arg0.rawValue
         val _name = name?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_ModuleMapDescriptor_setFrameworkModuleName(_arg0, _name)
+        val res = kni_clang_ModuleMapDescriptor_setFrameworkModuleName(_arg0, _name)
         CXErrorCode.byValue(res)
     }
 }
+
+private external fun kni_clang_ModuleMapDescriptor_setFrameworkModuleName(arg0: NativePtr, name: NativePtr): Int
 
 fun clang_ModuleMapDescriptor_setUmbrellaHeader(arg0: CXModuleMapDescriptor?, name: String?): CXErrorCode {
     return memScoped {
         val _arg0 = arg0.rawValue
         val _name = name?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_ModuleMapDescriptor_setUmbrellaHeader(_arg0, _name)
+        val res = kni_clang_ModuleMapDescriptor_setUmbrellaHeader(_arg0, _name)
         CXErrorCode.byValue(res)
     }
 }
+
+private external fun kni_clang_ModuleMapDescriptor_setUmbrellaHeader(arg0: NativePtr, name: NativePtr): Int
 
 fun clang_ModuleMapDescriptor_writeToBuffer(arg0: CXModuleMapDescriptor?, options: Int, out_buffer_ptr: CValuesRef<CPointerVar<ByteVar>>?, out_buffer_size: CValuesRef<IntVar>?): CXErrorCode {
     return memScoped {
@@ -329,104 +408,132 @@ fun clang_ModuleMapDescriptor_writeToBuffer(arg0: CXModuleMapDescriptor?, option
         val _options = options
         val _out_buffer_ptr = out_buffer_ptr?.getPointer(memScope).rawValue
         val _out_buffer_size = out_buffer_size?.getPointer(memScope).rawValue
-        val res = externals.clang_ModuleMapDescriptor_writeToBuffer(_arg0, _options, _out_buffer_ptr, _out_buffer_size)
+        val res = kni_clang_ModuleMapDescriptor_writeToBuffer(_arg0, _options, _out_buffer_ptr, _out_buffer_size)
         CXErrorCode.byValue(res)
     }
 }
 
+private external fun kni_clang_ModuleMapDescriptor_writeToBuffer(arg0: NativePtr, options: Int, out_buffer_ptr: NativePtr, out_buffer_size: NativePtr): Int
+
 fun clang_ModuleMapDescriptor_dispose(arg0: CXModuleMapDescriptor?): Unit {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_ModuleMapDescriptor_dispose(_arg0)
+    val res = kni_clang_ModuleMapDescriptor_dispose(_arg0)
     return res
 }
+
+private external fun kni_clang_ModuleMapDescriptor_dispose(arg0: NativePtr): Unit
 
 fun clang_createIndex(excludeDeclarationsFromPCH: Int, displayDiagnostics: Int): CXIndex? {
     val _excludeDeclarationsFromPCH = excludeDeclarationsFromPCH
     val _displayDiagnostics = displayDiagnostics
-    val res = externals.clang_createIndex(_excludeDeclarationsFromPCH, _displayDiagnostics)
+    val res = kni_clang_createIndex(_excludeDeclarationsFromPCH, _displayDiagnostics)
     return interpretCPointer<COpaque>(res)
 }
 
+private external fun kni_clang_createIndex(excludeDeclarationsFromPCH: Int, displayDiagnostics: Int): NativePtr
+
 fun clang_disposeIndex(index: CXIndex?): Unit {
     val _index = index.rawValue
-    val res = externals.clang_disposeIndex(_index)
+    val res = kni_clang_disposeIndex(_index)
     return res
 }
+
+private external fun kni_clang_disposeIndex(index: NativePtr): Unit
 
 fun clang_CXIndex_setGlobalOptions(arg0: CXIndex?, options: Int): Unit {
     val _arg0 = arg0.rawValue
     val _options = options
-    val res = externals.clang_CXIndex_setGlobalOptions(_arg0, _options)
+    val res = kni_clang_CXIndex_setGlobalOptions(_arg0, _options)
     return res
 }
 
+private external fun kni_clang_CXIndex_setGlobalOptions(arg0: NativePtr, options: Int): Unit
+
 fun clang_CXIndex_getGlobalOptions(arg0: CXIndex?): Int {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_CXIndex_getGlobalOptions(_arg0)
+    val res = kni_clang_CXIndex_getGlobalOptions(_arg0)
     return res
 }
+
+private external fun kni_clang_CXIndex_getGlobalOptions(arg0: NativePtr): Int
 
 fun clang_getFileName(SFile: CXFile?): CValue<CXString> {
     return memScoped {
         val _SFile = SFile.rawValue
-        val res = externals.clang_getFileName(_SFile, alloc<CXString>().rawPtr)
+        val res = kni_clang_getFileName(_SFile, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getFileName(SFile: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getFileTime(SFile: CXFile?): time_t {
     val _SFile = SFile.rawValue
-    val res = externals.clang_getFileTime(_SFile)
+    val res = kni_clang_getFileTime(_SFile)
     return res
 }
+
+private external fun kni_clang_getFileTime(SFile: NativePtr): Long
 
 fun clang_getFileUniqueID(file: CXFile?, outID: CValuesRef<CXFileUniqueID>?): Int {
     return memScoped {
         val _file = file.rawValue
         val _outID = outID?.getPointer(memScope).rawValue
-        val res = externals.clang_getFileUniqueID(_file, _outID)
+        val res = kni_clang_getFileUniqueID(_file, _outID)
         res
     }
 }
 
+private external fun kni_clang_getFileUniqueID(file: NativePtr, outID: NativePtr): Int
+
 fun clang_isFileMultipleIncludeGuarded(tu: CXTranslationUnit?, file: CXFile?): Int {
     val _tu = tu.rawValue
     val _file = file.rawValue
-    val res = externals.clang_isFileMultipleIncludeGuarded(_tu, _file)
+    val res = kni_clang_isFileMultipleIncludeGuarded(_tu, _file)
     return res
 }
+
+private external fun kni_clang_isFileMultipleIncludeGuarded(tu: NativePtr, file: NativePtr): Int
 
 fun clang_getFile(tu: CXTranslationUnit?, file_name: String?): CXFile? {
     return memScoped {
         val _tu = tu.rawValue
         val _file_name = file_name?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_getFile(_tu, _file_name)
+        val res = kni_clang_getFile(_tu, _file_name)
         interpretCPointer<COpaque>(res)
     }
 }
 
+private external fun kni_clang_getFile(tu: NativePtr, file_name: NativePtr): NativePtr
+
 fun clang_File_isEqual(file1: CXFile?, file2: CXFile?): Int {
     val _file1 = file1.rawValue
     val _file2 = file2.rawValue
-    val res = externals.clang_File_isEqual(_file1, _file2)
+    val res = kni_clang_File_isEqual(_file1, _file2)
     return res
 }
 
+private external fun kni_clang_File_isEqual(file1: NativePtr, file2: NativePtr): Int
+
 fun clang_getNullLocation(): CValue<CXSourceLocation> {
     return memScoped {
-        val res = externals.clang_getNullLocation(alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_getNullLocation(alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
+
+private external fun kni_clang_getNullLocation(retValPlacement: NativePtr): NativePtr
 
 fun clang_equalLocations(loc1: CValue<CXSourceLocation>, loc2: CValue<CXSourceLocation>): Int {
     return memScoped {
         val _loc1 = loc1.getPointer(memScope).rawValue
         val _loc2 = loc2.getPointer(memScope).rawValue
-        val res = externals.clang_equalLocations(_loc1, _loc2)
+        val res = kni_clang_equalLocations(_loc1, _loc2)
         res
     }
 }
+
+private external fun kni_clang_equalLocations(loc1: NativePtr, loc2: NativePtr): Int
 
 fun clang_getLocation(tu: CXTranslationUnit?, file: CXFile?, line: Int, column: Int): CValue<CXSourceLocation> {
     return memScoped {
@@ -434,69 +541,85 @@ fun clang_getLocation(tu: CXTranslationUnit?, file: CXFile?, line: Int, column: 
         val _file = file.rawValue
         val _line = line
         val _column = column
-        val res = externals.clang_getLocation(_tu, _file, _line, _column, alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_getLocation(_tu, _file, _line, _column, alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
+
+private external fun kni_clang_getLocation(tu: NativePtr, file: NativePtr, line: Int, column: Int, retValPlacement: NativePtr): NativePtr
 
 fun clang_getLocationForOffset(tu: CXTranslationUnit?, file: CXFile?, offset: Int): CValue<CXSourceLocation> {
     return memScoped {
         val _tu = tu.rawValue
         val _file = file.rawValue
         val _offset = offset
-        val res = externals.clang_getLocationForOffset(_tu, _file, _offset, alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_getLocationForOffset(_tu, _file, _offset, alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
 
+private external fun kni_clang_getLocationForOffset(tu: NativePtr, file: NativePtr, offset: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_Location_isInSystemHeader(location: CValue<CXSourceLocation>): Int {
     return memScoped {
         val _location = location.getPointer(memScope).rawValue
-        val res = externals.clang_Location_isInSystemHeader(_location)
+        val res = kni_clang_Location_isInSystemHeader(_location)
         res
     }
 }
+
+private external fun kni_clang_Location_isInSystemHeader(location: NativePtr): Int
 
 fun clang_Location_isFromMainFile(location: CValue<CXSourceLocation>): Int {
     return memScoped {
         val _location = location.getPointer(memScope).rawValue
-        val res = externals.clang_Location_isFromMainFile(_location)
+        val res = kni_clang_Location_isFromMainFile(_location)
         res
     }
 }
 
+private external fun kni_clang_Location_isFromMainFile(location: NativePtr): Int
+
 fun clang_getNullRange(): CValue<CXSourceRange> {
     return memScoped {
-        val res = externals.clang_getNullRange(alloc<CXSourceRange>().rawPtr)
+        val res = kni_clang_getNullRange(alloc<CXSourceRange>().rawPtr)
         interpretPointed<CXSourceRange>(res).readValue()
     }
 }
+
+private external fun kni_clang_getNullRange(retValPlacement: NativePtr): NativePtr
 
 fun clang_getRange(begin: CValue<CXSourceLocation>, end: CValue<CXSourceLocation>): CValue<CXSourceRange> {
     return memScoped {
         val _begin = begin.getPointer(memScope).rawValue
         val _end = end.getPointer(memScope).rawValue
-        val res = externals.clang_getRange(_begin, _end, alloc<CXSourceRange>().rawPtr)
+        val res = kni_clang_getRange(_begin, _end, alloc<CXSourceRange>().rawPtr)
         interpretPointed<CXSourceRange>(res).readValue()
     }
 }
+
+private external fun kni_clang_getRange(begin: NativePtr, end: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_equalRanges(range1: CValue<CXSourceRange>, range2: CValue<CXSourceRange>): Int {
     return memScoped {
         val _range1 = range1.getPointer(memScope).rawValue
         val _range2 = range2.getPointer(memScope).rawValue
-        val res = externals.clang_equalRanges(_range1, _range2)
+        val res = kni_clang_equalRanges(_range1, _range2)
         res
     }
 }
 
+private external fun kni_clang_equalRanges(range1: NativePtr, range2: NativePtr): Int
+
 fun clang_Range_isNull(range: CValue<CXSourceRange>): Int {
     return memScoped {
         val _range = range.getPointer(memScope).rawValue
-        val res = externals.clang_Range_isNull(_range)
+        val res = kni_clang_Range_isNull(_range)
         res
     }
 }
+
+private external fun kni_clang_Range_isNull(range: NativePtr): Int
 
 fun clang_getExpansionLocation(location: CValue<CXSourceLocation>, file: CValuesRef<CXFileVar>?, line: CValuesRef<IntVar>?, column: CValuesRef<IntVar>?, offset: CValuesRef<IntVar>?): Unit {
     return memScoped {
@@ -505,10 +628,12 @@ fun clang_getExpansionLocation(location: CValue<CXSourceLocation>, file: CValues
         val _line = line?.getPointer(memScope).rawValue
         val _column = column?.getPointer(memScope).rawValue
         val _offset = offset?.getPointer(memScope).rawValue
-        val res = externals.clang_getExpansionLocation(_location, _file, _line, _column, _offset)
+        val res = kni_clang_getExpansionLocation(_location, _file, _line, _column, _offset)
         res
     }
 }
+
+private external fun kni_clang_getExpansionLocation(location: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
 
 fun clang_getPresumedLocation(location: CValue<CXSourceLocation>, filename: CValuesRef<CXString>?, line: CValuesRef<IntVar>?, column: CValuesRef<IntVar>?): Unit {
     return memScoped {
@@ -516,10 +641,12 @@ fun clang_getPresumedLocation(location: CValue<CXSourceLocation>, filename: CVal
         val _filename = filename?.getPointer(memScope).rawValue
         val _line = line?.getPointer(memScope).rawValue
         val _column = column?.getPointer(memScope).rawValue
-        val res = externals.clang_getPresumedLocation(_location, _filename, _line, _column)
+        val res = kni_clang_getPresumedLocation(_location, _filename, _line, _column)
         res
     }
 }
+
+private external fun kni_clang_getPresumedLocation(location: NativePtr, filename: NativePtr, line: NativePtr, column: NativePtr): Unit
 
 fun clang_getInstantiationLocation(location: CValue<CXSourceLocation>, file: CValuesRef<CXFileVar>?, line: CValuesRef<IntVar>?, column: CValuesRef<IntVar>?, offset: CValuesRef<IntVar>?): Unit {
     return memScoped {
@@ -528,10 +655,12 @@ fun clang_getInstantiationLocation(location: CValue<CXSourceLocation>, file: CVa
         val _line = line?.getPointer(memScope).rawValue
         val _column = column?.getPointer(memScope).rawValue
         val _offset = offset?.getPointer(memScope).rawValue
-        val res = externals.clang_getInstantiationLocation(_location, _file, _line, _column, _offset)
+        val res = kni_clang_getInstantiationLocation(_location, _file, _line, _column, _offset)
         res
     }
 }
+
+private external fun kni_clang_getInstantiationLocation(location: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
 
 fun clang_getSpellingLocation(location: CValue<CXSourceLocation>, file: CValuesRef<CXFileVar>?, line: CValuesRef<IntVar>?, column: CValuesRef<IntVar>?, offset: CValuesRef<IntVar>?): Unit {
     return memScoped {
@@ -540,10 +669,12 @@ fun clang_getSpellingLocation(location: CValue<CXSourceLocation>, file: CValuesR
         val _line = line?.getPointer(memScope).rawValue
         val _column = column?.getPointer(memScope).rawValue
         val _offset = offset?.getPointer(memScope).rawValue
-        val res = externals.clang_getSpellingLocation(_location, _file, _line, _column, _offset)
+        val res = kni_clang_getSpellingLocation(_location, _file, _line, _column, _offset)
         res
     }
 }
+
+private external fun kni_clang_getSpellingLocation(location: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
 
 fun clang_getFileLocation(location: CValue<CXSourceLocation>, file: CValuesRef<CXFileVar>?, line: CValuesRef<IntVar>?, column: CValuesRef<IntVar>?, offset: CValuesRef<IntVar>?): Unit {
     return memScoped {
@@ -552,207 +683,263 @@ fun clang_getFileLocation(location: CValue<CXSourceLocation>, file: CValuesRef<C
         val _line = line?.getPointer(memScope).rawValue
         val _column = column?.getPointer(memScope).rawValue
         val _offset = offset?.getPointer(memScope).rawValue
-        val res = externals.clang_getFileLocation(_location, _file, _line, _column, _offset)
+        val res = kni_clang_getFileLocation(_location, _file, _line, _column, _offset)
         res
     }
 }
+
+private external fun kni_clang_getFileLocation(location: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
 
 fun clang_getRangeStart(range: CValue<CXSourceRange>): CValue<CXSourceLocation> {
     return memScoped {
         val _range = range.getPointer(memScope).rawValue
-        val res = externals.clang_getRangeStart(_range, alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_getRangeStart(_range, alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
+
+private external fun kni_clang_getRangeStart(range: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getRangeEnd(range: CValue<CXSourceRange>): CValue<CXSourceLocation> {
     return memScoped {
         val _range = range.getPointer(memScope).rawValue
-        val res = externals.clang_getRangeEnd(_range, alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_getRangeEnd(_range, alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
 
+private external fun kni_clang_getRangeEnd(range: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getSkippedRanges(tu: CXTranslationUnit?, file: CXFile?): CPointer<CXSourceRangeList>? {
     val _tu = tu.rawValue
     val _file = file.rawValue
-    val res = externals.clang_getSkippedRanges(_tu, _file)
+    val res = kni_clang_getSkippedRanges(_tu, _file)
     return interpretCPointer<CXSourceRangeList>(res)
 }
+
+private external fun kni_clang_getSkippedRanges(tu: NativePtr, file: NativePtr): NativePtr
 
 fun clang_disposeSourceRangeList(ranges: CValuesRef<CXSourceRangeList>?): Unit {
     return memScoped {
         val _ranges = ranges?.getPointer(memScope).rawValue
-        val res = externals.clang_disposeSourceRangeList(_ranges)
+        val res = kni_clang_disposeSourceRangeList(_ranges)
         res
     }
 }
 
+private external fun kni_clang_disposeSourceRangeList(ranges: NativePtr): Unit
+
 fun clang_getNumDiagnosticsInSet(Diags: CXDiagnosticSet?): Int {
     val _Diags = Diags.rawValue
-    val res = externals.clang_getNumDiagnosticsInSet(_Diags)
+    val res = kni_clang_getNumDiagnosticsInSet(_Diags)
     return res
 }
+
+private external fun kni_clang_getNumDiagnosticsInSet(Diags: NativePtr): Int
 
 fun clang_getDiagnosticInSet(Diags: CXDiagnosticSet?, Index: Int): CXDiagnostic? {
     val _Diags = Diags.rawValue
     val _Index = Index
-    val res = externals.clang_getDiagnosticInSet(_Diags, _Index)
+    val res = kni_clang_getDiagnosticInSet(_Diags, _Index)
     return interpretCPointer<COpaque>(res)
 }
+
+private external fun kni_clang_getDiagnosticInSet(Diags: NativePtr, Index: Int): NativePtr
 
 fun clang_loadDiagnostics(file: String?, error: CValuesRef<CXLoadDiag_Error.Var>?, errorString: CValuesRef<CXString>?): CXDiagnosticSet? {
     return memScoped {
         val _file = file?.cstr?.getPointer(memScope).rawValue
         val _error = error?.getPointer(memScope).rawValue
         val _errorString = errorString?.getPointer(memScope).rawValue
-        val res = externals.clang_loadDiagnostics(_file, _error, _errorString)
+        val res = kni_clang_loadDiagnostics(_file, _error, _errorString)
         interpretCPointer<COpaque>(res)
     }
 }
 
+private external fun kni_clang_loadDiagnostics(file: NativePtr, error: NativePtr, errorString: NativePtr): NativePtr
+
 fun clang_disposeDiagnosticSet(Diags: CXDiagnosticSet?): Unit {
     val _Diags = Diags.rawValue
-    val res = externals.clang_disposeDiagnosticSet(_Diags)
+    val res = kni_clang_disposeDiagnosticSet(_Diags)
     return res
 }
+
+private external fun kni_clang_disposeDiagnosticSet(Diags: NativePtr): Unit
 
 fun clang_getChildDiagnostics(D: CXDiagnostic?): CXDiagnosticSet? {
     val _D = D.rawValue
-    val res = externals.clang_getChildDiagnostics(_D)
+    val res = kni_clang_getChildDiagnostics(_D)
     return interpretCPointer<COpaque>(res)
 }
 
+private external fun kni_clang_getChildDiagnostics(D: NativePtr): NativePtr
+
 fun clang_getNumDiagnostics(Unit: CXTranslationUnit?): Int {
     val _Unit = Unit.rawValue
-    val res = externals.clang_getNumDiagnostics(_Unit)
+    val res = kni_clang_getNumDiagnostics(_Unit)
     return res
 }
+
+private external fun kni_clang_getNumDiagnostics(Unit: NativePtr): Int
 
 fun clang_getDiagnostic(Unit: CXTranslationUnit?, Index: Int): CXDiagnostic? {
     val _Unit = Unit.rawValue
     val _Index = Index
-    val res = externals.clang_getDiagnostic(_Unit, _Index)
+    val res = kni_clang_getDiagnostic(_Unit, _Index)
     return interpretCPointer<COpaque>(res)
 }
+
+private external fun kni_clang_getDiagnostic(Unit: NativePtr, Index: Int): NativePtr
 
 fun clang_getDiagnosticSetFromTU(Unit: CXTranslationUnit?): CXDiagnosticSet? {
     val _Unit = Unit.rawValue
-    val res = externals.clang_getDiagnosticSetFromTU(_Unit)
+    val res = kni_clang_getDiagnosticSetFromTU(_Unit)
     return interpretCPointer<COpaque>(res)
 }
 
+private external fun kni_clang_getDiagnosticSetFromTU(Unit: NativePtr): NativePtr
+
 fun clang_disposeDiagnostic(Diagnostic: CXDiagnostic?): Unit {
     val _Diagnostic = Diagnostic.rawValue
-    val res = externals.clang_disposeDiagnostic(_Diagnostic)
+    val res = kni_clang_disposeDiagnostic(_Diagnostic)
     return res
 }
+
+private external fun kni_clang_disposeDiagnostic(Diagnostic: NativePtr): Unit
 
 fun clang_formatDiagnostic(Diagnostic: CXDiagnostic?, Options: Int): CValue<CXString> {
     return memScoped {
         val _Diagnostic = Diagnostic.rawValue
         val _Options = Options
-        val res = externals.clang_formatDiagnostic(_Diagnostic, _Options, alloc<CXString>().rawPtr)
+        val res = kni_clang_formatDiagnostic(_Diagnostic, _Options, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_formatDiagnostic(Diagnostic: NativePtr, Options: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_defaultDiagnosticDisplayOptions(): Int {
-    val res = externals.clang_defaultDiagnosticDisplayOptions()
+    val res = kni_clang_defaultDiagnosticDisplayOptions()
     return res
 }
 
+private external fun kni_clang_defaultDiagnosticDisplayOptions(): Int
+
 fun clang_getDiagnosticSeverity(arg0: CXDiagnostic?): CXDiagnosticSeverity {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_getDiagnosticSeverity(_arg0)
+    val res = kni_clang_getDiagnosticSeverity(_arg0)
     return CXDiagnosticSeverity.byValue(res)
 }
+
+private external fun kni_clang_getDiagnosticSeverity(arg0: NativePtr): Int
 
 fun clang_getDiagnosticLocation(arg0: CXDiagnostic?): CValue<CXSourceLocation> {
     return memScoped {
         val _arg0 = arg0.rawValue
-        val res = externals.clang_getDiagnosticLocation(_arg0, alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_getDiagnosticLocation(_arg0, alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
 
+private external fun kni_clang_getDiagnosticLocation(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getDiagnosticSpelling(arg0: CXDiagnostic?): CValue<CXString> {
     return memScoped {
         val _arg0 = arg0.rawValue
-        val res = externals.clang_getDiagnosticSpelling(_arg0, alloc<CXString>().rawPtr)
+        val res = kni_clang_getDiagnosticSpelling(_arg0, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getDiagnosticSpelling(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getDiagnosticOption(Diag: CXDiagnostic?, Disable: CValuesRef<CXString>?): CValue<CXString> {
     return memScoped {
         val _Diag = Diag.rawValue
         val _Disable = Disable?.getPointer(memScope).rawValue
-        val res = externals.clang_getDiagnosticOption(_Diag, _Disable, alloc<CXString>().rawPtr)
+        val res = kni_clang_getDiagnosticOption(_Diag, _Disable, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getDiagnosticOption(Diag: NativePtr, Disable: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getDiagnosticCategory(arg0: CXDiagnostic?): Int {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_getDiagnosticCategory(_arg0)
+    val res = kni_clang_getDiagnosticCategory(_arg0)
     return res
 }
+
+private external fun kni_clang_getDiagnosticCategory(arg0: NativePtr): Int
 
 fun clang_getDiagnosticCategoryName(Category: Int): CValue<CXString> {
     return memScoped {
         val _Category = Category
-        val res = externals.clang_getDiagnosticCategoryName(_Category, alloc<CXString>().rawPtr)
+        val res = kni_clang_getDiagnosticCategoryName(_Category, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getDiagnosticCategoryName(Category: Int, retValPlacement: NativePtr): NativePtr
 
 fun clang_getDiagnosticCategoryText(arg0: CXDiagnostic?): CValue<CXString> {
     return memScoped {
         val _arg0 = arg0.rawValue
-        val res = externals.clang_getDiagnosticCategoryText(_arg0, alloc<CXString>().rawPtr)
+        val res = kni_clang_getDiagnosticCategoryText(_arg0, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getDiagnosticCategoryText(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getDiagnosticNumRanges(arg0: CXDiagnostic?): Int {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_getDiagnosticNumRanges(_arg0)
+    val res = kni_clang_getDiagnosticNumRanges(_arg0)
     return res
 }
+
+private external fun kni_clang_getDiagnosticNumRanges(arg0: NativePtr): Int
 
 fun clang_getDiagnosticRange(Diagnostic: CXDiagnostic?, Range: Int): CValue<CXSourceRange> {
     return memScoped {
         val _Diagnostic = Diagnostic.rawValue
         val _Range = Range
-        val res = externals.clang_getDiagnosticRange(_Diagnostic, _Range, alloc<CXSourceRange>().rawPtr)
+        val res = kni_clang_getDiagnosticRange(_Diagnostic, _Range, alloc<CXSourceRange>().rawPtr)
         interpretPointed<CXSourceRange>(res).readValue()
     }
 }
 
+private external fun kni_clang_getDiagnosticRange(Diagnostic: NativePtr, Range: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_getDiagnosticNumFixIts(Diagnostic: CXDiagnostic?): Int {
     val _Diagnostic = Diagnostic.rawValue
-    val res = externals.clang_getDiagnosticNumFixIts(_Diagnostic)
+    val res = kni_clang_getDiagnosticNumFixIts(_Diagnostic)
     return res
 }
+
+private external fun kni_clang_getDiagnosticNumFixIts(Diagnostic: NativePtr): Int
 
 fun clang_getDiagnosticFixIt(Diagnostic: CXDiagnostic?, FixIt: Int, ReplacementRange: CValuesRef<CXSourceRange>?): CValue<CXString> {
     return memScoped {
         val _Diagnostic = Diagnostic.rawValue
         val _FixIt = FixIt
         val _ReplacementRange = ReplacementRange?.getPointer(memScope).rawValue
-        val res = externals.clang_getDiagnosticFixIt(_Diagnostic, _FixIt, _ReplacementRange, alloc<CXString>().rawPtr)
+        val res = kni_clang_getDiagnosticFixIt(_Diagnostic, _FixIt, _ReplacementRange, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getDiagnosticFixIt(Diagnostic: NativePtr, FixIt: Int, ReplacementRange: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getTranslationUnitSpelling(CTUnit: CXTranslationUnit?): CValue<CXString> {
     return memScoped {
         val _CTUnit = CTUnit.rawValue
-        val res = externals.clang_getTranslationUnitSpelling(_CTUnit, alloc<CXString>().rawPtr)
+        val res = kni_clang_getTranslationUnitSpelling(_CTUnit, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getTranslationUnitSpelling(CTUnit: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_createTranslationUnitFromSourceFile(CIdx: CXIndex?, source_filename: String?, num_clang_command_line_args: Int, clang_command_line_args: CValuesRef<CPointerVar<ByteVar>>?, num_unsaved_files: Int, unsaved_files: CValuesRef<CXUnsavedFile>?): CXTranslationUnit? {
     return memScoped {
@@ -762,34 +949,42 @@ fun clang_createTranslationUnitFromSourceFile(CIdx: CXIndex?, source_filename: S
         val _clang_command_line_args = clang_command_line_args?.getPointer(memScope).rawValue
         val _num_unsaved_files = num_unsaved_files
         val _unsaved_files = unsaved_files?.getPointer(memScope).rawValue
-        val res = externals.clang_createTranslationUnitFromSourceFile(_CIdx, _source_filename, _num_clang_command_line_args, _clang_command_line_args, _num_unsaved_files, _unsaved_files)
+        val res = kni_clang_createTranslationUnitFromSourceFile(_CIdx, _source_filename, _num_clang_command_line_args, _clang_command_line_args, _num_unsaved_files, _unsaved_files)
         interpretCPointer<CXTranslationUnitImpl>(res)
     }
 }
+
+private external fun kni_clang_createTranslationUnitFromSourceFile(CIdx: NativePtr, source_filename: NativePtr, num_clang_command_line_args: Int, clang_command_line_args: NativePtr, num_unsaved_files: Int, unsaved_files: NativePtr): NativePtr
 
 fun clang_createTranslationUnit(CIdx: CXIndex?, ast_filename: String?): CXTranslationUnit? {
     return memScoped {
         val _CIdx = CIdx.rawValue
         val _ast_filename = ast_filename?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_createTranslationUnit(_CIdx, _ast_filename)
+        val res = kni_clang_createTranslationUnit(_CIdx, _ast_filename)
         interpretCPointer<CXTranslationUnitImpl>(res)
     }
 }
+
+private external fun kni_clang_createTranslationUnit(CIdx: NativePtr, ast_filename: NativePtr): NativePtr
 
 fun clang_createTranslationUnit2(CIdx: CXIndex?, ast_filename: String?, out_TU: CValuesRef<CXTranslationUnitVar>?): CXErrorCode {
     return memScoped {
         val _CIdx = CIdx.rawValue
         val _ast_filename = ast_filename?.cstr?.getPointer(memScope).rawValue
         val _out_TU = out_TU?.getPointer(memScope).rawValue
-        val res = externals.clang_createTranslationUnit2(_CIdx, _ast_filename, _out_TU)
+        val res = kni_clang_createTranslationUnit2(_CIdx, _ast_filename, _out_TU)
         CXErrorCode.byValue(res)
     }
 }
 
+private external fun kni_clang_createTranslationUnit2(CIdx: NativePtr, ast_filename: NativePtr, out_TU: NativePtr): Int
+
 fun clang_defaultEditingTranslationUnitOptions(): Int {
-    val res = externals.clang_defaultEditingTranslationUnitOptions()
+    val res = kni_clang_defaultEditingTranslationUnitOptions()
     return res
 }
+
+private external fun kni_clang_defaultEditingTranslationUnitOptions(): Int
 
 fun clang_parseTranslationUnit(CIdx: CXIndex?, source_filename: String?, command_line_args: CValuesRef<CPointerVar<ByteVar>>?, num_command_line_args: Int, unsaved_files: CValuesRef<CXUnsavedFile>?, num_unsaved_files: Int, options: Int): CXTranslationUnit? {
     return memScoped {
@@ -800,10 +995,12 @@ fun clang_parseTranslationUnit(CIdx: CXIndex?, source_filename: String?, command
         val _unsaved_files = unsaved_files?.getPointer(memScope).rawValue
         val _num_unsaved_files = num_unsaved_files
         val _options = options
-        val res = externals.clang_parseTranslationUnit(_CIdx, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _options)
+        val res = kni_clang_parseTranslationUnit(_CIdx, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _options)
         interpretCPointer<CXTranslationUnitImpl>(res)
     }
 }
+
+private external fun kni_clang_parseTranslationUnit(CIdx: NativePtr, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, options: Int): NativePtr
 
 fun clang_parseTranslationUnit2(CIdx: CXIndex?, source_filename: String?, command_line_args: CValuesRef<CPointerVar<ByteVar>>?, num_command_line_args: Int, unsaved_files: CValuesRef<CXUnsavedFile>?, num_unsaved_files: Int, options: Int, out_TU: CValuesRef<CXTranslationUnitVar>?): CXErrorCode {
     return memScoped {
@@ -815,10 +1012,12 @@ fun clang_parseTranslationUnit2(CIdx: CXIndex?, source_filename: String?, comman
         val _num_unsaved_files = num_unsaved_files
         val _options = options
         val _out_TU = out_TU?.getPointer(memScope).rawValue
-        val res = externals.clang_parseTranslationUnit2(_CIdx, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _options, _out_TU)
+        val res = kni_clang_parseTranslationUnit2(_CIdx, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _options, _out_TU)
         CXErrorCode.byValue(res)
     }
 }
+
+private external fun kni_clang_parseTranslationUnit2(CIdx: NativePtr, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, options: Int, out_TU: NativePtr): Int
 
 fun clang_parseTranslationUnit2FullArgv(CIdx: CXIndex?, source_filename: String?, command_line_args: CValuesRef<CPointerVar<ByteVar>>?, num_command_line_args: Int, unsaved_files: CValuesRef<CXUnsavedFile>?, num_unsaved_files: Int, options: Int, out_TU: CValuesRef<CXTranslationUnitVar>?): CXErrorCode {
     return memScoped {
@@ -830,38 +1029,48 @@ fun clang_parseTranslationUnit2FullArgv(CIdx: CXIndex?, source_filename: String?
         val _num_unsaved_files = num_unsaved_files
         val _options = options
         val _out_TU = out_TU?.getPointer(memScope).rawValue
-        val res = externals.clang_parseTranslationUnit2FullArgv(_CIdx, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _options, _out_TU)
+        val res = kni_clang_parseTranslationUnit2FullArgv(_CIdx, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _options, _out_TU)
         CXErrorCode.byValue(res)
     }
 }
 
+private external fun kni_clang_parseTranslationUnit2FullArgv(CIdx: NativePtr, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, options: Int, out_TU: NativePtr): Int
+
 fun clang_defaultSaveOptions(TU: CXTranslationUnit?): Int {
     val _TU = TU.rawValue
-    val res = externals.clang_defaultSaveOptions(_TU)
+    val res = kni_clang_defaultSaveOptions(_TU)
     return res
 }
+
+private external fun kni_clang_defaultSaveOptions(TU: NativePtr): Int
 
 fun clang_saveTranslationUnit(TU: CXTranslationUnit?, FileName: String?, options: Int): Int {
     return memScoped {
         val _TU = TU.rawValue
         val _FileName = FileName?.cstr?.getPointer(memScope).rawValue
         val _options = options
-        val res = externals.clang_saveTranslationUnit(_TU, _FileName, _options)
+        val res = kni_clang_saveTranslationUnit(_TU, _FileName, _options)
         res
     }
 }
 
+private external fun kni_clang_saveTranslationUnit(TU: NativePtr, FileName: NativePtr, options: Int): Int
+
 fun clang_disposeTranslationUnit(arg0: CXTranslationUnit?): Unit {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_disposeTranslationUnit(_arg0)
+    val res = kni_clang_disposeTranslationUnit(_arg0)
     return res
 }
 
+private external fun kni_clang_disposeTranslationUnit(arg0: NativePtr): Unit
+
 fun clang_defaultReparseOptions(TU: CXTranslationUnit?): Int {
     val _TU = TU.rawValue
-    val res = externals.clang_defaultReparseOptions(_TU)
+    val res = kni_clang_defaultReparseOptions(_TU)
     return res
 }
+
+private external fun kni_clang_defaultReparseOptions(TU: NativePtr): Int
 
 fun clang_reparseTranslationUnit(TU: CXTranslationUnit?, num_unsaved_files: Int, unsaved_files: CValuesRef<CXUnsavedFile>?, options: Int): Int {
     return memScoped {
@@ -869,166 +1078,212 @@ fun clang_reparseTranslationUnit(TU: CXTranslationUnit?, num_unsaved_files: Int,
         val _num_unsaved_files = num_unsaved_files
         val _unsaved_files = unsaved_files?.getPointer(memScope).rawValue
         val _options = options
-        val res = externals.clang_reparseTranslationUnit(_TU, _num_unsaved_files, _unsaved_files, _options)
+        val res = kni_clang_reparseTranslationUnit(_TU, _num_unsaved_files, _unsaved_files, _options)
         res
     }
 }
 
+private external fun kni_clang_reparseTranslationUnit(TU: NativePtr, num_unsaved_files: Int, unsaved_files: NativePtr, options: Int): Int
+
 fun clang_getTUResourceUsageName(kind: CXTUResourceUsageKind): CPointer<ByteVar>? {
     val _kind = kind.value
-    val res = externals.clang_getTUResourceUsageName(_kind)
+    val res = kni_clang_getTUResourceUsageName(_kind)
     return interpretCPointer<ByteVar>(res)
 }
+
+private external fun kni_clang_getTUResourceUsageName(kind: Int): NativePtr
 
 fun clang_getCXTUResourceUsage(TU: CXTranslationUnit?): CValue<CXTUResourceUsage> {
     return memScoped {
         val _TU = TU.rawValue
-        val res = externals.clang_getCXTUResourceUsage(_TU, alloc<CXTUResourceUsage>().rawPtr)
+        val res = kni_clang_getCXTUResourceUsage(_TU, alloc<CXTUResourceUsage>().rawPtr)
         interpretPointed<CXTUResourceUsage>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCXTUResourceUsage(TU: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_disposeCXTUResourceUsage(usage: CValue<CXTUResourceUsage>): Unit {
     return memScoped {
         val _usage = usage.getPointer(memScope).rawValue
-        val res = externals.clang_disposeCXTUResourceUsage(_usage)
+        val res = kni_clang_disposeCXTUResourceUsage(_usage)
         res
     }
 }
 
+private external fun kni_clang_disposeCXTUResourceUsage(usage: NativePtr): Unit
+
 fun clang_getNullCursor(): CValue<CXCursor> {
     return memScoped {
-        val res = externals.clang_getNullCursor(alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getNullCursor(alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
 
+private external fun kni_clang_getNullCursor(retValPlacement: NativePtr): NativePtr
+
 fun clang_getTranslationUnitCursor(arg0: CXTranslationUnit?): CValue<CXCursor> {
     return memScoped {
         val _arg0 = arg0.rawValue
-        val res = externals.clang_getTranslationUnitCursor(_arg0, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getTranslationUnitCursor(_arg0, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
+
+private external fun kni_clang_getTranslationUnitCursor(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_equalCursors(arg0: CValue<CXCursor>, arg1: CValue<CXCursor>): Int {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
         val _arg1 = arg1.getPointer(memScope).rawValue
-        val res = externals.clang_equalCursors(_arg0, _arg1)
+        val res = kni_clang_equalCursors(_arg0, _arg1)
         res
     }
 }
+
+private external fun kni_clang_equalCursors(arg0: NativePtr, arg1: NativePtr): Int
 
 fun clang_Cursor_isNull(cursor: CValue<CXCursor>): Int {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isNull(_cursor)
+        val res = kni_clang_Cursor_isNull(_cursor)
         res
     }
 }
+
+private external fun kni_clang_Cursor_isNull(cursor: NativePtr): Int
 
 fun clang_hashCursor(arg0: CValue<CXCursor>): Int {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_hashCursor(_arg0)
+        val res = kni_clang_hashCursor(_arg0)
         res
     }
 }
+
+private external fun kni_clang_hashCursor(arg0: NativePtr): Int
 
 fun clang_getCursorKind(arg0: CValue<CXCursor>): CXCursorKind {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorKind(_arg0)
+        val res = kni_clang_getCursorKind(_arg0)
         CXCursorKind.byValue(res)
     }
 }
 
+private external fun kni_clang_getCursorKind(arg0: NativePtr): Int
+
 fun clang_isDeclaration(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isDeclaration(_arg0)
+    val res = kni_clang_isDeclaration(_arg0)
     return res
 }
+
+private external fun kni_clang_isDeclaration(arg0: Int): Int
 
 fun clang_isReference(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isReference(_arg0)
+    val res = kni_clang_isReference(_arg0)
     return res
 }
+
+private external fun kni_clang_isReference(arg0: Int): Int
 
 fun clang_isExpression(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isExpression(_arg0)
+    val res = kni_clang_isExpression(_arg0)
     return res
 }
+
+private external fun kni_clang_isExpression(arg0: Int): Int
 
 fun clang_isStatement(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isStatement(_arg0)
+    val res = kni_clang_isStatement(_arg0)
     return res
 }
 
+private external fun kni_clang_isStatement(arg0: Int): Int
+
 fun clang_isAttribute(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isAttribute(_arg0)
+    val res = kni_clang_isAttribute(_arg0)
     return res
 }
+
+private external fun kni_clang_isAttribute(arg0: Int): Int
 
 fun clang_Cursor_hasAttrs(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_hasAttrs(_C)
+        val res = kni_clang_Cursor_hasAttrs(_C)
         res
     }
 }
 
+private external fun kni_clang_Cursor_hasAttrs(C: NativePtr): Int
+
 fun clang_isInvalid(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isInvalid(_arg0)
+    val res = kni_clang_isInvalid(_arg0)
     return res
 }
+
+private external fun kni_clang_isInvalid(arg0: Int): Int
 
 fun clang_isTranslationUnit(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isTranslationUnit(_arg0)
+    val res = kni_clang_isTranslationUnit(_arg0)
     return res
 }
+
+private external fun kni_clang_isTranslationUnit(arg0: Int): Int
 
 fun clang_isPreprocessing(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isPreprocessing(_arg0)
+    val res = kni_clang_isPreprocessing(_arg0)
     return res
 }
 
+private external fun kni_clang_isPreprocessing(arg0: Int): Int
+
 fun clang_isUnexposed(arg0: CXCursorKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_isUnexposed(_arg0)
+    val res = kni_clang_isUnexposed(_arg0)
     return res
 }
+
+private external fun kni_clang_isUnexposed(arg0: Int): Int
 
 fun clang_getCursorLinkage(cursor: CValue<CXCursor>): CXLinkageKind {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorLinkage(_cursor)
+        val res = kni_clang_getCursorLinkage(_cursor)
         CXLinkageKind.byValue(res)
     }
 }
 
+private external fun kni_clang_getCursorLinkage(cursor: NativePtr): Int
+
 fun clang_getCursorVisibility(cursor: CValue<CXCursor>): CXVisibilityKind {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorVisibility(_cursor)
+        val res = kni_clang_getCursorVisibility(_cursor)
         CXVisibilityKind.byValue(res)
     }
 }
 
+private external fun kni_clang_getCursorVisibility(cursor: NativePtr): Int
+
 fun clang_getCursorAvailability(cursor: CValue<CXCursor>): CXAvailabilityKind {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorAvailability(_cursor)
+        val res = kni_clang_getCursorAvailability(_cursor)
         CXAvailabilityKind.byValue(res)
     }
 }
+
+private external fun kni_clang_getCursorAvailability(cursor: NativePtr): Int
 
 fun clang_getCursorPlatformAvailability(cursor: CValue<CXCursor>, always_deprecated: CValuesRef<IntVar>?, deprecated_message: CValuesRef<CXString>?, always_unavailable: CValuesRef<IntVar>?, unavailable_message: CValuesRef<CXString>?, availability: CValuesRef<CXPlatformAvailability>?, availability_size: Int): Int {
     return memScoped {
@@ -1039,1011 +1294,1259 @@ fun clang_getCursorPlatformAvailability(cursor: CValue<CXCursor>, always_depreca
         val _unavailable_message = unavailable_message?.getPointer(memScope).rawValue
         val _availability = availability?.getPointer(memScope).rawValue
         val _availability_size = availability_size
-        val res = externals.clang_getCursorPlatformAvailability(_cursor, _always_deprecated, _deprecated_message, _always_unavailable, _unavailable_message, _availability, _availability_size)
+        val res = kni_clang_getCursorPlatformAvailability(_cursor, _always_deprecated, _deprecated_message, _always_unavailable, _unavailable_message, _availability, _availability_size)
         res
     }
 }
+
+private external fun kni_clang_getCursorPlatformAvailability(cursor: NativePtr, always_deprecated: NativePtr, deprecated_message: NativePtr, always_unavailable: NativePtr, unavailable_message: NativePtr, availability: NativePtr, availability_size: Int): Int
 
 fun clang_disposeCXPlatformAvailability(availability: CValuesRef<CXPlatformAvailability>?): Unit {
     return memScoped {
         val _availability = availability?.getPointer(memScope).rawValue
-        val res = externals.clang_disposeCXPlatformAvailability(_availability)
+        val res = kni_clang_disposeCXPlatformAvailability(_availability)
         res
     }
 }
 
+private external fun kni_clang_disposeCXPlatformAvailability(availability: NativePtr): Unit
+
 fun clang_getCursorLanguage(cursor: CValue<CXCursor>): CXLanguageKind {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorLanguage(_cursor)
+        val res = kni_clang_getCursorLanguage(_cursor)
         CXLanguageKind.byValue(res)
     }
 }
 
+private external fun kni_clang_getCursorLanguage(cursor: NativePtr): Int
+
 fun clang_Cursor_getTranslationUnit(arg0: CValue<CXCursor>): CXTranslationUnit? {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getTranslationUnit(_arg0)
+        val res = kni_clang_Cursor_getTranslationUnit(_arg0)
         interpretCPointer<CXTranslationUnitImpl>(res)
     }
 }
 
+private external fun kni_clang_Cursor_getTranslationUnit(arg0: NativePtr): NativePtr
+
 fun clang_createCXCursorSet(): CXCursorSet? {
-    val res = externals.clang_createCXCursorSet()
+    val res = kni_clang_createCXCursorSet()
     return interpretCPointer<CXCursorSetImpl>(res)
 }
 
+private external fun kni_clang_createCXCursorSet(): NativePtr
+
 fun clang_disposeCXCursorSet(cset: CXCursorSet?): Unit {
     val _cset = cset.rawValue
-    val res = externals.clang_disposeCXCursorSet(_cset)
+    val res = kni_clang_disposeCXCursorSet(_cset)
     return res
 }
+
+private external fun kni_clang_disposeCXCursorSet(cset: NativePtr): Unit
 
 fun clang_CXCursorSet_contains(cset: CXCursorSet?, cursor: CValue<CXCursor>): Int {
     return memScoped {
         val _cset = cset.rawValue
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_CXCursorSet_contains(_cset, _cursor)
+        val res = kni_clang_CXCursorSet_contains(_cset, _cursor)
         res
     }
 }
+
+private external fun kni_clang_CXCursorSet_contains(cset: NativePtr, cursor: NativePtr): Int
 
 fun clang_CXCursorSet_insert(cset: CXCursorSet?, cursor: CValue<CXCursor>): Int {
     return memScoped {
         val _cset = cset.rawValue
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_CXCursorSet_insert(_cset, _cursor)
+        val res = kni_clang_CXCursorSet_insert(_cset, _cursor)
         res
     }
 }
 
+private external fun kni_clang_CXCursorSet_insert(cset: NativePtr, cursor: NativePtr): Int
+
 fun clang_getCursorSemanticParent(cursor: CValue<CXCursor>): CValue<CXCursor> {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorSemanticParent(_cursor, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getCursorSemanticParent(_cursor, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCursorSemanticParent(cursor: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCursorLexicalParent(cursor: CValue<CXCursor>): CValue<CXCursor> {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorLexicalParent(_cursor, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getCursorLexicalParent(_cursor, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCursorLexicalParent(cursor: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getOverriddenCursors(cursor: CValue<CXCursor>, overridden: CValuesRef<CPointerVar<CXCursor>>?, num_overridden: CValuesRef<IntVar>?): Unit {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
         val _overridden = overridden?.getPointer(memScope).rawValue
         val _num_overridden = num_overridden?.getPointer(memScope).rawValue
-        val res = externals.clang_getOverriddenCursors(_cursor, _overridden, _num_overridden)
+        val res = kni_clang_getOverriddenCursors(_cursor, _overridden, _num_overridden)
         res
     }
 }
+
+private external fun kni_clang_getOverriddenCursors(cursor: NativePtr, overridden: NativePtr, num_overridden: NativePtr): Unit
 
 fun clang_disposeOverriddenCursors(overridden: CValuesRef<CXCursor>?): Unit {
     return memScoped {
         val _overridden = overridden?.getPointer(memScope).rawValue
-        val res = externals.clang_disposeOverriddenCursors(_overridden)
+        val res = kni_clang_disposeOverriddenCursors(_overridden)
         res
     }
 }
 
+private external fun kni_clang_disposeOverriddenCursors(overridden: NativePtr): Unit
+
 fun clang_getIncludedFile(cursor: CValue<CXCursor>): CXFile? {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getIncludedFile(_cursor)
+        val res = kni_clang_getIncludedFile(_cursor)
         interpretCPointer<COpaque>(res)
     }
 }
+
+private external fun kni_clang_getIncludedFile(cursor: NativePtr): NativePtr
 
 fun clang_getCursor(arg0: CXTranslationUnit?, arg1: CValue<CXSourceLocation>): CValue<CXCursor> {
     return memScoped {
         val _arg0 = arg0.rawValue
         val _arg1 = arg1.getPointer(memScope).rawValue
-        val res = externals.clang_getCursor(_arg0, _arg1, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getCursor(_arg0, _arg1, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCursor(arg0: NativePtr, arg1: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCursorLocation(arg0: CValue<CXCursor>): CValue<CXSourceLocation> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorLocation(_arg0, alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_getCursorLocation(_arg0, alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCursorLocation(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCursorExtent(arg0: CValue<CXCursor>): CValue<CXSourceRange> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorExtent(_arg0, alloc<CXSourceRange>().rawPtr)
+        val res = kni_clang_getCursorExtent(_arg0, alloc<CXSourceRange>().rawPtr)
         interpretPointed<CXSourceRange>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCursorExtent(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCursorType(C: CValue<CXCursor>): CValue<CXType> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorType(_C, alloc<CXType>().rawPtr)
+        val res = kni_clang_getCursorType(_C, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCursorType(C: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getTypeSpelling(CT: CValue<CXType>): CValue<CXString> {
     return memScoped {
         val _CT = CT.getPointer(memScope).rawValue
-        val res = externals.clang_getTypeSpelling(_CT, alloc<CXString>().rawPtr)
+        val res = kni_clang_getTypeSpelling(_CT, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getTypeSpelling(CT: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getTypedefDeclUnderlyingType(C: CValue<CXCursor>): CValue<CXType> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getTypedefDeclUnderlyingType(_C, alloc<CXType>().rawPtr)
+        val res = kni_clang_getTypedefDeclUnderlyingType(_C, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getTypedefDeclUnderlyingType(C: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getEnumDeclIntegerType(C: CValue<CXCursor>): CValue<CXType> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getEnumDeclIntegerType(_C, alloc<CXType>().rawPtr)
+        val res = kni_clang_getEnumDeclIntegerType(_C, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
 
+private external fun kni_clang_getEnumDeclIntegerType(C: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getEnumConstantDeclValue(C: CValue<CXCursor>): Long {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getEnumConstantDeclValue(_C)
+        val res = kni_clang_getEnumConstantDeclValue(_C)
         res
     }
 }
+
+private external fun kni_clang_getEnumConstantDeclValue(C: NativePtr): Long
 
 fun clang_getEnumConstantDeclUnsignedValue(C: CValue<CXCursor>): Long {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getEnumConstantDeclUnsignedValue(_C)
+        val res = kni_clang_getEnumConstantDeclUnsignedValue(_C)
         res
     }
 }
+
+private external fun kni_clang_getEnumConstantDeclUnsignedValue(C: NativePtr): Long
 
 fun clang_getFieldDeclBitWidth(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getFieldDeclBitWidth(_C)
+        val res = kni_clang_getFieldDeclBitWidth(_C)
         res
     }
 }
 
+private external fun kni_clang_getFieldDeclBitWidth(C: NativePtr): Int
+
 fun clang_Cursor_getNumArguments(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getNumArguments(_C)
+        val res = kni_clang_Cursor_getNumArguments(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_getNumArguments(C: NativePtr): Int
 
 fun clang_Cursor_getArgument(C: CValue<CXCursor>, i: Int): CValue<CXCursor> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
         val _i = i
-        val res = externals.clang_Cursor_getArgument(_C, _i, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_Cursor_getArgument(_C, _i, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
 
+private external fun kni_clang_Cursor_getArgument(C: NativePtr, i: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_Cursor_getNumTemplateArguments(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getNumTemplateArguments(_C)
+        val res = kni_clang_Cursor_getNumTemplateArguments(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_getNumTemplateArguments(C: NativePtr): Int
 
 fun clang_Cursor_getTemplateArgumentKind(C: CValue<CXCursor>, I: Int): CXTemplateArgumentKind {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
         val _I = I
-        val res = externals.clang_Cursor_getTemplateArgumentKind(_C, _I)
+        val res = kni_clang_Cursor_getTemplateArgumentKind(_C, _I)
         CXTemplateArgumentKind.byValue(res)
     }
 }
+
+private external fun kni_clang_Cursor_getTemplateArgumentKind(C: NativePtr, I: Int): Int
 
 fun clang_Cursor_getTemplateArgumentType(C: CValue<CXCursor>, I: Int): CValue<CXType> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
         val _I = I
-        val res = externals.clang_Cursor_getTemplateArgumentType(_C, _I, alloc<CXType>().rawPtr)
+        val res = kni_clang_Cursor_getTemplateArgumentType(_C, _I, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_Cursor_getTemplateArgumentType(C: NativePtr, I: Int, retValPlacement: NativePtr): NativePtr
 
 fun clang_Cursor_getTemplateArgumentValue(C: CValue<CXCursor>, I: Int): Long {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
         val _I = I
-        val res = externals.clang_Cursor_getTemplateArgumentValue(_C, _I)
+        val res = kni_clang_Cursor_getTemplateArgumentValue(_C, _I)
         res
     }
 }
+
+private external fun kni_clang_Cursor_getTemplateArgumentValue(C: NativePtr, I: Int): Long
 
 fun clang_Cursor_getTemplateArgumentUnsignedValue(C: CValue<CXCursor>, I: Int): Long {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
         val _I = I
-        val res = externals.clang_Cursor_getTemplateArgumentUnsignedValue(_C, _I)
+        val res = kni_clang_Cursor_getTemplateArgumentUnsignedValue(_C, _I)
         res
     }
 }
+
+private external fun kni_clang_Cursor_getTemplateArgumentUnsignedValue(C: NativePtr, I: Int): Long
 
 fun clang_equalTypes(A: CValue<CXType>, B: CValue<CXType>): Int {
     return memScoped {
         val _A = A.getPointer(memScope).rawValue
         val _B = B.getPointer(memScope).rawValue
-        val res = externals.clang_equalTypes(_A, _B)
+        val res = kni_clang_equalTypes(_A, _B)
         res
     }
 }
+
+private external fun kni_clang_equalTypes(A: NativePtr, B: NativePtr): Int
 
 fun clang_getCanonicalType(T: CValue<CXType>): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getCanonicalType(_T, alloc<CXType>().rawPtr)
+        val res = kni_clang_getCanonicalType(_T, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCanonicalType(T: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_isConstQualifiedType(T: CValue<CXType>): Int {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_isConstQualifiedType(_T)
+        val res = kni_clang_isConstQualifiedType(_T)
         res
     }
 }
+
+private external fun kni_clang_isConstQualifiedType(T: NativePtr): Int
 
 fun clang_Cursor_isMacroFunctionLike(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isMacroFunctionLike(_C)
+        val res = kni_clang_Cursor_isMacroFunctionLike(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_isMacroFunctionLike(C: NativePtr): Int
 
 fun clang_Cursor_isMacroBuiltin(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isMacroBuiltin(_C)
+        val res = kni_clang_Cursor_isMacroBuiltin(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_isMacroBuiltin(C: NativePtr): Int
 
 fun clang_Cursor_isFunctionInlined(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isFunctionInlined(_C)
+        val res = kni_clang_Cursor_isFunctionInlined(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_isFunctionInlined(C: NativePtr): Int
 
 fun clang_isVolatileQualifiedType(T: CValue<CXType>): Int {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_isVolatileQualifiedType(_T)
+        val res = kni_clang_isVolatileQualifiedType(_T)
         res
     }
 }
+
+private external fun kni_clang_isVolatileQualifiedType(T: NativePtr): Int
 
 fun clang_isRestrictQualifiedType(T: CValue<CXType>): Int {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_isRestrictQualifiedType(_T)
+        val res = kni_clang_isRestrictQualifiedType(_T)
         res
     }
 }
+
+private external fun kni_clang_isRestrictQualifiedType(T: NativePtr): Int
 
 fun clang_getPointeeType(T: CValue<CXType>): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getPointeeType(_T, alloc<CXType>().rawPtr)
+        val res = kni_clang_getPointeeType(_T, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getPointeeType(T: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getTypeDeclaration(T: CValue<CXType>): CValue<CXCursor> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getTypeDeclaration(_T, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getTypeDeclaration(_T, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
 
+private external fun kni_clang_getTypeDeclaration(T: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getDeclObjCTypeEncoding(C: CValue<CXCursor>): CValue<CXString> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getDeclObjCTypeEncoding(_C, alloc<CXString>().rawPtr)
+        val res = kni_clang_getDeclObjCTypeEncoding(_C, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getDeclObjCTypeEncoding(C: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Type_getObjCEncoding(type: CValue<CXType>): CValue<CXString> {
     return memScoped {
         val _type = type.getPointer(memScope).rawValue
-        val res = externals.clang_Type_getObjCEncoding(_type, alloc<CXString>().rawPtr)
+        val res = kni_clang_Type_getObjCEncoding(_type, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_Type_getObjCEncoding(type: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getTypeKindSpelling(K: CXTypeKind): CValue<CXString> {
     return memScoped {
         val _K = K.value
-        val res = externals.clang_getTypeKindSpelling(_K, alloc<CXString>().rawPtr)
+        val res = kni_clang_getTypeKindSpelling(_K, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getTypeKindSpelling(K: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_getFunctionTypeCallingConv(T: CValue<CXType>): CXCallingConv {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getFunctionTypeCallingConv(_T)
+        val res = kni_clang_getFunctionTypeCallingConv(_T)
         CXCallingConv.byValue(res)
     }
 }
 
+private external fun kni_clang_getFunctionTypeCallingConv(T: NativePtr): Int
+
 fun clang_getResultType(T: CValue<CXType>): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getResultType(_T, alloc<CXType>().rawPtr)
+        val res = kni_clang_getResultType(_T, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
 
+private external fun kni_clang_getResultType(T: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getNumArgTypes(T: CValue<CXType>): Int {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getNumArgTypes(_T)
+        val res = kni_clang_getNumArgTypes(_T)
         res
     }
 }
+
+private external fun kni_clang_getNumArgTypes(T: NativePtr): Int
 
 fun clang_getArgType(T: CValue<CXType>, i: Int): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
         val _i = i
-        val res = externals.clang_getArgType(_T, _i, alloc<CXType>().rawPtr)
+        val res = kni_clang_getArgType(_T, _i, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getArgType(T: NativePtr, i: Int, retValPlacement: NativePtr): NativePtr
 
 fun clang_isFunctionTypeVariadic(T: CValue<CXType>): Int {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_isFunctionTypeVariadic(_T)
+        val res = kni_clang_isFunctionTypeVariadic(_T)
         res
     }
 }
+
+private external fun kni_clang_isFunctionTypeVariadic(T: NativePtr): Int
 
 fun clang_getCursorResultType(C: CValue<CXCursor>): CValue<CXType> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorResultType(_C, alloc<CXType>().rawPtr)
+        val res = kni_clang_getCursorResultType(_C, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCursorResultType(C: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_isPODType(T: CValue<CXType>): Int {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_isPODType(_T)
+        val res = kni_clang_isPODType(_T)
         res
     }
 }
+
+private external fun kni_clang_isPODType(T: NativePtr): Int
 
 fun clang_getElementType(T: CValue<CXType>): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getElementType(_T, alloc<CXType>().rawPtr)
+        val res = kni_clang_getElementType(_T, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getElementType(T: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getNumElements(T: CValue<CXType>): Long {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getNumElements(_T)
+        val res = kni_clang_getNumElements(_T)
         res
     }
 }
+
+private external fun kni_clang_getNumElements(T: NativePtr): Long
 
 fun clang_getArrayElementType(T: CValue<CXType>): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getArrayElementType(_T, alloc<CXType>().rawPtr)
+        val res = kni_clang_getArrayElementType(_T, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getArrayElementType(T: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getArraySize(T: CValue<CXType>): Long {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_getArraySize(_T)
+        val res = kni_clang_getArraySize(_T)
         res
     }
 }
+
+private external fun kni_clang_getArraySize(T: NativePtr): Long
 
 fun clang_Type_getNamedType(T: CValue<CXType>): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_Type_getNamedType(_T, alloc<CXType>().rawPtr)
+        val res = kni_clang_Type_getNamedType(_T, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_Type_getNamedType(T: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Type_getAlignOf(T: CValue<CXType>): Long {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_Type_getAlignOf(_T)
+        val res = kni_clang_Type_getAlignOf(_T)
         res
     }
 }
+
+private external fun kni_clang_Type_getAlignOf(T: NativePtr): Long
 
 fun clang_Type_getClassType(T: CValue<CXType>): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_Type_getClassType(_T, alloc<CXType>().rawPtr)
+        val res = kni_clang_Type_getClassType(_T, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
 
+private external fun kni_clang_Type_getClassType(T: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_Type_getSizeOf(T: CValue<CXType>): Long {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_Type_getSizeOf(_T)
+        val res = kni_clang_Type_getSizeOf(_T)
         res
     }
 }
+
+private external fun kni_clang_Type_getSizeOf(T: NativePtr): Long
 
 fun clang_Type_getOffsetOf(T: CValue<CXType>, S: String?): Long {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
         val _S = S?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_Type_getOffsetOf(_T, _S)
+        val res = kni_clang_Type_getOffsetOf(_T, _S)
         res
     }
 }
+
+private external fun kni_clang_Type_getOffsetOf(T: NativePtr, S: NativePtr): Long
 
 fun clang_Cursor_getOffsetOfField(C: CValue<CXCursor>): Long {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getOffsetOfField(_C)
+        val res = kni_clang_Cursor_getOffsetOfField(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_getOffsetOfField(C: NativePtr): Long
 
 fun clang_Cursor_isAnonymous(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isAnonymous(_C)
+        val res = kni_clang_Cursor_isAnonymous(_C)
         res
     }
 }
 
+private external fun kni_clang_Cursor_isAnonymous(C: NativePtr): Int
+
 fun clang_Type_getNumTemplateArguments(T: CValue<CXType>): Int {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_Type_getNumTemplateArguments(_T)
+        val res = kni_clang_Type_getNumTemplateArguments(_T)
         res
     }
 }
+
+private external fun kni_clang_Type_getNumTemplateArguments(T: NativePtr): Int
 
 fun clang_Type_getTemplateArgumentAsType(T: CValue<CXType>, i: Int): CValue<CXType> {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
         val _i = i
-        val res = externals.clang_Type_getTemplateArgumentAsType(_T, _i, alloc<CXType>().rawPtr)
+        val res = kni_clang_Type_getTemplateArgumentAsType(_T, _i, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
 
+private external fun kni_clang_Type_getTemplateArgumentAsType(T: NativePtr, i: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_Type_getCXXRefQualifier(T: CValue<CXType>): CXRefQualifierKind {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
-        val res = externals.clang_Type_getCXXRefQualifier(_T)
+        val res = kni_clang_Type_getCXXRefQualifier(_T)
         res
     }
 }
+
+private external fun kni_clang_Type_getCXXRefQualifier(T: NativePtr): Int
 
 fun clang_Cursor_isBitField(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isBitField(_C)
+        val res = kni_clang_Cursor_isBitField(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_isBitField(C: NativePtr): Int
 
 fun clang_isVirtualBase(arg0: CValue<CXCursor>): Int {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_isVirtualBase(_arg0)
+        val res = kni_clang_isVirtualBase(_arg0)
         res
     }
 }
+
+private external fun kni_clang_isVirtualBase(arg0: NativePtr): Int
 
 fun clang_getCXXAccessSpecifier(arg0: CValue<CXCursor>): CX_CXXAccessSpecifier {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCXXAccessSpecifier(_arg0)
+        val res = kni_clang_getCXXAccessSpecifier(_arg0)
         CX_CXXAccessSpecifier.byValue(res)
     }
 }
 
+private external fun kni_clang_getCXXAccessSpecifier(arg0: NativePtr): Int
+
 fun clang_Cursor_getStorageClass(arg0: CValue<CXCursor>): CX_StorageClass {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getStorageClass(_arg0)
+        val res = kni_clang_Cursor_getStorageClass(_arg0)
         CX_StorageClass.byValue(res)
     }
 }
 
+private external fun kni_clang_Cursor_getStorageClass(arg0: NativePtr): Int
+
 fun clang_getNumOverloadedDecls(cursor: CValue<CXCursor>): Int {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getNumOverloadedDecls(_cursor)
+        val res = kni_clang_getNumOverloadedDecls(_cursor)
         res
     }
 }
+
+private external fun kni_clang_getNumOverloadedDecls(cursor: NativePtr): Int
 
 fun clang_getOverloadedDecl(cursor: CValue<CXCursor>, index: Int): CValue<CXCursor> {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
         val _index = index
-        val res = externals.clang_getOverloadedDecl(_cursor, _index, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getOverloadedDecl(_cursor, _index, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
 
+private external fun kni_clang_getOverloadedDecl(cursor: NativePtr, index: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_getIBOutletCollectionType(arg0: CValue<CXCursor>): CValue<CXType> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getIBOutletCollectionType(_arg0, alloc<CXType>().rawPtr)
+        val res = kni_clang_getIBOutletCollectionType(_arg0, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_getIBOutletCollectionType(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_visitChildren(parent: CValue<CXCursor>, visitor: CXCursorVisitor?, client_data: CXClientData?): Int {
     return memScoped {
         val _parent = parent.getPointer(memScope).rawValue
         val _visitor = visitor.rawValue
         val _client_data = client_data.rawValue
-        val res = externals.clang_visitChildren(_parent, _visitor, _client_data)
+        val res = kni_clang_visitChildren(_parent, _visitor, _client_data)
         res
     }
 }
 
+private external fun kni_clang_visitChildren(parent: NativePtr, visitor: NativePtr, client_data: NativePtr): Int
+
 fun clang_getCursorUSR(arg0: CValue<CXCursor>): CValue<CXString> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorUSR(_arg0, alloc<CXString>().rawPtr)
+        val res = kni_clang_getCursorUSR(_arg0, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCursorUSR(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_constructUSR_ObjCClass(class_name: String?): CValue<CXString> {
     return memScoped {
         val _class_name = class_name?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_constructUSR_ObjCClass(_class_name, alloc<CXString>().rawPtr)
+        val res = kni_clang_constructUSR_ObjCClass(_class_name, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_constructUSR_ObjCClass(class_name: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_constructUSR_ObjCCategory(class_name: String?, category_name: String?): CValue<CXString> {
     return memScoped {
         val _class_name = class_name?.cstr?.getPointer(memScope).rawValue
         val _category_name = category_name?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_constructUSR_ObjCCategory(_class_name, _category_name, alloc<CXString>().rawPtr)
+        val res = kni_clang_constructUSR_ObjCCategory(_class_name, _category_name, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_constructUSR_ObjCCategory(class_name: NativePtr, category_name: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_constructUSR_ObjCProtocol(protocol_name: String?): CValue<CXString> {
     return memScoped {
         val _protocol_name = protocol_name?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_constructUSR_ObjCProtocol(_protocol_name, alloc<CXString>().rawPtr)
+        val res = kni_clang_constructUSR_ObjCProtocol(_protocol_name, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_constructUSR_ObjCProtocol(protocol_name: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_constructUSR_ObjCIvar(name: String?, classUSR: CValue<CXString>): CValue<CXString> {
     return memScoped {
         val _name = name?.cstr?.getPointer(memScope).rawValue
         val _classUSR = classUSR.getPointer(memScope).rawValue
-        val res = externals.clang_constructUSR_ObjCIvar(_name, _classUSR, alloc<CXString>().rawPtr)
+        val res = kni_clang_constructUSR_ObjCIvar(_name, _classUSR, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_constructUSR_ObjCIvar(name: NativePtr, classUSR: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_constructUSR_ObjCMethod(name: String?, isInstanceMethod: Int, classUSR: CValue<CXString>): CValue<CXString> {
     return memScoped {
         val _name = name?.cstr?.getPointer(memScope).rawValue
         val _isInstanceMethod = isInstanceMethod
         val _classUSR = classUSR.getPointer(memScope).rawValue
-        val res = externals.clang_constructUSR_ObjCMethod(_name, _isInstanceMethod, _classUSR, alloc<CXString>().rawPtr)
+        val res = kni_clang_constructUSR_ObjCMethod(_name, _isInstanceMethod, _classUSR, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_constructUSR_ObjCMethod(name: NativePtr, isInstanceMethod: Int, classUSR: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_constructUSR_ObjCProperty(property: String?, classUSR: CValue<CXString>): CValue<CXString> {
     return memScoped {
         val _property = property?.cstr?.getPointer(memScope).rawValue
         val _classUSR = classUSR.getPointer(memScope).rawValue
-        val res = externals.clang_constructUSR_ObjCProperty(_property, _classUSR, alloc<CXString>().rawPtr)
+        val res = kni_clang_constructUSR_ObjCProperty(_property, _classUSR, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_constructUSR_ObjCProperty(property: NativePtr, classUSR: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCursorSpelling(arg0: CValue<CXCursor>): CValue<CXString> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorSpelling(_arg0, alloc<CXString>().rawPtr)
+        val res = kni_clang_getCursorSpelling(_arg0, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCursorSpelling(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Cursor_getSpellingNameRange(arg0: CValue<CXCursor>, pieceIndex: Int, options: Int): CValue<CXSourceRange> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
         val _pieceIndex = pieceIndex
         val _options = options
-        val res = externals.clang_Cursor_getSpellingNameRange(_arg0, _pieceIndex, _options, alloc<CXSourceRange>().rawPtr)
+        val res = kni_clang_Cursor_getSpellingNameRange(_arg0, _pieceIndex, _options, alloc<CXSourceRange>().rawPtr)
         interpretPointed<CXSourceRange>(res).readValue()
     }
 }
 
+private external fun kni_clang_Cursor_getSpellingNameRange(arg0: NativePtr, pieceIndex: Int, options: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCursorDisplayName(arg0: CValue<CXCursor>): CValue<CXString> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorDisplayName(_arg0, alloc<CXString>().rawPtr)
+        val res = kni_clang_getCursorDisplayName(_arg0, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCursorDisplayName(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCursorReferenced(arg0: CValue<CXCursor>): CValue<CXCursor> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorReferenced(_arg0, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getCursorReferenced(_arg0, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCursorReferenced(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getCursorDefinition(arg0: CValue<CXCursor>): CValue<CXCursor> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorDefinition(_arg0, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getCursorDefinition(_arg0, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCursorDefinition(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_isCursorDefinition(arg0: CValue<CXCursor>): Int {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_isCursorDefinition(_arg0)
+        val res = kni_clang_isCursorDefinition(_arg0)
         res
     }
 }
+
+private external fun kni_clang_isCursorDefinition(arg0: NativePtr): Int
 
 fun clang_getCanonicalCursor(arg0: CValue<CXCursor>): CValue<CXCursor> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getCanonicalCursor(_arg0, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getCanonicalCursor(_arg0, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCanonicalCursor(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_Cursor_getObjCSelectorIndex(arg0: CValue<CXCursor>): Int {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getObjCSelectorIndex(_arg0)
+        val res = kni_clang_Cursor_getObjCSelectorIndex(_arg0)
         res
     }
 }
+
+private external fun kni_clang_Cursor_getObjCSelectorIndex(arg0: NativePtr): Int
 
 fun clang_Cursor_isDynamicCall(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isDynamicCall(_C)
+        val res = kni_clang_Cursor_isDynamicCall(_C)
         res
     }
 }
 
+private external fun kni_clang_Cursor_isDynamicCall(C: NativePtr): Int
+
 fun clang_Cursor_getReceiverType(C: CValue<CXCursor>): CValue<CXType> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getReceiverType(_C, alloc<CXType>().rawPtr)
+        val res = kni_clang_Cursor_getReceiverType(_C, alloc<CXType>().rawPtr)
         interpretPointed<CXType>(res).readValue()
     }
 }
+
+private external fun kni_clang_Cursor_getReceiverType(C: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Cursor_getObjCPropertyAttributes(C: CValue<CXCursor>, reserved: Int): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
         val _reserved = reserved
-        val res = externals.clang_Cursor_getObjCPropertyAttributes(_C, _reserved)
+        val res = kni_clang_Cursor_getObjCPropertyAttributes(_C, _reserved)
         res
     }
 }
+
+private external fun kni_clang_Cursor_getObjCPropertyAttributes(C: NativePtr, reserved: Int): Int
 
 fun clang_Cursor_getObjCDeclQualifiers(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getObjCDeclQualifiers(_C)
+        val res = kni_clang_Cursor_getObjCDeclQualifiers(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_getObjCDeclQualifiers(C: NativePtr): Int
 
 fun clang_Cursor_isObjCOptional(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isObjCOptional(_C)
+        val res = kni_clang_Cursor_isObjCOptional(_C)
         res
     }
 }
+
+private external fun kni_clang_Cursor_isObjCOptional(C: NativePtr): Int
 
 fun clang_Cursor_isVariadic(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_isVariadic(_C)
+        val res = kni_clang_Cursor_isVariadic(_C)
         res
     }
 }
 
+private external fun kni_clang_Cursor_isVariadic(C: NativePtr): Int
+
 fun clang_Cursor_getCommentRange(C: CValue<CXCursor>): CValue<CXSourceRange> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getCommentRange(_C, alloc<CXSourceRange>().rawPtr)
+        val res = kni_clang_Cursor_getCommentRange(_C, alloc<CXSourceRange>().rawPtr)
         interpretPointed<CXSourceRange>(res).readValue()
     }
 }
 
+private external fun kni_clang_Cursor_getCommentRange(C: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_Cursor_getRawCommentText(C: CValue<CXCursor>): CValue<CXString> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getRawCommentText(_C, alloc<CXString>().rawPtr)
+        val res = kni_clang_Cursor_getRawCommentText(_C, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_Cursor_getRawCommentText(C: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Cursor_getBriefCommentText(C: CValue<CXCursor>): CValue<CXString> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getBriefCommentText(_C, alloc<CXString>().rawPtr)
+        val res = kni_clang_Cursor_getBriefCommentText(_C, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_Cursor_getBriefCommentText(C: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Cursor_getMangling(arg0: CValue<CXCursor>): CValue<CXString> {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getMangling(_arg0, alloc<CXString>().rawPtr)
+        val res = kni_clang_Cursor_getMangling(_arg0, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_Cursor_getMangling(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Cursor_getCXXManglings(arg0: CValue<CXCursor>): CPointer<CXStringSet>? {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getCXXManglings(_arg0)
+        val res = kni_clang_Cursor_getCXXManglings(_arg0)
         interpretCPointer<CXStringSet>(res)
     }
 }
 
+private external fun kni_clang_Cursor_getCXXManglings(arg0: NativePtr): NativePtr
+
 fun clang_Cursor_getModule(C: CValue<CXCursor>): CXModule? {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_getModule(_C)
+        val res = kni_clang_Cursor_getModule(_C)
         interpretCPointer<COpaque>(res)
     }
 }
 
+private external fun kni_clang_Cursor_getModule(C: NativePtr): NativePtr
+
 fun clang_getModuleForFile(arg0: CXTranslationUnit?, arg1: CXFile?): CXModule? {
     val _arg0 = arg0.rawValue
     val _arg1 = arg1.rawValue
-    val res = externals.clang_getModuleForFile(_arg0, _arg1)
+    val res = kni_clang_getModuleForFile(_arg0, _arg1)
     return interpretCPointer<COpaque>(res)
 }
+
+private external fun kni_clang_getModuleForFile(arg0: NativePtr, arg1: NativePtr): NativePtr
 
 fun clang_Module_getASTFile(Module: CXModule?): CXFile? {
     val _Module = Module.rawValue
-    val res = externals.clang_Module_getASTFile(_Module)
+    val res = kni_clang_Module_getASTFile(_Module)
     return interpretCPointer<COpaque>(res)
 }
 
+private external fun kni_clang_Module_getASTFile(Module: NativePtr): NativePtr
+
 fun clang_Module_getParent(Module: CXModule?): CXModule? {
     val _Module = Module.rawValue
-    val res = externals.clang_Module_getParent(_Module)
+    val res = kni_clang_Module_getParent(_Module)
     return interpretCPointer<COpaque>(res)
 }
+
+private external fun kni_clang_Module_getParent(Module: NativePtr): NativePtr
 
 fun clang_Module_getName(Module: CXModule?): CValue<CXString> {
     return memScoped {
         val _Module = Module.rawValue
-        val res = externals.clang_Module_getName(_Module, alloc<CXString>().rawPtr)
+        val res = kni_clang_Module_getName(_Module, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_Module_getName(Module: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Module_getFullName(Module: CXModule?): CValue<CXString> {
     return memScoped {
         val _Module = Module.rawValue
-        val res = externals.clang_Module_getFullName(_Module, alloc<CXString>().rawPtr)
+        val res = kni_clang_Module_getFullName(_Module, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_Module_getFullName(Module: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_Module_isSystem(Module: CXModule?): Int {
     val _Module = Module.rawValue
-    val res = externals.clang_Module_isSystem(_Module)
+    val res = kni_clang_Module_isSystem(_Module)
     return res
 }
+
+private external fun kni_clang_Module_isSystem(Module: NativePtr): Int
 
 fun clang_Module_getNumTopLevelHeaders(arg0: CXTranslationUnit?, Module: CXModule?): Int {
     val _arg0 = arg0.rawValue
     val _Module = Module.rawValue
-    val res = externals.clang_Module_getNumTopLevelHeaders(_arg0, _Module)
+    val res = kni_clang_Module_getNumTopLevelHeaders(_arg0, _Module)
     return res
 }
+
+private external fun kni_clang_Module_getNumTopLevelHeaders(arg0: NativePtr, Module: NativePtr): Int
 
 fun clang_Module_getTopLevelHeader(arg0: CXTranslationUnit?, Module: CXModule?, Index: Int): CXFile? {
     val _arg0 = arg0.rawValue
     val _Module = Module.rawValue
     val _Index = Index
-    val res = externals.clang_Module_getTopLevelHeader(_arg0, _Module, _Index)
+    val res = kni_clang_Module_getTopLevelHeader(_arg0, _Module, _Index)
     return interpretCPointer<COpaque>(res)
 }
+
+private external fun kni_clang_Module_getTopLevelHeader(arg0: NativePtr, Module: NativePtr, Index: Int): NativePtr
 
 fun clang_CXXConstructor_isConvertingConstructor(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXConstructor_isConvertingConstructor(_C)
+        val res = kni_clang_CXXConstructor_isConvertingConstructor(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXConstructor_isConvertingConstructor(C: NativePtr): Int
 
 fun clang_CXXConstructor_isCopyConstructor(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXConstructor_isCopyConstructor(_C)
+        val res = kni_clang_CXXConstructor_isCopyConstructor(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXConstructor_isCopyConstructor(C: NativePtr): Int
 
 fun clang_CXXConstructor_isDefaultConstructor(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXConstructor_isDefaultConstructor(_C)
+        val res = kni_clang_CXXConstructor_isDefaultConstructor(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXConstructor_isDefaultConstructor(C: NativePtr): Int
 
 fun clang_CXXConstructor_isMoveConstructor(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXConstructor_isMoveConstructor(_C)
+        val res = kni_clang_CXXConstructor_isMoveConstructor(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXConstructor_isMoveConstructor(C: NativePtr): Int
 
 fun clang_CXXField_isMutable(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXField_isMutable(_C)
+        val res = kni_clang_CXXField_isMutable(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXField_isMutable(C: NativePtr): Int
 
 fun clang_CXXMethod_isDefaulted(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXMethod_isDefaulted(_C)
+        val res = kni_clang_CXXMethod_isDefaulted(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXMethod_isDefaulted(C: NativePtr): Int
 
 fun clang_CXXMethod_isPureVirtual(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXMethod_isPureVirtual(_C)
+        val res = kni_clang_CXXMethod_isPureVirtual(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXMethod_isPureVirtual(C: NativePtr): Int
 
 fun clang_CXXMethod_isStatic(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXMethod_isStatic(_C)
+        val res = kni_clang_CXXMethod_isStatic(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXMethod_isStatic(C: NativePtr): Int
 
 fun clang_CXXMethod_isVirtual(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXMethod_isVirtual(_C)
+        val res = kni_clang_CXXMethod_isVirtual(_C)
         res
     }
 }
+
+private external fun kni_clang_CXXMethod_isVirtual(C: NativePtr): Int
 
 fun clang_CXXMethod_isConst(C: CValue<CXCursor>): Int {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_CXXMethod_isConst(_C)
+        val res = kni_clang_CXXMethod_isConst(_C)
         res
     }
 }
 
+private external fun kni_clang_CXXMethod_isConst(C: NativePtr): Int
+
 fun clang_getTemplateCursorKind(C: CValue<CXCursor>): CXCursorKind {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getTemplateCursorKind(_C)
+        val res = kni_clang_getTemplateCursorKind(_C)
         CXCursorKind.byValue(res)
     }
 }
 
+private external fun kni_clang_getTemplateCursorKind(C: NativePtr): Int
+
 fun clang_getSpecializedCursorTemplate(C: CValue<CXCursor>): CValue<CXCursor> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_getSpecializedCursorTemplate(_C, alloc<CXCursor>().rawPtr)
+        val res = kni_clang_getSpecializedCursorTemplate(_C, alloc<CXCursor>().rawPtr)
         interpretPointed<CXCursor>(res).readValue()
     }
 }
+
+private external fun kni_clang_getSpecializedCursorTemplate(C: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getCursorReferenceNameRange(C: CValue<CXCursor>, NameFlags: Int, PieceIndex: Int): CValue<CXSourceRange> {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
         val _NameFlags = NameFlags
         val _PieceIndex = PieceIndex
-        val res = externals.clang_getCursorReferenceNameRange(_C, _NameFlags, _PieceIndex, alloc<CXSourceRange>().rawPtr)
+        val res = kni_clang_getCursorReferenceNameRange(_C, _NameFlags, _PieceIndex, alloc<CXSourceRange>().rawPtr)
         interpretPointed<CXSourceRange>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCursorReferenceNameRange(C: NativePtr, NameFlags: Int, PieceIndex: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_getTokenKind(arg0: CValue<CXToken>): CXTokenKind {
     return memScoped {
         val _arg0 = arg0.getPointer(memScope).rawValue
-        val res = externals.clang_getTokenKind(_arg0)
+        val res = kni_clang_getTokenKind(_arg0)
         CXTokenKind.byValue(res)
     }
 }
+
+private external fun kni_clang_getTokenKind(arg0: NativePtr): Int
 
 fun clang_getTokenSpelling(arg0: CXTranslationUnit?, arg1: CValue<CXToken>): CValue<CXString> {
     return memScoped {
         val _arg0 = arg0.rawValue
         val _arg1 = arg1.getPointer(memScope).rawValue
-        val res = externals.clang_getTokenSpelling(_arg0, _arg1, alloc<CXString>().rawPtr)
+        val res = kni_clang_getTokenSpelling(_arg0, _arg1, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getTokenSpelling(arg0: NativePtr, arg1: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getTokenLocation(arg0: CXTranslationUnit?, arg1: CValue<CXToken>): CValue<CXSourceLocation> {
     return memScoped {
         val _arg0 = arg0.rawValue
         val _arg1 = arg1.getPointer(memScope).rawValue
-        val res = externals.clang_getTokenLocation(_arg0, _arg1, alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_getTokenLocation(_arg0, _arg1, alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
+
+private external fun kni_clang_getTokenLocation(arg0: NativePtr, arg1: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getTokenExtent(arg0: CXTranslationUnit?, arg1: CValue<CXToken>): CValue<CXSourceRange> {
     return memScoped {
         val _arg0 = arg0.rawValue
         val _arg1 = arg1.getPointer(memScope).rawValue
-        val res = externals.clang_getTokenExtent(_arg0, _arg1, alloc<CXSourceRange>().rawPtr)
+        val res = kni_clang_getTokenExtent(_arg0, _arg1, alloc<CXSourceRange>().rawPtr)
         interpretPointed<CXSourceRange>(res).readValue()
     }
 }
+
+private external fun kni_clang_getTokenExtent(arg0: NativePtr, arg1: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_tokenize(TU: CXTranslationUnit?, Range: CValue<CXSourceRange>, Tokens: CValuesRef<CPointerVar<CXToken>>?, NumTokens: CValuesRef<IntVar>?): Unit {
     return memScoped {
@@ -2051,10 +2554,12 @@ fun clang_tokenize(TU: CXTranslationUnit?, Range: CValue<CXSourceRange>, Tokens:
         val _Range = Range.getPointer(memScope).rawValue
         val _Tokens = Tokens?.getPointer(memScope).rawValue
         val _NumTokens = NumTokens?.getPointer(memScope).rawValue
-        val res = externals.clang_tokenize(_TU, _Range, _Tokens, _NumTokens)
+        val res = kni_clang_tokenize(_TU, _Range, _Tokens, _NumTokens)
         res
     }
 }
+
+private external fun kni_clang_tokenize(TU: NativePtr, Range: NativePtr, Tokens: NativePtr, NumTokens: NativePtr): Unit
 
 fun clang_annotateTokens(TU: CXTranslationUnit?, Tokens: CValuesRef<CXToken>?, NumTokens: Int, Cursors: CValuesRef<CXCursor>?): Unit {
     return memScoped {
@@ -2062,28 +2567,34 @@ fun clang_annotateTokens(TU: CXTranslationUnit?, Tokens: CValuesRef<CXToken>?, N
         val _Tokens = Tokens?.getPointer(memScope).rawValue
         val _NumTokens = NumTokens
         val _Cursors = Cursors?.getPointer(memScope).rawValue
-        val res = externals.clang_annotateTokens(_TU, _Tokens, _NumTokens, _Cursors)
+        val res = kni_clang_annotateTokens(_TU, _Tokens, _NumTokens, _Cursors)
         res
     }
 }
+
+private external fun kni_clang_annotateTokens(TU: NativePtr, Tokens: NativePtr, NumTokens: Int, Cursors: NativePtr): Unit
 
 fun clang_disposeTokens(TU: CXTranslationUnit?, Tokens: CValuesRef<CXToken>?, NumTokens: Int): Unit {
     return memScoped {
         val _TU = TU.rawValue
         val _Tokens = Tokens?.getPointer(memScope).rawValue
         val _NumTokens = NumTokens
-        val res = externals.clang_disposeTokens(_TU, _Tokens, _NumTokens)
+        val res = kni_clang_disposeTokens(_TU, _Tokens, _NumTokens)
         res
     }
 }
 
+private external fun kni_clang_disposeTokens(TU: NativePtr, Tokens: NativePtr, NumTokens: Int): Unit
+
 fun clang_getCursorKindSpelling(Kind: CXCursorKind): CValue<CXString> {
     return memScoped {
         val _Kind = Kind.value
-        val res = externals.clang_getCursorKindSpelling(_Kind, alloc<CXString>().rawPtr)
+        val res = kni_clang_getCursorKindSpelling(_Kind, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCursorKindSpelling(Kind: Int, retValPlacement: NativePtr): NativePtr
 
 fun clang_getDefinitionSpellingAndExtent(arg0: CValue<CXCursor>, startBuf: CValuesRef<CPointerVar<ByteVar>>?, endBuf: CValuesRef<CPointerVar<ByteVar>>?, startLine: CValuesRef<IntVar>?, startColumn: CValuesRef<IntVar>?, endLine: CValuesRef<IntVar>?, endColumn: CValuesRef<IntVar>?): Unit {
     return memScoped {
@@ -2094,109 +2605,139 @@ fun clang_getDefinitionSpellingAndExtent(arg0: CValue<CXCursor>, startBuf: CValu
         val _startColumn = startColumn?.getPointer(memScope).rawValue
         val _endLine = endLine?.getPointer(memScope).rawValue
         val _endColumn = endColumn?.getPointer(memScope).rawValue
-        val res = externals.clang_getDefinitionSpellingAndExtent(_arg0, _startBuf, _endBuf, _startLine, _startColumn, _endLine, _endColumn)
+        val res = kni_clang_getDefinitionSpellingAndExtent(_arg0, _startBuf, _endBuf, _startLine, _startColumn, _endLine, _endColumn)
         res
     }
 }
 
+private external fun kni_clang_getDefinitionSpellingAndExtent(arg0: NativePtr, startBuf: NativePtr, endBuf: NativePtr, startLine: NativePtr, startColumn: NativePtr, endLine: NativePtr, endColumn: NativePtr): Unit
+
 fun clang_enableStackTraces(): Unit {
-    val res = externals.clang_enableStackTraces()
+    val res = kni_clang_enableStackTraces()
     return res
 }
 
-fun clang_executeOnThread(fn: CPointer<CFunction<CFunctionType2>>?, user_data: COpaquePointer?, stack_size: Int): Unit {
+private external fun kni_clang_enableStackTraces(): Unit
+
+fun clang_executeOnThread(fn: CPointer<CFunction<(COpaquePointer?) -> Unit>>?, user_data: COpaquePointer?, stack_size: Int): Unit {
     val _fn = fn.rawValue
     val _user_data = user_data.rawValue
     val _stack_size = stack_size
-    val res = externals.clang_executeOnThread(_fn, _user_data, _stack_size)
+    val res = kni_clang_executeOnThread(_fn, _user_data, _stack_size)
     return res
 }
+
+private external fun kni_clang_executeOnThread(fn: NativePtr, user_data: NativePtr, stack_size: Int): Unit
 
 fun clang_getCompletionChunkKind(completion_string: CXCompletionString?, chunk_number: Int): CXCompletionChunkKind {
     val _completion_string = completion_string.rawValue
     val _chunk_number = chunk_number
-    val res = externals.clang_getCompletionChunkKind(_completion_string, _chunk_number)
+    val res = kni_clang_getCompletionChunkKind(_completion_string, _chunk_number)
     return CXCompletionChunkKind.byValue(res)
 }
+
+private external fun kni_clang_getCompletionChunkKind(completion_string: NativePtr, chunk_number: Int): Int
 
 fun clang_getCompletionChunkText(completion_string: CXCompletionString?, chunk_number: Int): CValue<CXString> {
     return memScoped {
         val _completion_string = completion_string.rawValue
         val _chunk_number = chunk_number
-        val res = externals.clang_getCompletionChunkText(_completion_string, _chunk_number, alloc<CXString>().rawPtr)
+        val res = kni_clang_getCompletionChunkText(_completion_string, _chunk_number, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCompletionChunkText(completion_string: NativePtr, chunk_number: Int, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCompletionChunkCompletionString(completion_string: CXCompletionString?, chunk_number: Int): CXCompletionString? {
     val _completion_string = completion_string.rawValue
     val _chunk_number = chunk_number
-    val res = externals.clang_getCompletionChunkCompletionString(_completion_string, _chunk_number)
+    val res = kni_clang_getCompletionChunkCompletionString(_completion_string, _chunk_number)
     return interpretCPointer<COpaque>(res)
 }
 
+private external fun kni_clang_getCompletionChunkCompletionString(completion_string: NativePtr, chunk_number: Int): NativePtr
+
 fun clang_getNumCompletionChunks(completion_string: CXCompletionString?): Int {
     val _completion_string = completion_string.rawValue
-    val res = externals.clang_getNumCompletionChunks(_completion_string)
+    val res = kni_clang_getNumCompletionChunks(_completion_string)
     return res
 }
+
+private external fun kni_clang_getNumCompletionChunks(completion_string: NativePtr): Int
 
 fun clang_getCompletionPriority(completion_string: CXCompletionString?): Int {
     val _completion_string = completion_string.rawValue
-    val res = externals.clang_getCompletionPriority(_completion_string)
+    val res = kni_clang_getCompletionPriority(_completion_string)
     return res
 }
+
+private external fun kni_clang_getCompletionPriority(completion_string: NativePtr): Int
 
 fun clang_getCompletionAvailability(completion_string: CXCompletionString?): CXAvailabilityKind {
     val _completion_string = completion_string.rawValue
-    val res = externals.clang_getCompletionAvailability(_completion_string)
+    val res = kni_clang_getCompletionAvailability(_completion_string)
     return CXAvailabilityKind.byValue(res)
 }
 
+private external fun kni_clang_getCompletionAvailability(completion_string: NativePtr): Int
+
 fun clang_getCompletionNumAnnotations(completion_string: CXCompletionString?): Int {
     val _completion_string = completion_string.rawValue
-    val res = externals.clang_getCompletionNumAnnotations(_completion_string)
+    val res = kni_clang_getCompletionNumAnnotations(_completion_string)
     return res
 }
+
+private external fun kni_clang_getCompletionNumAnnotations(completion_string: NativePtr): Int
 
 fun clang_getCompletionAnnotation(completion_string: CXCompletionString?, annotation_number: Int): CValue<CXString> {
     return memScoped {
         val _completion_string = completion_string.rawValue
         val _annotation_number = annotation_number
-        val res = externals.clang_getCompletionAnnotation(_completion_string, _annotation_number, alloc<CXString>().rawPtr)
+        val res = kni_clang_getCompletionAnnotation(_completion_string, _annotation_number, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCompletionAnnotation(completion_string: NativePtr, annotation_number: Int, retValPlacement: NativePtr): NativePtr
 
 fun clang_getCompletionParent(completion_string: CXCompletionString?, kind: CValuesRef<CXCursorKind.Var>?): CValue<CXString> {
     return memScoped {
         val _completion_string = completion_string.rawValue
         val _kind = kind?.getPointer(memScope).rawValue
-        val res = externals.clang_getCompletionParent(_completion_string, _kind, alloc<CXString>().rawPtr)
+        val res = kni_clang_getCompletionParent(_completion_string, _kind, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_getCompletionParent(completion_string: NativePtr, kind: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getCompletionBriefComment(completion_string: CXCompletionString?): CValue<CXString> {
     return memScoped {
         val _completion_string = completion_string.rawValue
-        val res = externals.clang_getCompletionBriefComment(_completion_string, alloc<CXString>().rawPtr)
+        val res = kni_clang_getCompletionBriefComment(_completion_string, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getCompletionBriefComment(completion_string: NativePtr, retValPlacement: NativePtr): NativePtr
+
 fun clang_getCursorCompletionString(cursor: CValue<CXCursor>): CXCompletionString? {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
-        val res = externals.clang_getCursorCompletionString(_cursor)
+        val res = kni_clang_getCursorCompletionString(_cursor)
         interpretCPointer<COpaque>(res)
     }
 }
 
+private external fun kni_clang_getCursorCompletionString(cursor: NativePtr): NativePtr
+
 fun clang_defaultCodeCompleteOptions(): Int {
-    val res = externals.clang_defaultCodeCompleteOptions()
+    val res = kni_clang_defaultCodeCompleteOptions()
     return res
 }
+
+private external fun kni_clang_defaultCodeCompleteOptions(): Int
 
 fun clang_codeCompleteAt(TU: CXTranslationUnit?, complete_filename: String?, complete_line: Int, complete_column: Int, unsaved_files: CValuesRef<CXUnsavedFile>?, num_unsaved_files: Int, options: Int): CPointer<CXCodeCompleteResults>? {
     return memScoped {
@@ -2207,159 +2748,201 @@ fun clang_codeCompleteAt(TU: CXTranslationUnit?, complete_filename: String?, com
         val _unsaved_files = unsaved_files?.getPointer(memScope).rawValue
         val _num_unsaved_files = num_unsaved_files
         val _options = options
-        val res = externals.clang_codeCompleteAt(_TU, _complete_filename, _complete_line, _complete_column, _unsaved_files, _num_unsaved_files, _options)
+        val res = kni_clang_codeCompleteAt(_TU, _complete_filename, _complete_line, _complete_column, _unsaved_files, _num_unsaved_files, _options)
         interpretCPointer<CXCodeCompleteResults>(res)
     }
 }
+
+private external fun kni_clang_codeCompleteAt(TU: NativePtr, complete_filename: NativePtr, complete_line: Int, complete_column: Int, unsaved_files: NativePtr, num_unsaved_files: Int, options: Int): NativePtr
 
 fun clang_sortCodeCompletionResults(Results: CValuesRef<CXCompletionResult>?, NumResults: Int): Unit {
     return memScoped {
         val _Results = Results?.getPointer(memScope).rawValue
         val _NumResults = NumResults
-        val res = externals.clang_sortCodeCompletionResults(_Results, _NumResults)
+        val res = kni_clang_sortCodeCompletionResults(_Results, _NumResults)
         res
     }
 }
+
+private external fun kni_clang_sortCodeCompletionResults(Results: NativePtr, NumResults: Int): Unit
 
 fun clang_disposeCodeCompleteResults(Results: CValuesRef<CXCodeCompleteResults>?): Unit {
     return memScoped {
         val _Results = Results?.getPointer(memScope).rawValue
-        val res = externals.clang_disposeCodeCompleteResults(_Results)
+        val res = kni_clang_disposeCodeCompleteResults(_Results)
         res
     }
 }
 
+private external fun kni_clang_disposeCodeCompleteResults(Results: NativePtr): Unit
+
 fun clang_codeCompleteGetNumDiagnostics(Results: CValuesRef<CXCodeCompleteResults>?): Int {
     return memScoped {
         val _Results = Results?.getPointer(memScope).rawValue
-        val res = externals.clang_codeCompleteGetNumDiagnostics(_Results)
+        val res = kni_clang_codeCompleteGetNumDiagnostics(_Results)
         res
     }
 }
+
+private external fun kni_clang_codeCompleteGetNumDiagnostics(Results: NativePtr): Int
 
 fun clang_codeCompleteGetDiagnostic(Results: CValuesRef<CXCodeCompleteResults>?, Index: Int): CXDiagnostic? {
     return memScoped {
         val _Results = Results?.getPointer(memScope).rawValue
         val _Index = Index
-        val res = externals.clang_codeCompleteGetDiagnostic(_Results, _Index)
+        val res = kni_clang_codeCompleteGetDiagnostic(_Results, _Index)
         interpretCPointer<COpaque>(res)
     }
 }
 
+private external fun kni_clang_codeCompleteGetDiagnostic(Results: NativePtr, Index: Int): NativePtr
+
 fun clang_codeCompleteGetContexts(Results: CValuesRef<CXCodeCompleteResults>?): Long {
     return memScoped {
         val _Results = Results?.getPointer(memScope).rawValue
-        val res = externals.clang_codeCompleteGetContexts(_Results)
+        val res = kni_clang_codeCompleteGetContexts(_Results)
         res
     }
 }
+
+private external fun kni_clang_codeCompleteGetContexts(Results: NativePtr): Long
 
 fun clang_codeCompleteGetContainerKind(Results: CValuesRef<CXCodeCompleteResults>?, IsIncomplete: CValuesRef<IntVar>?): CXCursorKind {
     return memScoped {
         val _Results = Results?.getPointer(memScope).rawValue
         val _IsIncomplete = IsIncomplete?.getPointer(memScope).rawValue
-        val res = externals.clang_codeCompleteGetContainerKind(_Results, _IsIncomplete)
+        val res = kni_clang_codeCompleteGetContainerKind(_Results, _IsIncomplete)
         CXCursorKind.byValue(res)
     }
 }
 
+private external fun kni_clang_codeCompleteGetContainerKind(Results: NativePtr, IsIncomplete: NativePtr): Int
+
 fun clang_codeCompleteGetContainerUSR(Results: CValuesRef<CXCodeCompleteResults>?): CValue<CXString> {
     return memScoped {
         val _Results = Results?.getPointer(memScope).rawValue
-        val res = externals.clang_codeCompleteGetContainerUSR(_Results, alloc<CXString>().rawPtr)
+        val res = kni_clang_codeCompleteGetContainerUSR(_Results, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_codeCompleteGetContainerUSR(Results: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_codeCompleteGetObjCSelector(Results: CValuesRef<CXCodeCompleteResults>?): CValue<CXString> {
     return memScoped {
         val _Results = Results?.getPointer(memScope).rawValue
-        val res = externals.clang_codeCompleteGetObjCSelector(_Results, alloc<CXString>().rawPtr)
+        val res = kni_clang_codeCompleteGetObjCSelector(_Results, alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
+
+private external fun kni_clang_codeCompleteGetObjCSelector(Results: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_getClangVersion(): CValue<CXString> {
     return memScoped {
-        val res = externals.clang_getClangVersion(alloc<CXString>().rawPtr)
+        val res = kni_clang_getClangVersion(alloc<CXString>().rawPtr)
         interpretPointed<CXString>(res).readValue()
     }
 }
 
+private external fun kni_clang_getClangVersion(retValPlacement: NativePtr): NativePtr
+
 fun clang_toggleCrashRecovery(isEnabled: Int): Unit {
     val _isEnabled = isEnabled
-    val res = externals.clang_toggleCrashRecovery(_isEnabled)
+    val res = kni_clang_toggleCrashRecovery(_isEnabled)
     return res
 }
+
+private external fun kni_clang_toggleCrashRecovery(isEnabled: Int): Unit
 
 fun clang_getInclusions(tu: CXTranslationUnit?, visitor: CXInclusionVisitor?, client_data: CXClientData?): Unit {
     val _tu = tu.rawValue
     val _visitor = visitor.rawValue
     val _client_data = client_data.rawValue
-    val res = externals.clang_getInclusions(_tu, _visitor, _client_data)
+    val res = kni_clang_getInclusions(_tu, _visitor, _client_data)
     return res
 }
+
+private external fun kni_clang_getInclusions(tu: NativePtr, visitor: NativePtr, client_data: NativePtr): Unit
 
 fun clang_Cursor_Evaluate(C: CValue<CXCursor>): CXEvalResult? {
     return memScoped {
         val _C = C.getPointer(memScope).rawValue
-        val res = externals.clang_Cursor_Evaluate(_C)
+        val res = kni_clang_Cursor_Evaluate(_C)
         interpretCPointer<COpaque>(res)
     }
 }
 
+private external fun kni_clang_Cursor_Evaluate(C: NativePtr): NativePtr
+
 fun clang_EvalResult_getKind(E: CXEvalResult?): CXEvalResultKind {
     val _E = E.rawValue
-    val res = externals.clang_EvalResult_getKind(_E)
+    val res = kni_clang_EvalResult_getKind(_E)
     return CXEvalResultKind.byValue(res)
 }
 
+private external fun kni_clang_EvalResult_getKind(E: NativePtr): Int
+
 fun clang_EvalResult_getAsInt(E: CXEvalResult?): Int {
     val _E = E.rawValue
-    val res = externals.clang_EvalResult_getAsInt(_E)
+    val res = kni_clang_EvalResult_getAsInt(_E)
     return res
 }
+
+private external fun kni_clang_EvalResult_getAsInt(E: NativePtr): Int
 
 fun clang_EvalResult_getAsDouble(E: CXEvalResult?): Double {
     val _E = E.rawValue
-    val res = externals.clang_EvalResult_getAsDouble(_E)
+    val res = kni_clang_EvalResult_getAsDouble(_E)
     return res
 }
+
+private external fun kni_clang_EvalResult_getAsDouble(E: NativePtr): Double
 
 fun clang_EvalResult_getAsStr(E: CXEvalResult?): CPointer<ByteVar>? {
     val _E = E.rawValue
-    val res = externals.clang_EvalResult_getAsStr(_E)
+    val res = kni_clang_EvalResult_getAsStr(_E)
     return interpretCPointer<ByteVar>(res)
 }
 
+private external fun kni_clang_EvalResult_getAsStr(E: NativePtr): NativePtr
+
 fun clang_EvalResult_dispose(E: CXEvalResult?): Unit {
     val _E = E.rawValue
-    val res = externals.clang_EvalResult_dispose(_E)
+    val res = kni_clang_EvalResult_dispose(_E)
     return res
 }
+
+private external fun kni_clang_EvalResult_dispose(E: NativePtr): Unit
 
 fun clang_getRemappings(path: String?): CXRemapping? {
     return memScoped {
         val _path = path?.cstr?.getPointer(memScope).rawValue
-        val res = externals.clang_getRemappings(_path)
+        val res = kni_clang_getRemappings(_path)
         interpretCPointer<COpaque>(res)
     }
 }
+
+private external fun kni_clang_getRemappings(path: NativePtr): NativePtr
 
 fun clang_getRemappingsFromFileList(filePaths: CValuesRef<CPointerVar<ByteVar>>?, numFiles: Int): CXRemapping? {
     return memScoped {
         val _filePaths = filePaths?.getPointer(memScope).rawValue
         val _numFiles = numFiles
-        val res = externals.clang_getRemappingsFromFileList(_filePaths, _numFiles)
+        val res = kni_clang_getRemappingsFromFileList(_filePaths, _numFiles)
         interpretCPointer<COpaque>(res)
     }
 }
 
+private external fun kni_clang_getRemappingsFromFileList(filePaths: NativePtr, numFiles: Int): NativePtr
+
 fun clang_remap_getNumFiles(arg0: CXRemapping?): Int {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_remap_getNumFiles(_arg0)
+    val res = kni_clang_remap_getNumFiles(_arg0)
     return res
 }
+
+private external fun kni_clang_remap_getNumFiles(arg0: NativePtr): Int
 
 fun clang_remap_getFilenames(arg0: CXRemapping?, index: Int, original: CValuesRef<CXString>?, transformed: CValuesRef<CXString>?): Unit {
     return memScoped {
@@ -2367,144 +2950,180 @@ fun clang_remap_getFilenames(arg0: CXRemapping?, index: Int, original: CValuesRe
         val _index = index
         val _original = original?.getPointer(memScope).rawValue
         val _transformed = transformed?.getPointer(memScope).rawValue
-        val res = externals.clang_remap_getFilenames(_arg0, _index, _original, _transformed)
+        val res = kni_clang_remap_getFilenames(_arg0, _index, _original, _transformed)
         res
     }
 }
 
+private external fun kni_clang_remap_getFilenames(arg0: NativePtr, index: Int, original: NativePtr, transformed: NativePtr): Unit
+
 fun clang_remap_dispose(arg0: CXRemapping?): Unit {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_remap_dispose(_arg0)
+    val res = kni_clang_remap_dispose(_arg0)
     return res
 }
+
+private external fun kni_clang_remap_dispose(arg0: NativePtr): Unit
 
 fun clang_findReferencesInFile(cursor: CValue<CXCursor>, file: CXFile?, visitor: CValue<CXCursorAndRangeVisitor>): CXResult {
     return memScoped {
         val _cursor = cursor.getPointer(memScope).rawValue
         val _file = file.rawValue
         val _visitor = visitor.getPointer(memScope).rawValue
-        val res = externals.clang_findReferencesInFile(_cursor, _file, _visitor)
+        val res = kni_clang_findReferencesInFile(_cursor, _file, _visitor)
         CXResult.byValue(res)
     }
 }
+
+private external fun kni_clang_findReferencesInFile(cursor: NativePtr, file: NativePtr, visitor: NativePtr): Int
 
 fun clang_findIncludesInFile(TU: CXTranslationUnit?, file: CXFile?, visitor: CValue<CXCursorAndRangeVisitor>): CXResult {
     return memScoped {
         val _TU = TU.rawValue
         val _file = file.rawValue
         val _visitor = visitor.getPointer(memScope).rawValue
-        val res = externals.clang_findIncludesInFile(_TU, _file, _visitor)
+        val res = kni_clang_findIncludesInFile(_TU, _file, _visitor)
         CXResult.byValue(res)
     }
 }
 
+private external fun kni_clang_findIncludesInFile(TU: NativePtr, file: NativePtr, visitor: NativePtr): Int
+
 fun clang_index_isEntityObjCContainerKind(arg0: CXIdxEntityKind): Int {
     val _arg0 = arg0.value
-    val res = externals.clang_index_isEntityObjCContainerKind(_arg0)
+    val res = kni_clang_index_isEntityObjCContainerKind(_arg0)
     return res
 }
+
+private external fun kni_clang_index_isEntityObjCContainerKind(arg0: Int): Int
 
 fun clang_index_getObjCContainerDeclInfo(arg0: CValuesRef<CXIdxDeclInfo>?): CPointer<CXIdxObjCContainerDeclInfo>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getObjCContainerDeclInfo(_arg0)
+        val res = kni_clang_index_getObjCContainerDeclInfo(_arg0)
         interpretCPointer<CXIdxObjCContainerDeclInfo>(res)
     }
 }
 
+private external fun kni_clang_index_getObjCContainerDeclInfo(arg0: NativePtr): NativePtr
+
 fun clang_index_getObjCInterfaceDeclInfo(arg0: CValuesRef<CXIdxDeclInfo>?): CPointer<CXIdxObjCInterfaceDeclInfo>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getObjCInterfaceDeclInfo(_arg0)
+        val res = kni_clang_index_getObjCInterfaceDeclInfo(_arg0)
         interpretCPointer<CXIdxObjCInterfaceDeclInfo>(res)
     }
 }
 
+private external fun kni_clang_index_getObjCInterfaceDeclInfo(arg0: NativePtr): NativePtr
+
 fun clang_index_getObjCCategoryDeclInfo(arg0: CValuesRef<CXIdxDeclInfo>?): CPointer<CXIdxObjCCategoryDeclInfo>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getObjCCategoryDeclInfo(_arg0)
+        val res = kni_clang_index_getObjCCategoryDeclInfo(_arg0)
         interpretCPointer<CXIdxObjCCategoryDeclInfo>(res)
     }
 }
 
+private external fun kni_clang_index_getObjCCategoryDeclInfo(arg0: NativePtr): NativePtr
+
 fun clang_index_getObjCProtocolRefListInfo(arg0: CValuesRef<CXIdxDeclInfo>?): CPointer<CXIdxObjCProtocolRefListInfo>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getObjCProtocolRefListInfo(_arg0)
+        val res = kni_clang_index_getObjCProtocolRefListInfo(_arg0)
         interpretCPointer<CXIdxObjCProtocolRefListInfo>(res)
     }
 }
 
+private external fun kni_clang_index_getObjCProtocolRefListInfo(arg0: NativePtr): NativePtr
+
 fun clang_index_getObjCPropertyDeclInfo(arg0: CValuesRef<CXIdxDeclInfo>?): CPointer<CXIdxObjCPropertyDeclInfo>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getObjCPropertyDeclInfo(_arg0)
+        val res = kni_clang_index_getObjCPropertyDeclInfo(_arg0)
         interpretCPointer<CXIdxObjCPropertyDeclInfo>(res)
     }
 }
 
+private external fun kni_clang_index_getObjCPropertyDeclInfo(arg0: NativePtr): NativePtr
+
 fun clang_index_getIBOutletCollectionAttrInfo(arg0: CValuesRef<CXIdxAttrInfo>?): CPointer<CXIdxIBOutletCollectionAttrInfo>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getIBOutletCollectionAttrInfo(_arg0)
+        val res = kni_clang_index_getIBOutletCollectionAttrInfo(_arg0)
         interpretCPointer<CXIdxIBOutletCollectionAttrInfo>(res)
     }
 }
 
+private external fun kni_clang_index_getIBOutletCollectionAttrInfo(arg0: NativePtr): NativePtr
+
 fun clang_index_getCXXClassDeclInfo(arg0: CValuesRef<CXIdxDeclInfo>?): CPointer<CXIdxCXXClassDeclInfo>? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getCXXClassDeclInfo(_arg0)
+        val res = kni_clang_index_getCXXClassDeclInfo(_arg0)
         interpretCPointer<CXIdxCXXClassDeclInfo>(res)
     }
 }
 
+private external fun kni_clang_index_getCXXClassDeclInfo(arg0: NativePtr): NativePtr
+
 fun clang_index_getClientContainer(arg0: CValuesRef<CXIdxContainerInfo>?): CXIdxClientContainer? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getClientContainer(_arg0)
+        val res = kni_clang_index_getClientContainer(_arg0)
         interpretCPointer<COpaque>(res)
     }
 }
+
+private external fun kni_clang_index_getClientContainer(arg0: NativePtr): NativePtr
 
 fun clang_index_setClientContainer(arg0: CValuesRef<CXIdxContainerInfo>?, arg1: CXIdxClientContainer?): Unit {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
         val _arg1 = arg1.rawValue
-        val res = externals.clang_index_setClientContainer(_arg0, _arg1)
+        val res = kni_clang_index_setClientContainer(_arg0, _arg1)
         res
     }
 }
 
+private external fun kni_clang_index_setClientContainer(arg0: NativePtr, arg1: NativePtr): Unit
+
 fun clang_index_getClientEntity(arg0: CValuesRef<CXIdxEntityInfo>?): CXIdxClientEntity? {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
-        val res = externals.clang_index_getClientEntity(_arg0)
+        val res = kni_clang_index_getClientEntity(_arg0)
         interpretCPointer<COpaque>(res)
     }
 }
+
+private external fun kni_clang_index_getClientEntity(arg0: NativePtr): NativePtr
 
 fun clang_index_setClientEntity(arg0: CValuesRef<CXIdxEntityInfo>?, arg1: CXIdxClientEntity?): Unit {
     return memScoped {
         val _arg0 = arg0?.getPointer(memScope).rawValue
         val _arg1 = arg1.rawValue
-        val res = externals.clang_index_setClientEntity(_arg0, _arg1)
+        val res = kni_clang_index_setClientEntity(_arg0, _arg1)
         res
     }
 }
 
+private external fun kni_clang_index_setClientEntity(arg0: NativePtr, arg1: NativePtr): Unit
+
 fun clang_IndexAction_create(CIdx: CXIndex?): CXIndexAction? {
     val _CIdx = CIdx.rawValue
-    val res = externals.clang_IndexAction_create(_CIdx)
+    val res = kni_clang_IndexAction_create(_CIdx)
     return interpretCPointer<COpaque>(res)
 }
 
+private external fun kni_clang_IndexAction_create(CIdx: NativePtr): NativePtr
+
 fun clang_IndexAction_dispose(arg0: CXIndexAction?): Unit {
     val _arg0 = arg0.rawValue
-    val res = externals.clang_IndexAction_dispose(_arg0)
+    val res = kni_clang_IndexAction_dispose(_arg0)
     return res
 }
+
+private external fun kni_clang_IndexAction_dispose(arg0: NativePtr): Unit
 
 fun clang_indexSourceFile(arg0: CXIndexAction?, client_data: CXClientData?, index_callbacks: CValuesRef<IndexerCallbacks>?, index_callbacks_size: Int, index_options: Int, source_filename: String?, command_line_args: CValuesRef<CPointerVar<ByteVar>>?, num_command_line_args: Int, unsaved_files: CValuesRef<CXUnsavedFile>?, num_unsaved_files: Int, out_TU: CValuesRef<CXTranslationUnitVar>?, TU_options: Int): Int {
     return memScoped {
@@ -2520,10 +3139,12 @@ fun clang_indexSourceFile(arg0: CXIndexAction?, client_data: CXClientData?, inde
         val _num_unsaved_files = num_unsaved_files
         val _out_TU = out_TU?.getPointer(memScope).rawValue
         val _TU_options = TU_options
-        val res = externals.clang_indexSourceFile(_arg0, _client_data, _index_callbacks, _index_callbacks_size, _index_options, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _out_TU, _TU_options)
+        val res = kni_clang_indexSourceFile(_arg0, _client_data, _index_callbacks, _index_callbacks_size, _index_options, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _out_TU, _TU_options)
         res
     }
 }
+
+private external fun kni_clang_indexSourceFile(arg0: NativePtr, client_data: NativePtr, index_callbacks: NativePtr, index_callbacks_size: Int, index_options: Int, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, out_TU: NativePtr, TU_options: Int): Int
 
 fun clang_indexSourceFileFullArgv(arg0: CXIndexAction?, client_data: CXClientData?, index_callbacks: CValuesRef<IndexerCallbacks>?, index_callbacks_size: Int, index_options: Int, source_filename: String?, command_line_args: CValuesRef<CPointerVar<ByteVar>>?, num_command_line_args: Int, unsaved_files: CValuesRef<CXUnsavedFile>?, num_unsaved_files: Int, out_TU: CValuesRef<CXTranslationUnitVar>?, TU_options: Int): Int {
     return memScoped {
@@ -2539,10 +3160,12 @@ fun clang_indexSourceFileFullArgv(arg0: CXIndexAction?, client_data: CXClientDat
         val _num_unsaved_files = num_unsaved_files
         val _out_TU = out_TU?.getPointer(memScope).rawValue
         val _TU_options = TU_options
-        val res = externals.clang_indexSourceFileFullArgv(_arg0, _client_data, _index_callbacks, _index_callbacks_size, _index_options, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _out_TU, _TU_options)
+        val res = kni_clang_indexSourceFileFullArgv(_arg0, _client_data, _index_callbacks, _index_callbacks_size, _index_options, _source_filename, _command_line_args, _num_command_line_args, _unsaved_files, _num_unsaved_files, _out_TU, _TU_options)
         res
     }
 }
+
+private external fun kni_clang_indexSourceFileFullArgv(arg0: NativePtr, client_data: NativePtr, index_callbacks: NativePtr, index_callbacks_size: Int, index_options: Int, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, out_TU: NativePtr, TU_options: Int): Int
 
 fun clang_indexTranslationUnit(arg0: CXIndexAction?, client_data: CXClientData?, index_callbacks: CValuesRef<IndexerCallbacks>?, index_callbacks_size: Int, index_options: Int, arg5: CXTranslationUnit?): Int {
     return memScoped {
@@ -2552,10 +3175,12 @@ fun clang_indexTranslationUnit(arg0: CXIndexAction?, client_data: CXClientData?,
         val _index_callbacks_size = index_callbacks_size
         val _index_options = index_options
         val _arg5 = arg5.rawValue
-        val res = externals.clang_indexTranslationUnit(_arg0, _client_data, _index_callbacks, _index_callbacks_size, _index_options, _arg5)
+        val res = kni_clang_indexTranslationUnit(_arg0, _client_data, _index_callbacks, _index_callbacks_size, _index_options, _arg5)
         res
     }
 }
+
+private external fun kni_clang_indexTranslationUnit(arg0: NativePtr, client_data: NativePtr, index_callbacks: NativePtr, index_callbacks_size: Int, index_options: Int, arg5: NativePtr): Int
 
 fun clang_indexLoc_getFileLocation(loc: CValue<CXIdxLoc>, indexFile: CValuesRef<CXIdxClientFileVar>?, file: CValuesRef<CXFileVar>?, line: CValuesRef<IntVar>?, column: CValuesRef<IntVar>?, offset: CValuesRef<IntVar>?): Unit {
     return memScoped {
@@ -2565,303 +3190,582 @@ fun clang_indexLoc_getFileLocation(loc: CValue<CXIdxLoc>, indexFile: CValuesRef<
         val _line = line?.getPointer(memScope).rawValue
         val _column = column?.getPointer(memScope).rawValue
         val _offset = offset?.getPointer(memScope).rawValue
-        val res = externals.clang_indexLoc_getFileLocation(_loc, _indexFile, _file, _line, _column, _offset)
+        val res = kni_clang_indexLoc_getFileLocation(_loc, _indexFile, _file, _line, _column, _offset)
         res
     }
 }
 
+private external fun kni_clang_indexLoc_getFileLocation(loc: NativePtr, indexFile: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
+
 fun clang_indexLoc_getCXSourceLocation(loc: CValue<CXIdxLoc>): CValue<CXSourceLocation> {
     return memScoped {
         val _loc = loc.getPointer(memScope).rawValue
-        val res = externals.clang_indexLoc_getCXSourceLocation(_loc, alloc<CXSourceLocation>().rawPtr)
+        val res = kni_clang_indexLoc_getCXSourceLocation(_loc, alloc<CXSourceLocation>().rawPtr)
         interpretPointed<CXSourceLocation>(res).readValue()
     }
 }
+
+private external fun kni_clang_indexLoc_getCXSourceLocation(loc: NativePtr, retValPlacement: NativePtr): NativePtr
 
 fun clang_Type_visitFields(T: CValue<CXType>, visitor: CXFieldVisitor?, client_data: CXClientData?): Int {
     return memScoped {
         val _T = T.getPointer(memScope).rawValue
         val _visitor = visitor.rawValue
         val _client_data = client_data.rawValue
-        val res = externals.clang_Type_visitFields(_T, _visitor, _client_data)
+        val res = kni_clang_Type_visitFields(_T, _visitor, _client_data)
         res
     }
 }
 
+private external fun kni_clang_Type_visitFields(T: NativePtr, visitor: NativePtr, client_data: NativePtr): Int
+
 val __llvm__: Int = 1
+
 val __clang__: Int = 1
+
 val __clang_major__: Int = 3
+
 val __clang_minor__: Int = 9
+
 val __clang_patchlevel__: Int = 0
+
 val __GNUC_MINOR__: Int = 2
+
 val __GNUC_PATCHLEVEL__: Int = 1
+
 val __GNUC__: Int = 4
+
 val __GXX_ABI_VERSION: Int = 1002
+
 val __ATOMIC_RELAXED: Int = 0
+
 val __ATOMIC_CONSUME: Int = 1
+
 val __ATOMIC_ACQUIRE: Int = 2
+
 val __ATOMIC_RELEASE: Int = 3
+
 val __ATOMIC_ACQ_REL: Int = 4
+
 val __ATOMIC_SEQ_CST: Int = 5
+
 val __PRAGMA_REDEFINE_EXTNAME: Int = 1
+
 val __STRICT_ANSI__: Int = 1
+
 val __CONSTANT_CFSTRINGS__: Int = 1
+
 val __BLOCKS__: Int = 1
+
 val __ORDER_LITTLE_ENDIAN__: Int = 1234
+
 val __ORDER_BIG_ENDIAN__: Int = 4321
+
 val __ORDER_PDP_ENDIAN__: Int = 3412
+
 val __BYTE_ORDER__: Int = 1234
+
 val __LITTLE_ENDIAN__: Int = 1
+
 val _LP64: Int = 1
+
 val __LP64__: Int = 1
+
 val __CHAR_BIT__: Int = 8
+
 val __SCHAR_MAX__: Int = 127
+
 val __SHRT_MAX__: Int = 32767
+
 val __INT_MAX__: Int = 2147483647
+
 val __LONG_MAX__: Long = 9223372036854775807
+
 val __LONG_LONG_MAX__: Long = 9223372036854775807
+
 val __WCHAR_MAX__: Int = 2147483647
+
 val __INTMAX_MAX__: Long = 9223372036854775807
+
 val __SIZE_MAX__: Long = -1
+
 val __UINTMAX_MAX__: Long = -1
+
 val __PTRDIFF_MAX__: Long = 9223372036854775807
+
 val __INTPTR_MAX__: Long = 9223372036854775807
+
 val __UINTPTR_MAX__: Long = -1
+
 val __SIZEOF_DOUBLE__: Int = 8
+
 val __SIZEOF_FLOAT__: Int = 4
+
 val __SIZEOF_INT__: Int = 4
+
 val __SIZEOF_LONG__: Int = 8
+
 val __SIZEOF_LONG_DOUBLE__: Int = 16
+
 val __SIZEOF_LONG_LONG__: Int = 8
+
 val __SIZEOF_POINTER__: Int = 8
+
 val __SIZEOF_SHORT__: Int = 2
+
 val __SIZEOF_PTRDIFF_T__: Int = 8
+
 val __SIZEOF_SIZE_T__: Int = 8
+
 val __SIZEOF_WCHAR_T__: Int = 4
+
 val __SIZEOF_WINT_T__: Int = 4
+
 val __SIZEOF_INT128__: Int = 16
+
 val __INTMAX_WIDTH__: Int = 64
+
 val __PTRDIFF_WIDTH__: Int = 64
+
 val __INTPTR_WIDTH__: Int = 64
+
 val __SIZE_WIDTH__: Int = 64
+
 val __WCHAR_WIDTH__: Int = 32
+
 val __WINT_WIDTH__: Int = 32
+
 val __SIG_ATOMIC_WIDTH__: Int = 32
+
 val __SIG_ATOMIC_MAX__: Int = 2147483647
+
 val __UINTMAX_WIDTH__: Int = 64
+
 val __UINTPTR_WIDTH__: Int = 64
+
 val __FLT_DENORM_MIN__: Float = bitsToFloat(1) /* == 1.4E-45 */
+
 val __FLT_HAS_DENORM__: Int = 1
+
 val __FLT_DIG__: Int = 6
+
 val __FLT_DECIMAL_DIG__: Int = 9
+
 val __FLT_EPSILON__: Float = bitsToFloat(872415232) /* == 1.1920929E-7 */
+
 val __FLT_HAS_INFINITY__: Int = 1
+
 val __FLT_HAS_QUIET_NAN__: Int = 1
+
 val __FLT_MANT_DIG__: Int = 24
+
 val __FLT_MAX_10_EXP__: Int = 38
+
 val __FLT_MAX_EXP__: Int = 128
+
 val __FLT_MAX__: Float = bitsToFloat(2139095039) /* == 3.4028235E38 */
+
 val __FLT_MIN_10_EXP__: Int = -37
+
 val __FLT_MIN_EXP__: Int = -125
+
 val __FLT_MIN__: Float = bitsToFloat(8388608) /* == 1.17549435E-38 */
+
 val __DBL_DENORM_MIN__: Double = bitsToDouble(1) /* == 4.9E-324 */
+
 val __DBL_HAS_DENORM__: Int = 1
+
 val __DBL_DIG__: Int = 15
+
 val __DBL_DECIMAL_DIG__: Int = 17
+
 val __DBL_EPSILON__: Double = bitsToDouble(4372995238176751616) /* == 2.220446049250313E-16 */
+
 val __DBL_HAS_INFINITY__: Int = 1
+
 val __DBL_HAS_QUIET_NAN__: Int = 1
+
 val __DBL_MANT_DIG__: Int = 53
+
 val __DBL_MAX_10_EXP__: Int = 308
+
 val __DBL_MAX_EXP__: Int = 1024
+
 val __DBL_MAX__: Double = bitsToDouble(9218868437227405311) /* == 1.7976931348623157E308 */
+
 val __DBL_MIN_10_EXP__: Int = -307
+
 val __DBL_MIN_EXP__: Int = -1021
+
 val __DBL_MIN__: Double = bitsToDouble(4503599627370496) /* == 2.2250738585072014E-308 */
+
+
 val __LDBL_HAS_DENORM__: Int = 1
+
 val __LDBL_DIG__: Int = 18
+
 val __LDBL_DECIMAL_DIG__: Int = 21
+
+
 val __LDBL_HAS_INFINITY__: Int = 1
+
 val __LDBL_HAS_QUIET_NAN__: Int = 1
+
 val __LDBL_MANT_DIG__: Int = 64
+
 val __LDBL_MAX_10_EXP__: Int = 4932
+
 val __LDBL_MAX_EXP__: Int = 16384
+
+
 val __LDBL_MIN_10_EXP__: Int = -4931
+
 val __LDBL_MIN_EXP__: Int = -16381
+
+
 val __POINTER_WIDTH__: Int = 64
+
 val __BIGGEST_ALIGNMENT__: Int = 16
+
 val __UINT8_MAX__: Int = 255
+
 val __INT8_MAX__: Int = 127
+
 val __UINT16_MAX__: Int = 65535
+
 val __INT16_MAX__: Int = 32767
+
 val __UINT32_MAX__: Int = -1
+
 val __INT32_MAX__: Int = 2147483647
+
 val __UINT64_MAX__: Long = -1
+
 val __INT64_MAX__: Long = 9223372036854775807
+
 val __INT_LEAST8_MAX__: Int = 127
+
 val __UINT_LEAST8_MAX__: Int = 255
+
 val __INT_LEAST16_MAX__: Int = 32767
+
 val __UINT_LEAST16_MAX__: Int = 65535
+
 val __INT_LEAST32_MAX__: Int = 2147483647
+
 val __UINT_LEAST32_MAX__: Int = -1
+
 val __INT_LEAST64_MAX__: Long = 9223372036854775807
+
 val __UINT_LEAST64_MAX__: Long = -1
+
 val __INT_FAST8_MAX__: Int = 127
+
 val __UINT_FAST8_MAX__: Int = 255
+
 val __INT_FAST16_MAX__: Int = 32767
+
 val __UINT_FAST16_MAX__: Int = 65535
+
 val __INT_FAST32_MAX__: Int = 2147483647
+
 val __UINT_FAST32_MAX__: Int = -1
+
 val __INT_FAST64_MAX__: Long = 9223372036854775807
+
 val __UINT_FAST64_MAX__: Long = -1
+
 val __FINITE_MATH_ONLY__: Int = 0
+
 val __GNUC_STDC_INLINE__: Int = 1
+
 val __GCC_ATOMIC_TEST_AND_SET_TRUEVAL: Int = 1
+
 val __GCC_ATOMIC_BOOL_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_CHAR_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_CHAR16_T_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_CHAR32_T_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_WCHAR_T_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_SHORT_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_INT_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_LONG_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_LLONG_LOCK_FREE: Int = 2
+
 val __GCC_ATOMIC_POINTER_LOCK_FREE: Int = 2
+
 val __NO_INLINE__: Int = 1
+
 val __PIC__: Int = 2
+
 val __pic__: Int = 2
+
 val __FLT_EVAL_METHOD__: Int = 0
+
 val __FLT_RADIX__: Int = 2
+
 val __DECIMAL_DIG__: Int = 21
+
 val __SSP__: Int = 1
+
 val __amd64__: Int = 1
+
 val __amd64: Int = 1
+
 val __x86_64: Int = 1
+
 val __x86_64__: Int = 1
+
 val __core2: Int = 1
+
 val __core2__: Int = 1
+
 val __tune_core2__: Int = 1
+
 val __NO_MATH_INLINES: Int = 1
+
 val __FXSR__: Int = 1
+
 val __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16: Int = 1
+
 val __SSSE3__: Int = 1
+
 val __SSE3__: Int = 1
+
 val __SSE2__: Int = 1
+
 val __SSE2_MATH__: Int = 1
+
 val __SSE__: Int = 1
+
 val __SSE_MATH__: Int = 1
+
 val __MMX__: Int = 1
+
 val __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1: Int = 1
+
 val __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2: Int = 1
+
 val __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4: Int = 1
+
 val __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8: Int = 1
+
 val __APPLE_CC__: Int = 6000
+
 val __APPLE__: Int = 1
+
 val OBJC_NEW_PROPERTIES: Int = 1
+
 val __DYNAMIC__: Int = 1
-val __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__: Int = 101000
+
+val __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__: Int = 101100
+
 val __MACH__: Int = 1
+
 val __STDC__: Int = 1
+
 val __STDC_HOSTED__: Int = 1
+
 val __STDC_VERSION__: Long = 199901
+
 val __STDC_UTF_16__: Int = 1
+
 val __STDC_UTF_32__: Int = 1
+
 val __DARWIN_ONLY_64_BIT_INO_T: Int = 0
+
 val __DARWIN_ONLY_VERS_1050: Int = 0
+
 val __DARWIN_ONLY_UNIX_CONFORMANCE: Int = 1
+
 val __DARWIN_UNIX03: Int = 1
+
 val __DARWIN_64_BIT_INO_T: Int = 1
+
 val __DARWIN_VERS_1050: Int = 1
+
 val __DARWIN_NON_CANCELABLE: Int = 0
+
 val __DARWIN_C_ANSI: Long = 4096
+
 val __DARWIN_C_FULL: Long = 900000
+
 val __DARWIN_C_LEVEL: Long = 900000
+
 val _DARWIN_FEATURE_64_BIT_INODE: Int = 1
+
 val _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: Int = 1
+
 val _DARWIN_FEATURE_UNIX_CONFORMANCE: Int = 3
+
 val __PTHREAD_SIZE__: Int = 8176
+
 val __PTHREAD_ATTR_SIZE__: Int = 56
+
 val __PTHREAD_MUTEXATTR_SIZE__: Int = 8
+
 val __PTHREAD_MUTEX_SIZE__: Int = 56
+
 val __PTHREAD_CONDATTR_SIZE__: Int = 8
+
 val __PTHREAD_COND_SIZE__: Int = 40
+
 val __PTHREAD_ONCE_SIZE__: Int = 8
+
 val __PTHREAD_RWLOCK_SIZE__: Int = 192
+
 val __PTHREAD_RWLOCKATTR_SIZE__: Int = 16
+
 val __DARWIN_WCHAR_MAX: Int = 2147483647
+
 val __DARWIN_WCHAR_MIN: Int = -2147483648
+
 val __DARWIN_WEOF: __darwin_wint_t = -1
+
 val _FORTIFY_SOURCE: Int = 2
+
 val __MAC_10_0: Int = 1000
+
 val __MAC_10_1: Int = 1010
+
 val __MAC_10_2: Int = 1020
+
 val __MAC_10_3: Int = 1030
+
 val __MAC_10_4: Int = 1040
+
 val __MAC_10_5: Int = 1050
+
 val __MAC_10_6: Int = 1060
+
 val __MAC_10_7: Int = 1070
+
 val __MAC_10_8: Int = 1080
+
 val __MAC_10_9: Int = 1090
+
 val __MAC_10_10: Int = 101000
+
 val __MAC_10_10_2: Int = 101002
+
 val __MAC_10_10_3: Int = 101003
+
 val __MAC_10_11: Int = 101100
+
 val __MAC_10_11_2: Int = 101102
+
 val __MAC_10_11_3: Int = 101103
+
 val __MAC_10_11_4: Int = 101104
+
 val __MAC_10_12: Int = 101200
+
 val __IPHONE_2_0: Int = 20000
+
 val __IPHONE_2_1: Int = 20100
+
 val __IPHONE_2_2: Int = 20200
+
 val __IPHONE_3_0: Int = 30000
+
 val __IPHONE_3_1: Int = 30100
+
 val __IPHONE_3_2: Int = 30200
+
 val __IPHONE_4_0: Int = 40000
+
 val __IPHONE_4_1: Int = 40100
+
 val __IPHONE_4_2: Int = 40200
+
 val __IPHONE_4_3: Int = 40300
+
 val __IPHONE_5_0: Int = 50000
+
 val __IPHONE_5_1: Int = 50100
+
 val __IPHONE_6_0: Int = 60000
+
 val __IPHONE_6_1: Int = 60100
+
 val __IPHONE_7_0: Int = 70000
+
 val __IPHONE_7_1: Int = 70100
+
 val __IPHONE_8_0: Int = 80000
+
 val __IPHONE_8_1: Int = 80100
+
 val __IPHONE_8_2: Int = 80200
+
 val __IPHONE_8_3: Int = 80300
+
 val __IPHONE_8_4: Int = 80400
+
 val __IPHONE_9_0: Int = 90000
+
 val __IPHONE_9_1: Int = 90100
+
 val __IPHONE_9_2: Int = 90200
+
 val __IPHONE_9_3: Int = 90300
+
 val __IPHONE_10_0: Int = 100000
+
 val __TVOS_9_0: Int = 90000
+
 val __TVOS_9_1: Int = 90100
+
 val __TVOS_9_2: Int = 90200
+
 val __TVOS_10_0: Int = 100000
+
 val __WATCHOS_1_0: Int = 10000
+
 val __WATCHOS_2_0: Int = 20000
+
 val __WATCHOS_3_0: Int = 30000
-val __MAC_OS_X_VERSION_MIN_REQUIRED: Int = 101000
+
+val __MAC_OS_X_VERSION_MIN_REQUIRED: Int = 101100
+
 val __MAC_OS_X_VERSION_MAX_ALLOWED: Int = 101200
+
 val CLOCKS_PER_SEC: Int = 1000000
+
 val CLOCK_REALTIME: Int = 0
+
 val CLOCK_MONOTONIC: Int = 6
+
 val CLOCK_MONOTONIC_RAW: Int = 4
+
 val CLOCK_MONOTONIC_RAW_APPROX: Int = 5
+
 val CLOCK_UPTIME_RAW: Int = 8
+
 val CLOCK_UPTIME_RAW_APPROX: Int = 9
+
 val CLOCK_PROCESS_CPUTIME_ID: Int = 12
+
 val CLOCK_THREAD_CPUTIME_ID: Int = 16
+
 val CINDEX_VERSION_MAJOR: Int = 0
+
 val CINDEX_VERSION_MINOR: Int = 35
+
 val CINDEX_VERSION: Int = 35
 
 class __mbstate_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(128, 8)
     
+    @CLength(128)
     val __mbstate8: CArrayPointer<ByteVar>
         get() = arrayMemberAt(0)
     
@@ -2899,13 +3803,14 @@ class __builtin_va_list(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("__routine", "__arg", "__next")
 class __darwin_pthread_handler_rec(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
     
-    var __routine: CPointer<CFunction<CFunctionType2>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType2>>>(0).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType2>>>(0).value = value }
+    var __routine: CPointer<CFunction<(COpaquePointer?) -> Unit>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?) -> Unit>>>(0).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?) -> Unit>>>(0).value = value }
     
     var __arg: COpaquePointer?
         get() = memberAt<COpaquePointerVar>(8).value
@@ -2917,6 +3822,7 @@ class __darwin_pthread_handler_rec(override val rawPtr: NativePtr) : CStructVar(
     
 }
 
+@CNaturalStruct("__sig", "__opaque")
 class _opaque_pthread_attr_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(64, 8)
@@ -2925,11 +3831,13 @@ class _opaque_pthread_attr_t(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<LongVar>(0).value
         set(value) { memberAt<LongVar>(0).value = value }
     
+    @CLength(56)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("__sig", "__opaque")
 class _opaque_pthread_cond_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(48, 8)
@@ -2938,11 +3846,13 @@ class _opaque_pthread_cond_t(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<LongVar>(0).value
         set(value) { memberAt<LongVar>(0).value = value }
     
+    @CLength(40)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("__sig", "__opaque")
 class _opaque_pthread_condattr_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -2951,11 +3861,13 @@ class _opaque_pthread_condattr_t(override val rawPtr: NativePtr) : CStructVar() 
         get() = memberAt<LongVar>(0).value
         set(value) { memberAt<LongVar>(0).value = value }
     
+    @CLength(8)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("__sig", "__opaque")
 class _opaque_pthread_mutex_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(64, 8)
@@ -2964,11 +3876,13 @@ class _opaque_pthread_mutex_t(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<LongVar>(0).value
         set(value) { memberAt<LongVar>(0).value = value }
     
+    @CLength(56)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("__sig", "__opaque")
 class _opaque_pthread_mutexattr_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -2977,11 +3891,13 @@ class _opaque_pthread_mutexattr_t(override val rawPtr: NativePtr) : CStructVar()
         get() = memberAt<LongVar>(0).value
         set(value) { memberAt<LongVar>(0).value = value }
     
+    @CLength(8)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("__sig", "__opaque")
 class _opaque_pthread_once_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -2990,11 +3906,13 @@ class _opaque_pthread_once_t(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<LongVar>(0).value
         set(value) { memberAt<LongVar>(0).value = value }
     
+    @CLength(8)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("__sig", "__opaque")
 class _opaque_pthread_rwlock_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(200, 8)
@@ -3003,11 +3921,13 @@ class _opaque_pthread_rwlock_t(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<LongVar>(0).value
         set(value) { memberAt<LongVar>(0).value = value }
     
+    @CLength(192)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("__sig", "__opaque")
 class _opaque_pthread_rwlockattr_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
@@ -3016,11 +3936,13 @@ class _opaque_pthread_rwlockattr_t(override val rawPtr: NativePtr) : CStructVar(
         get() = memberAt<LongVar>(0).value
         set(value) { memberAt<LongVar>(0).value = value }
     
+    @CLength(16)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("__sig", "__cleanup_stack", "__opaque")
 class _opaque_pthread_t(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(8192, 8)
@@ -3033,11 +3955,13 @@ class _opaque_pthread_t(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<CPointerVar<__darwin_pthread_handler_rec>>(8).value
         set(value) { memberAt<CPointerVar<__darwin_pthread_handler_rec>>(8).value = value }
     
+    @CLength(8176)
     val __opaque: CArrayPointer<ByteVar>
         get() = arrayMemberAt(16)
     
 }
 
+@CNaturalStruct("tv_sec", "tv_nsec")
 class timespec(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3052,6 +3976,7 @@ class timespec(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("tm_sec", "tm_min", "tm_hour", "tm_mday", "tm_mon", "tm_year", "tm_wday", "tm_yday", "tm_isdst", "tm_gmtoff", "tm_zone")
 class tm(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(56, 8)
@@ -3102,6 +4027,7 @@ class tm(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("data", "private_flags")
 class CXString(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3116,6 +4042,7 @@ class CXString(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("Strings", "Count")
 class CXStringSet(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3136,6 +4063,7 @@ class CXModuleMapDescriptorImpl(override val rawPtr: NativePtr) : COpaque
 
 class CXTranslationUnitImpl(override val rawPtr: NativePtr) : COpaque
 
+@CNaturalStruct("Filename", "Contents", "Length")
 class CXUnsavedFile(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
@@ -3154,6 +4082,7 @@ class CXUnsavedFile(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("Major", "Minor", "Subminor")
 class CXVersion(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(12, 4)
@@ -3172,19 +4101,23 @@ class CXVersion(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("data")
 class CXFileUniqueID(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
     
+    @CLength(3)
     val data: CArrayPointer<LongVar>
         get() = arrayMemberAt(0)
     
 }
 
+@CNaturalStruct("ptr_data", "int_data")
 class CXSourceLocation(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
     
+    @CLength(2)
     val ptr_data: CArrayPointer<COpaquePointerVar>
         get() = arrayMemberAt(0)
     
@@ -3194,10 +4127,12 @@ class CXSourceLocation(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("ptr_data", "begin_int_data", "end_int_data")
 class CXSourceRange(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
     
+    @CLength(2)
     val ptr_data: CArrayPointer<COpaquePointerVar>
         get() = arrayMemberAt(0)
     
@@ -3211,6 +4146,7 @@ class CXSourceRange(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("count", "ranges")
 class CXSourceRangeList(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3225,6 +4161,7 @@ class CXSourceRangeList(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("kind", "amount")
 class CXTUResourceUsageEntry(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3239,6 +4176,7 @@ class CXTUResourceUsageEntry(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("data", "numEntries", "entries")
 class CXTUResourceUsage(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
@@ -3257,6 +4195,7 @@ class CXTUResourceUsage(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("kind", "xdata", "data")
 class CXCursor(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(32, 8)
@@ -3269,11 +4208,13 @@ class CXCursor(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<IntVar>(4).value
         set(value) { memberAt<IntVar>(4).value = value }
     
+    @CLength(3)
     val data: CArrayPointer<COpaquePointerVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("Platform", "Introduced", "Deprecated", "Obsoleted", "Unavailable", "Message")
 class CXPlatformAvailability(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(72, 8)
@@ -3301,6 +4242,7 @@ class CXPlatformAvailability(override val rawPtr: NativePtr) : CStructVar() {
 
 class CXCursorSetImpl(override val rawPtr: NativePtr) : COpaque
 
+@CNaturalStruct("kind", "data")
 class CXType(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
@@ -3309,15 +4251,18 @@ class CXType(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<CXTypeKind.Var>(0).value
         set(value) { memberAt<CXTypeKind.Var>(0).value = value }
     
+    @CLength(2)
     val data: CArrayPointer<COpaquePointerVar>
         get() = arrayMemberAt(8)
     
 }
 
+@CNaturalStruct("int_data", "ptr_data")
 class CXToken(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
     
+    @CLength(4)
     val int_data: CArrayPointer<IntVar>
         get() = arrayMemberAt(0)
     
@@ -3327,6 +4272,7 @@ class CXToken(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("CursorKind", "CompletionString")
 class CXCompletionResult(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3341,6 +4287,7 @@ class CXCompletionResult(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("Results", "NumResults")
 class CXCodeCompleteResults(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3355,6 +4302,7 @@ class CXCodeCompleteResults(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("context", "visit")
 class CXCursorAndRangeVisitor(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3363,16 +4311,18 @@ class CXCursorAndRangeVisitor(override val rawPtr: NativePtr) : CStructVar() {
         get() = memberAt<COpaquePointerVar>(0).value
         set(value) { memberAt<COpaquePointerVar>(0).value = value }
     
-    var visit: CPointer<CFunction<CFunctionType5>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType5>>>(8).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType5>>>(8).value = value }
+    var visit: CPointer<CFunction<(COpaquePointer?, CValue<CXCursor>, CValue<CXSourceRange>) -> CXVisitorResult>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CValue<CXCursor>, CValue<CXSourceRange>) -> CXVisitorResult>>>(8).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CValue<CXCursor>, CValue<CXSourceRange>) -> CXVisitorResult>>>(8).value = value }
     
 }
 
+@CNaturalStruct("ptr_data", "int_data")
 class CXIdxLoc(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
     
+    @CLength(2)
     val ptr_data: CArrayPointer<COpaquePointerVar>
         get() = arrayMemberAt(0)
     
@@ -3382,6 +4332,7 @@ class CXIdxLoc(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("hashLoc", "filename", "file", "isImport", "isAngled", "isModuleImport")
 class CXIdxIncludedFileInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(56, 8)
@@ -3411,6 +4362,7 @@ class CXIdxIncludedFileInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("file", "module", "loc", "isImplicit")
 class CXIdxImportedASTFileInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(48, 8)
@@ -3432,6 +4384,7 @@ class CXIdxImportedASTFileInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("kind", "cursor", "loc")
 class CXIdxAttrInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(64, 8)
@@ -3448,6 +4401,7 @@ class CXIdxAttrInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("kind", "templateKind", "lang", "name", "USR", "cursor", "attributes", "numAttributes")
 class CXIdxEntityInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(80, 8)
@@ -3485,6 +4439,7 @@ class CXIdxEntityInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("cursor")
 class CXIdxContainerInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(32, 8)
@@ -3494,6 +4449,7 @@ class CXIdxContainerInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("attrInfo", "objcClass", "classCursor", "classLoc")
 class CXIdxIBOutletCollectionAttrInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(72, 8)
@@ -3514,6 +4470,7 @@ class CXIdxIBOutletCollectionAttrInfo(override val rawPtr: NativePtr) : CStructV
     
 }
 
+@CNaturalStruct("entityInfo", "cursor", "loc", "semanticContainer", "lexicalContainer", "isRedeclaration", "isDefinition", "isContainer", "declAsContainer", "isImplicit", "attributes", "numAttributes", "flags")
 class CXIdxDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(128, 8)
@@ -3570,6 +4527,7 @@ class CXIdxDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("declInfo", "kind")
 class CXIdxObjCContainerDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3584,6 +4542,7 @@ class CXIdxObjCContainerDeclInfo(override val rawPtr: NativePtr) : CStructVar() 
     
 }
 
+@CNaturalStruct("base", "cursor", "loc")
 class CXIdxBaseClassInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(64, 8)
@@ -3600,6 +4559,7 @@ class CXIdxBaseClassInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("protocol", "cursor", "loc")
 class CXIdxObjCProtocolRefInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(64, 8)
@@ -3616,6 +4576,7 @@ class CXIdxObjCProtocolRefInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("protocols", "numProtocols")
 class CXIdxObjCProtocolRefListInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(16, 8)
@@ -3630,6 +4591,7 @@ class CXIdxObjCProtocolRefListInfo(override val rawPtr: NativePtr) : CStructVar(
     
 }
 
+@CNaturalStruct("containerInfo", "superInfo", "protocols")
 class CXIdxObjCInterfaceDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
@@ -3648,6 +4610,7 @@ class CXIdxObjCInterfaceDeclInfo(override val rawPtr: NativePtr) : CStructVar() 
     
 }
 
+@CNaturalStruct("containerInfo", "objcClass", "classCursor", "classLoc", "protocols")
 class CXIdxObjCCategoryDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(80, 8)
@@ -3672,6 +4635,7 @@ class CXIdxObjCCategoryDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("declInfo", "getter", "setter")
 class CXIdxObjCPropertyDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
@@ -3690,6 +4654,7 @@ class CXIdxObjCPropertyDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("declInfo", "bases", "numBases")
 class CXIdxCXXClassDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(24, 8)
@@ -3708,6 +4673,7 @@ class CXIdxCXXClassDeclInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("kind", "cursor", "loc", "referencedEntity", "parentEntity", "container")
 class CXIdxEntityRefInfo(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(88, 8)
@@ -3736,41 +4702,42 @@ class CXIdxEntityRefInfo(override val rawPtr: NativePtr) : CStructVar() {
     
 }
 
+@CNaturalStruct("abortQuery", "diagnostic", "enteredMainFile", "ppIncludedFile", "importedASTFile", "startedTranslationUnit", "indexDeclaration", "indexEntityReference")
 class IndexerCallbacks(override val rawPtr: NativePtr) : CStructVar() {
     
     companion object : Type(64, 8)
     
-    var abortQuery: CPointer<CFunction<CFunctionType6>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType6>>>(0).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType6>>>(0).value = value }
+    var abortQuery: CPointer<CFunction<(COpaquePointer?, COpaquePointer?) -> Int>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?) -> Int>>>(0).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?) -> Int>>>(0).value = value }
     
-    var diagnostic: CPointer<CFunction<CFunctionType7>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType7>>>(8).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType7>>>(8).value = value }
+    var diagnostic: CPointer<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> Unit>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> Unit>>>(8).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> Unit>>>(8).value = value }
     
-    var enteredMainFile: CPointer<CFunction<CFunctionType8>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType8>>>(16).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType8>>>(16).value = value }
+    var enteredMainFile: CPointer<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>>(16).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>>(16).value = value }
     
-    var ppIncludedFile: CPointer<CFunction<CFunctionType9>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType9>>>(24).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType9>>>(24).value = value }
+    var ppIncludedFile: CPointer<CFunction<(COpaquePointer?, CPointer<CXIdxIncludedFileInfo>?) -> COpaquePointer?>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxIncludedFileInfo>?) -> COpaquePointer?>>>(24).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxIncludedFileInfo>?) -> COpaquePointer?>>>(24).value = value }
     
-    var importedASTFile: CPointer<CFunction<CFunctionType10>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType10>>>(32).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType10>>>(32).value = value }
+    var importedASTFile: CPointer<CFunction<(COpaquePointer?, CPointer<CXIdxImportedASTFileInfo>?) -> COpaquePointer?>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxImportedASTFileInfo>?) -> COpaquePointer?>>>(32).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxImportedASTFileInfo>?) -> COpaquePointer?>>>(32).value = value }
     
-    var startedTranslationUnit: CPointer<CFunction<CFunctionType11>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType11>>>(40).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType11>>>(40).value = value }
+    var startedTranslationUnit: CPointer<CFunction<(COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>>(40).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, COpaquePointer?) -> COpaquePointer?>>>(40).value = value }
     
-    var indexDeclaration: CPointer<CFunction<CFunctionType12>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType12>>>(48).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType12>>>(48).value = value }
+    var indexDeclaration: CPointer<CFunction<(COpaquePointer?, CPointer<CXIdxDeclInfo>?) -> Unit>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxDeclInfo>?) -> Unit>>>(48).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxDeclInfo>?) -> Unit>>>(48).value = value }
     
-    var indexEntityReference: CPointer<CFunction<CFunctionType13>>?
-        get() = memberAt<CPointerVar<CFunction<CFunctionType13>>>(56).value
-        set(value) { memberAt<CPointerVar<CFunction<CFunctionType13>>>(56).value = value }
+    var indexEntityReference: CPointer<CFunction<(COpaquePointer?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>?
+        get() = memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>>(56).value
+        set(value) { memberAt<CPointerVar<CFunction<(COpaquePointer?, CPointer<CXIdxEntityRefInfo>?) -> Unit>>>(56).value = value }
     
 }
 
@@ -4924,7 +5891,7 @@ typealias CXCursorSetVar = CPointerVarOf<CXCursorSet>
 typealias CXCursorSet = CPointer<CXCursorSetImpl>
 
 typealias CXCursorVisitorVar = CPointerVarOf<CXCursorVisitor>
-typealias CXCursorVisitor = CPointer<CFunction<CFunctionType1>>
+typealias CXCursorVisitor = CPointer<CFunction<(CValue<CXCursor>, CValue<CXCursor>, COpaquePointer?) -> CXChildVisitResult>>
 
 typealias CXModuleVar = CPointerVarOf<CXModule>
 typealias CXModule = COpaquePointer
@@ -4933,7 +5900,7 @@ typealias CXCompletionStringVar = CPointerVarOf<CXCompletionString>
 typealias CXCompletionString = COpaquePointer
 
 typealias CXInclusionVisitorVar = CPointerVarOf<CXInclusionVisitor>
-typealias CXInclusionVisitor = CPointer<CFunction<CFunctionType3>>
+typealias CXInclusionVisitor = CPointer<CFunction<(COpaquePointer?, CPointer<CXSourceLocation>?, Int, COpaquePointer?) -> Unit>>
 
 typealias CXEvalResultVar = CPointerVarOf<CXEvalResult>
 typealias CXEvalResult = COpaquePointer
@@ -4957,724 +5924,6 @@ typealias CXIndexActionVar = CPointerVarOf<CXIndexAction>
 typealias CXIndexAction = COpaquePointer
 
 typealias CXFieldVisitorVar = CPointerVarOf<CXFieldVisitor>
-typealias CXFieldVisitor = CPointer<CFunction<CFunctionType4>>
+typealias CXFieldVisitor = CPointer<CFunction<(CValue<CXCursor>, COpaquePointer?) -> CXVisitorResult>>
 
-object CFunctionType1 : CAdaptedFunctionTypeImpl<(CXCursor, CXCursor, COpaquePointer?) -> CXChildVisitResult>(UInt32, Struct(UInt32, SInt32, Struct(Pointer, Pointer, Pointer)), Struct(UInt32, SInt32, Struct(Pointer, Pointer, Pointer)), Pointer) {
-    override fun invoke(function: (CXCursor, CXCursor, COpaquePointer?) -> CXChildVisitResult,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<CXCursor>().pointed, args[1]!!.reinterpret<CXCursor>().pointed, args[2]!!.reinterpret<COpaquePointerVar>().pointed.value)
-        ret.reinterpret<CXChildVisitResult.Var>().pointed.value = res
-    }
-}
-
-object CFunctionType2 : CAdaptedFunctionTypeImpl<(COpaquePointer?) -> Unit>(Void, Pointer) {
-    override fun invoke(function: (COpaquePointer?) -> Unit,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value)
-    }
-}
-
-object CFunctionType3 : CAdaptedFunctionTypeImpl<(COpaquePointer?, CPointer<CXSourceLocation>?, Int, COpaquePointer?) -> Unit>(Void, Pointer, Pointer, UInt32, Pointer) {
-    override fun invoke(function: (COpaquePointer?, CPointer<CXSourceLocation>?, Int, COpaquePointer?) -> Unit,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<CPointerVar<CXSourceLocation>>().pointed.value, args[2]!!.reinterpret<IntVar>().pointed.value, args[3]!!.reinterpret<COpaquePointerVar>().pointed.value)
-    }
-}
-
-object CFunctionType4 : CAdaptedFunctionTypeImpl<(CXCursor, COpaquePointer?) -> CXVisitorResult>(UInt32, Struct(UInt32, SInt32, Struct(Pointer, Pointer, Pointer)), Pointer) {
-    override fun invoke(function: (CXCursor, COpaquePointer?) -> CXVisitorResult,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<CXCursor>().pointed, args[1]!!.reinterpret<COpaquePointerVar>().pointed.value)
-        ret.reinterpret<CXVisitorResult.Var>().pointed.value = res
-    }
-}
-
-object CFunctionType5 : CAdaptedFunctionTypeImpl<(COpaquePointer?, CXCursor, CXSourceRange) -> CXVisitorResult>(UInt32, Pointer, Struct(UInt32, SInt32, Struct(Pointer, Pointer, Pointer)), Struct(Struct(Pointer, Pointer), UInt32, UInt32)) {
-    override fun invoke(function: (COpaquePointer?, CXCursor, CXSourceRange) -> CXVisitorResult,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<CXCursor>().pointed, args[2]!!.reinterpret<CXSourceRange>().pointed)
-        ret.reinterpret<CXVisitorResult.Var>().pointed.value = res
-    }
-}
-
-object CFunctionType6 : CAdaptedFunctionTypeImpl<(COpaquePointer?, COpaquePointer?) -> Int>(SInt32, Pointer, Pointer) {
-    override fun invoke(function: (COpaquePointer?, COpaquePointer?) -> Int,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<COpaquePointerVar>().pointed.value)
-        ret.reinterpret<IntVar>().pointed.value = res
-    }
-}
-
-object CFunctionType7 : CAdaptedFunctionTypeImpl<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> Unit>(Void, Pointer, Pointer, Pointer) {
-    override fun invoke(function: (COpaquePointer?, COpaquePointer?, COpaquePointer?) -> Unit,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<COpaquePointerVar>().pointed.value, args[2]!!.reinterpret<COpaquePointerVar>().pointed.value)
-    }
-}
-
-object CFunctionType8 : CAdaptedFunctionTypeImpl<(COpaquePointer?, COpaquePointer?, COpaquePointer?) -> COpaquePointer?>(Pointer, Pointer, Pointer, Pointer) {
-    override fun invoke(function: (COpaquePointer?, COpaquePointer?, COpaquePointer?) -> COpaquePointer?,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<COpaquePointerVar>().pointed.value, args[2]!!.reinterpret<COpaquePointerVar>().pointed.value)
-        ret.reinterpret<COpaquePointerVar>().pointed.value = res
-    }
-}
-
-object CFunctionType9 : CAdaptedFunctionTypeImpl<(COpaquePointer?, CPointer<CXIdxIncludedFileInfo>?) -> COpaquePointer?>(Pointer, Pointer, Pointer) {
-    override fun invoke(function: (COpaquePointer?, CPointer<CXIdxIncludedFileInfo>?) -> COpaquePointer?,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<CPointerVar<CXIdxIncludedFileInfo>>().pointed.value)
-        ret.reinterpret<COpaquePointerVar>().pointed.value = res
-    }
-}
-
-object CFunctionType10 : CAdaptedFunctionTypeImpl<(COpaquePointer?, CPointer<CXIdxImportedASTFileInfo>?) -> COpaquePointer?>(Pointer, Pointer, Pointer) {
-    override fun invoke(function: (COpaquePointer?, CPointer<CXIdxImportedASTFileInfo>?) -> COpaquePointer?,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<CPointerVar<CXIdxImportedASTFileInfo>>().pointed.value)
-        ret.reinterpret<COpaquePointerVar>().pointed.value = res
-    }
-}
-
-object CFunctionType11 : CAdaptedFunctionTypeImpl<(COpaquePointer?, COpaquePointer?) -> COpaquePointer?>(Pointer, Pointer, Pointer) {
-    override fun invoke(function: (COpaquePointer?, COpaquePointer?) -> COpaquePointer?,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<COpaquePointerVar>().pointed.value)
-        ret.reinterpret<COpaquePointerVar>().pointed.value = res
-    }
-}
-
-object CFunctionType12 : CAdaptedFunctionTypeImpl<(COpaquePointer?, CPointer<CXIdxDeclInfo>?) -> Unit>(Void, Pointer, Pointer) {
-    override fun invoke(function: (COpaquePointer?, CPointer<CXIdxDeclInfo>?) -> Unit,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<CPointerVar<CXIdxDeclInfo>>().pointed.value)
-    }
-}
-
-object CFunctionType13 : CAdaptedFunctionTypeImpl<(COpaquePointer?, CPointer<CXIdxEntityRefInfo>?) -> Unit>(Void, Pointer, Pointer) {
-    override fun invoke(function: (COpaquePointer?, CPointer<CXIdxEntityRefInfo>?) -> Unit,  args: CArrayPointer<COpaquePointerVar>, ret: COpaquePointer) {
-        val res = function(args[0]!!.reinterpret<COpaquePointerVar>().pointed.value, args[1]!!.reinterpret<CPointerVar<CXIdxEntityRefInfo>>().pointed.value)
-    }
-}
-
-object externals {
-    init { System.loadLibrary("clangstubs") }
-    external fun asctime(arg0: NativePtr): NativePtr
-    
-    external fun clock(): Long
-    
-    external fun ctime(arg0: NativePtr): NativePtr
-    
-    external fun difftime(arg0: Long, arg1: Long): Double
-    
-    external fun getdate(arg0: NativePtr): NativePtr
-    
-    external fun gmtime(arg0: NativePtr): NativePtr
-    
-    external fun localtime(arg0: NativePtr): NativePtr
-    
-    external fun mktime(arg0: NativePtr): Long
-    
-    external fun strftime(arg0: NativePtr, arg1: Long, arg2: NativePtr, arg3: NativePtr): Long
-    
-    external fun strptime(arg0: NativePtr, arg1: NativePtr, arg2: NativePtr): NativePtr
-    
-    external fun time(arg0: NativePtr): Long
-    
-    external fun tzset(): Unit
-    
-    external fun asctime_r(arg0: NativePtr, arg1: NativePtr): NativePtr
-    
-    external fun ctime_r(arg0: NativePtr, arg1: NativePtr): NativePtr
-    
-    external fun gmtime_r(arg0: NativePtr, arg1: NativePtr): NativePtr
-    
-    external fun localtime_r(arg0: NativePtr, arg1: NativePtr): NativePtr
-    
-    external fun posix2time(arg0: Long): Long
-    
-    external fun tzsetwall(): Unit
-    
-    external fun time2posix(arg0: Long): Long
-    
-    external fun timelocal(arg0: NativePtr): Long
-    
-    external fun timegm(arg0: NativePtr): Long
-    
-    external fun nanosleep(__rqtp: NativePtr, __rmtp: NativePtr): Int
-    
-    external fun clock_getres(__clock_id: Int, __res: NativePtr): Int
-    
-    external fun clock_gettime(__clock_id: Int, __tp: NativePtr): Int
-    
-    external fun clock_gettime_nsec_np(__clock_id: Int): Long
-    
-    external fun clock_settime(__clock_id: Int, __tp: NativePtr): Int
-    
-    external fun clang_getCString(string: NativePtr): NativePtr
-    
-    external fun clang_disposeString(string: NativePtr): Unit
-    
-    external fun clang_disposeStringSet(set: NativePtr): Unit
-    
-    external fun clang_getBuildSessionTimestamp(): Long
-    
-    external fun clang_VirtualFileOverlay_create(options: Int): NativePtr
-    
-    external fun clang_VirtualFileOverlay_addFileMapping(arg0: NativePtr, virtualPath: NativePtr, realPath: NativePtr): Int
-    
-    external fun clang_VirtualFileOverlay_setCaseSensitivity(arg0: NativePtr, caseSensitive: Int): Int
-    
-    external fun clang_VirtualFileOverlay_writeToBuffer(arg0: NativePtr, options: Int, out_buffer_ptr: NativePtr, out_buffer_size: NativePtr): Int
-    
-    external fun clang_free(buffer: NativePtr): Unit
-    
-    external fun clang_VirtualFileOverlay_dispose(arg0: NativePtr): Unit
-    
-    external fun clang_ModuleMapDescriptor_create(options: Int): NativePtr
-    
-    external fun clang_ModuleMapDescriptor_setFrameworkModuleName(arg0: NativePtr, name: NativePtr): Int
-    
-    external fun clang_ModuleMapDescriptor_setUmbrellaHeader(arg0: NativePtr, name: NativePtr): Int
-    
-    external fun clang_ModuleMapDescriptor_writeToBuffer(arg0: NativePtr, options: Int, out_buffer_ptr: NativePtr, out_buffer_size: NativePtr): Int
-    
-    external fun clang_ModuleMapDescriptor_dispose(arg0: NativePtr): Unit
-    
-    external fun clang_createIndex(excludeDeclarationsFromPCH: Int, displayDiagnostics: Int): NativePtr
-    
-    external fun clang_disposeIndex(index: NativePtr): Unit
-    
-    external fun clang_CXIndex_setGlobalOptions(arg0: NativePtr, options: Int): Unit
-    
-    external fun clang_CXIndex_getGlobalOptions(arg0: NativePtr): Int
-    
-    external fun clang_getFileName(SFile: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getFileTime(SFile: NativePtr): Long
-    
-    external fun clang_getFileUniqueID(file: NativePtr, outID: NativePtr): Int
-    
-    external fun clang_isFileMultipleIncludeGuarded(tu: NativePtr, file: NativePtr): Int
-    
-    external fun clang_getFile(tu: NativePtr, file_name: NativePtr): NativePtr
-    
-    external fun clang_File_isEqual(file1: NativePtr, file2: NativePtr): Int
-    
-    external fun clang_getNullLocation(retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_equalLocations(loc1: NativePtr, loc2: NativePtr): Int
-    
-    external fun clang_getLocation(tu: NativePtr, file: NativePtr, line: Int, column: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getLocationForOffset(tu: NativePtr, file: NativePtr, offset: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Location_isInSystemHeader(location: NativePtr): Int
-    
-    external fun clang_Location_isFromMainFile(location: NativePtr): Int
-    
-    external fun clang_getNullRange(retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getRange(begin: NativePtr, end: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_equalRanges(range1: NativePtr, range2: NativePtr): Int
-    
-    external fun clang_Range_isNull(range: NativePtr): Int
-    
-    external fun clang_getExpansionLocation(location: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
-    
-    external fun clang_getPresumedLocation(location: NativePtr, filename: NativePtr, line: NativePtr, column: NativePtr): Unit
-    
-    external fun clang_getInstantiationLocation(location: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
-    
-    external fun clang_getSpellingLocation(location: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
-    
-    external fun clang_getFileLocation(location: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
-    
-    external fun clang_getRangeStart(range: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getRangeEnd(range: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getSkippedRanges(tu: NativePtr, file: NativePtr): NativePtr
-    
-    external fun clang_disposeSourceRangeList(ranges: NativePtr): Unit
-    
-    external fun clang_getNumDiagnosticsInSet(Diags: NativePtr): Int
-    
-    external fun clang_getDiagnosticInSet(Diags: NativePtr, Index: Int): NativePtr
-    
-    external fun clang_loadDiagnostics(file: NativePtr, error: NativePtr, errorString: NativePtr): NativePtr
-    
-    external fun clang_disposeDiagnosticSet(Diags: NativePtr): Unit
-    
-    external fun clang_getChildDiagnostics(D: NativePtr): NativePtr
-    
-    external fun clang_getNumDiagnostics(Unit: NativePtr): Int
-    
-    external fun clang_getDiagnostic(Unit: NativePtr, Index: Int): NativePtr
-    
-    external fun clang_getDiagnosticSetFromTU(Unit: NativePtr): NativePtr
-    
-    external fun clang_disposeDiagnostic(Diagnostic: NativePtr): Unit
-    
-    external fun clang_formatDiagnostic(Diagnostic: NativePtr, Options: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_defaultDiagnosticDisplayOptions(): Int
-    
-    external fun clang_getDiagnosticSeverity(arg0: NativePtr): Int
-    
-    external fun clang_getDiagnosticLocation(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getDiagnosticSpelling(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getDiagnosticOption(Diag: NativePtr, Disable: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getDiagnosticCategory(arg0: NativePtr): Int
-    
-    external fun clang_getDiagnosticCategoryName(Category: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getDiagnosticCategoryText(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getDiagnosticNumRanges(arg0: NativePtr): Int
-    
-    external fun clang_getDiagnosticRange(Diagnostic: NativePtr, Range: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getDiagnosticNumFixIts(Diagnostic: NativePtr): Int
-    
-    external fun clang_getDiagnosticFixIt(Diagnostic: NativePtr, FixIt: Int, ReplacementRange: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTranslationUnitSpelling(CTUnit: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_createTranslationUnitFromSourceFile(CIdx: NativePtr, source_filename: NativePtr, num_clang_command_line_args: Int, clang_command_line_args: NativePtr, num_unsaved_files: Int, unsaved_files: NativePtr): NativePtr
-    
-    external fun clang_createTranslationUnit(CIdx: NativePtr, ast_filename: NativePtr): NativePtr
-    
-    external fun clang_createTranslationUnit2(CIdx: NativePtr, ast_filename: NativePtr, out_TU: NativePtr): Int
-    
-    external fun clang_defaultEditingTranslationUnitOptions(): Int
-    
-    external fun clang_parseTranslationUnit(CIdx: NativePtr, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, options: Int): NativePtr
-    
-    external fun clang_parseTranslationUnit2(CIdx: NativePtr, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, options: Int, out_TU: NativePtr): Int
-    
-    external fun clang_parseTranslationUnit2FullArgv(CIdx: NativePtr, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, options: Int, out_TU: NativePtr): Int
-    
-    external fun clang_defaultSaveOptions(TU: NativePtr): Int
-    
-    external fun clang_saveTranslationUnit(TU: NativePtr, FileName: NativePtr, options: Int): Int
-    
-    external fun clang_disposeTranslationUnit(arg0: NativePtr): Unit
-    
-    external fun clang_defaultReparseOptions(TU: NativePtr): Int
-    
-    external fun clang_reparseTranslationUnit(TU: NativePtr, num_unsaved_files: Int, unsaved_files: NativePtr, options: Int): Int
-    
-    external fun clang_getTUResourceUsageName(kind: Int): NativePtr
-    
-    external fun clang_getCXTUResourceUsage(TU: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_disposeCXTUResourceUsage(usage: NativePtr): Unit
-    
-    external fun clang_getNullCursor(retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTranslationUnitCursor(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_equalCursors(arg0: NativePtr, arg1: NativePtr): Int
-    
-    external fun clang_Cursor_isNull(cursor: NativePtr): Int
-    
-    external fun clang_hashCursor(arg0: NativePtr): Int
-    
-    external fun clang_getCursorKind(arg0: NativePtr): Int
-    
-    external fun clang_isDeclaration(arg0: Int): Int
-    
-    external fun clang_isReference(arg0: Int): Int
-    
-    external fun clang_isExpression(arg0: Int): Int
-    
-    external fun clang_isStatement(arg0: Int): Int
-    
-    external fun clang_isAttribute(arg0: Int): Int
-    
-    external fun clang_Cursor_hasAttrs(C: NativePtr): Int
-    
-    external fun clang_isInvalid(arg0: Int): Int
-    
-    external fun clang_isTranslationUnit(arg0: Int): Int
-    
-    external fun clang_isPreprocessing(arg0: Int): Int
-    
-    external fun clang_isUnexposed(arg0: Int): Int
-    
-    external fun clang_getCursorLinkage(cursor: NativePtr): Int
-    
-    external fun clang_getCursorVisibility(cursor: NativePtr): Int
-    
-    external fun clang_getCursorAvailability(cursor: NativePtr): Int
-    
-    external fun clang_getCursorPlatformAvailability(cursor: NativePtr, always_deprecated: NativePtr, deprecated_message: NativePtr, always_unavailable: NativePtr, unavailable_message: NativePtr, availability: NativePtr, availability_size: Int): Int
-    
-    external fun clang_disposeCXPlatformAvailability(availability: NativePtr): Unit
-    
-    external fun clang_getCursorLanguage(cursor: NativePtr): Int
-    
-    external fun clang_Cursor_getTranslationUnit(arg0: NativePtr): NativePtr
-    
-    external fun clang_createCXCursorSet(): NativePtr
-    
-    external fun clang_disposeCXCursorSet(cset: NativePtr): Unit
-    
-    external fun clang_CXCursorSet_contains(cset: NativePtr, cursor: NativePtr): Int
-    
-    external fun clang_CXCursorSet_insert(cset: NativePtr, cursor: NativePtr): Int
-    
-    external fun clang_getCursorSemanticParent(cursor: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorLexicalParent(cursor: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getOverriddenCursors(cursor: NativePtr, overridden: NativePtr, num_overridden: NativePtr): Unit
-    
-    external fun clang_disposeOverriddenCursors(overridden: NativePtr): Unit
-    
-    external fun clang_getIncludedFile(cursor: NativePtr): NativePtr
-    
-    external fun clang_getCursor(arg0: NativePtr, arg1: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorLocation(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorExtent(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorType(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTypeSpelling(CT: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTypedefDeclUnderlyingType(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getEnumDeclIntegerType(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getEnumConstantDeclValue(C: NativePtr): Long
-    
-    external fun clang_getEnumConstantDeclUnsignedValue(C: NativePtr): Long
-    
-    external fun clang_getFieldDeclBitWidth(C: NativePtr): Int
-    
-    external fun clang_Cursor_getNumArguments(C: NativePtr): Int
-    
-    external fun clang_Cursor_getArgument(C: NativePtr, i: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getNumTemplateArguments(C: NativePtr): Int
-    
-    external fun clang_Cursor_getTemplateArgumentKind(C: NativePtr, I: Int): Int
-    
-    external fun clang_Cursor_getTemplateArgumentType(C: NativePtr, I: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getTemplateArgumentValue(C: NativePtr, I: Int): Long
-    
-    external fun clang_Cursor_getTemplateArgumentUnsignedValue(C: NativePtr, I: Int): Long
-    
-    external fun clang_equalTypes(A: NativePtr, B: NativePtr): Int
-    
-    external fun clang_getCanonicalType(T: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_isConstQualifiedType(T: NativePtr): Int
-    
-    external fun clang_Cursor_isMacroFunctionLike(C: NativePtr): Int
-    
-    external fun clang_Cursor_isMacroBuiltin(C: NativePtr): Int
-    
-    external fun clang_Cursor_isFunctionInlined(C: NativePtr): Int
-    
-    external fun clang_isVolatileQualifiedType(T: NativePtr): Int
-    
-    external fun clang_isRestrictQualifiedType(T: NativePtr): Int
-    
-    external fun clang_getPointeeType(T: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTypeDeclaration(T: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getDeclObjCTypeEncoding(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Type_getObjCEncoding(type: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTypeKindSpelling(K: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getFunctionTypeCallingConv(T: NativePtr): Int
-    
-    external fun clang_getResultType(T: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getNumArgTypes(T: NativePtr): Int
-    
-    external fun clang_getArgType(T: NativePtr, i: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_isFunctionTypeVariadic(T: NativePtr): Int
-    
-    external fun clang_getCursorResultType(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_isPODType(T: NativePtr): Int
-    
-    external fun clang_getElementType(T: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getNumElements(T: NativePtr): Long
-    
-    external fun clang_getArrayElementType(T: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getArraySize(T: NativePtr): Long
-    
-    external fun clang_Type_getNamedType(T: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Type_getAlignOf(T: NativePtr): Long
-    
-    external fun clang_Type_getClassType(T: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Type_getSizeOf(T: NativePtr): Long
-    
-    external fun clang_Type_getOffsetOf(T: NativePtr, S: NativePtr): Long
-    
-    external fun clang_Cursor_getOffsetOfField(C: NativePtr): Long
-    
-    external fun clang_Cursor_isAnonymous(C: NativePtr): Int
-    
-    external fun clang_Type_getNumTemplateArguments(T: NativePtr): Int
-    
-    external fun clang_Type_getTemplateArgumentAsType(T: NativePtr, i: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Type_getCXXRefQualifier(T: NativePtr): Int
-    
-    external fun clang_Cursor_isBitField(C: NativePtr): Int
-    
-    external fun clang_isVirtualBase(arg0: NativePtr): Int
-    
-    external fun clang_getCXXAccessSpecifier(arg0: NativePtr): Int
-    
-    external fun clang_Cursor_getStorageClass(arg0: NativePtr): Int
-    
-    external fun clang_getNumOverloadedDecls(cursor: NativePtr): Int
-    
-    external fun clang_getOverloadedDecl(cursor: NativePtr, index: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getIBOutletCollectionType(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_visitChildren(parent: NativePtr, visitor: NativePtr, client_data: NativePtr): Int
-    
-    external fun clang_getCursorUSR(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_constructUSR_ObjCClass(class_name: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_constructUSR_ObjCCategory(class_name: NativePtr, category_name: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_constructUSR_ObjCProtocol(protocol_name: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_constructUSR_ObjCIvar(name: NativePtr, classUSR: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_constructUSR_ObjCMethod(name: NativePtr, isInstanceMethod: Int, classUSR: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_constructUSR_ObjCProperty(property: NativePtr, classUSR: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorSpelling(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getSpellingNameRange(arg0: NativePtr, pieceIndex: Int, options: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorDisplayName(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorReferenced(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorDefinition(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_isCursorDefinition(arg0: NativePtr): Int
-    
-    external fun clang_getCanonicalCursor(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getObjCSelectorIndex(arg0: NativePtr): Int
-    
-    external fun clang_Cursor_isDynamicCall(C: NativePtr): Int
-    
-    external fun clang_Cursor_getReceiverType(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getObjCPropertyAttributes(C: NativePtr, reserved: Int): Int
-    
-    external fun clang_Cursor_getObjCDeclQualifiers(C: NativePtr): Int
-    
-    external fun clang_Cursor_isObjCOptional(C: NativePtr): Int
-    
-    external fun clang_Cursor_isVariadic(C: NativePtr): Int
-    
-    external fun clang_Cursor_getCommentRange(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getRawCommentText(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getBriefCommentText(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getMangling(arg0: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getCXXManglings(arg0: NativePtr): NativePtr
-    
-    external fun clang_Cursor_getModule(C: NativePtr): NativePtr
-    
-    external fun clang_getModuleForFile(arg0: NativePtr, arg1: NativePtr): NativePtr
-    
-    external fun clang_Module_getASTFile(Module: NativePtr): NativePtr
-    
-    external fun clang_Module_getParent(Module: NativePtr): NativePtr
-    
-    external fun clang_Module_getName(Module: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Module_getFullName(Module: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Module_isSystem(Module: NativePtr): Int
-    
-    external fun clang_Module_getNumTopLevelHeaders(arg0: NativePtr, Module: NativePtr): Int
-    
-    external fun clang_Module_getTopLevelHeader(arg0: NativePtr, Module: NativePtr, Index: Int): NativePtr
-    
-    external fun clang_CXXConstructor_isConvertingConstructor(C: NativePtr): Int
-    
-    external fun clang_CXXConstructor_isCopyConstructor(C: NativePtr): Int
-    
-    external fun clang_CXXConstructor_isDefaultConstructor(C: NativePtr): Int
-    
-    external fun clang_CXXConstructor_isMoveConstructor(C: NativePtr): Int
-    
-    external fun clang_CXXField_isMutable(C: NativePtr): Int
-    
-    external fun clang_CXXMethod_isDefaulted(C: NativePtr): Int
-    
-    external fun clang_CXXMethod_isPureVirtual(C: NativePtr): Int
-    
-    external fun clang_CXXMethod_isStatic(C: NativePtr): Int
-    
-    external fun clang_CXXMethod_isVirtual(C: NativePtr): Int
-    
-    external fun clang_CXXMethod_isConst(C: NativePtr): Int
-    
-    external fun clang_getTemplateCursorKind(C: NativePtr): Int
-    
-    external fun clang_getSpecializedCursorTemplate(C: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorReferenceNameRange(C: NativePtr, NameFlags: Int, PieceIndex: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTokenKind(arg0: NativePtr): Int
-    
-    external fun clang_getTokenSpelling(arg0: NativePtr, arg1: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTokenLocation(arg0: NativePtr, arg1: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getTokenExtent(arg0: NativePtr, arg1: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_tokenize(TU: NativePtr, Range: NativePtr, Tokens: NativePtr, NumTokens: NativePtr): Unit
-    
-    external fun clang_annotateTokens(TU: NativePtr, Tokens: NativePtr, NumTokens: Int, Cursors: NativePtr): Unit
-    
-    external fun clang_disposeTokens(TU: NativePtr, Tokens: NativePtr, NumTokens: Int): Unit
-    
-    external fun clang_getCursorKindSpelling(Kind: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getDefinitionSpellingAndExtent(arg0: NativePtr, startBuf: NativePtr, endBuf: NativePtr, startLine: NativePtr, startColumn: NativePtr, endLine: NativePtr, endColumn: NativePtr): Unit
-    
-    external fun clang_enableStackTraces(): Unit
-    
-    external fun clang_executeOnThread(fn: NativePtr, user_data: NativePtr, stack_size: Int): Unit
-    
-    external fun clang_getCompletionChunkKind(completion_string: NativePtr, chunk_number: Int): Int
-    
-    external fun clang_getCompletionChunkText(completion_string: NativePtr, chunk_number: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCompletionChunkCompletionString(completion_string: NativePtr, chunk_number: Int): NativePtr
-    
-    external fun clang_getNumCompletionChunks(completion_string: NativePtr): Int
-    
-    external fun clang_getCompletionPriority(completion_string: NativePtr): Int
-    
-    external fun clang_getCompletionAvailability(completion_string: NativePtr): Int
-    
-    external fun clang_getCompletionNumAnnotations(completion_string: NativePtr): Int
-    
-    external fun clang_getCompletionAnnotation(completion_string: NativePtr, annotation_number: Int, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCompletionParent(completion_string: NativePtr, kind: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCompletionBriefComment(completion_string: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getCursorCompletionString(cursor: NativePtr): NativePtr
-    
-    external fun clang_defaultCodeCompleteOptions(): Int
-    
-    external fun clang_codeCompleteAt(TU: NativePtr, complete_filename: NativePtr, complete_line: Int, complete_column: Int, unsaved_files: NativePtr, num_unsaved_files: Int, options: Int): NativePtr
-    
-    external fun clang_sortCodeCompletionResults(Results: NativePtr, NumResults: Int): Unit
-    
-    external fun clang_disposeCodeCompleteResults(Results: NativePtr): Unit
-    
-    external fun clang_codeCompleteGetNumDiagnostics(Results: NativePtr): Int
-    
-    external fun clang_codeCompleteGetDiagnostic(Results: NativePtr, Index: Int): NativePtr
-    
-    external fun clang_codeCompleteGetContexts(Results: NativePtr): Long
-    
-    external fun clang_codeCompleteGetContainerKind(Results: NativePtr, IsIncomplete: NativePtr): Int
-    
-    external fun clang_codeCompleteGetContainerUSR(Results: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_codeCompleteGetObjCSelector(Results: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_getClangVersion(retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_toggleCrashRecovery(isEnabled: Int): Unit
-    
-    external fun clang_getInclusions(tu: NativePtr, visitor: NativePtr, client_data: NativePtr): Unit
-    
-    external fun clang_Cursor_Evaluate(C: NativePtr): NativePtr
-    
-    external fun clang_EvalResult_getKind(E: NativePtr): Int
-    
-    external fun clang_EvalResult_getAsInt(E: NativePtr): Int
-    
-    external fun clang_EvalResult_getAsDouble(E: NativePtr): Double
-    
-    external fun clang_EvalResult_getAsStr(E: NativePtr): NativePtr
-    
-    external fun clang_EvalResult_dispose(E: NativePtr): Unit
-    
-    external fun clang_getRemappings(path: NativePtr): NativePtr
-    
-    external fun clang_getRemappingsFromFileList(filePaths: NativePtr, numFiles: Int): NativePtr
-    
-    external fun clang_remap_getNumFiles(arg0: NativePtr): Int
-    
-    external fun clang_remap_getFilenames(arg0: NativePtr, index: Int, original: NativePtr, transformed: NativePtr): Unit
-    
-    external fun clang_remap_dispose(arg0: NativePtr): Unit
-    
-    external fun clang_findReferencesInFile(cursor: NativePtr, file: NativePtr, visitor: NativePtr): Int
-    
-    external fun clang_findIncludesInFile(TU: NativePtr, file: NativePtr, visitor: NativePtr): Int
-    
-    external fun clang_index_isEntityObjCContainerKind(arg0: Int): Int
-    
-    external fun clang_index_getObjCContainerDeclInfo(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_getObjCInterfaceDeclInfo(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_getObjCCategoryDeclInfo(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_getObjCProtocolRefListInfo(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_getObjCPropertyDeclInfo(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_getIBOutletCollectionAttrInfo(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_getCXXClassDeclInfo(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_getClientContainer(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_setClientContainer(arg0: NativePtr, arg1: NativePtr): Unit
-    
-    external fun clang_index_getClientEntity(arg0: NativePtr): NativePtr
-    
-    external fun clang_index_setClientEntity(arg0: NativePtr, arg1: NativePtr): Unit
-    
-    external fun clang_IndexAction_create(CIdx: NativePtr): NativePtr
-    
-    external fun clang_IndexAction_dispose(arg0: NativePtr): Unit
-    
-    external fun clang_indexSourceFile(arg0: NativePtr, client_data: NativePtr, index_callbacks: NativePtr, index_callbacks_size: Int, index_options: Int, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, out_TU: NativePtr, TU_options: Int): Int
-    
-    external fun clang_indexSourceFileFullArgv(arg0: NativePtr, client_data: NativePtr, index_callbacks: NativePtr, index_callbacks_size: Int, index_options: Int, source_filename: NativePtr, command_line_args: NativePtr, num_command_line_args: Int, unsaved_files: NativePtr, num_unsaved_files: Int, out_TU: NativePtr, TU_options: Int): Int
-    
-    external fun clang_indexTranslationUnit(arg0: NativePtr, client_data: NativePtr, index_callbacks: NativePtr, index_callbacks_size: Int, index_options: Int, arg5: NativePtr): Int
-    
-    external fun clang_indexLoc_getFileLocation(loc: NativePtr, indexFile: NativePtr, file: NativePtr, line: NativePtr, column: NativePtr, offset: NativePtr): Unit
-    
-    external fun clang_indexLoc_getCXSourceLocation(loc: NativePtr, retValPlacement: NativePtr): NativePtr
-    
-    external fun clang_Type_visitFields(T: NativePtr, visitor: NativePtr, client_data: NativePtr): Int
-    
-}
+private val loadLibrary = System.loadLibrary("clangstubs")

--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
@@ -137,7 +137,7 @@ internal fun visitChildren(parent: CValue<CXCursor>, visitor: CursorVisitor) {
     clang_visitChildren(parent, staticCFunction { cursor, parent, clientData ->
         @Suppress("NAME_SHADOWING", "UNCHECKED_CAST")
         val visitor = StableObjPtr.fromValue(clientData!!).get() as CursorVisitor
-        visitor(cursor.readValue(), parent.readValue())
+        visitor(cursor, parent)
     }, clientData)
 }
 

--- a/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmTypes.kt
+++ b/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmTypes.kt
@@ -52,17 +52,81 @@ fun <T : CPointed> interpretCPointer(rawValue: NativePtr) =
             CPointer<T>(rawValue)
         }
 
-inline fun <reified T : CAdaptedFunctionType<*>> CAdaptedFunctionType.Companion.getInstanceOf(): T =
-        T::class.objectInstance!!
-
 internal fun CPointer<*>.cPointerToString() = "CPointer(raw=0x%x)".format(rawValue)
 
-/**
- * Returns a pointer to `T`-typed C function which calls given Kotlin *static* function.
- * @see CAdaptedFunctionType.fromStatic
- */
-inline fun <reified F : Function<*>, reified T : CAdaptedFunctionType<F>> staticCFunction(body: F): CFunctionPointer<T> {
-    val type = CAdaptedFunctionType.getInstanceOf<T>()
-    return interpretPointed<CFunction<T>>(type.fromStatic(body)).ptr
-}
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CLength(val value: Int)
 
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CNaturalStruct(vararg val fieldNames: String)
+
+fun <R> staticCFunction(function: () -> R): CPointer<CFunction<() -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, R> staticCFunction(function: (P1) -> R): CPointer<CFunction<(P1) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, R> staticCFunction(function: (P1, P2) -> R): CPointer<CFunction<(P1, P2) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, R> staticCFunction(function: (P1, P2, P3) -> R): CPointer<CFunction<(P1, P2, P3) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, R> staticCFunction(function: (P1, P2, P3, P4) -> R): CPointer<CFunction<(P1, P2, P3, P4) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, R> staticCFunction(function: (P1, P2, P3, P4, P5) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R>> =
+        staticCFunctionImpl(function)
+
+fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R>> =
+        staticCFunctionImpl(function)

--- a/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Types.kt
+++ b/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Types.kt
@@ -382,42 +382,15 @@ typealias CArrayPointer<T> = CPointer<T>
 typealias CArrayPointerVar<T> = CPointerVar<T>
 
 /**
- * The type of C function.
- */
-interface CFunctionType
-
-/**
- * The type of C function constructed from some Kotlin function, possibly using an adapter.
- * The (non-abstract) implementation classes are supposed to be object declarations.
- */
-interface CAdaptedFunctionType<F : Function<*>> : CFunctionType {
-
-    /**
-     * Returns a raw pointer to C function of this type, which calls given Kotlin *static* function.
-     *
-     * This inconvenient method should not be used directly; use [staticCFunction] instead.
-     *
-     * @param function must be *static*, i.e. an (unbound) reference to a Kotlin function or
-     * a closure which doesn't capture any variable
-     */
-    fun fromStatic(function: F): NativePtr
-
-    companion object
-}
-
-/**
  * The C function.
  */
-class CFunction<T : CFunctionType>(override val rawPtr: NativePtr) : CPointed
+class CFunction<T : Function<*>>(override val rawPtr: NativePtr) : CPointed
 
 /**
- * The pointer to [CFunction].
- * TODO: remove.
+ * Returns a pointer to C function which calls given Kotlin *static* function.
+ *
+ * @param function must be *static*, i.e. an (unbound) reference to a Kotlin function or
+ * a closure which doesn't capture any variable
  */
-typealias CFunctionPointer<T> = CPointer<CFunction<T>>
-
-/**
- * The variable containing a [CFunctionPointer].
- * TODO: remove.
- */
-typealias CFunctionPointerVar<T> = CPointerVarOf<CFunctionPointer<T>>
+@Deprecated("The function type is too general. Supply argument with known arity.", level = DeprecationLevel.ERROR)
+external fun <F : Function<*>> staticCFunction(function: F): CPointer<CFunction<F>>

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeCallbacks.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeCallbacks.kt
@@ -45,12 +45,3 @@ private external fun disposeStablePointer(pointer: COpaquePointer)
 
 @SymbolName("Kotlin_Interop_derefStablePointer")
 private external fun derefStablePointer(pointer: COpaquePointer): Any
-
-/**
- * The type of C function which can be constructed from the appropriate Kotlin function without using any adapter.
- */
-abstract class CTriviallyAdaptedFunctionType<F : Function<*>> : CAdaptedFunctionType<F> {
-    @konan.internal.Intrinsic
-    override final fun fromStatic(function: F): NativePtr =
-            throw Error("CTriviallyAdaptedFunctionType.fromStatic is called virtually")
-}

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeTypes.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeTypes.kt
@@ -34,21 +34,50 @@ fun <T : CVariable> typeOf(): CVariable.Type = throw Error("typeOf() is called w
 
 @Intrinsic external fun CPointer<*>.getRawValue(): NativePtr
 
-inline fun <reified T : CAdaptedFunctionType<*>> CAdaptedFunctionType.Companion.getInstanceOf(): T =
-        TODO("CAdaptedFunctionType.getInstanceOf 11")
-
 internal fun CPointer<*>.cPointerToString() = "CPointer(raw=$rawValue)"
 
-/**
- * Returns a pointer to `T`-typed C function which calls given Kotlin *static* function.
- * @see CAdaptedFunctionType.fromStatic
- */
-// TODO: This function is not inline, whereas the same name function in JvmTypes.kt 
-// is inline. We can't make it inline here, because native interop lowering 
-// expects to find and transform it. And native interop lowering is done after
-// inline expansions.
-fun <F : Function<*>, T : CAdaptedFunctionType<F>> staticCFunction(body: F): CFunctionPointer<T> {
-    val type = CAdaptedFunctionType.getInstanceOf<T>()
-    return interpretPointed<CFunction<T>>(type.fromStatic(body)).ptr
-}
+@Intrinsic external fun <R> staticCFunction(function: () -> R): CPointer<CFunction<() -> R>>
 
+@Intrinsic external fun <P1, R> staticCFunction(function: (P1) -> R): CPointer<CFunction<(P1) -> R>>
+
+@Intrinsic external fun <P1, P2, R> staticCFunction(function: (P1, P2) -> R): CPointer<CFunction<(P1, P2) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, R> staticCFunction(function: (P1, P2, P3) -> R): CPointer<CFunction<(P1, P2, P3) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, R> staticCFunction(function: (P1, P2, P3, P4) -> R): CPointer<CFunction<(P1, P2, P3, P4) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, R> staticCFunction(function: (P1, P2, P3, P4, P5) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> R>>
+
+@Intrinsic external fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22, R> staticCFunction(function: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R): CPointer<CFunction<(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> R>>

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
@@ -1388,10 +1388,13 @@ class StubGenerator(
         out("")
 
         stubs.forEach {
-            it.nativeStubLines.forEach {
-                out(it)
+            val lines = it.nativeStubLines
+            if (lines.isNotEmpty()) {
+                lines.forEach {
+                    out(it)
+                }
+                out("")
             }
-            out("")
         }
 
         if (entryPoint != null) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InteropUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InteropUtils.kt
@@ -144,20 +144,7 @@ internal class InteropBuiltIns(builtIns: KonanBuiltIns) {
 
     val bitsToDouble = packageScope.getContributedFunctions("bitsToDouble").single()
 
-    val staticCFunction = packageScope.getContributedFunctions("staticCFunction").single()
-
-    private val triviallyAdaptedFunctionTypeClass =
-            packageScope.getContributedClassifier("CTriviallyAdaptedFunctionType") as ClassDescriptor
-
-    private val trivallyAdaptedFunctionTypeType =
-            triviallyAdaptedFunctionTypeClass.defaultType.replace(
-                    newArguments = listOf(
-                            StarProjectionImpl(triviallyAdaptedFunctionTypeClass.declaredTypeParameters.single())
-                    )
-            )
-
-    fun isTriviallyAdaptedFunctionType(type: KotlinType): Boolean =
-            type.isSubtypeOf(trivallyAdaptedFunctionTypeType)
+    val staticCFunction = packageScope.getContributedFunctions("staticCFunction").toSet()
 
     val signExtend = packageScope.getContributedFunctions("signExtend").single()
 

--- a/samples/libcurl/callbacks.h
+++ b/samples/libcurl/callbacks.h
@@ -1,5 +1,0 @@
-#include <stddef.h>
-
-// Those types are needed but not defined or used in libcurl headers.
-typedef size_t header_callback(char *buffer,   size_t size,   size_t nitems, void *userdata);
-typedef size_t write_data_callback(void *buffer, size_t size, size_t nmemb, void *userp);

--- a/samples/libcurl/libcurl.def
+++ b/samples/libcurl/libcurl.def
@@ -1,2 +1,2 @@
-headers = curl/curl.h callbacks.h
+headers = curl/curl.h
 excludedFunctions = zopen pfctlinput

--- a/samples/libcurl/src/org/konan/libcurl/CUrl.kt
+++ b/samples/libcurl/src/org/konan/libcurl/CUrl.kt
@@ -10,7 +10,7 @@ class CUrl(val url: String)  {
 
     init {
         curl_easy_setopt(curl, CURLOPT_URL, url)
-        val header: CPointer<header_callback> = staticCFunction(::header_callback)
+        val header = staticCFunction(::header_callback)
         curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header)
         curl_easy_setopt(curl, CURLOPT_HEADERDATA, stablePtr.value)
     }

--- a/samples/libcurl/src/org/konan/libcurl/Program.kt
+++ b/samples/libcurl/src/org/konan/libcurl/Program.kt
@@ -12,7 +12,7 @@ fun main(args: Array<String>) {
     curl.close()
 
 /*
-    val write_data: CPointer<write_data_callback> = staticCFunction(::write_data)
+    val write_data = staticCFunction(::write_data)
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
 */
 }


### PR DESCRIPTION
*   Do not rely on type inference and `CFunctionType`;
*   Represent struct-typed parameters and return values as `CValue<*>`
    (currently supported only on JVM).