### PR TITLE
build: Don't use java-gradle-plugin

### DIFF
--- a/tools/kotlin-native-gradle-plugin/build.gradle
+++ b/tools/kotlin-native-gradle-plugin/build.gradle
@@ -19,7 +19,6 @@ apply plugin: 'kotlin'
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
-apply plugin: 'java-gradle-plugin'
 
 group = 'org.jetbrains.kotlin'
 version = konanVersion


### PR DESCRIPTION
The `java-gradle-plugin` includes the `shared` project into pom-file
of the generated maven artifact as a dependency. We don't need this
because we create the output artifact manually as a fat jar including
the `shared` project.