### PR TITLE
Gradle plugin: add artifacts to the IDE project model

### DIFF
--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/KonanCompilerTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/KonanCompilerTask.kt
@@ -36,7 +36,7 @@ open class KonanCompileTask: DefaultTask() {
 
     // Output artifact --------------------------------------------------------
 
-    protected lateinit var artifactName: String
+    lateinit var artifactName: String
 
     @OutputDirectory
     lateinit var outputDir: File

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/KonanToolingModelBuilder.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/KonanToolingModelBuilder.kt
@@ -18,16 +18,27 @@ package org.jetbrains.kotlin.gradle.plugin
 
 import org.gradle.api.Project
 import org.gradle.tooling.provider.model.ToolingModelBuilder
+import org.jetbrains.kotlin.gradle.plugin.model.KonanArtifact
 import org.jetbrains.kotlin.gradle.plugin.model.KonanModel
 
 object KonanToolingModelBuilder : ToolingModelBuilder {
     override fun canBuild(modelName: String): Boolean = KonanModel::class.java.name == modelName
 
     override fun buildAll(modelName: String, project: Project): KonanModel {
-        return KonanModelImpl(project.konanVersion)
+        val artifacts = project.supportedCompileTasks
+                .toList()
+                .map { KonanArtifactImpl(it.artifactName, it.artifactPath) }
+        return KonanModelImpl(project.konanVersion, artifacts)
     }
 }
 
 private class KonanModelImpl(
-        override val konanVersion: String
+        override val konanVersion: String,
+        override val artifacts: List<KonanArtifact>
 ) : KonanModel
+
+
+private class KonanArtifactImpl(
+        override val name: String,
+        override val path: String
+) : KonanArtifact

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/model/KonanModel.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/model/KonanModel.kt
@@ -24,4 +24,10 @@ import java.io.Serializable
  */
 interface KonanModel : Serializable {
     val konanVersion: String
+    val artifacts: List<KonanArtifact>
+}
+
+interface KonanArtifact : Serializable {
+    val name: String
+    val path: String
 }


### PR DESCRIPTION
Добавил артефакты в проектную модель, чтобы можно было их запускать из IDE. Постарался сделать максимально минимально, потому что кажется, что модель артефактов ещё сильно меняться будет. 

cc @ilmat192 