### PR TITLE
Always use at least register-sized buffer for return value in ffi_call

### DIFF
--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/Varargs.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/Varargs.kt
@@ -69,6 +69,24 @@ private tailrec fun convertArgument(
     else -> throw Error("unsupported argument: $argument")
 }
 
+inline fun <reified T  : CVariable> NativePlacement.allocFfiReturnValueBuffer(type: CVariable.Type): T {
+    var size = type.size
+    var align = type.align
+
+    // libffi requires return value buffer to be no smaller than system register size;
+    // TODO: system register size is not exactly the same as pointer size.
+
+    if (size < pointerSize) {
+        size = pointerSize.toLong()
+    }
+
+    if (align < pointerSize) {
+        align = pointerSize
+    }
+
+    return this.alloc(size, align).reinterpret<T>()
+}
+
 fun callWithVarargs(codePtr: NativePtr, returnValuePtr: NativePtr, returnTypeKind: FfiTypeKind,
                     fixedArguments: Array<out Any?>, variadicArguments: Array<out Any?>,
                     argumentsPlacement: NativePlacement) {

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
@@ -891,7 +891,8 @@ class StubGenerator(
             val returnValueMirror = mirror(func.returnType)
             block(header) {
                 val resultPtr = if (!func.returnsVoid()) {
-                    out("val resultVar = alloc<${returnValueMirror.pointedTypeName}>()")
+                    val returnType = returnValueMirror.pointedTypeName
+                    out("val resultVar = allocFfiReturnValueBuffer<$returnType>($returnType)")
                     "resultVar.rawPtr"
                 } else {
                     "nativeNullPtr"


### PR DESCRIPTION
As required by the libffi docs.