### PR TITLE
backend: Process 'until  MIN_VALUE' in for loops

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/common/ir/Ir.kt
@@ -81,7 +81,7 @@ open class Symbols<out T: CommonBackendContext>(val context: T, private val symb
 
     val checkProgressionStep = context.getInternalFunctions("checkProgressionStep")
             .map { Pair(it.returnType, symbolTable.referenceSimpleFunction(it)) }.toMap()
-    val getProgressionBound = context.getInternalFunctions("getProgressionBound")
+    val getProgressionLast = context.getInternalFunctions("getProgressionLast")
             .map { Pair(it.returnType, symbolTable.referenceSimpleFunction(it)) }.toMap()
 
     val defaultConstructorMarker = symbolTable.referenceClass(context.getInternalClass("DefaultConstructorMarker"))

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -357,6 +357,11 @@ task codegen_controlflow_for_loops_coroutines(type: RunKonanTest) {
             "Got: 0 2 4 6\n"
 }
 
+task codegen_controlflow_for_loops_call_order(type: RunKonanTest) {
+    source = "codegen/controlflow/for_loops_call_order.kt"
+    goldValue = "1234\n1234\n2134\n"
+}
+
 task local_variable(type: RunKonanTest) {
     source = "codegen/basics/local_variable.kt"
 }

--- a/backend.native/tests/codegen/controlflow/for_loops_call_order.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_call_order.kt
@@ -1,0 +1,10 @@
+fun f1(): Int { print("1"); return 0 }
+fun f2(): Int { print("2"); return 6 }
+fun f3(): Int { print("3"); return 2 }
+fun f4(): Int { print("4"); return 3 }
+
+fun main(args: Array<String>) {
+    for (i in f1()..f2() step f3() step f4()) { }; println()
+    for (i in f1() until f2() step f3() step f4()) {}; println()
+    for (i in f2() downTo f1() step f3() step f4()) {}; println()
+}

--- a/backend.native/tests/codegen/controlflow/for_loops_overflow.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_overflow.kt
@@ -3,6 +3,20 @@ fun main(args: Array<String>) {
     for (i in Int.MAX_VALUE - 1 until Int.MAX_VALUE) { print(i); print(' ') }; println()
     for (i in Int.MIN_VALUE + 1 downTo Int.MIN_VALUE) { print(i); print(' ') }; println()
 
+    // Empty loops
+    for (i in Byte.MIN_VALUE  until Byte.MIN_VALUE)  { print(i); print(' ') }
+    for (i in Short.MIN_VALUE until Short.MIN_VALUE) { print(i); print(' ') }
+    for (i in Int.MIN_VALUE   until Int.MIN_VALUE)   { print(i); print(' ') }
+    for (i in Long.MIN_VALUE  until Long.MIN_VALUE)  { print(i); print(' ') }
+    for (i in 0.toChar()      until 0.toChar())      { print(i); print(' ') }
+
+    for (i in 0 until Byte.MIN_VALUE)  { print(i); print(' ') }
+    for (i in 0 until Short.MIN_VALUE) { print(i); print(' ') }
+    for (i in 0 until Int.MIN_VALUE)   { print(i); print(' ') }
+    for (i in 0 until Long.MIN_VALUE)  { print(i); print(' ') }
+    for (i in 'a' until 0.toChar())    { print(i); print(' ') }
+
+
     val M = Int.MAX_VALUE / 2
     for (i in M + 4..M + 10 step M)  { print(i); print(' ') }; println()
 }

--- a/runtime/src/main/kotlin/konan/internal/RuntimeUtils.kt
+++ b/runtime/src/main/kotlin/konan/internal/RuntimeUtils.kt
@@ -91,8 +91,8 @@ fun <T: Enum<T>> valuesForEnum(values: Array<T>): Array<T>
 fun checkProgressionStep(step: Int)  = if (step > 0) step else throw IllegalArgumentException("Step must be positive, was: $step.")
 fun checkProgressionStep(step: Long) = if (step > 0) step else throw IllegalArgumentException("Step must be positive, was: $step.")
 
-fun getProgressionBound(start: Char, end: Char, step: Int): Char =
-        getProgressionBound(start.toInt(), end.toInt(), step).toChar()
+fun getProgressionLast(start: Char, end: Char, step: Int): Char =
+        getProgressionLast(start.toInt(), end.toInt(), step).toChar()
 
-fun getProgressionBound(start: Int, end: Int, step: Int): Int = getProgressionLastElement(start, end, step)
-fun getProgressionBound(start: Long, end: Long, step: Long): Long = getProgressionLastElement(start, end, step)
+fun getProgressionLast(start: Int, end: Int, step: Int): Int = getProgressionLastElement(start, end, step)
+fun getProgressionLast(start: Long, end: Long, step: Long): Long = getProgressionLastElement(start, end, step)


### PR DESCRIPTION
This patch takes into account a corner case available for loops
over a progression (see backend.native/tests/external/codegen/box/
ranges/forInUntil/forInUntilMinint.kt test):

for (i in 0 until Int.MIN_VALUE) { ... }

Here we cannot use subtraction to obtain a right bound of the loop
due to an overflow. Instead we consider any loop with MIN_VALUE in
it's right bound as empty loop. Such behaviour is similar to the one
of 'until' method.

So now the empty check for a loops with 'until' call:

for (i in first until bound) { ... }

is as follows:

val last = getProgressionLast(first, bound, step) // Only if step==1
if (first <= last && bound > <Int|Long|Char>.MIN_VALUE) {
    do { ... } while(i != last)
}

Further improvements: We can generate a simpler IR for some simple
frequent cases (e.g. for until calls without steps) and eliminate
loops if we can prove that they are empty.