### PR TITLE
The linker -S flag to omit unnecessary symbols from the final binary

### DIFF
--- a/backend.native/konan.properties
+++ b/backend.native/konan.properties
@@ -130,6 +130,7 @@ dependencies.linux-raspberrypi = \
 
 quadruple.raspberrypi = armv6-unknown-linux-gnueabihf
 entrySelector.raspberrypi = --defsym main=Konan_main
+linkerDebugFlags.raspberrypi = -S
 linkerOptimizationFlags.raspberrypi = --gc-sections
 targetSysRoot.raspberrypi = target-sysroot-1-raspberrypi
 # We could reuse host toolchain here.


### PR DESCRIPTION
was missing for raspberrypi.