### PR TITLE
[build][platform libs] order build of libraries in topological order

### DIFF
--- a/Interop/StubGenerator/build.gradle
+++ b/Interop/StubGenerator/build.gradle
@@ -26,4 +26,5 @@ mainClassName = "org.jetbrains.kotlin.native.interop.gen.jvm.MainKt"
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile project(':Interop:Indexer')
+    compile project(':shared')
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
@@ -63,7 +63,7 @@ class LibraryReaderImpl(var libraryFile: File, val currentAbiVersion: Int,
         get() = (realFiles.includedDir.listFiles).map{it.absolutePath}
 
     override val linkerOpts: List<String>
-        get() = manifestProperties.propertyList("linkerOpts", target!!.targetSuffix)
+        get() = manifestProperties.propertyList("linkerOpts", target!!.detailedName)
 
     val moduleHeaderData: ByteArray by lazy {
         reader.loadSerializedModule()

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
 import groovy.io.FileType
 import org.jetbrains.kotlin.konan.target.*
 import org.jetbrains.kotlin.konan.properties.*
+import org.jetbrains.kotlin.konan.util.*
 
 defaultTasks 'clean', 'dist'
 
@@ -267,19 +268,20 @@ targetList.each { target ->
 
     targetDefFiles(target).forEach{
         defFile ->
-            def taskName = defFileToTaskName(target, defFile)
+            def taskName = defFileToTaskName(target, defFile.name)
             def suffix = null
             if (new PlatformInfo().isWindows())
                 suffix = 'bat'
             task(taskName, type:GradleBuild) {
                 dependsOn ':tools:kotlin-native-gradle-plugin:jar'
+                dependsOn defFile.config.depends.collect{defFileToTaskName(target, it)}
                 tasks = ['clean', 'klibInstall']
                 buildFile project('klib').file('platform.gradle')
                 dir project(':klib').projectDir
                 startParameter.projectProperties = [
                         'kotlin_version' : kotlin_version,
-                        'name'           : defToLibName(defFile),
-                        'defFile'        : defFile.absolutePath,
+                        'name'           : defFile.name,
+                        'defFile'        : defFile.file.absolutePath,
                         'konan.home'     : project.file('dist'),
                         'target'         : target,
                         'suffix'         : suffix
@@ -288,27 +290,31 @@ targetList.each { target ->
     }
 }
 
-private ArrayList<File> targetDefFiles(String target) {
+private ArrayList<DefFile> targetDefFiles(String target) {
     def platform = targetToPlatform(target)
-    project(':klib').file("src/platform/$platform").listFiles().findAll { it.name.endsWith(".def") }
+    def substitution = ['arch': target,
+                        'os'  : targetToOs(target)]
+    project(':klib').file("src/platform/$platform")
+            .listFiles()
+            .findAll { it.name.endsWith(".def") }
+            .collect { new DefFile(it, substitution) }
 }
 
 private String targetToPlatform(String target) {
-    new TargetManager(target).target.platform.name().toLowerCase()
+    new TargetManager(target).target.family.name().toLowerCase()
 }
 
-private String defFileToTaskName(String target, File defFile) {
-    def libname = defToLibName(defFile)
-    return "$target-$libname".toString()
+private String targetToOs(String target) {
+    new TargetManager(target).target.detailedName.toLowerCase()
 }
 
-private String defToLibName(File defFile) {
-    defFile.name.split('\\.').dropRight(1).join('.')
+private String defFileToTaskName(String target, String name) {
+    return "$target-$name".toString()
 }
 
 task distPlatformLibs {
     def target = TargetManager.host.name().toLowerCase()
-    dependsOn  targetDefFiles(target).collect {defFileToTaskName(target, it)}
+    dependsOn  targetDefFiles(target).collect {defFileToTaskName(target, it.name)}
 }
 
 task dist {

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
@@ -16,49 +16,37 @@
 
 package org.jetbrains.kotlin.konan.target
 
-enum class Platform {
-    OSX,
-    LINUX,
-    WINDOWS,
-    ANDROID,
-    WASM
+enum class Family(name:String, val exeSuffix:String) {
+    OSX("osx", "kexe"),
+    LINUX("linux", "kexe"),
+    WINDOWS("windows", "exe"),
+    ANDROID("android", "so"),
+    WASM("wasm", "wasm")
 }
 
-enum class KonanTarget(val targetSuffix: String, val programSuffix: String, var enabled: Boolean = false) {
-    ANDROID_ARM32("android_arm32", "so"),
-    ANDROID_ARM64("android_arm64", "so"),
-    IPHONE("ios", "kexe"),
-    IPHONE_SIM("ios_sim", "kexe"),
-    LINUX("linux", "kexe"),
-    MINGW("mingw", "exe"),
-    MACBOOK("osx", "kexe"),
-    RASPBERRYPI("raspberrypi", "kexe"),
-    LINUX_MIPS32("linux_mips32", "kexe"),
-    LINUX_MIPSEL32("linux_mipsel32", "kexe"),
-    WASM32("wasm32", "wasm");
+
+enum class KonanTarget(val family: Family, val detailedName: String, var enabled: Boolean = false) {
+    ANDROID_ARM32(Family.ANDROID, "android_arm32"),
+    ANDROID_ARM64(Family.ANDROID, "android_arm64"),
+    IPHONE(Family.OSX, "ios"),
+    IPHONE_SIM(Family.OSX, "ios_sim"),
+    LINUX(Family.LINUX, "linux"),
+    MINGW(Family.WINDOWS, "mingw"),
+    MACBOOK(Family.OSX, "osx"),
+    RASPBERRYPI(Family.LINUX, "raspberrypi"),
+    LINUX_MIPS32(Family.LINUX, "linux_mips32"),
+    LINUX_MIPSEL32(Family.LINUX, "linux_mipsel32"),
+    WASM32(Family.WASM, "wasm32");
 
     val userName get() = name.toLowerCase()
-    val platform get() = when (this) {
-        ANDROID_ARM32   -> Platform.ANDROID
-        ANDROID_ARM64   -> Platform.ANDROID
-        IPHONE          -> Platform.OSX
-        IPHONE_SIM      -> Platform.OSX
-        MACBOOK         -> Platform.OSX
-        RASPBERRYPI     -> Platform.LINUX
-        LINUX           -> Platform.LINUX
-        LINUX_MIPS32    -> Platform.LINUX
-        LINUX_MIPSEL32  -> Platform.LINUX
-        MINGW           -> Platform.WINDOWS
-        WASM32          -> Platform.WASM
-    }
 }
 
 fun hostTargetSuffix(host: KonanTarget, target: KonanTarget) =
-    if (target == host) host.targetSuffix else "${host.targetSuffix}-${target.targetSuffix}"
+    if (target == host) host.detailedName else "${host.detailedName}-${target.detailedName}"
 
 enum class CompilerOutputKind {
     PROGRAM {
-        override fun suffix(target: KonanTarget?) = ".${target!!.programSuffix}"
+        override fun suffix(target: KonanTarget?) = ".${target!!.family.exeSuffix}"
     },
     LIBRARY {
         override fun suffix(target: KonanTarget?) = ".klib"
@@ -102,9 +90,7 @@ class TargetManager(val userRequest: String? = null) {
     }
 
     val hostTargetSuffix get() = hostTargetSuffix(host, target)
-    val targetSuffix get() = target.targetSuffix
-
-    val programSuffix get() = CompilerOutputKind.PROGRAM.suffix(target)
+    val targetSuffix get() = target.detailedName
 
     companion object {
 
@@ -157,7 +143,7 @@ class TargetManager(val userRequest: String? = null) {
             else -> throw TargetSupportException("Unknown host target: ${host_os()} ${host_arch()}")
         }
 
-        val hostSuffix get() = host.targetSuffix
+        val hostSuffix get() = host.detailedName
         @JvmStatic
         val hostName get() = host.name.toLowerCase()
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/TargetProperties.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/TargetProperties.kt
@@ -19,16 +19,16 @@ package org.jetbrains.kotlin.konan.properties
 import org.jetbrains.kotlin.konan.target.*
 
 fun Properties.hostString(name: String): String?
-    = this.propertyString(name, TargetManager.host.targetSuffix)
+    = this.propertyString(name, TargetManager.host.detailedName)
 
 fun Properties.hostList(name: String): List<String>
-    = this.propertyList(name, TargetManager.host.targetSuffix)
+    = this.propertyList(name, TargetManager.host.detailedName)
 
 fun Properties.targetString(name: String, target: KonanTarget): String?
-    = this.propertyString(name, target.targetSuffix)
+    = this.propertyString(name, target.detailedName)
 
 fun Properties.targetList(name: String, target: KonanTarget): List<String>
-    = this.propertyList(name, target.targetSuffix)
+    = this.propertyList(name, target.detailedName)
 
 fun Properties.hostTargetString(name: String, target: KonanTarget): String?
     = this.propertyString(name, hostTargetSuffix(TargetManager.host, target))

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DefFile.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DefFile.kt
@@ -71,6 +71,10 @@ class DefFile(val file:File?, val config:DefFileConfig, val manifestAddendProper
         val nonStrictEnums by lazy {
             properties.getSpaceSeparated("nonStrictEnums")
         }
+
+        val depends by lazy {
+            properties.getSpaceSeparated("depends")
+        }
     }
 }
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DefFile.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DefFile.kt
@@ -1,0 +1,133 @@
+package org.jetbrains.kotlin.konan.util
+
+import java.io.File
+import java.io.StringReader
+import java.util.*
+
+class DefFile(val file:File?, val config:DefFileConfig, val manifestAddendProperties:Properties, val defHeaderLines:List<String>) {
+    private constructor(file0:File?, triple: Triple<Properties, Properties, List<String>>): this(file0, DefFileConfig(triple.first), triple.second, triple.third)
+    constructor(file:File?, substitutions: Map<String, String>) : this(file, parseDefFile(file, substitutions))
+
+    val name by lazy {
+        file?.nameWithoutExtension ?: ""
+    }
+    class DefFileConfig(private val properties: Properties) {
+        val headers by lazy {
+            properties.getSpaceSeparated("headers")
+        }
+
+        val language by lazy {
+            properties.getProperty("language")
+        }
+
+        val compilerOpts by lazy {
+            properties.getSpaceSeparated("compilerOpts")
+        }
+
+        val excludeSystemLibs by lazy {
+            properties.getProperty("excludeSystemLibs")?.toBoolean() ?: false
+        }
+
+        val excludeDependentModules by lazy {
+            properties.getProperty("excludeDependentModules")?.toBoolean() ?: false
+        }
+
+        val entryPoints by lazy {
+            properties.getSpaceSeparated("entryPoint")
+        }
+
+        val linkerOpts by lazy {
+            properties.getSpaceSeparated("linkerOpts")
+        }
+
+        val linker by lazy {
+            properties.getProperty("linker", "clang")
+        }
+
+        val excludedFunctions by lazy {
+            properties.getSpaceSeparated("excludedFunctions")
+        }
+
+        val staticLibraries by lazy {
+            properties.getSpaceSeparated("staticLibraries")
+        }
+
+        val libraryPaths by lazy {
+            properties.getSpaceSeparated("libraryPaths")
+        }
+
+        val packageName by lazy {
+            properties.getProperty("package")
+        }
+
+        val headerFilter by lazy {
+            properties.getSpaceSeparated("headerFilter")
+        }
+
+        val strictEnums by lazy {
+            properties.getSpaceSeparated("strictEnums")
+        }
+
+        val nonStrictEnums by lazy {
+            properties.getSpaceSeparated("nonStrictEnums")
+        }
+    }
+}
+
+private fun Properties.getSpaceSeparated(name: String): List<String> {
+    return this.getProperty(name)?.split(' ')?.filter { it.isNotEmpty() } ?: emptyList()
+}
+
+private fun parseDefFile(file: File?, substitutions: Map<String, String>): Triple<Properties, Properties, List<String>> {
+     val properties = Properties()
+
+     if (file == null) {
+         return Triple(properties, Properties(), emptyList())
+     }
+
+     val lines = file.readLines()
+
+     val separator = "---"
+     val separatorIndex = lines.indexOf(separator)
+
+     val propertyLines: List<String>
+     val headerLines: List<String>
+
+     if (separatorIndex != -1) {
+         propertyLines = lines.subList(0, separatorIndex)
+         headerLines = lines.subList(separatorIndex + 1, lines.size)
+     } else {
+         propertyLines = lines
+         headerLines = emptyList()
+     }
+
+     val propertiesReader = StringReader(propertyLines.joinToString(System.lineSeparator()))
+     properties.load(propertiesReader)
+
+     // Pass unsubstituted copy of properties we have obtained from `.def`
+     // to compiler `-maniest`.
+     val manifestAddendProperties = properties.duplicate()
+
+     substitute(properties, substitutions)
+
+     return Triple(properties, manifestAddendProperties, headerLines)
+}
+
+// Performs substitution similar to:
+//  foo = ${foo} ${foo.${arch}} ${foo.${os}}
+fun substitute(properties: Properties, substitutions: Map<String, String>) {
+    for (key in properties.stringPropertyNames()) {
+        for (substitution in substitutions.values) {
+            val suffix = ".$substitution"
+            if (key.endsWith(suffix)) {
+                val baseKey = key.removeSuffix(suffix)
+                val oldValue = properties.getProperty(baseKey, "")
+                val appendedValue = properties.getProperty(key, "")
+                val newValue = if (oldValue != "") "$oldValue $appendedValue" else appendedValue
+                properties.setProperty(baseKey, newValue)
+            }
+        }
+    }
+}
+
+private fun Properties.duplicate() = Properties().apply { putAll(this@duplicate) }


### PR DESCRIPTION
build libraries in topological order, tested with following changes in platform libs configurations
```
diff --git a/klib/src/platform/osx/objc.def b/klib/src/platform/osx/objc.def
index 9631fe3b..510de838 100644
--- a/klib/src/platform/osx/objc.def
+++ b/klib/src/platform/osx/objc.def
@@ -7,6 +7,6 @@ headers = objc/List.h objc/NSObjCRuntime.h objc/NSObject.h objc/Object.h objc/Pr
 
 compilerOpts = -D_XOPEN_SOURCE
 linkerOpts = -lobjc
-
+depends = osx posix
 ---
 // objc-auto.h is excluded so far due to interop issues.
diff --git a/klib/src/platform/osx/osx.def b/klib/src/platform/osx/osx.def
index 8dfd8116..6573dc0c 100644
--- a/klib/src/platform/osx/osx.def
+++ b/klib/src/platform/osx/osx.def
@@ -28,6 +28,7 @@ headers = AppleTextureEncoder.h AssertMacros.h Availability.h AvailabilityIntern
 
 compilerOpts = -D_XOPEN_SOURCE
 linkerOpts = -ldl -lz
+depends = posix
 
 ---
 
diff --git a/klib/src/platform/osx/zlib.def b/klib/src/platform/osx/zlib.def
index 46ed691d..e3cab7ba 100644
--- a/klib/src/platform/osx/zlib.def
+++ b/klib/src/platform/osx/zlib.def
@@ -1,3 +1,4 @@
 package = platform.zlib
 headers = zconf.h zlib.h
 linkerOpts = -lz
+depends=posix
```