### PR TITLE
gradle-plugin: Don't use Project.getTasksByName method

### DIFF
--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
@@ -215,23 +215,17 @@ class KonanPlugin @Inject constructor(private val registry: ToolingModelBuilderR
         }.getProperty("default-konan-version") ?: throw RuntimeException("Cannot read the default compiler version")
     }
 
+    /** Looks for task with given name in the given project. Throws [UnknownTaskException] if there's not such task. */
+    private fun Project.getTask(name: String): Task = tasks.getByPath(name)
+
     /**
      * Looks for task with given name in the given project.
      * If such task isn't found, will create it. Returns created/found task.
      */
-    private fun Project.getTask(name: String): Task = getTasksByName(name, false).single()
-
-    private fun Project.getOrCreateTask(name: String): Task {
-        val tasks = getTasksByName(name, false)
-        assert(tasks.size <= 1)
-        return if (tasks.isEmpty()) {
-            this.tasks.create(name, DefaultTask::class.java)
-        } else {
-            tasks.single()
-        }
+    private fun Project.getOrCreateTask(name: String): Task = with(tasks) {
+        findByPath(name) ?: create(name, DefaultTask::class.java)
     }
 
-    // TODO: Create default config? what about test sources?
     override fun apply(project: Project?) {
         if (project == null) { return }
         registry.register(KonanToolingModelBuilder)

--- a/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/KonanProject.groovy
+++ b/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/KonanProject.groovy
@@ -18,6 +18,7 @@ class KonanProject {
 
     File         buildFile
     File         propertiesFile
+    File         settingsFile
 
     Set<File>    srcFiles = []
 
@@ -77,10 +78,16 @@ class KonanProject {
         createSubDir("src", "main", "kotlin")
     }
 
-    /** Generates a build.gradle file in root project directory with the given content. */
+    /** Generates a build.gradle file in the root project directory with the given content. */
     File generateBuildFile(String content) {
         buildFile = createFile(projectPath, "build.gradle", content)
         return buildFile
+    }
+
+    /** Generates a settings.gradle file in the root project directory with the given content. */
+    File generateSettingsFile(String content) {
+        settingsFile = createFile(projectPath, "settings.gradle", content)
+        return settingsFile
     }
 
     /**
@@ -197,6 +204,7 @@ class KonanProject {
             generateFolders()
             generateBuildFile()
             generatePropertiesFile(konanHome)
+            generateSettingsFile("")
         }
         return result
     }


### PR DESCRIPTION
Call of Project.getTasksByName in KonanPluing.apply causes subproject
evaluation. So in such a build script the plugin 'foo' will not be
applied to the subprojects:

subprojects {
    apply 'konan'
    apply 'foo'
}

This patch uses methods available via Project.tasks property to
work with tasks without causing subproject evaluation.

Related issue: KT-19916