### PR TITLE
Easier adding library project as dependency

### DIFF
--- a/GRADLE_PLUGIN.md
+++ b/GRADLE_PLUGIN.md
@@ -230,6 +230,12 @@ For this project the task graph will be the following:
 
              // *.klib library for linking.
              library project.file('path/to/library')
+             
+             // library project
+             library project(':lib')
+             
+             // artifect in a library project
+             library(project(':lib'), 'artifectName')
 
              // naitve library for linking.
              nativeLibrary project.file('path/to/native/library/')

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanCompileTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanCompileTask.kt
@@ -201,6 +201,17 @@ open class KonanCompileConfig(
 
     // DSL. Libraries.
 
+    fun library(project: Project) = {
+        this.project.evaluationDependsOn(project.path)
+        compilationTask.dependsOn(project.tasks.findByPath("compileKonan"))
+        libraries(project.fileTree(project.konanCompilerOutputDir).include("*.klib"))
+    }
+    fun library(project: Project, artifactName: String) = {
+        this.project.evaluationDependsOn(project.path)
+        compilationTask.dependsOn(project.konanArtifactsContainer.getByName(artifactName).compilationTask)
+        library("${project.konanCompilerOutputDir}/$artifactName.klib")
+    }
+
     fun library(lib: Any) = libraries(lib)
     fun libraries(vararg libs: Any) = with(compilationTask) {
         libraries.add(project.files(*libs))


### PR DESCRIPTION
Currently if I want to declare dependency on another project, I have to write `dependsOn` on tasks, and then include the `klib` files manually. So I added a derivative to make declaring such dependency easier.