### PR TITLE
Add recursive klibs in cinterop

### DIFF
--- a/klib/platform.gradle
+++ b/klib/platform.gradle
@@ -15,6 +15,7 @@ konanInterop {
         defFile gradle.startParameter.projectProperties.defFile
         pkg gradle.startParameter.projectProperties.name
         target gradle.startParameter.projectProperties.target
+        noDefaultLibs true
     }
 }
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/file/NoJavaUtil.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/file/NoJavaUtil.kt
@@ -24,7 +24,7 @@ import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.StandardOpenOption
 
-class File constructor(internal val javaPath: Path) {
+data class File constructor(internal val javaPath: Path) {
     constructor(parent: Path, child: String): this(parent.resolve(child))
     constructor(parent: File, child: String): this(parent.javaPath.resolve(child))
     constructor(path: String): this(Paths.get(path))

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanCompileTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanCompileTask.kt
@@ -87,6 +87,8 @@ open class KonanCompileTask: KonanTargetableTask() {
         internal set
     @Input var enableAssertions   = false
         internal set
+    @Input var noDefaultLibs      = false
+        internal set
     @Console var measureTime      = false
         internal set
 
@@ -122,6 +124,7 @@ open class KonanCompileTask: KonanTargetableTask() {
         addKey("-nomain", noMain)
         addKey("-opt", enableOptimization)
         addKey("-ea", enableAssertions)
+        addKey("-nodefaultlibs", noDefaultLibs)
         addKey("--time", measureTime)
 
         addAll(extraOpts)
@@ -282,6 +285,10 @@ open class KonanCompileConfig(
 
     fun enableAssertions() = with(compilationTask) {
         enableAssertions = true
+    }
+
+    fun noDefaultLibs(flag: Boolean) = with(compilationTask) {
+        noDefaultLibs = flag
     }
 
     fun measureTime(value: Boolean) = with(compilationTask) {

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanInteropTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanInteropTask.kt
@@ -56,6 +56,8 @@ open class KonanInteropTask: KonanTargetableTask() {
 
     @Input var dumpParameters = false
         internal set
+    @Input var noDefaultLibs  = false
+        internal set
 
     @Input val compilerOpts   = mutableListOf<String>()
     @Input val linkerOpts     = mutableListOf<String>()
@@ -87,6 +89,8 @@ open class KonanInteropTask: KonanTargetableTask() {
         addArg("-pkg", pkg ?: libName)
 
         addFileArgs("-h", headers)
+
+        addKey("-nodefaultlibs", noDefaultLibs)
 
         compilerOpts.forEach {
             addArg("-copt", it)
@@ -191,6 +195,10 @@ open class KonanInteropConfig(
 
     fun dumpParameters(value: Boolean) = with(interopProcessingTask) {
         dumpParameters = value
+    }
+
+    fun noDefaultLibs(flag: Boolean) = with(interopProcessingTask) {
+        noDefaultLibs = flag
     }
 
     fun dependsOn(dependency: Any) = interopProcessingTask.dependsOn(dependency)


### PR DESCRIPTION
 * Support -r option in the cinterop tool.
 * Move klib resolve into separate methods.
 * Don't treat directory as a library if it doesn't contain a manifest.
 * Rework recursive library search + duplicate removal.
 * Support recursive klib processing in the cinterop tool.