### PR TITLE
[build] fix conflict between bulid and jars tasks

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -145,7 +145,7 @@ dependencies {
 }
 
 
-build.dependsOn 'compilerClasses','cli_bcClasses','bc_frontendClasses'
+classes.dependsOn 'compilerClasses','cli_bcClasses','bc_frontendClasses'
 
 
 // These are just a couple of aliases
@@ -210,14 +210,14 @@ task run {
     }
 }
 
-task jars(type: Jar) {
+jar {
     from 'build/classes/cli_bc', 
          'build/classes/compiler', 
          'build/classes/hashInteropStubs', 
          'build/classes/llvmInteropStubs',
          'build/resources/compiler'
 
-    dependsOn 'build', ':runtime:hostRuntime', 'external_jars'
+    dependsOn ':runtime:hostRuntime', 'external_jars'
 }
 
 task external_jars(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ task cross_dist(dependsOn: "crossDist")
 task list_dist(dependsOn: "listDist")
 
 task distCompiler(type: Copy) {
-    dependsOn ':backend.native:jars'
+    dependsOn ':backend.native:jar'
     dependsOn ':utilities:jar'
     dependsOn ':klib:jar'
     dependsOn ':shared:jar'


### PR DESCRIPTION
The file `backend.native/build/libs/backend.native.jar` was produced
by two different tasks `:backend.native:jar` (default task of Java
Plugin) and `:backend.native:jars` (our custom task). This caused the
`:dist: task to never be UP-TO-DATE.