### PR TITLE
Only allow library prunning for the default links for now.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -233,12 +233,7 @@ internal class LinkStage(val context: Context) {
     private val emitted = context.bitcodeFileName
     private val libraries = context.config.libraries 
         .map { 
-            if (!it.isNeededForLink) { 
-                if (!it.isDefaultLink) {
-                    context.reportCompilationWarning("The '${it.libraryName}' library has not been referenced. Omitted from the final link.")
-                }
-                null
-            } else it
+            if (!it.isNeededForLink && it.isDefaultLink) null else it
         }.filterNotNull()
 
     private fun MutableList<String>.addNonEmpty(elements: List<String>) {


### PR DESCRIPTION
Don't forget to bring it back when library dependency info is available.