### PR TITLE
[debug] fix line info for artificial IrElements

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/DebugUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/DebugUtils.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.ir.SourceManager.FileEntry
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.konan.file.File
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
 
@@ -76,7 +75,7 @@ internal class DebugInfo internal constructor(override val context: Context):Con
  * File entry starts offsets from zero while dwarf number lines/column starting from 1.
  */
 private fun FileEntry.location(offset:Int, offsetToNumber:(Int) -> Int):Int {
-    return if (offset < 0) -1
+    return if (offset < 0) 0 // lldb uses 1-based unsigned integers, so 0 is "no-info"
     else offsetToNumber(offset) + 1
 }
 


### PR DESCRIPTION
Some IrElements have -1 as a startOffset (for example, generated methods
of data classes). To represent such offsets in debuginfo, we should use
0 instead of -1, because line/columns are one-based unsigneds.

closes KT-20443

The assembly before this change has the following entries: `.loc    1 4294967295 0`. The assembly after has `.loc    1 0 0` which seems more reasonable. Looks like the clag does use `0` for generated stuff too:


```C++
struct Foo {
    int x;
    Foo();
    Foo(Foo const&);
};

Foo::Foo() = default;

Foo::Foo(Foo const&) = default;
```

has some `!24 = !DILocation(line: 0, scope: !6)` in bitcode. 