### PR TITLE
dependencies: Add "airplane mode"

### DIFF
--- a/backend.native/konan.properties
+++ b/backend.native/konan.properties
@@ -17,6 +17,10 @@
 # TODO: Do we need a $variable substitution mechanism here?
 dependenciesUrl = http://download.jetbrains.com/kotlin/native
 
+# Don't check dependencies on a server.
+# If true, dependency downloader will throw an exception if a dependency isn't found in konan.home.
+airplaneMode = false
+
 # Mac OS X.
 llvmVersion.osx = 3.9.0
 llvmHome.osx = clang-llvm-3.9.0-darwin-macos

--- a/tools/helpers/src/main/kotlin/Helper0.kt
+++ b/tools/helpers/src/main/kotlin/Helper0.kt
@@ -27,7 +27,8 @@ class Helper0(val dependenciesDir: String,
         DependencyDownloader(
                 File(dependenciesDir),
                 properties.getProperty("dependenciesUrl", "https://download.jetbrains.com/kotlin/native"),
-                dependencies
+                dependencies,
+                airplaneMode = properties.getProperty("airplaneMode")?.toBoolean() ?: false
         ).run()
     }
 }


### PR DESCRIPTION
The patch adds airplaneMode parameter in konan.properties.
If airplaneMode = true the dependency downloader will throw
an exception instead of downloading a missing dependency.