### PR TITLE
Fix issue for gtk sample

### DIFF
--- a/samples/gtk/README.md
+++ b/samples/gtk/README.md
@@ -3,18 +3,37 @@
  This example shows how one may use _Kotlin/Native_ to build GUI
  applications with the GTK toolkit.
 
-To build use `../gradlew build` or `./build.sh`.
+To build use `../gradlew build` or `./build.sh [-I=/include/path]`.
 
-Do not forget to install GTK3.
+Do not forget to install GTK3. See bellow.
 
 On Mac use `port install gtk3`, on Debian flavours of Linux - `apt-get install libgtk-3-dev`.
 To run on Mac also install XQuartz X server (https://www.xquartz.org/), and then
 
     ../gradlew run
-    
-Alternatively you can run artifact directly 
+
+Alternatively you can run artifact directly
 
     ./build/konan/bin/Gtk3Demo/Gtk3Demo.kexe
 
 Dialog box with the button will be shown, and application will print message
 and terminate on button click.
+
+
+#### GTK3 Install
+
+on Mac use
+
+    brew install gtk+3
+
+or
+
+    port install gtk3
+
+on Debian flavours of Linux
+
+    sudo apt-get install libgtk-3-dev
+
+on Fedora
+
+    sudo dnf install gtk3-devel

--- a/samples/gtk/build.sh
+++ b/samples/gtk/build.sh
@@ -27,9 +27,8 @@ mkdir -p $DIR/build/bin/
 
 echo "Generating GTK stubs, may take few mins depending on the hardware..."
 cinterop -J-Xmx8g -copt $IPREFIX/atk-1.0 -compilerOpts $IPREFIX/gdk-pixbuf-2.0 -copt $IPREFIX/cairo -copt $IPREFIX/pango-1.0 \
-	 -copt -I/opt/local/lib/glib-2.0/include -copt -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -copt -I/usr/local/lib/glib-2.0/include \
-	 -copt $IPREFIX/gtk-3.0 -copt $IPREFIX/glib-2.0 -def $DIR/src/main/c_interop/gtk3.def \
-	 -target $TARGET -o $DIR/build/c_interop/gtk3 || exit 1
+	 -copt -I/opt/local/lib/glib-2.0/include -copt $IPREFIX/gtk-3.0 -copt $IPREFIX/glib-2.0 \
+	 -def $DIR/src/main/c_interop/gtk3.def -target $TARGET -o $DIR/build/c_interop/gtk3 || exit 1
 
 konanc -target $TARGET $DIR/src/main/kotlin -library $DIR/build/c_interop/gtk3 \
        -o $DIR/build/bin/Gtk3Demo || exit 1

--- a/samples/gtk/src/main/c_interop/gtk3.def
+++ b/samples/gtk/src/main/c_interop/gtk3.def
@@ -1,4 +1,8 @@
 headers = gtk/gtk.h
 headerFilter = gtk/* gobject/* gio/*
+compilerOpts.osx = -I/usr/local/include/gtk-3.0 -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include \
+-I/usr/local/include/pango-1.0 -I/usr/local/include/cairo -I/usr/local/include -I/usr/local/include/gdk-pixbuf-2.0 \
+-I/usr/local/include/atk-1.0
+compilerOpts.linux = -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/local/lib/glib-2.0/include -I/usr/lib64/glib-2.0/include
 linkerOpts.osx = -L/opt/local/lib -L/usr/local/lib -lglib-2.0 -lgdk-3.0 -lgtk-3 -lgio-2.0 -lgobject-2.0
 linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -lglib-2.0 -lgdk-3 -lgtk-3 -lgio-2.0 -lgobject-2.0


### PR DESCRIPTION
### Fix for sample GTK

#### Problem
Using non standard include directory on mac os

```

Generating GTK stubs, may take few mins depending on the hardware...
Exception in thread "main" java.lang.Error: /var/folders/8p/x5dxkyrs4d78n96h43nldj7s2vmnqp/T/tmp2879105455459228259.c:1:10: fatal error: 'gtk/gtk.h' file not found
....

```

#### Solution
- Validate default brew directory and then `/opt`
- Add an option to `build.sh` -I=/path/to/include for OSX
- Return with an error 
