### PR TITLE
Support interop modularity

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/Imports.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/Imports.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.native.interop.gen
+
+import org.jetbrains.kotlin.native.interop.indexer.HeaderId
+import org.jetbrains.kotlin.native.interop.indexer.HeaderInclusionPolicy
+import org.jetbrains.kotlin.native.interop.indexer.Location
+
+interface Imports {
+    fun getPackage(location: Location): String?
+}
+
+class ImportsImpl(internal val headerIdToPackage: Map<HeaderId, String>) : Imports {
+
+    override fun getPackage(location: Location): String? =
+            headerIdToPackage[location.headerId]
+
+}
+
+class HeadersInclusionPolicyImpl(
+        private val nameGlobs: List<String>,
+        private val importsImpl: ImportsImpl
+) : HeaderInclusionPolicy {
+
+    override fun excludeUnused(headerName: String?): Boolean {
+        if (nameGlobs.isEmpty()) {
+            return false
+        }
+
+        if (headerName == null) {
+            // Builtins; included only if no globs are specified:
+            return true
+        }
+
+        return nameGlobs.all { !headerName.matchesToGlob(it) }
+    }
+
+    override fun excludeAll(headerId: HeaderId): Boolean {
+        return headerId in importsImpl.headerIdToPackage
+    }
+
+}
+
+private fun String.matchesToGlob(glob: String): Boolean =
+        java.nio.file.FileSystems.getDefault()
+                .getPathMatcher("glob:$glob").matches(java.nio.file.Paths.get(this))

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.native.interop.gen
+
+import kotlin.reflect.KProperty
+
+interface KotlinScope {
+    /**
+     * @return the string to be used to reference the classifier in current scope.
+     */
+    fun reference(classifier: Classifier): String
+
+    /**
+     * @return the string to be used as a name in the declaration of the classifier in current scope.
+     */
+    fun declare(classifier: Classifier): String
+}
+
+data class Classifier(
+        val pkg: String,
+        val topLevelName: String,
+        private val nestedNames: List<String> = emptyList()
+) {
+
+    companion object {
+        fun topLevel(pkg: String, name: String): Classifier {
+            assert(!name.contains('.'))
+            assert(!name.contains('`'))
+            return Classifier(pkg, name)
+        }
+    }
+
+    val isTopLevel: Boolean get() = this.nestedNames.isEmpty()
+
+    fun nested(name: String): Classifier {
+        assert(!name.contains('.'))
+        assert(!name.contains('`'))
+        return this.copy(nestedNames = nestedNames + name)
+    }
+
+    val relativeFqName: String get() = buildString {
+        append(topLevelName.asSimpleName())
+        nestedNames.forEach {
+            append('.')
+            append(it.asSimpleName())
+        }
+    }
+
+    val fqName: String get() = buildString {
+        if (pkg.isNotEmpty()) {
+            append(pkg)
+            append('.')
+        }
+        append(relativeFqName)
+    }
+}
+
+val Classifier.type
+    get() = KotlinClassifierType(this, arguments = emptyList(), nullable = false)
+
+fun Classifier.typeWith(vararg arguments: KotlinType) =
+        KotlinClassifierType(this, arguments.toList(), nullable = false)
+
+interface KotlinType {
+    /**
+     * @return the string to be used in the given scope to denote this type.
+     */
+    fun render(scope: KotlinScope): String
+}
+
+data class KotlinClassifierType(
+        val classifier: Classifier,
+        val arguments: List<KotlinType>,
+        val nullable: Boolean
+) : KotlinType {
+
+    override fun render(scope: KotlinScope): String = buildString {
+        append(scope.reference(classifier))
+        if (arguments.isNotEmpty()) {
+            append('<')
+            arguments.joinTo(this) { it.render(scope) }
+            append('>')
+        }
+        if (nullable) {
+            append('?')
+        }
+    }
+}
+
+fun KotlinClassifierType.makeNullableAsSpecified(nullable: Boolean) = if (this.nullable == nullable) {
+    this
+} else {
+    this.copy(nullable = nullable)
+}
+
+fun KotlinClassifierType.makeNullable() = this.makeNullableAsSpecified(true)
+
+data class KotlinFunctionType(
+        val parameterTypes: List<KotlinType>,
+        val returnType: KotlinType
+) : KotlinType {
+
+    override fun render(scope: KotlinScope) = buildString {
+        append('(')
+        parameterTypes.joinTo(this) { it.render(scope) }
+        append(") -> ")
+        append(returnType.render(scope))
+    }
+}
+
+internal val cnamesStructsPackageName = "cnames.structs"
+
+object KotlinTypes {
+    val boolean by BuiltInType
+    val byte by BuiltInType
+    val short by BuiltInType
+    val int by BuiltInType
+    val long by BuiltInType
+    val float by BuiltInType
+    val double by BuiltInType
+    val unit by BuiltInType
+    val string by BuiltInType
+    val any by BuiltInType
+
+    val nativePtr by InteropType
+
+    val cOpaque by InteropType
+    val cOpaquePointer by InteropType
+    val cOpaquePointerVar by InteropType
+
+    val booleanVarOf by InteropClassifier
+
+    val objCObject by InteropClassifier
+    val objCObjectMeta by InteropClassifier
+    val objCClass by InteropClassifier
+
+    val cValuesRef by InteropClassifier
+
+    val cPointer by InteropClassifier
+    val cPointerVar by InteropClassifier
+    val cArrayPointer by InteropClassifier
+    val cArrayPointerVar by InteropClassifier
+    val cPointerVarOf by InteropClassifier
+
+    val cFunction by InteropClassifier
+
+    val objCObjectVar by InteropClassifier
+    val objCStringVarOf by InteropClassifier
+
+    val objCObjectBase by InteropClassifier
+    val objCObjectBaseMeta by InteropClassifier
+
+    val cValue by InteropClassifier
+
+    private object BuiltInType {
+        operator fun getValue(thisRef: KotlinTypes, property: KProperty<*>): KotlinClassifierType =
+                Classifier.topLevel("kotlin", property.name.capitalize()).type
+    }
+
+    private object InteropClassifier {
+        operator fun getValue(thisRef: KotlinTypes, property: KProperty<*>): Classifier =
+                Classifier.topLevel("kotlinx.cinterop", property.name.capitalize())
+    }
+
+    private object InteropType {
+        operator fun getValue(thisRef: KotlinTypes, property: KProperty<*>): KotlinClassifierType =
+                InteropClassifier.getValue(thisRef, property).type
+    }
+}
+
+class KotlinFile(
+        val pkg: String,
+        namesToBeDeclared: List<String>
+) : KotlinScope {
+
+    // Note: all names are related to classifiers currently.
+
+    private val namesToBeDeclared: Set<String>
+
+    init {
+        this.namesToBeDeclared = mutableSetOf()
+
+        namesToBeDeclared.forEach {
+            if (it in this.namesToBeDeclared) {
+                throw IllegalArgumentException("'$it' is going to be declared twice")
+            } else {
+                this.namesToBeDeclared.add(it)
+            }
+        }
+    }
+
+    private val importedNameToPkg = mutableMapOf<String, String>()
+
+    override fun reference(classifier: Classifier): String = if (classifier.topLevelName in namesToBeDeclared) {
+        if (classifier.pkg == this.pkg) {
+            classifier.relativeFqName
+        } else {
+            // Don't import if would clash with own declaration:
+            classifier.fqName
+        }
+    } else if (classifier.pkg == this.pkg) {
+        throw IllegalArgumentException(
+                "'${classifier.topLevelName}' from the file package was not reserved for declaration"
+        )
+    } else {
+        val pkg = importedNameToPkg.getOrPut(classifier.topLevelName) { classifier.pkg }
+        if (pkg == classifier.pkg) {
+            // Is successfully imported:
+            classifier.relativeFqName
+        } else {
+            classifier.fqName
+        }
+    }
+
+    private val alreadyDeclared = mutableSetOf<String>()
+
+    override fun declare(classifier: Classifier): String {
+        if (classifier.pkg != this.pkg) {
+            throw IllegalArgumentException("wrong package; expected '$pkg', got '${classifier.pkg}'")
+        }
+
+        if (!classifier.isTopLevel) {
+            throw IllegalArgumentException(
+                    "'${classifier.relativeFqName}' is not top-level thus can't be declared at file scope"
+            )
+        }
+
+        val topLevelName = classifier.topLevelName
+        if (topLevelName in alreadyDeclared) {
+            throw IllegalStateException("'$topLevelName' is already declared")
+        }
+        alreadyDeclared.add(topLevelName)
+
+        return topLevelName.asSimpleName()
+    }
+
+    fun buildImports(): List<String> = importedNameToPkg.mapNotNull { (name, pkg) ->
+        if (pkg == "kotlin" || pkg == "kotlinx.cinterop") {
+            // Is already imported either by default or with '*':
+            null
+        } else {
+            "import $pkg.${name.asSimpleName()}"
+        }
+    }.sorted()
+
+}

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGenerator.kt
@@ -19,16 +19,16 @@ package org.jetbrains.kotlin.native.interop.gen
 /**
  * The type which has exact counterparts on both Kotlin and native side and can be directly passed through bridges.
  */
-enum class BridgedType(val kotlinType: String, val convertor: String? = null) {
-    BYTE("kotlin.Byte", "toByte"),
-    SHORT("kotlin.Short", "toShort"),
-    INT("kotlin.Int",  "toInt"),
-    LONG("kotlin.Long", "toLong"),
-    FLOAT("kotlin.Float", "toFloat"),
-    DOUBLE("kotlin.Double", "toDouble"),
-    NATIVE_PTR("NativePtr"),
-    OBJC_POINTER("NativePtr"),
-    VOID("kotlin.Unit")
+enum class BridgedType(val kotlinType: KotlinClassifierType, val convertor: String? = null) {
+    BYTE(KotlinTypes.byte, "toByte"),
+    SHORT(KotlinTypes.short, "toShort"),
+    INT(KotlinTypes.int, "toInt"),
+    LONG(KotlinTypes.long, "toLong"),
+    FLOAT(KotlinTypes.float, "toFloat"),
+    DOUBLE(KotlinTypes.double, "toDouble"),
+    NATIVE_PTR(KotlinTypes.nativePtr),
+    OBJC_POINTER(KotlinTypes.nativePtr),
+    VOID(KotlinTypes.unit)
 }
 
 data class BridgeTypedKotlinValue(val type: BridgedType, val value: KotlinExpression)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InteropUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InteropUtils.kt
@@ -16,7 +16,12 @@
 
 package org.jetbrains.kotlin.backend.konan
 
+import org.jetbrains.kotlin.backend.konan.descriptors.ClassifierAliasingPackageFragmentDescriptor
+import org.jetbrains.kotlin.backend.konan.descriptors.ExportedForwardDeclarationsPackageFragmentDescriptor
+import org.jetbrains.kotlin.backend.konan.library.KonanLibraryReader
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.name.FqName
@@ -24,6 +29,23 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.util.OperatorNameConventions
+
+interface InteropLibrary {
+    fun createSyntheticPackages(
+            module: ModuleDescriptor,
+            kotlinPackageFragments: List<PackageFragmentDescriptor>
+    ): List<PackageFragmentDescriptor>
+}
+
+fun createInteropLibrary(reader: KonanLibraryReader): InteropLibrary? {
+    val pkg = reader.manifestProperties.getProperty("pkg") ?: return null
+    val exportForwardDeclarations = reader.manifestProperties
+            .getProperty("exportForwardDeclarations").split(' ')
+            .map { it.trim() }.filter { it.isNotEmpty() }
+            .map { FqName(it) }
+
+    return InteropLibraryImpl(FqName(pkg), exportForwardDeclarations)
+}
 
 private val cPointerName = "CPointer"
 private val nativePointedName = "NativePointed"
@@ -35,6 +57,13 @@ internal class InteropBuiltIns(builtIns: KonanBuiltIns) {
 
         val cPointer = packageName.child(Name.identifier(cPointerName)).toUnsafe()
         val nativePointed = packageName.child(Name.identifier(nativePointedName)).toUnsafe()
+
+        val cNames = FqName("cnames")
+        val cNamesStructs = cNames.child(Name.identifier("structs"))
+
+        val objCNames = FqName("objcnames")
+        val objCNamesClasses = objCNames.child(Name.identifier("classes"))
+        val objCNamesProtocols = objCNames.child(Name.identifier("protocols"))
     }
 
     private val packageScope = builtIns.builtInsModule.getPackage(FqNames.packageName).memberScope
@@ -175,3 +204,31 @@ private fun MemberScope.getContributedClass(name: String): ClassDescriptor =
 
 private fun MemberScope.getContributedFunctions(name: String) =
         this.getContributedFunctions(Name.identifier(name), NoLookupLocation.FROM_BUILTINS)
+
+private class InteropLibraryImpl(
+        private val packageFqName: FqName,
+        private val exportForwardDeclarations: List<FqName>
+) : InteropLibrary {
+    override fun createSyntheticPackages(
+            module: ModuleDescriptor,
+            kotlinPackageFragments: List<PackageFragmentDescriptor>
+    ): List<PackageFragmentDescriptor> {
+        val interopPackageFragments = kotlinPackageFragments.filter { it.fqName == packageFqName }
+
+        val fqNames = InteropBuiltIns.FqNames
+
+        val result = mutableListOf<PackageFragmentDescriptor>()
+
+        // Allow references to forwarding declarations to be resolved into classifiers declared in this library:
+        listOf(fqNames.cNamesStructs, fqNames.objCNamesClasses, fqNames.objCNamesProtocols).mapTo(result) { fqName ->
+            ClassifierAliasingPackageFragmentDescriptor(interopPackageFragments, module, fqName)
+        }
+        // TODO: use separate namespaces for structs, enums, Objective-C protocols etc.
+
+        result.add(ExportedForwardDeclarationsPackageFragmentDescriptor(
+                module, packageFqName, exportForwardDeclarations
+        ))
+
+        return result
+    }
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
@@ -39,7 +39,8 @@ object TopDownAnalyzerFacadeForKonan {
         builtIns.builtInsModule = module
 
         if (!module.isStdlib()) {
-            context.setDependencies(listOf(module) + config.moduleDescriptors)
+            context.setDependencies(listOf(module) + config.moduleDescriptors +
+                    config.getOrCreateForwardDeclarationsModule(builtIns, projectContext.storageManager))
         } else {
             assert (config.moduleDescriptors.isEmpty())
             context.setDependencies(module)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/InteropDescriptors.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/InteropDescriptors.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.backend.konan.descriptors
+
+import org.jetbrains.kotlin.backend.konan.InteropBuiltIns
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.descriptors.impl.ClassDescriptorImpl
+import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.descriptors.impl.PackageFragmentDescriptorImpl
+import org.jetbrains.kotlin.incremental.components.LookupLocation
+import org.jetbrains.kotlin.incremental.components.NoLookupLocation
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
+import org.jetbrains.kotlin.resolve.scopes.MemberScope
+import org.jetbrains.kotlin.resolve.scopes.MemberScopeImpl
+import org.jetbrains.kotlin.storage.StorageManager
+import org.jetbrains.kotlin.storage.getValue
+import org.jetbrains.kotlin.utils.Printer
+import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
+
+/**
+ * The package fragment to export forward declarations from interop package namespace, i.e.
+ * redirect "$pkg.$name" to e.g. "cnames.structs.$name".
+ */
+class ExportedForwardDeclarationsPackageFragmentDescriptor(
+        module: ModuleDescriptor, fqName: FqName, declarations: List<FqName>
+) : PackageFragmentDescriptorImpl(module, fqName) {
+
+    private val memberScope = object : MemberScopeImpl() {
+
+        private val nameToFqName = declarations.map { it.shortName() to it }.toMap()
+
+        override fun getContributedClassifier(name: Name, location: LookupLocation): ClassifierDescriptor? {
+            val declFqName = nameToFqName[name] ?: return null
+
+            val packageView = module.getPackage(declFqName.parent())
+            return packageView.memberScope.getContributedClassifier(name, location)
+        }
+
+        override fun printScopeStructure(p: Printer) {
+            p.println(this::class.java.simpleName, " {")
+            p.pushIndent()
+
+            // TODO
+
+            p.popIndent()
+            p.println("}")
+        }
+
+    }
+
+    override fun getMemberScope() = memberScope
+}
+
+/**
+ * The package fragment that redirects all requests for classifier lookup to its targets.
+ */
+class ClassifierAliasingPackageFragmentDescriptor(
+        targets: List<PackageFragmentDescriptor>, module: ModuleDescriptor, fqName: FqName
+) : PackageFragmentDescriptorImpl(module, fqName) {
+
+    private val memberScope = object : MemberScopeImpl() {
+
+        override fun getContributedClassifier(name: Name, location: LookupLocation) =
+                targets.firstNotNullResult {
+                    it.getMemberScope().getContributedClassifier(name, location)
+                }
+
+        override fun printScopeStructure(p: Printer) {
+            p.println(this::class.java.simpleName, " {")
+            p.pushIndent()
+
+            p.println("targets = " + targets)
+
+            p.popIndent()
+            p.println("}")
+        }
+    }
+
+    override fun getMemberScope(): MemberScope = memberScope
+}
+
+/**
+ * Package fragment which creates descriptors for forward declarations on demand.
+ */
+private class ForwardDeclarationsPackageFragmentDescriptor(
+        storageManager: StorageManager,
+        module: ModuleDescriptor, fqName: FqName, supertypeName: Name, classKind: ClassKind
+) : PackageFragmentDescriptorImpl(module, fqName) {
+
+    private val memberScope = object : MemberScopeImpl() {
+
+        private val declarations = storageManager.createMemoizedFunction(this::createDeclaration)
+
+        private val supertype by storageManager.createLazyValue {
+            val descriptor = builtIns.builtInsModule.getPackage(InteropBuiltIns.FqNames.packageName)
+                    .memberScope
+                    .getContributedClassifier(supertypeName, NoLookupLocation.FROM_BACKEND) as ClassDescriptor
+
+            descriptor.defaultType
+        }
+
+        private fun createDeclaration(name: Name): ClassDescriptor {
+            return ClassDescriptorImpl(
+                    this@ForwardDeclarationsPackageFragmentDescriptor,
+                    name, Modality.FINAL, classKind,
+                    listOf(supertype), SourceElement.NO_SOURCE, false
+            ).apply {
+                this.initialize(MemberScope.Empty, emptySet(), null)
+            }
+        }
+
+        override fun getContributedClassifier(name: Name, location: LookupLocation) = declarations(name)
+
+        override fun printScopeStructure(p: Printer) {
+            p.println(this::class.java.simpleName, "{}")
+        }
+    }
+
+    override fun getMemberScope(): MemberScope = memberScope
+}
+
+/**
+ * Creates module which "contains" forward declarations.
+ * Note: this module should be unique per compilation and should always be the last dependency of any module.
+ */
+fun createForwardDeclarationsModule(builtIns: KotlinBuiltIns, storageManager: StorageManager): ModuleDescriptorImpl {
+    val module = ModuleDescriptorImpl(
+            Name.special("<forward declarations>"),
+            storageManager,
+            builtIns
+    )
+
+    fun createPackage(fqName: FqName, supertypeName: String, classKind: ClassKind = ClassKind.CLASS) =
+            ForwardDeclarationsPackageFragmentDescriptor(
+                    storageManager,
+                    module,
+                    fqName,
+                    Name.identifier(supertypeName),
+                    classKind
+            )
+
+    val fqNames = InteropBuiltIns.FqNames
+
+    val packageFragmentProvider = PackageFragmentProviderImpl(
+            listOf(
+                    createPackage(fqNames.cNamesStructs, "COpaque"),
+                    createPackage(fqNames.objCNamesClasses, "ObjCObjectBase"),
+                    createPackage(fqNames.objCNamesProtocols, "ObjCObject", ClassKind.INTERFACE)
+            )
+    )
+
+    module.initialize(packageFragmentProvider)
+    module.setDependencies(module)
+
+    return module
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibraryReader.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibraryReader.kt
@@ -18,6 +18,7 @@ package org.jetbrains.kotlin.backend.konan.library
 
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.konan.properties.Properties
 
 interface KonanLibraryReader {
     val libraryName: String
@@ -25,6 +26,7 @@ interface KonanLibraryReader {
     val includedPaths: List<String>
     val linkerOpts: List<String>
     val escapeAnalysis: ByteArray?
+    val manifestProperties: Properties
     fun moduleDescriptor(specifics: LanguageVersionSettings): ModuleDescriptor
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
@@ -17,6 +17,7 @@
 package org.jetbrains.kotlin.backend.konan.library.impl
 
 import org.jetbrains.kotlin.backend.konan.library.KonanLibraryReader
+import org.jetbrains.kotlin.backend.konan.createInteropLibrary
 import org.jetbrains.kotlin.backend.konan.serialization.deserializeModule
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.properties.*
@@ -34,7 +35,7 @@ class LibraryReaderImpl(var libraryFile: File, val currentAbiVersion: Int, val t
 
     private val reader = MetadataReaderImpl(inPlace)
 
-    val manifestProperties: Properties by lazy {
+    override val manifestProperties: Properties by lazy {
         inPlace.manifestFile.loadProperties()
     }
 
@@ -69,7 +70,7 @@ class LibraryReaderImpl(var libraryFile: File, val currentAbiVersion: Int, val t
         reader.loadSerializedPackageFragment(fqName)
 
     override fun moduleDescriptor(specifics: LanguageVersionSettings) 
-        = deserializeModule(specifics, {packageMetadata(it)}, moduleHeaderData)
+        = deserializeModule(specifics, {packageMetadata(it)}, moduleHeaderData, createInteropLibrary(this))
 
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -473,7 +473,7 @@ internal class InteropLoweringPart1(val context: Context) : IrBuildingTransforme
 
             if (!useKotlinDispatch) {
                 val arguments = descriptor.valueParameters.map { expression.getValueArgument(it)!! }
-                assert(expression.extensionReceiver == null)
+                assert(expression.dispatchReceiver == null || expression.extensionReceiver == null)
 
                 if (expression.superQualifier?.isObjCMetaClass() == true) {
                     context.reportCompilationError(
@@ -493,7 +493,7 @@ internal class InteropLoweringPart1(val context: Context) : IrBuildingTransforme
                 return builder.genLoweredObjCMethodCall(
                         methodInfo,
                         superQualifier = expression.superQualifierSymbol,
-                        receiver = expression.dispatchReceiver!!,
+                        receiver = expression.dispatchReceiver ?: expression.extensionReceiver!!,
                         arguments = arguments
                 )
             }

--- a/backend.native/tests/interop/basics/0.kt
+++ b/backend.native/tests/interop/basics/0.kt
@@ -2,7 +2,7 @@ import sysstat.*
 import kotlinx.cinterop.*
 
 fun main(args: Array<String>) {
-    val statBuf = nativeHeap.alloc<statStruct>()
+    val statBuf = nativeHeap.alloc<stat>()
     val res = stat("/", statBuf.ptr)
     println(res)
     println(statBuf.st_uid)

--- a/backend.native/tests/interop/objc/smoke.h
+++ b/backend.native/tests/interop/objc/smoke.h
@@ -7,8 +7,11 @@
 
 @interface Foo : NSObject
 @property NSString* name;
--(void)hello;
 -(void)helloWithPrinter:(id <Printer>)printer;
+@end;
+
+@interface Foo (FooExtensions)
+-(void)hello;
 @end;
 
 @protocol MutablePair

--- a/backend.native/tests/interop/objc/smoke.m
+++ b/backend.native/tests/interop/objc/smoke.m
@@ -24,11 +24,6 @@
     return self;
 }
 
--(void)hello {
-    CPrinter* printer = [[CPrinter alloc] init];
-    [self helloWithPrinter:printer];
-}
-
 -(void)helloWithPrinter:(id <Printer>)printer {
     NSString* message = [NSString stringWithFormat:@"Hello, %@!", self.name];
     [printer print:message.UTF8String];
@@ -38,6 +33,14 @@
     printf("Deallocated\n");
 }
 
+@end;
+
+@implementation Foo (FooExtensions)
+
+-(void)hello {
+    CPrinter* printer = [[CPrinter alloc] init];
+    [self helloWithPrinter:printer];
+}
 @end;
 
 void replacePairElements(id <MutablePair> pair, int first, int second) {

--- a/klib/src/platform/osx/objc.def
+++ b/klib/src/platform/osx/objc.def
@@ -1,3 +1,4 @@
+language = Objective-C
 package = platform.objc
 headers = objc/List.h objc/NSObjCRuntime.h objc/NSObject.h objc/Object.h objc/Protocol.h \
     objc/hashtable.h objc/hashtable2.h objc/message.h objc/objc-api.h \

--- a/klib/src/platform/osx/osx.def
+++ b/klib/src/platform/osx/osx.def
@@ -1,3 +1,4 @@
+language = Objective-C
 package = platform.osx
 headers = AppleTextureEncoder.h AssertMacros.h Availability.h AvailabilityInternal.h \
     AvailabilityMacros.h Block.h ConditionalMacros.h MacTypes.h NSSystemDirectories.h \

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/file/NoJavaUtil.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/file/NoJavaUtil.kt
@@ -156,7 +156,11 @@ private val File.zipUri: URI
 fun File.zipFileSystem(mutable: Boolean = false): FileSystem {
     val zipUri = this.zipUri
     val attributes = hashMapOf("create" to mutable.toString())
-    return FileSystems.newFileSystem(zipUri, attributes, null)
+    return try {
+        FileSystems.newFileSystem(zipUri, attributes, null)
+    } catch (e: FileSystemAlreadyExistsException) {
+        FileSystems.getFileSystem(zipUri)
+    }
 }
 
 fun File.mutableZipFileSystem() = this.zipFileSystem(mutable = true)

--- a/utilities/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/main.kt
+++ b/utilities/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/main.kt
@@ -1,6 +1,9 @@
 package org.jetbrains.kotlin.cli.utilities
 
+import org.jetbrains.kotlin.backend.konan.library.impl.KonanLibrary
 import org.jetbrains.kotlin.konan.file.File
+import org.jetbrains.kotlin.konan.properties.loadProperties
+import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.cli.bc.main as konancMain
 import org.jetbrains.kotlin.native.interop.gen.jvm.interop 
 import org.jetbrains.kotlin.cli.klib.main as klibMain
@@ -8,11 +11,16 @@ import org.jetbrains.kotlin.cli.klib.main as klibMain
 fun invokeCinterop(args: Array<String>) {
     var outputFileName = "nativelib"
     var target = "host"
+    val libraries = mutableListOf<String>()
     for (i in args.indices) {
-        if (args[i].startsWith("-o")) 
-            outputFileName = args.getOrElse(i+1){outputFileName}
-        if (args[i] == "-target") 
-            target = args.getOrElse(i+1){target}
+        val arg = args[i]
+        val nextArg = args.getOrNull(i + 1)
+        if (arg.startsWith("-o"))
+            outputFileName = nextArg ?: outputFileName
+        if (arg == "-target")
+            target = nextArg ?: target
+        if (arg == "-library")
+            libraries.addIfNotNull(nextArg)
     }
 
     val buildDir = File("$outputFileName-build")
@@ -21,12 +29,23 @@ fun invokeCinterop(args: Array<String>) {
     val cstubsName ="cstubs"
     val manifest = File(buildDir, "manifest.properties")
 
+    val importArgs = libraries.flatMap {
+        val library = KonanLibrary(File(it))
+        val manifestProperties = library.manifestFile.loadProperties()
+        // TODO: handle missing properties?
+        val pkg = manifestProperties["pkg"] as String
+        val headerIds = (manifestProperties["includedHeaders"] as String).split(' ')
+        val arg = "$pkg:${headerIds.joinToString(",")}"
+        listOf("-import", arg)
+    }
+
     val additionalArgs = listOf<String>(
         "-generated", generatedDir.path, 
         "-natives", nativesDir.path, 
         "-cstubsname", cstubsName,
         "-manifest", manifest.path,
-        "-flavor", "native")
+        "-flavor", "native"
+    ) + importArgs
 
     val cinteropArgs = (additionalArgs + args.toList()).toTypedArray()
     val cinteropArgsToCompiler = mutableListOf<String>()
@@ -39,7 +58,7 @@ fun invokeCinterop(args: Array<String>) {
         "-o", outputFileName,
         "-target", target,
         "-manifest", manifest.path
-     ) + cinteropArgsToCompiler
+    ) + cinteropArgsToCompiler + libraries.flatMap { listOf("-library", it) }
     konancMain(konancArgs)
 }
 


### PR DESCRIPTION
* Add list of included headers into the manifest
* Implement importing "foreign" type declarations
* Implement forward declarations more natively in the compiler
* Represent Objective-C categories as Kotlin extension methods and
  properties

Also:
* Do some refactoring in stub generation
* Call bridges directly in stubs for Objective-C properties