### PR TITLE
[debug] fix off by one error in DebugObjectToUtf8Array

### DIFF
--- a/runtime/src/main/cpp/KDebug.cpp
+++ b/runtime/src/main/cpp/KDebug.cpp
@@ -52,7 +52,7 @@ RUNTIME_USED KInt Konan_DebugObjectToUtf8Array(KRef obj, char* buffer, KInt buff
   if (data == nullptr) return 0;
   KInt toCopy = data->count_ > bufferSize - 1 ? bufferSize - 1 : data->count_;
   ::memcpy(buffer, ByteArrayAddressOfElementAt(data, 0), toCopy);
-  buffer[toCopy + 1] = '\0';
+  buffer[toCopy] = '\0';
   return toCopy + 1;
 }
 


### PR DESCRIPTION
We've copied exactly `toCopy` bytes, so the byte after the last copied
has index `toCopy`. Note that if `toCopy` is exactly (bufferSize - 1),
the previous code would write to memory outside of the buffer.