### PR TITLE
Fix humanReadable formatting of bytes.

### DIFF
--- a/tools/helpers/src/main/kotlin/DependencyDownloader.kt
+++ b/tools/helpers/src/main/kotlin/DependencyDownloader.kt
@@ -135,7 +135,7 @@ class DependencyDownloader(dependenciesRoot: File,
             }
             val exp = (Math.log(this.toDouble()) / Math.log(1024.0)).toInt()
             val prefix = "kMGTPE"[exp-1]
-            return "%.1f %sB".format(this / Math.pow(1024.0, exp.toDouble()), prefix)
+            return "%.1f %siB".format(this / Math.pow(1024.0, exp.toDouble()), prefix)
         }
 
     private fun updateProgressMsg(url: String, currentBytes: Long, totalBytes: Long) {


### PR DESCRIPTION
Previously, the Long.humanReadable function in the DependencyDownloader class would display byte unit suffixes as `kB`, `MB`, etc., even though the calculations on byte counts were using a base of 2.

I've revised this to display sizes in the format of `kiB` or `MiB`, for kebibyte, and mebibyte - the base 2 unit equivalents of kilobyte and megabyte respectively.