### PR TITLE
backend: Fix enum constructor default parameters

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
@@ -18,6 +18,7 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.deepCopyWithVariables
 import org.jetbrains.kotlin.backend.common.lower.SimpleMemberScope
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
 import org.jetbrains.kotlin.backend.jvm.descriptors.createValueParameter
@@ -268,7 +269,7 @@ internal class EnumClassLowering(val context: Context) : ClassLoweringPass {
                 if (irConstructor != null) {
                     it.valueParameters.filter { it.declaresDefaultValue() }.forEach { argument ->
                         val loweredArgument = loweredEnumConstructor.valueParameters[argument.loweredIndex()]
-                        val body = irConstructor.getDefault(loweredArgument)!!
+                        val body = irConstructor.getDefault(loweredArgument)!!.deepCopyWithVariables()
                         body.transformChildrenVoid(ParameterMapper(constructor))
                         constructor.putDefault(constructorDescriptor.valueParameters[loweredArgument.index], body)
                     }
@@ -396,7 +397,19 @@ internal class EnumClassLowering(val context: Context) : ClassLoweringPass {
 
             enumConstructor.descriptor.valueParameters.filter { it.declaresDefaultValue() }.forEach {
                 val body = enumConstructor.getDefault(it)!!
-                body.transformChildrenVoid(ParameterMapper(enumConstructor))
+                body.transformChildrenVoid(object: IrElementTransformerVoid() {
+                    override fun visitGetValue(expression: IrGetValue): IrExpression {
+                        val descriptor = expression.descriptor
+                        when (descriptor) {
+                            is ValueParameterDescriptor -> {
+                                return IrGetValueImpl(expression.startOffset,
+                                        expression.endOffset,
+                                        loweredEnumConstructor.valueParameters[descriptor.loweredIndex()].symbol)
+                            }
+                        }
+                        return expression
+                    }
+                })
                 loweredEnumConstructor.putDefault(loweredConstructorDescriptor.valueParameters[it.loweredIndex()], body)
                 descriptorToIrConstructorWithDefaultArguments[loweredConstructorDescriptor] = loweredEnumConstructor
             }

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -252,50 +252,55 @@ task sum2(type: RunKonanTest) {
     source = "codegen/function/sum_imm.kt"
 }
 
-task defaults(type: RunKonanTest) {
+task function_defaults(type: RunKonanTest) {
     source = "codegen/function/defaults.kt"
 }
 
-task defaults1(type: RunKonanTest) {
+task function_defaults1(type: RunKonanTest) {
     source = "codegen/function/defaults1.kt"
 }
 
-task defaults2(type: RunKonanTest) {
+task function_defaults2(type: RunKonanTest) {
     source = "codegen/function/defaults2.kt"
 }
 
-task defaults3(type: RunKonanTest) {
+task function_defaults3(type: RunKonanTest) {
     source = "codegen/function/defaults3.kt"
 }
 
-task defaults4(type: RunKonanTest) {
+task function_defaults4(type: RunKonanTest) {
     goldValue = "43\n"
     source = "codegen/function/defaults4.kt"
 }
 
-task defaults5(type: RunKonanTest) {
+task function_defaults5(type: RunKonanTest) {
     goldValue = "5\n6\n"
     source = "codegen/function/defaults5.kt"
 }
 
-task defaults6(type: RunKonanTest) {
+task function_defaults6(type: RunKonanTest) {
     goldValue = "42\n"
     source = "codegen/function/defaults6.kt"
 }
 
-task defaults7(type: RunKonanTest) {
+task function_defaults7(type: RunKonanTest) {
     goldValue = "42\n"
     source = "codegen/function/defaults7.kt"
 }
 
-task defaults8(type: RunKonanTest) {
+task function_defaults8(type: RunKonanTest) {
     goldValue = "2\n"
     source = "codegen/function/defaults8.kt"
 }
 
-task defaults9(type: RunKonanTest) {
+task function_defaults9(type: RunKonanTest) {
     goldValue = "1\n"
     source = "codegen/function/defaults9.kt"
+}
+
+task function_defaults10(type: RunKonanTest) {
+    goldValue = "42\n"
+    source = "codegen/function/defaults10.kt"
 }
 
 task sum_3const(type: RunKonanTest) {

--- a/backend.native/tests/codegen/function/defaults10.kt
+++ b/backend.native/tests/codegen/function/defaults10.kt
@@ -1,0 +1,7 @@
+enum class A(one: Int, val two: Int = one) {
+    FOO(42)
+}
+
+fun main(args: Array<String>) {
+    println(A.FOO.two)
+}


### PR DESCRIPTION
The problem was observed in the follwing code:

enum class A(one: Int, val two: Int = one) ...

The problem is in the `two` default value. Here the enum constructor
lowering used an old (not lowered) symbol for `one`. Also the lowering
didn't copy the default expression for DEFAULT class.
The patch fixes both problems.