### PR TITLE
Moved clang flags out of the root build.gradle.

### DIFF
--- a/Interop/Runtime/build.gradle
+++ b/Interop/Runtime/build.gradle
@@ -35,7 +35,8 @@ model {
                 include '**/*.c'
             }
             binaries.all {
-                def host = rootProject.ext.host
+                def host = rootProject.ext.hostName
+
                 def hostLibffiDir = rootProject.ext.get("${host}LibffiDir")
 
                 cCompiler.args hostCompilerArgsForJni

--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -106,7 +106,7 @@ kotlinNativeInterop {
      compilerOpts '-fPIC'
      linkerOpts '-fPIC'
      linker 'clang++'
-     linkOutputs ":common:${host}Hash"
+     linkOutputs ":common:${hostName}Hash"
 
      headers fileTree('../common/src/hash/headers') {
        include '**/*.h'
@@ -148,8 +148,8 @@ build.dependsOn 'compilerClasses','cli_bcClasses','bc_frontendClasses'
 
 
 // These are just a couple of aliases
-task stdlib(dependsOn: "${host}Stdlib")
-task start(dependsOn: "${host}Start")
+task stdlib(dependsOn: "${hostName}Stdlib")
+task start(dependsOn: "${hostName}Start")
 
 // These files are built before the 'dist' is complete,
 // so we provide custom values for

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -20,7 +20,6 @@ import com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.backend.konan.library.KonanLibraryReader
 import org.jetbrains.kotlin.backend.konan.library.KonanLibrarySearchPathResolver
 import org.jetbrains.kotlin.backend.konan.library.impl.LibraryReaderImpl
-import org.jetbrains.kotlin.backend.konan.util.File
 import org.jetbrains.kotlin.backend.konan.util.profile
 import org.jetbrains.kotlin.backend.konan.util.removeSuffixIfPresent
 import org.jetbrains.kotlin.backend.konan.util.suffixIfNot
@@ -30,6 +29,7 @@ import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.*
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.target.*
 import org.jetbrains.kotlin.konan.target.TargetManager.*
 import org.jetbrains.kotlin.konan.target.CompilerOutputKind.*

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/KonanIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/KonanIr.kt
@@ -16,7 +16,6 @@
 
 package org.jetbrains.kotlin.backend.konan.ir
 
-import org.jetbrains.kotlin.backend.konan.util.File
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
@@ -38,6 +37,7 @@ import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrBindableSymbolBase
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
+import org.jetbrains.kotlin.konan.file.*
 import org.jetbrains.kotlin.types.KotlinType
 
 //-----------------------------------------------------------------------------//

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibrary.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibrary.kt
@@ -17,7 +17,7 @@
 package org.jetbrains.kotlin.backend.konan.library
 
 import org.jetbrains.kotlin.konan.target.KonanTarget
-import org.jetbrains.kotlin.backend.konan.util.File
+import org.jetbrains.kotlin.konan.file.File
 
 // This scheme describes the Konan Library (klib) layout.
 interface KonanLibraryLayout {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
@@ -16,9 +16,9 @@
 
 package org.jetbrains.kotlin.backend.konan.library
 
-import org.jetbrains.kotlin.backend.konan.util.File
 import org.jetbrains.kotlin.backend.konan.util.removeSuffixIfPresent
 import org.jetbrains.kotlin.backend.konan.util.suffixIfNot
+import org.jetbrains.kotlin.konan.file.File
 
 interface SearchPathResolver {
     val searchRoots: List<File>

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibrary.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibrary.kt
@@ -17,7 +17,8 @@
 package org.jetbrains.kotlin.backend.konan.library.impl
 
 import org.jetbrains.kotlin.backend.konan.library.KonanLibrary
-import org.jetbrains.kotlin.backend.konan.util.*
+import org.jetbrains.kotlin.backend.konan.util.removeSuffixIfPresent
+import org.jetbrains.kotlin.konan.file.*
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
 open class ZippedKonanLibrary(val klibFile: File, override val target: KonanTarget? = null): KonanLibrary {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
@@ -18,10 +18,8 @@ package org.jetbrains.kotlin.backend.konan.library.impl
 
 import org.jetbrains.kotlin.backend.konan.library.KonanLibraryReader
 import org.jetbrains.kotlin.backend.konan.serialization.deserializeModule
-import org.jetbrains.kotlin.backend.konan.util.File
-import org.jetbrains.kotlin.backend.konan.util.Properties
-import org.jetbrains.kotlin.backend.konan.util.loadProperties
-import org.jetbrains.kotlin.backend.konan.util.propertyList
+import org.jetbrains.kotlin.konan.file.File
+import org.jetbrains.kotlin.konan.properties.*
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.konan.target.KonanTarget
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryWriterImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryWriterImpl.kt
@@ -21,7 +21,8 @@ import llvm.LLVMWriteBitcodeToFile
 import org.jetbrains.kotlin.backend.konan.library.KonanLibrary
 import org.jetbrains.kotlin.backend.konan.library.KonanLibraryWriter
 import org.jetbrains.kotlin.backend.konan.library.LinkData
-import org.jetbrains.kotlin.backend.konan.util.*
+import org.jetbrains.kotlin.konan.file.*
+import org.jetbrains.kotlin.konan.properties.*
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
 abstract class FileBasedLibraryWriter (

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/MetadataWriterImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/MetadataWriterImpl.kt
@@ -18,7 +18,7 @@ package org.jetbrains.kotlin.backend.konan.library.impl
 
 import org.jetbrains.kotlin.backend.konan.library.KonanLibrary
 import org.jetbrains.kotlin.backend.konan.library.LinkData
-import org.jetbrains.kotlin.backend.konan.util.File
+import org.jetbrains.kotlin.konan.file.File
 
 internal class MetadataWriterImpl(library: KonanLibrary): KonanLibrary by library {
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/DebugUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/DebugUtils.kt
@@ -22,13 +22,13 @@ import llvm.*
 import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.backend.konan.KonanConfigKeys
 import org.jetbrains.kotlin.backend.konan.KonanVersion
-import org.jetbrains.kotlin.backend.konan.util.File
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.ir.SourceManager.FileEntry
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
 

--- a/backend.native/konan.properties
+++ b/backend.native/konan.properties
@@ -89,6 +89,7 @@ osVersionMin.ios_sim = 8.0
 # Linux x86-64.
 llvmVersion.linux = 3.9.0
 llvmHome.linux = clang-llvm-3.9.0-linux-x86-64
+gccToolchain.linux = target-gcc-toolchain-3-linux-x86-64
 targetToolchain.linux = target-gcc-toolchain-3-linux-x86-64/x86_64-unknown-linux-gnu
 
 quadruple.linux = x86_64-unknown-linux-gnu

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 import groovy.io.FileType
-
-//ant.importBuild 'backend.native/kotlin-ir/build.xml'
+import org.jetbrains.kotlin.konan.target.*
+import org.jetbrains.kotlin.konan.properties.*
 
 defaultTasks 'clean', 'dist'
 
 convention.plugins.platformInfo = new PlatformInfo()
+
+ext {
+        konanPropertiesFile = project(':backend.native').file('konan.properties')
+        konanProperties = PropertiesKt.loadProperties(konanPropertiesFile.absolutePath)
+
+        dependenciesDir = rootProject.file("dist/dependencies")
+        clangManager = new ClangManager(konanProperties, dependenciesDir.absolutePath)
+}
 
 allprojects {
     if (path != ":dependencies") {
@@ -33,14 +41,20 @@ allprojects {
         }
     }
 
+    setupHostAndTarget()
     loadCommandLineProperties()
     loadLocalProperties()
-    setupCompilationFlags()
     setupClang(project)
+}
+
+void setupHostAndTarget() {
+    ext.hostName = TargetManager.hostName
+    ext.targetList = TargetManager.enabled*.userName as List
 }
 
 void setupClang(Project project) {
 
+    project.convention.plugins.clangManager = project.rootProject.ext.clangManager
     project.convention.plugins.execClang = new org.jetbrains.kotlin.ExecClang(project)
 
     project.plugins.withType(NativeComponentPlugin) {
@@ -67,13 +81,13 @@ void setupClang(Project project) {
 
                 toolChains {
                     clang(Clang) {
-                        clangPath.each {
+                        hostClang.hostClangPath.each {
                             path it
                         }
 
                         eachPlatform { // TODO: will not work when cross-compiling
                             [cCompiler, cppCompiler, linker].each {
-                                it.withArguments { it.addAll(hostClangArgs) }
+                                it.withArguments { it.addAll(project.hostClangArgs) }
                             }
 
                         }
@@ -82,98 +96,6 @@ void setupClang(Project project) {
             }
         }
     }
-}
-
-String getTargetArg(String target) {
-    def result = konanProperties.getProperty("quadruple.$target")
-    if (result == null) {
-        throw IllegalArgumentException("konan.properties has no LLVM target args for target: $target")
-    }
-    return result
-}
-
-void setupCompilationFlags() {
-    ext.clangPath = ["$llvmDir/bin"]
-    ext.clangArgs = []
-    ext.targetArgs = [:]
-    final String binDir
-
-    if (isLinux()) {
-    ext.host = "linux"
-    ext.targetArgs <<
-        [(ext.host):
-           ["--sysroot=${gccToolchainDir}/${gnuTriplet}/sysroot",
-            "-DUSE_GCC_UNWIND=1", "-DUSE_ELF_SYMBOLS=1", "-DELFSIZE=64"],
-         "raspberrypi":
-           ["-target", getTargetArg("raspberrypi"),
-            "-mfpu=vfp", "-mfloat-abi=hard",
-            "-DUSE_GCC_UNWIND=1", "-DUSE_ELF_SYMBOLS=1", "-DELFSIZE=32",
-            "--sysroot=$raspberrypiSysrootDir",
-            // TODO: those two are hacks.
-            "-I$raspberrypiSysrootDir/usr/include/c++/4.8.3",
-            "-I$raspberrypiSysrootDir/usr/include/c++/4.8.3/arm-linux-gnueabihf"]
-        ]
-    } else if (isWindows()) {
-        ext.host = "mingw"
-        ext.targetArgs <<
-                [(ext.host):
-                         ["-target", "x86_64-w64-mingw32", "--sysroot=${mingwWithLlvmDir}",
-                          "-DUSE_GCC_UNWIND=1", "-DUSE_PE_COFF_SYMBOLS=1", "-DKONAN_WINDOWS=1"]]
-    } else {
-         ext.host = "macbook"
-         ext.targetArgs <<
-            [(ext.host):
-                ["--sysroot=$macbookSysrootDir", "-mmacosx-version-min=10.11"],
-             "iphone":
-                ["-stdlib=libc++", "-arch", "arm64", "-isysroot", "$iphoneSysrootDir",
-                 "-miphoneos-version-min=8.0.0"]
-// TODO: re-enable after simulator sysroot is available in the dependencies
-//             "iphone_sim":
-//                ["-stdlib=libc++", "-isysroot", "$iphoneSimSysrootDir", "-miphoneos-version-min=8.0.0"],
-            ]
-     }
-
-     if (isLinux() || isMac()) {
-         ext.targetArgs << [
-                 "android_arm32":
-                         ["-target", getTargetArg("android_arm32"),
-                          "--sysroot=$android_arm32SysrootDir",
-                          "-D__ANDROID__", "-DUSE_GCC_UNWIND=1", "-DUSE_ELF_SYMBOLS=1", "-DELFSIZE=32", "-DKONAN_ANDROID",
-                          // HACKS!
-                          "-I$android_arm32SysrootDir/usr/include/c++/4.9.x",
-                          "-I$android_arm32SysrootDir/usr/include/c++/4.9.x/arm-linux-androideabi"],
-                 "android_arm64":
-                        ["-target", getTargetArg("android_arm64"),
-                         "--sysroot=$android_arm64SysrootDir",
-                         "-D__ANDROID__", "-DUSE_GCC_UNWIND=1", "-DUSE_ELF_SYMBOLS=1", "-DELFSIZE=64", "-DKONAN_ANDROID",
-                         // HACKS!
-                         "-I$android_arm64SysrootDir/usr/include/c++/4.9.x",
-                         "-I$android_arm64SysrootDir/usr/include/c++/4.9.x/aarch64-linux-android"]
-
-         ]
-    }
-
-    ext.targetList = ext.targetArgs.keySet() as List
-
-    if (isLinux()) {
-        binDir = "$gccToolchainDir/$gnuTriplet/bin"
-        ext.clangArgs.addAll([
-            "--gcc-toolchain=$gccToolchainDir"
-        ])
-    } else if (isWindows()) {
-        binDir = "$mingwWithLlvmDir/bin"
-    } else {
-        binDir = "$macbookSysrootDir/usr/bin"
-    }
-    ext.clangArgs << "-B$binDir"
-    ext.hostClangArgs = ext.clangArgs.clone() 
-    ext.hostClangArgs.addAll(ext.targetArgs[host])
-
-    ext.clangPath << binDir
-    ext.jvmArgs = ["-ea"]
-
-    File jdkHome = new File(System.getProperty('java.home')).absoluteFile.parentFile
-    ext.hostCompilerArgsForJni = ["", jniHostPlatformIncludeDir()].collect { "-I$jdkHome/include/$it" } as String[]
 }
 
 void loadLocalProperties() {
@@ -197,50 +119,20 @@ void loadCommandLineProperties() {
 }
 
 class PlatformInfo {
-    private final String osName = System.properties['os.name']
-    private final String osArch = System.properties['os.arch']
-
     boolean isMac() {
-        return osName == 'Mac OS X'
+        return TargetManager.host == KonanTarget.MACBOOK
     }
 
     boolean isWindows() {
-        return osName.startsWith('Windows');
+        return TargetManager.host == KonanTarget.MINGW
     }
 
     boolean isLinux() {
-        return osName == 'Linux'
-    }
-
-    boolean isAmd64() {
-        return osArch in ['x86_64', 'amd64']
-    }
-
-    String getGnuTriplet() {
-        if (isLinux() && isAmd64()) {
-            return "x86_64-unknown-linux-gnu"
-        } else {
-            throw unsupportedPlatformException()
-        }
-    }
-
-    String simpleOsName() {
-        if (isMac()) return 'macos'
-        if (isLinux()) return 'linux'
-        if (isWindows()) return 'windows'
-        throw unsupportedPlatformException()
-    }
-
-    String jniHostPlatformIncludeDir() {
-        if (isMac()) return "darwin"
-        if (isLinux()) return "linux"
-        if (isWindows()) return "win32"
-
-        throw unsupportedPlatformException()
+        return TargetManager.host == KonanTarget.LINUX
     }
 
     Throwable unsupportedPlatformException() {
-        return new Error("unsupported platform: $osName/$osArch")
+        return new TargetSupportException()
     }
 }
 
@@ -323,7 +215,7 @@ task listDist(type: Exec) {
 }
 
 task distRuntime(type: Copy) {
-    dependsOn "${host}CrossDistRuntime"
+    dependsOn "${hostName}CrossDistRuntime"
     dependsOn('commonDistRuntime')
 }
 
@@ -331,7 +223,7 @@ task commonDistRuntime(type: Copy) {
     destinationDir file('dist')
 
     // Target independant common part.
-    from(project(':runtime').file("build/${host}Stdlib")) {
+    from(project(':runtime').file("build/${hostName}Stdlib")) {
         include('**')
         into('klib/stdlib')
     }
@@ -375,7 +267,8 @@ task crossDist {
 
 task bundle(type: (isWindows()) ? Zip : Tar) {
     dependsOn('crossDist')
-    baseName = "kotlin-native-${simpleOsName()}-${project.konanVersion}"
+    def simpleOsName = TargetManager.simpleOsName()
+    baseName = "kotlin-native-$simpleOsName-${project.konanVersion}"
     from("$project.rootDir/dist") {
         include '**'
         exclude 'dependencies'

--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/ExecClang.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/ExecClang.groovy
@@ -53,12 +53,9 @@ class ExecClang {
                         throw new GradleException("unsupported clang executable: $executable")
                     }
 
-                    environment["PATH"] = project.files(project.clangPath).asPath +
+                    environment["PATH"] = project.files(project.hostClang.hostClangPath).asPath +
                             File.pathSeparator + environment["PATH"]
-
-                    args project.clangArgs
                 }
-
             }
         }
         return project.exec(extendedAction)

--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/NativeInteropPlugin.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/NativeInteropPlugin.groovy
@@ -228,7 +228,7 @@ class NamedNativeInteropConfig implements Named {
                 }
 
                 // TODO: the interop plugin should probably be reworked to execute clang from build scripts directly
-                environment['PATH'] = project.files(project.clangPath).asPath +
+                environment['PATH'] = project.files(project.hostClang.hostClangPath).asPath +
                         File.pathSeparator + environment['PATH']
 
                 args compilerOpts.collectMany { ['-copt', it] }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,12 +22,11 @@ targetList.each { targetName ->
     task ("${targetName}Hash", type: CompileCppToBitcode) {
         name 'hash'
         target targetName
-        compilerArgs targetArgs[targetName]
     }
 }
 
 task build {
-    dependsOn "${host}Hash"
+    dependsOn "${hostName}Hash"
 }
 
 task clean {

--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -15,6 +15,10 @@
  */
 
 import static DependencyTaskKind.*
+import org.jetbrains.kotlin.konan.target.*
+import static org.jetbrains.kotlin.konan.target.KonanTarget.*
+import org.jetbrains.kotlin.konan.properties.KonanProperties
+import org.jetbrains.kotlin.konan.properties.*
 
 buildscript {
     repositories {
@@ -29,10 +33,6 @@ buildscript {
 }
 
 apply plugin: 'com.jfrog.bintray'
-
-rootProject.ext.konanPropertiesFile = project(':backend.native').file('konan.properties')
-rootProject.ext.konanProperties = new Properties()
-rootProject.konanProperties.load(new FileInputStream(rootProject.konanPropertiesFile))
 
 configurations {
     kotlin_compiler_jar
@@ -106,20 +106,7 @@ task update_kotlin_compiler(type: DefaultTask) {
 }
 
 abstract class NativeDep extends DefaultTask {
-
-    private String getCurrentHostTarget() {
-        if (project.isMac() && project.isAmd64()) {
-            return 'darwin-macos'
-        } else if (project.isLinux() && project.isAmd64()) {
-            return 'linux-x86-64'
-        } else if (project.isWindows() && project.isAmd64()) {
-            return 'windows-x86-64'
-        } else {
-            throw project.unsupportedPlatformException()
-        }
-    }
-
-    protected final String host = getCurrentHostTarget();
+    protected final String hostSystem = TargetManager.longerSystemName();
     String baseUrl = "https://jetbrains.bintray.com/kotlin-native-dependencies"
 
     @Input
@@ -130,7 +117,7 @@ abstract class NativeDep extends DefaultTask {
     }
 
     protected File getBaseOutDir() {
-        final File res = project.rootProject.file("dist/dependencies")
+        final File res = project.rootProject.ext.dependenciesDir
         res.mkdirs()
         return res
     }
@@ -193,15 +180,6 @@ class HelperNativeDep extends TgzNativeDep {
     }
 }
 
-static String substituteName(String name) {
-    switch (name) {
-        case "macbook": return "osx"
-        case "iphone": return "ios"
-        case "iphoneSim": return "ios_sim"
-    }
-    return name
-}
-
 enum DependencyTaskKind {
     LIBFFI("Libffi"), SYSROOT("Sysroot")
 
@@ -213,22 +191,23 @@ enum DependencyTaskKind {
     String toString() { return name }
 }
 
-void dependencyTask(String target, DependencyTaskKind kind) {
+void dependencyTask(KonanTarget target, DependencyTaskKind kind) {
     String dependencyBaseName
-    def properties = rootProject.konanProperties
+    def properties = rootProject.ext.konanProperties
+    def dirs = new KonanProperties(target, properties, null)
     switch (kind) {
         case LIBFFI:
-            dependencyBaseName = properties.getProperty("libffiDir.${substituteName(target)}")
+            dependencyBaseName = dirs.libffiDir
             break
         case SYSROOT:
-            dependencyBaseName = properties.getProperty("targetSysRoot.${substituteName(target)}")
+            dependencyBaseName = dirs.targetSysRoot
             break
     }
     if (dependencyBaseName == null) {
         throw project.unsupportedPlatformException()
     }
 
-    task "${target}${kind}"(type: HelperNativeDep) {
+    task "${target.userName}${kind}"(type: HelperNativeDep) {
         baseName = dependencyBaseName
     }
 }
@@ -236,37 +215,36 @@ void dependencyTask(String target, DependencyTaskKind kind) {
 if (isLinux()) {
     // The gcc toolchain contains the sysroot for linux platform.
     task gccToolchain(type: HelperNativeDep) {
-        baseName = "target-gcc-toolchain-3-$host"
+        baseName = "target-gcc-toolchain-3-$hostSystem"
     }
 
-    dependencyTask("linux", LIBFFI)
-    dependencyTask("raspberrypi", SYSROOT)
-    dependencyTask("raspberrypi", LIBFFI)
+    dependencyTask(LINUX, LIBFFI)
+    dependencyTask(RASPBERRYPI, SYSROOT)
+    dependencyTask(RASPBERRYPI, LIBFFI)
 } else if (isWindows()) {
     task mingwWithLlvm(type: HelperNativeDep) {
-        baseName = "msys2-mingw-w64-x86_64-gcc-6.3.0-clang-llvm-3.9.1-$host"
+        baseName = "msys2-mingw-w64-x86_64-gcc-6.3.0-clang-llvm-3.9.1-$hostSystem"
     }
 
-    dependencyTask("mingw", LIBFFI)
+    dependencyTask(MINGW, LIBFFI)
 } else {
-    dependencyTask("macbook", SYSROOT)
-    dependencyTask("macbook", LIBFFI)
-    dependencyTask("iphone", SYSROOT)
-    dependencyTask("iphone", LIBFFI)
-
+    dependencyTask(MACBOOK, SYSROOT)
+    dependencyTask(MACBOOK, LIBFFI)
+    dependencyTask(IPHONE, SYSROOT)
+    dependencyTask(IPHONE, LIBFFI)
     // TODO: re-enable when we known how to bring the simulator sysroot to dependencies.
-    // dependencyTask("iphoneSim", SYSROOT)
+    // dependencyTask(IPHONE_SIM, SYSROOT)
 }
 
 if (isLinux() || isMac()) {
     task llvm(type: HelperNativeDep) {
-        baseName = "clang-llvm-$llvmVersion-$host"
+        baseName = "clang-llvm-$llvmVersion-$hostSystem"
     }
 
-    dependencyTask("android_arm32", SYSROOT)
-    dependencyTask("android_arm32", LIBFFI)
-    dependencyTask("android_arm64", SYSROOT)
-    dependencyTask("android_arm64", LIBFFI)
+    dependencyTask(ANDROID_ARM32, SYSROOT)
+    dependencyTask(ANDROID_ARM32, LIBFFI)
+    dependencyTask(ANDROID_ARM64, SYSROOT)
+    dependencyTask(ANDROID_ARM64, LIBFFI)
 }
 
 task update(type: Copy) {

--- a/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
+++ b/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
@@ -22,7 +22,7 @@ import java.util.Properties
 import org.jetbrains.kotlin.backend.konan.library.impl.*
 import org.jetbrains.kotlin.backend.konan.library.KonanLibrary
 import org.jetbrains.kotlin.backend.konan.library.KonanLibrarySearchPathResolver
-import org.jetbrains.kotlin.backend.konan.util.File
+import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.target.TargetManager
 
 fun printUsage() {

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -25,7 +25,6 @@ targetList.each { targetName ->
         dependsOn ":common:${targetName}Hash"
         dependsOn "${targetName}Launcher"
         target targetName
-        compilerArgs targetArgs[targetName]
         compilerArgs '-g'
         compilerArgs '-I' + project.file('../common/src/hash/headers')
         compilerArgs '-I' + project.file(rootProject.ext.get("${targetName}LibffiDir") + "/include")
@@ -38,14 +37,13 @@ targetList.each { targetName ->
         name "launcher"
         srcRoot file('src/launcher')
         target targetName
-        compilerArgs targetArgs[targetName]
         compilerArgs '-g'
         compilerArgs '-I' + project.file('../common/src/hash/headers')
         compilerArgs '-I' + project.file('src/main/cpp')
     }
 }
 
-task hostRuntime(dependsOn: "${rootProject.ext.host}Runtime")
+task hostRuntime(dependsOn: "${hostName}Runtime")
 
 task clean {
     doLast {

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed -> in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.konan.target
+
+import org.jetbrains.kotlin.konan.properties.KonanProperties
+import org.jetbrains.kotlin.konan.file.File
+
+class ClangTarget(val target: KonanTarget, val konanProperties: KonanProperties) {
+
+    val sysRoot = konanProperties.absoluteTargetSysRoot!!
+    val targetArg = konanProperties.targetArg
+
+    val specificClangArgs: List<String> get() {
+        return when (target) {
+
+            KonanTarget.LINUX ->
+                listOf("--sysroot=$sysRoot", 
+                        "-DUSE_GCC_UNWIND=1", "-DUSE_ELF_SYMBOLS=1", "-DELFSIZE=64")
+            KonanTarget.RASPBERRYPI ->
+                listOf("-target", targetArg!!,
+                        "-mfpu=vfp", "-mfloat-abi=hard",
+                        "-DUSE_GCC_UNWIND=1", "-DUSE_ELF_SYMBOLS=1", "-DELFSIZE=32",
+                        "--sysroot=$sysRoot",
+                        // TODO: those two are hacks.
+                        "-I$sysRoot/usr/include/c++/4.8.3",
+                        "-I$sysRoot/usr/include/c++/4.8.3/arm-linux-gnueabihf")
+
+            KonanTarget.MINGW ->
+                listOf("-target", targetArg!!, "--sysroot=$sysRoot",
+                        "-DUSE_GCC_UNWIND=1", "-DUSE_PE_COFF_SYMBOLS=1", "-DKONAN_WINDOWS=1")
+
+            KonanTarget.MACBOOK ->
+                listOf("--sysroot=$sysRoot", "-mmacosx-version-min=10.11")
+
+            KonanTarget.IPHONE ->
+                listOf("-stdlib=libc++", "-arch", "arm64", "-isysroot", "$sysRoot", "-miphoneos-version-min=8.0.0")
+
+            KonanTarget.IPHONE_SIM ->
+                listOf("-stdlib=libc++", "-isysroot", "$sysRoot", "-miphoneos-version-min=8.0.0")
+
+            KonanTarget.ANDROID_ARM32 ->
+                listOf("-target", targetArg!!,
+                        "--sysroot=$sysRoot",
+                        "-D__ANDROID__", "-DUSE_GCC_UNWIND=1", "-DUSE_ELF_SYMBOLS=1", "-DELFSIZE=32", "-DKONAN_ANDROID",
+                        // HACKS!
+                        "-I$sysRoot/usr/include/c++/4.9.x",
+                        "-I$sysRoot/usr/include/c++/4.9.x/arm-linux-androideabi")
+
+            KonanTarget.ANDROID_ARM64 ->
+                listOf("-target", targetArg!!,
+                        "--sysroot=$sysRoot",
+                        "-D__ANDROID__", "-DUSE_GCC_UNWIND=1", "-DUSE_ELF_SYMBOLS=1", "-DELFSIZE=64", "-DKONAN_ANDROID",
+                        // HACKS!
+                        "-I$sysRoot/usr/include/c++/4.9.x",
+                        "-I$sysRoot/usr/include/c++/4.9.x/aarch64-linux-android")
+        }
+    }
+}
+
+class ClangHost(val hostProperties: KonanProperties) {
+
+    val targetToolchain get() = hostProperties.absoluteTargetToolchain
+    val gccToolchain get() = hostProperties.absoluteGccToolchain
+    val sysRoot get() = hostProperties.absoluteTargetSysRoot
+    val llvmDir get() = hostProperties.absoluteLlvmHome
+
+    val binDir = when(TargetManager.host) {
+        KonanTarget.LINUX -> "$targetToolchain/bin"
+        KonanTarget.MINGW -> "$sysRoot/bin"
+        KonanTarget.MACBOOK -> "$sysRoot/usr/bin"
+        else -> throw TargetSupportException("Unexpected host platform")
+    }
+
+    private val extraHostClangArgs = 
+        if (TargetManager.host == KonanTarget.LINUX) {
+            listOf("--gcc-toolchain=$gccToolchain")
+        } else {
+            emptyList()
+        }
+
+    val commonClangArgs = listOf("-B$binDir") + extraHostClangArgs
+
+    val hostClangPath = listOf("$llvmDir/bin", binDir)
+
+    private val jdkHome = File.jdkHome.absoluteFile.parent
+
+    val hostCompilerArgsForJni = listOf("", TargetManager.jniHostPlatformIncludeDir).map { "-I$jdkHome/include/$it" }
+}
+

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangCross.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangCross.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed -> in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.konan.target
+
+import org.jetbrains.kotlin.konan.properties.*
+
+class ClangManager(val properties: Properties, val baseDir: String) {
+    private val host = TargetManager.host
+    private val enabledTargets = TargetManager.enabled
+    private val konanProperties = enabledTargets.map {
+        it to KonanProperties(it, properties, baseDir)
+    }.toMap()
+
+    private val targetClangs = enabledTargets.map {
+        it to ClangTarget(it, konanProperties[it]!!) 
+    }.toMap()
+
+    private val hostClang = ClangHost(konanProperties[host]!!)
+
+    // These are converted to arrays to be convenient
+    // in groovy plugins.
+    val hostClangArgs = (hostClang.commonClangArgs + targetClangs[host]!!.specificClangArgs).toTypedArray()
+
+    fun targetClangArgs(target: KonanTarget)
+        = (hostClang.commonClangArgs + targetClangs[target]!!.specificClangArgs).toTypedArray()
+
+    val hostCompilerArgsForJni = hostClang.hostCompilerArgsForJni.toTypedArray()
+}
+

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanProperties.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanProperties.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed -> in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.konan.properties
+
+import org.jetbrains.kotlin.konan.file.*
+import org.jetbrains.kotlin.konan.target.*
+
+class KonanProperties(val target: KonanTarget, val properties: Properties, val baseDir: String? = null) {
+
+    fun targetString(key: String): String? 
+        = properties.targetString(key, target)
+    fun targetList(key: String): List<String> 
+        = properties.targetList(key, target)
+    fun hostString(key: String): String? 
+        = properties.hostString(key)
+    fun hostList(key: String): List<String> 
+        = properties.hostList(key)
+    fun hostTargetString(key: String): String? 
+        = properties.hostTargetString(key, target)
+    fun hostTargetList(key: String): List<String> 
+        = properties.hostTargetList(key, target)
+
+    // TODO: Delegate to a map?
+    val llvmLtoNooptFlags get() = targetList("llvmLtoNooptFlags")
+    val llvmLtoOptFlags get() = targetList("llvmLtoOptFlags")
+    val llvmLtoFlags get() = targetList("llvmLtoFlags")
+    val entrySelector get() = targetList("entrySelector")
+    val linkerOptimizationFlags get() = targetList("linkerOptimizationFlags")
+    val linkerKonanFlags get() = targetList("linkerKonanFlags")
+    val linkerDebugFlags get() = targetList("linkerDebugFlags")
+    val llvmDebugOptFlags get() = targetList("llvmDebugOptFlags")
+
+    val targetSysRoot get() = targetString("targetSysRoot")
+    val libffiDir get() = targetString("libffiDir")
+    val gccToolchain get() = targetString("gccToolchain")
+    val targetArg get() = targetString("quadruple")
+    val llvmHome get() = targetString("llvmHome")
+    // Notice: this one is host-target.
+    val targetToolchain get() = hostTargetString("targetToolchain") 
+
+    fun absolute(value: String?) = "${baseDir!!}/${value!!}"
+
+    val absoluteTargetSysRoot get() = absolute(targetSysRoot)
+    val absoluteTargetToolchain get() = absolute(targetToolchain)
+    val absoluteGccToolchain get() = absolute(gccToolchain)
+    val absoluteLlvmHome get() = absolute(llvmHome)
+    val absoluteLibffiDir get() = absolute(libffiDir)
+
+    val mingwWithLlvm: String?
+        get() { 
+            if (target != KonanTarget.MINGW) {
+                error("Only mingw target can have '.mingwWithLlvm' property")
+            }
+            // TODO: make it a property in the konan.properties.
+            // Use (equal) llvmHome fow now.
+            return targetString("llvmHome")
+        }
+}

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Properties.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Properties.kt
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package org.jetbrains.kotlin.backend.konan.util
+package org.jetbrains.kotlin.konan.properties
+
+import org.jetbrains.kotlin.konan.file.*
 
 typealias Properties = java.util.Properties
 
@@ -25,6 +27,8 @@ fun File.loadProperties(): Properties {
     }
     return properties
 }
+
+fun loadProperties(path: String): Properties = File(path).loadProperties()
 
 fun File.saveProperties(properties: Properties) {
     this.outputStream().use { 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/TargetProperties.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/TargetProperties.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jetbrains.kotlin.backend.konan.util
+package org.jetbrains.kotlin.konan.properties
 
 import org.jetbrains.kotlin.konan.target.*
 
@@ -29,3 +29,9 @@ fun Properties.targetString(name: String, target: KonanTarget): String?
 
 fun Properties.targetList(name: String, target: KonanTarget): List<String>
     = this.propertyList(name, target.targetSuffix)
+
+fun Properties.hostTargetString(name: String, target: KonanTarget): String?
+    = this.propertyString(name, hostTargetSuffix(TargetManager.host, target))
+
+fun Properties.hostTargetList(name: String, target: KonanTarget): List<String>
+    = this.propertyList(name, hostTargetSuffix(TargetManager.host, target))

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/NoJavaUtil.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/NoJavaUtil.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jetbrains.kotlin.backend.konan.util
+package org.jetbrains.kotlin.konan.file
 
 import java.io.BufferedReader
 import java.io.InputStream
@@ -127,6 +127,9 @@ class File constructor(internal val javaPath: Path) {
 
         val userHome
             get() = File(System.getProperty("user.home"))
+
+        val jdkHome
+            get() = File(System.getProperty("java.home"))
 
     }
 }

--- a/utilities/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/main.kt
+++ b/utilities/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/main.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlin.cli.utilities
 
-import org.jetbrains.kotlin.backend.konan.util.File
+import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.cli.bc.main as konancMain
 import org.jetbrains.kotlin.native.interop.gen.jvm.main as cinteropMain
 import org.jetbrains.kotlin.cli.klib.main as klibMain


### PR DESCRIPTION
Moved clang flags out of the root build.gardle and dependencies/build.gradle.
Moved lots of string based host/target manipulations to KonanTarget.
Collected clang args in ClangArgs.kt
Introduced KonanProperties to take care of target specific properties.