### PR TITLE
Report an explicit error when linker invocation fails.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -305,6 +305,7 @@ internal class LinkStage(val context: Context) {
         try {
             runTool(*linkCommand.toTypedArray())
         } catch (e: KonanExternalToolFailure) {
+            context.reportCompilationError("linker invocation reported errors")
             return null
         }
         if (platform is MacOSBasedPlatform && context.shouldContainDebugInfo()) {


### PR DESCRIPTION
In addition it makes exit code 1, rather than 0 if it
was the only problem during compilation.