### PR TITLE
Support armv6 devices (Pi Zero)

### DIFF
--- a/backend.native/konan.properties
+++ b/backend.native/konan.properties
@@ -86,8 +86,8 @@ dependencies.linux = \
     libffi-3.2.1-2-linux-x86-64
 
 # Raspberry Pi
-arch.linux-raspberrypi = armv7
-quadruple.linux-raspberrypi = armv7-unknown-linux-gnueabihf
+arch.linux-raspberrypi = armv6
+quadruple.linux-raspberrypi = armv6-unknown-linux-gnueabihf
 targetSysRoot.linux-raspberrypi = target-sysroot-1-raspberrypi
 libffiDir.linux-raspberrypi = libffi-3.2.1-2-raspberrypi
 libGcc.linux-raspberrypi = target-sysroot-1-raspberrypi/lib/gcc/arm-linux-gnueabihf/4.8.3/

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ void setupCompilationFlags() {
             [(ext.host): 
                ["--sysroot=${gccToolchainDir}/${gnuTriplet}/sysroot"],
              "raspberrypi":
-               ["-target", "armv7-unknown-linux-gnueabihf",
+               ["-target", "armv6-unknown-linux-gnueabihf",
                 "-mfpu=vfp", "-mfloat-abi=hard",
                 "--sysroot=$raspberryPiSysrootDir",
                 // TODO: those two are hacks.


### PR DESCRIPTION
Dear Kotlin-native team,

I was eager to try this new tool with my Raspberry Pi Zero but unfortunately it was not working. After compiling a very simple "hello world", I got an "Illegal Instruction" error when running on my Raspberry Pi Zero.

Digging a bit in the kotlin-native project I saw that you are targeting ARMv7, rather than ARMv6 which is the architecture of the Pi Zero model.

With a simple tweak (just replacing `armv7` with `armv6`) I was able to build my Hello World and run it on my Pi Zero.

In this Pull Request you will find the tweaks I did. Please feel free to modify or reject the PR if you find appropriate, or include the changes in some other way.

Thanks for your hard work.

For reference, this is the code I was compiling:
```kotlin
fun main(args: Array<String>) {
    println("Hello Pi")
}
```
And the command line to build the program:
```
konanc hello.kt -target raspberrypi -o hello
```

