### PR TITLE
Update kotlin-compiler snapshot version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,5 @@ remoteRoot=konan_tests
 #kotlinCompilerModule=org.jetbrains.kotlin:kotlin-compiler:1.1-SNAPSHOT
 # Download artifacts of https://teamcity.jetbrains.com/viewType.html?buildTypeId=bt345
 testDataVersion=1053418:id
-kotlinCompilerModule=org.jetbrains.kotlin:kotlin-compiler:1.1-20170426.212805-507
+kotlinCompilerModule=org.jetbrains.kotlin:kotlin-compiler:1.1-20170427.203056-511
 konanVersion=0.1


### PR DESCRIPTION
Replace removed snapshot (`1.1-20170426.212805-507`) with the latest version (`1.1-20170427.203056-511`) available here:

https://oss.sonatype.org/content/repositories/snapshots/org/jetbrains/kotlin/kotlin-compiler/1.1-SNAPSHOT/