### PR TITLE
Eliminate duplicates of libraries acquired by rombic inclusions.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -104,6 +104,7 @@ class KonanConfig(val project: Project, val configuration: CompilerConfiguration
                 .map { it.dependencies } .flatten()
                 .map { resolver.resolve(it) }
                 .map { LibraryReaderImpl(it, currentAbiVersion, targetManager.target) }
+                .distinctBy { it.libraryFile.absolutePath }
 
             val newDependencies = dependencies.deleteMatching(result, { it.libraryFile.absolutePath })
             result.addAll(newDependencies)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
@@ -39,7 +39,7 @@ class KonanLibrarySearchPathResolver(repositories: List<String>,
         get() = if (!skipCurrentDir) File.userDir else null
 
     private val repoRoots: List<File> by lazy {
-        repositories.map{File(it).klib}
+        repositories.map{File(it)}
     }
 
     // This is the place where we specify the order of library search.


### PR DESCRIPTION
Allow repositories without /klib bottom level directory.