### PR TITLE
Of all the uses of .contributedMethods only the use for the binary

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/ClassVtablesBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/ClassVtablesBuilder.kt
@@ -81,7 +81,7 @@ internal class ClassVtablesBuilder(val classDescriptor: ClassDescriptor, val con
             context.getVtableBuilder(classDescriptor.getSuperClassOrAny()).vtableEntries
         }
 
-        val methods = classDescriptor.contributedMethods
+        val methods = classDescriptor.sortedContributedMethods
         val newVtableSlots = mutableListOf<OverriddenFunctionDescriptor>()
 
         val inheritedVtableSlots = superVtableEntries.map { superMethod ->
@@ -117,7 +117,7 @@ internal class ClassVtablesBuilder(val classDescriptor: ClassDescriptor, val con
     val methodTableEntries: List<OverriddenFunctionDescriptor> by lazy {
         assert(!classDescriptor.isAbstract())
 
-        classDescriptor.contributedMethods
+        classDescriptor.sortedContributedMethods
                 .flatMap { method -> method.allOverriddenDescriptors.map { OverriddenFunctionDescriptor(method, it) } }
                 .filter { it.canBeCalledVirtually }
                 .distinctBy { Triple(it.overriddenDescriptor.functionName, it.descriptor, it.needBridge) }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/DescriptorUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/DescriptorUtils.kt
@@ -172,8 +172,16 @@ internal val <T : CallableMemberDescriptor> T.allOverriddenDescriptors: List<T>
         return result
     }
 
+internal val ClassDescriptor.sortedContributedMethods: List<FunctionDescriptor>
+    get () = unsubstitutedMemberScope.sortedContributedMethods
+
 internal val ClassDescriptor.contributedMethods: List<FunctionDescriptor>
     get () = unsubstitutedMemberScope.contributedMethods
+
+internal val MemberScope.sortedContributedMethods: List<FunctionDescriptor>
+    get () = contributedMethods.sortedBy {
+            it.functionName.localHash.value
+    }
 
 internal val MemberScope.contributedMethods: List<FunctionDescriptor>
     get () {
@@ -185,13 +193,8 @@ internal val MemberScope.contributedMethods: List<FunctionDescriptor>
         val getters = properties.mapNotNull { it.getter }
         val setters = properties.mapNotNull { it.setter }
 
-        val allMethods = (functions + getters + setters).sortedBy {
-            it.functionName.localHash.value
-        }
-
-        return allMethods
+        return functions + getters + setters
     }
-
 
 fun ClassDescriptor.isAbstract() = this.modality == Modality.SEALED || this.modality == Modality.ABSTRACT
         || this.kind == ClassKind.ENUM_CLASS

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
@@ -22,23 +22,14 @@ import org.jetbrains.kotlin.backend.common.lower.SimpleMemberScope
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
 import org.jetbrains.kotlin.backend.jvm.descriptors.createValueParameter
 import org.jetbrains.kotlin.backend.konan.Context
-import org.jetbrains.kotlin.backend.konan.KonanBuiltIns
-import org.jetbrains.kotlin.backend.konan.LoweredEnum
-import org.jetbrains.kotlin.backend.konan.descriptors.contributedMethods
 import org.jetbrains.kotlin.backend.konan.descriptors.getKonanInternalFunctions
-import org.jetbrains.kotlin.backend.konan.descriptors.konanInternal
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.createArrayOfExpression
 import org.jetbrains.kotlin.backend.konan.ir.createSimpleDelegatingConstructor
 import org.jetbrains.kotlin.backend.konan.ir.createSimpleDelegatingConstructorDescriptor
-import org.jetbrains.kotlin.backend.konan.llvm.functionName
 import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.descriptors.annotations.Annotations
 import org.jetbrains.kotlin.descriptors.impl.ClassConstructorDescriptorImpl
 import org.jetbrains.kotlin.descriptors.impl.ClassDescriptorImpl
-import org.jetbrains.kotlin.descriptors.impl.SimpleFunctionDescriptorImpl
-import org.jetbrains.kotlin.descriptors.impl.ValueParameterDescriptorImpl
-import org.jetbrains.kotlin.incremental.components.LookupLocation
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.*
@@ -53,8 +44,6 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
-import org.jetbrains.kotlin.resolve.scopes.MemberScope
-import org.jetbrains.kotlin.script.getFileContents
 import org.jetbrains.kotlin.types.TypeProjectionImpl
 import org.jetbrains.kotlin.types.TypeSubstitutor
 


### PR DESCRIPTION
interface generation needs sorting by the hash.