### PR TITLE
Gradle plugin: groundwork for tooling API support

### DIFF
--- a/tools/gradle-plugin/src/main/kotlin/KonanPlugin.kt
+++ b/tools/gradle-plugin/src/main/kotlin/KonanPlugin.kt
@@ -24,6 +24,8 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import javax.inject.Inject
 
 /**
  * We use the following properties:
@@ -107,7 +109,8 @@ internal fun MutableList<String>.addListArg(parameter: String, values: List<Stri
     }
 }
 
-class KonanPlugin: Plugin<ProjectInternal> {
+class KonanPlugin @Inject constructor(private val registry: ToolingModelBuilderRegistry)
+    : Plugin<ProjectInternal> {
 
     companion object {
         internal const val COMPILER_EXTENSION_NAME = "konanArtifacts"
@@ -146,6 +149,7 @@ class KonanPlugin: Plugin<ProjectInternal> {
     // TODO: Create default config? what about test sources?
     override fun apply(project: ProjectInternal?) {
         if (project == null) { return }
+        registry.register(KonanToolingModelBuilder)
         project.tasks.create(KONAN_DOWNLOAD_TASK_NAME, CompilerDownloadTask::class.java)
         project.extensions.add(COMPILER_EXTENSION_NAME, KonanArtifactsContainer(project))
         project.extensions.add(INTEROP_EXTENSION_NAME, KonanInteropContainer(project))

--- a/tools/gradle-plugin/src/main/kotlin/KonanToolingModelBuilder.kt
+++ b/tools/gradle-plugin/src/main/kotlin/KonanToolingModelBuilder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin
+
+import org.gradle.api.Project
+import org.gradle.tooling.provider.model.ToolingModelBuilder
+import org.jetbrains.kotlin.gradle.plugin.model.KonanModel
+
+object KonanToolingModelBuilder : ToolingModelBuilder {
+    override fun canBuild(modelName: String): Boolean = KonanModel::class.java.name == modelName
+
+    override fun buildAll(modelName: String, project: Project): KonanModel {
+        return KonanModelImpl(project.konanVersion)
+    }
+}
+
+private class KonanModelImpl(
+        override val konanVersion: String
+) : KonanModel

--- a/tools/gradle-plugin/src/main/kotlin/model/KonanModel.kt
+++ b/tools/gradle-plugin/src/main/kotlin/model/KonanModel.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.gradle.plugin.model
+
+import java.io.Serializable
+
+/**
+ * An immutable representation of Konan's project model for gradle tooling API.
+ * This model is shared with the client processes such as an IDE.
+ */
+interface KonanModel : Serializable {
+    val konanVersion: String
+}


### PR DESCRIPTION
Добавил возможность получить проектную модель грейдл плагина из IDE. Пока в проектной модели только версия плагина.

cc @ilmat192 