### PR TITLE
fix leaked non-daemon thread in Downloader

### DIFF
--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyDownloader.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyDownloader.kt
@@ -12,7 +12,15 @@ class DependencyDownloader(
         var maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
         var attemptIntervalMs: Long = DEFAULT_ATTEMPT_INTERVAL_MS
 ) {
-    val executor = ExecutorCompletionService<Unit>(Executors.newSingleThreadExecutor())
+    val executor = ExecutorCompletionService<Unit>(Executors.newSingleThreadExecutor(object : ThreadFactory {
+        override fun newThread(r: Runnable?): Thread {
+            val thread = Thread(r)
+            thread.name = "konan-dependency-downloader"
+            thread.isDaemon = true
+
+            return thread
+      }
+    }))
 
     enum class ReplacingMode {
         /** Redownload the file and replace the existing one. */


### PR DESCRIPTION
Running Gradle build in TeamCity. Builds tend to stuck endlessly. Checking the logs shown, there is running Kotlin/Native process with one thread called "pool-1-thread-1". The build log always ends on Downloading phase. 

I check the Kotlin/Native code and found out the place, where such a non-daemon thread can be created. The `Executors.newSingleThreadExecutor()` uses default thread factory, which names threads in with the same pattern. Also, the default factory does create non-daemon threads. The only chance for my build to complete is to be executed on the same build agent (it's likely to be false for my case) several times to have compiler not downloading any dependency, so that thread is not created. 

The proposed fix tends to cover the issue. It's tricky to add unit test for the case, as one need starting a fresh JVM with the downloader. Let' me know if it's indeed necessary 

The original threaddump
```
/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/bin/java -Djava.library.path=/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/nativelib -Dkonan.home=/Users/builduser/.konan/kotlin-native-macos-0.3.2 -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -cp /Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/backend.native.jar:/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/Indexer.jar:/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/klib.jar:/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/kotlin-compiler.jar:/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/protobuf-java-2.6.1.jar:/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/Runtime.jar:/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/shared.jar:/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/StubGenerator.jar:/Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/lib/utilities.jar org.jetbrains.kotlin.native.interop.gen.jvm.MainKt -properties /Users/builduser/.konan/kotlin-native-macos-0.3.2/konan/konan.properties -flavor native -generated  <REMOVED>

2017-09-10 02:09:36
Full thread dump Java HotSpot(TM) 64-Bit Server VM (25.45-b02 mixed mode):
"DestroyJavaVM" #23 prio=5 os_prio=31 tid=0x00007fe283c83800 nid=0x1c03 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"Thread-2" #22 daemon prio=5 os_prio=31 tid=0x00007fe284fe4800 nid=0x4b13 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"Thread-1" #21 daemon prio=5 os_prio=31 tid=0x00007fe28446a000 nid=0x4b0b runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"Thread-0" #20 daemon prio=5 os_prio=31 tid=0x00007fe283cf9800 nid=0x4b07 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"Attach Listener" #17 daemon prio=9 os_prio=31 tid=0x00007fe283891000 nid=0x120b waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"pool-1-thread-1" #10 prio=5 os_prio=31 tid=0x00007fe284407000 nid=0x470b waiting on condition [0x00007000102fc000]
   java.lang.Thread.State: WAITING (parking)
    at sun.misc.Unsafe.park(Native Method)
    - parking to wait for  <0x0000000760543900> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
    at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
    at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
    at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1067)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1127)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
"Service Thread" #7 daemon prio=9 os_prio=31 tid=0x00007fe284091800 nid=0x4303 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"C1 CompilerThread1" #6 daemon prio=9 os_prio=31 tid=0x00007fe284075800 nid=0x4103 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"C2 CompilerThread0" #5 daemon prio=9 os_prio=31 tid=0x00007fe283838000 nid=0x3f03 waiting on condition [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"Signal Dispatcher" #4 daemon prio=9 os_prio=31 tid=0x00007fe283827000 nid=0x3d03 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
"Finalizer" #3 daemon prio=8 os_prio=31 tid=0x00007fe283820000 nid=0x2d03 in Object.wait() [0x000070000fcea000]
   java.lang.Thread.State: WAITING (on object monitor)
    at java.lang.Object.wait(Native Method)
    - waiting on <0x00000007605bd7f0> (a java.lang.ref.ReferenceQueue$Lock)
    at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:143)
    - locked <0x00000007605bd7f0> (a java.lang.ref.ReferenceQueue$Lock)
    at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:164)
    at java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:209)
"Reference Handler" #2 daemon prio=10 os_prio=31 tid=0x00007fe28381f000 nid=0x2b03 in Object.wait() [0x000070000fbe7000]
   java.lang.Thread.State: WAITING (on object monitor)
    at java.lang.Object.wait(Native Method)
    - waiting on <0x00000007605d2e90> (a java.lang.ref.Reference$Lock)
    at java.lang.Object.wait(Object.java:502)
    at java.lang.ref.Reference$ReferenceHandler.run(Reference.java:157)
    - locked <0x00000007605d2e90> (a java.lang.ref.Reference$Lock)
"VM Thread" os_prio=31 tid=0x00007fe28381c800 nid=0x2903 runnable 
"GC task thread#0 (ParallelGC)" os_prio=31 tid=0x00007fe284013000 nid=0x2503 runnable 
"GC task thread#1 (ParallelGC)" os_prio=31 tid=0x00007fe283808800 nid=0x2703 runnable 
"VM Periodic Task Thread" os_prio=31 tid=0x00007fe284092000 nid=0x4503 waiting on condition 
JNI global references: 314
```

