### PR TITLE
 Represent Objective-C block pointers in methods as Kotlin functions

### DIFF
--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
@@ -258,5 +258,9 @@ data class ObjCIdType(
 ) : ObjCQualifiedPointer()
 
 data class ObjCInstanceType(override val nullability: Nullability) : ObjCPointer()
+data class ObjCBlockPointer(
+        override val nullability: Nullability,
+        val parameterTypes: List<Type>, val returnType: Type
+) : ObjCPointer()
 
 object UnsupportedType : Type

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
@@ -124,6 +124,19 @@ annotation class InteropStubs()
 @Retention(AnnotationRetention.SOURCE)
 private annotation class ObjCMethodImp(val selector: String, val encoding: String)
 
+@konan.internal.ExportForCppRuntime("Kotlin_Interop_getObjCClass")
+private fun getObjCClassByName(name: NativePtr): NativePtr {
+    val result = objc_lookUpClass(name)
+    if (result == nativeNullPtr) {
+        val className = interpretCPointer<ByteVar>(name)!!.toKString()
+        val message = """Objective-C class '$className' not found.
+            |Ensure that the containing framework or library was linked.""".trimMargin()
+
+        throw RuntimeException(message)
+    }
+    return result
+}
+
 @konan.internal.ExportForCompiler
 private fun <T : ObjCObject> allocObjCObject(clazz: NativePtr): T {
     val rawResult = objc_allocWithZone(clazz)
@@ -183,3 +196,6 @@ external fun objc_retain(ptr: NativePtr): NativePtr
 
 @SymbolName("Kotlin_objc_release")
 external fun objc_release(ptr: NativePtr)
+
+@SymbolName("Kotlin_objc_lookUpClass")
+external fun objc_lookUpClass(name: NativePtr): NativePtr

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
@@ -86,17 +86,31 @@ inline val ObjCObject?.rawPtr: NativePtr get() = if (this != null) {
     nativeNullPtr
 }
 
+@SymbolName("Kotlin_Interop_createKotlinObjectHolder")
+external fun createKotlinObjectHolder(any: Any?): NativePtr
+
+inline fun <reified T : Any> unwrapKotlinObjectHolder(holder: ObjCObject?): T {
+    return unwrapKotlinObjectHolderImpl(holder!!.rawPtr) as T
+}
+
+@PublishedApi
+@SymbolName("Kotlin_Interop_unwrapKotlinObjectHolder")
+external internal fun unwrapKotlinObjectHolderImpl(ptr: NativePtr): Any
+
 class ObjCObjectVar<T : ObjCObject?>(rawPtr: NativePtr) : CVariable(rawPtr) {
     companion object : CVariable.Type(pointerSize.toLong(), pointerSize)
 }
 
-class ObjCStringVarOf<T : String?>(rawPtr: NativePtr) : CVariable(rawPtr) {
+class ObjCNotImplementedVar<T : Any?>(rawPtr: NativePtr) : CVariable(rawPtr) {
     companion object : CVariable.Type(pointerSize.toLong(), pointerSize)
 }
 
-var <T : String?> ObjCStringVarOf<T>.value: T
+var <T : Any?> ObjCNotImplementedVar<T>.value: T
     get() = TODO()
     set(value) = TODO()
+
+typealias ObjCStringVarOf<T> = ObjCNotImplementedVar<T>
+typealias ObjCBlockVar<T> = ObjCNotImplementedVar<T>
 
 @konan.internal.Intrinsic external fun getReceiverOrSuper(receiver: NativePtr, superClass: NativePtr): COpaquePointer?
 

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/CodeBuilders.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/CodeBuilders.kt
@@ -16,7 +16,11 @@
 
 package org.jetbrains.kotlin.native.interop.gen
 
-class NativeCodeBuilder {
+interface NativeScope {
+    val mappingBridgeGenerator: MappingBridgeGenerator
+}
+
+class NativeCodeBuilder(val scope: NativeScope) {
     val lines = mutableListOf<String>()
 
     fun out(line: String): Unit {
@@ -24,13 +28,13 @@ class NativeCodeBuilder {
     }
 }
 
-inline fun buildNativeCodeLines(block: NativeCodeBuilder.() -> Unit): List<String> {
-    val builder = NativeCodeBuilder()
+inline fun buildNativeCodeLines(scope: NativeScope, block: NativeCodeBuilder.() -> Unit): List<String> {
+    val builder = NativeCodeBuilder(scope)
     builder.block()
     return builder.lines
 }
 
-class KotlinCodeBuilder {
+class KotlinCodeBuilder(val scope: KotlinScope) {
     private val lines = mutableListOf<String>()
 
     private val freeStack = mutableListOf<String>()
@@ -69,8 +73,8 @@ class KotlinCodeBuilder {
     }
 }
 
-inline fun buildKotlinCodeLines(block: KotlinCodeBuilder.() -> Unit): List<String> {
-    val builder = KotlinCodeBuilder()
+inline fun buildKotlinCodeLines(scope: KotlinScope, block: KotlinCodeBuilder.() -> Unit): List<String> {
+    val builder = KotlinCodeBuilder(scope)
     builder.block()
     return builder.build()
 }

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/GlobalVariableStub.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/GlobalVariableStub.kt
@@ -47,7 +47,7 @@ class GlobalVariableStub(global: GlobalDecl, stubGenerator: StubGenerator) : Kot
 
         if (unwrappedType is ArrayType) {
             kotlinType = (mirror as TypeMirror.ByValue).valueType
-            getter = mirror.info.argFromBridged(getAddressExpression, kotlinScope) + "!!"
+            getter = mirror.info.argFromBridged(getAddressExpression, kotlinScope, nativeBacked = this) + "!!"
             setter = null
         } else {
             val pointedTypeName = mirror.pointedType.render(kotlinScope)

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -92,7 +92,7 @@ class ObjCMethodStub(stubGenerator: StubGenerator,
     private val bridgeHeader: String
 
     init {
-        val bodyGenerator = KotlinCodeBuilder()
+        val bodyGenerator = KotlinCodeBuilder(scope = stubGenerator.kotlinFile)
 
         val kotlinParameters = mutableListOf<Pair<String, KotlinType>>()
         val kotlinObjCBridgeParameters = mutableListOf<Pair<String, KotlinType>>()
@@ -215,7 +215,7 @@ class ObjCMethodStub(stubGenerator: StubGenerator,
 
     private fun genImplementationTemplate(stubGenerator: StubGenerator): String = when (container) {
         is ObjCClassOrProtocol -> {
-            val codeBuilder = NativeCodeBuilder()
+            val codeBuilder = NativeCodeBuilder(stubGenerator.simpleBridgeGenerator.topLevelNativeScope)
 
             val result = codeBuilder.genMethodImp(stubGenerator, this, method, container)
             stubGenerator.simpleBridgeGenerator.insertNativeBridge(this, emptyList(), codeBuilder.lines)

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGenerator.kt
@@ -44,6 +44,8 @@ interface NativeBacked
  */
 interface SimpleBridgeGenerator {
 
+    val topLevelNativeScope: NativeScope
+
     /**
      * Generates the expression to convert given Kotlin values to native counterparts, pass through the bridge,
      * use inside the native code produced by [block] and then return the result back.

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/TypeUtils.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/TypeUtils.kt
@@ -51,6 +51,7 @@ fun Type.getStringRepresentation(): String = when (this) {
         is ObjCClassPointer -> "Class$protocolQualifier"
         is ObjCObjectPointer -> "${def.name}$protocolQualifier*"
         is ObjCInstanceType -> TODO(this.toString()) // Must have already been handled.
+        is ObjCBlockPointer -> "id"
     }
 
     else -> throw kotlin.NotImplementedError()
@@ -63,4 +64,19 @@ tailrec fun Type.unwrapTypedefs(): Type = if (this is Typedef) {
     this.def.aliased.unwrapTypedefs()
 } else {
     this
+}
+
+fun blockTypeStringRepresentation(type: ObjCBlockPointer): String {
+    return buildString {
+        append(type.returnType.getStringRepresentation())
+        append("(^)")
+        append("(")
+        val blockParameters = if (type.parameterTypes.isEmpty()) {
+            "void"
+        } else {
+            type.parameterTypes.joinToString { it.getStringRepresentation() }
+        }
+        append(blockParameters)
+        append(")")
+    }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
@@ -133,12 +133,19 @@ class ObjCOverridabilityCondition : ExternalOverridabilityCondition {
         assert(superDescriptor.name == subDescriptor.name)
 
         val superClass = superDescriptor.containingDeclaration as? ClassDescriptor
-        if (superClass == null || !superClass.isObjCClass()) {
+        val subClass = subDescriptor.containingDeclaration as? ClassDescriptor
+
+        if (superClass == null || !superClass.isObjCClass() || subClass == null) {
             return ExternalOverridabilityCondition.Result.UNKNOWN
         }
 
         return if (areSelectorsEqual(superDescriptor, subDescriptor)) {
-            ExternalOverridabilityCondition.Result.OVERRIDABLE
+            // Also check the method signatures if the subclass is user-defined:
+            if (subClass.isExternalObjCClass()) {
+                ExternalOverridabilityCondition.Result.OVERRIDABLE
+            } else {
+                ExternalOverridabilityCondition.Result.UNKNOWN
+            }
         } else {
             ExternalOverridabilityCondition.Result.INCOMPATIBLE
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -2081,7 +2081,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         assert(!classDescriptor.isInterface)
 
         return if (classDescriptor.isExternalObjCClass()) {
-            val lookUpFunction = context.llvm.externalFunction("objc_lookUpClass",
+            val lookUpFunction = context.llvm.externalFunction("Kotlin_Interop_getObjCClass",
                     functionType(int8TypePtr, false, int8TypePtr))
 
             call(lookUpFunction,

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2199,7 +2199,7 @@ if (isMac()) {
 
     task interop_objc_smoke(type: RunInteropKonanTest) {
         disabled = (project.testTarget == 'wasm32') // No interop for wasm yet.
-        goldValue = "Hello, World!\nKotlin says: Hello, everybody!\nHello from Kotlin\n2, 1\n" +
+        goldValue = "84\nFoo\nHello, World!\nKotlin says: Hello, everybody!\nHello from Kotlin\n2, 1\n" +
                 "true\ntrue\nDeallocated\nDeallocated\n"
 
         source = "interop/objc/smoke.kt"

--- a/backend.native/tests/interop/objc/smoke.h
+++ b/backend.native/tests/interop/objc/smoke.h
@@ -5,8 +5,10 @@
 -(void)print:(const char*)string;
 @end;
 
+typedef NSString NSStringTypedef;
+
 @interface Foo : NSObject
-@property NSString* name;
+@property NSStringTypedef* name;
 -(void)helloWithPrinter:(id <Printer>)printer;
 @end;
 

--- a/backend.native/tests/interop/objc/smoke.h
+++ b/backend.native/tests/interop/objc/smoke.h
@@ -25,3 +25,14 @@
 @end;
 
 void replacePairElements(id <MutablePair> pair, int first, int second);
+
+int invoke1(int arg, int (^block)(int)) {
+    return block(arg);
+}
+
+void invoke2(void (^block)(void)) {
+    block();
+}
+
+int (^getSupplier(int x))(void);
+Class (^ _Nonnull getClassGetter(NSObject* obj))(void);

--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -8,7 +8,17 @@ fun main(args: Array<String>) {
 }
 
 fun run() {
+    println(
+            getSupplier(
+                    invoke1(42) { it * 2 }
+            )!!()
+    )
+
     val foo = Foo()
+
+    val classGetter = getClassGetter(foo)
+    invoke2 { println(classGetter()) }
+
     foo.hello()
     foo.name = "everybody"
     foo.helloWithPrinter(object : NSObject(), PrinterProtocol {

--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -48,8 +48,8 @@ fun MutablePairProtocol.swap() {
 }
 
 class Bar : Foo() {
-    override fun helloWithPrinter(printer: PrinterProtocol) = memScoped {
-        printer.print("Hello from Kotlin".cstr.getPointer(memScope))
+    override fun helloWithPrinter(printer: PrinterProtocol?) = memScoped {
+        printer!!.print("Hello from Kotlin".cstr.getPointer(memScope))
     }
 }
 

--- a/backend.native/tests/interop/objc/smoke.m
+++ b/backend.native/tests/interop/objc/smoke.m
@@ -47,3 +47,13 @@ void replacePairElements(id <MutablePair> pair, int first, int second) {
     [pair update:0 add:(first - pair.first)];
     [pair update:1 sub:(pair.second - second)];
 }
+
+int (^getSupplier(int x))(void) {
+    return ^{
+        return x;
+    };
+}
+
+Class (^ _Nonnull getClassGetter(NSObject* obj))() {
+    return ^{ return obj.class; };
+}

--- a/runtime/src/main/cpp/ObjCInterop.cpp
+++ b/runtime/src/main/cpp/ObjCInterop.cpp
@@ -27,6 +27,8 @@
 
 extern "C" {
 
+Class Kotlin_Interop_getObjCClass(const char* name);
+
 struct KotlinClassData {
   const TypeInfo* typeInfo;
   int32_t bodyOffset;
@@ -67,8 +69,7 @@ static void DeallocImp(id self, SEL _cmd) {
 }
 
 static void AddDeallocMethod(Class clazz) {
-  Class nsObjectClass = objc_getClass("NSObject");
-  RuntimeAssert(nsObjectClass != nullptr, "NSObject class not found");
+  Class nsObjectClass = Kotlin_Interop_getObjCClass("NSObject");
 
   SEL deallocSelector = sel_registerName("dealloc");
   Method nsObjectDeallocMethod = class_getInstanceMethod(nsObjectClass, deallocSelector);
@@ -136,7 +137,7 @@ void* CreateKotlinObjCClass(const KotlinObjCClassInfo* info) {
     className = classNameBuffer;
   }
 
-  Class superclass = objc_getClass(info->superclassName);
+  Class superclass = Kotlin_Interop_getObjCClass(info->superclassName);
   Class newClass = objc_allocateClassPair(superclass, className, sizeof(struct KotlinClassData));
   RuntimeAssert(newClass != nullptr, "Failed to allocate Objective-C class");
 
@@ -205,6 +206,10 @@ void Kotlin_objc_release(id ptr) {
   objc_release(ptr);
 }
 
+Class Kotlin_objc_lookUpClass(const char* name) {
+  return objc_lookUpClass(name);
+}
+
 } // extern "C"
 
 #else  // KONAN_OBJC_INTEROP
@@ -233,6 +238,10 @@ void* Kotlin_objc_retain(void* ptr) {
 }
 
 void Kotlin_objc_release(void* ptr) {
+  RuntimeAssert(false, "Objective-C interop is disabled");
+}
+
+void* Kotlin_objc_lookUpClass(const char* name) {
   RuntimeAssert(false, "Objective-C interop is disabled");
 }
 

--- a/samples/objc/build.gradle
+++ b/samples/objc/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'konan'
 
-konanInterop {
-    objective_c {
-        target "macbook"
-    }
-}
-
 konanArtifacts {
     Window {
-        useInterop 'objective_c'
         target "macbook"
     }
 }

--- a/samples/objc/src/main/c_interop/objective_c.def
+++ b/samples/objc/src/main/c_interop/objective_c.def
@@ -1,4 +1,0 @@
-headers = Foundation/Foundation.h Cocoa/Cocoa.h AppKit/NSApplication.h AppKit/NSWindow.h
-headerFilter = Foundation/** Cocoa/** AppKit/**
-language = Objective-C
-linkerOpts = -framework AppKit

--- a/samples/objc/src/main/kotlin/Window.kt
+++ b/samples/objc/src/main/kotlin/Window.kt
@@ -1,7 +1,8 @@
+import kotlinx.cinterop.*
+import platform.AppKit.*
+import platform.Foundation.*
 import platform.objc.*
 import platform.osx.*
-import objective_c.*
-import kotlinx.cinterop.*
 
 fun main(args: Array<String>) {
     autoreleasepool {

--- a/samples/uikit/build.gradle
+++ b/samples/uikit/build.gradle
@@ -1,15 +1,7 @@
 apply plugin: 'konan'
 
-konanInterop {
-    objc {
-        target "iphone"
-    }
-}
-
-
 konanArtifacts {
     app {
-        useInterop 'objc'
         target "iphone"
     }
 }

--- a/samples/uikit/src/main/c_interop/objc.def
+++ b/samples/uikit/src/main/c_interop/objc.def
@@ -1,4 +1,0 @@
-headers = Foundation/Foundation.h UIKit/UIKit.h
-headerFilter = Foundation/** UIKit/**
-language = Objective-C
-linkerOpts = -framework Foundation -framework UIKit

--- a/samples/uikit/src/main/kotlin/main.kt
+++ b/samples/uikit/src/main/kotlin/main.kt
@@ -1,5 +1,6 @@
-import objc.*
 import kotlinx.cinterop.*
+import platform.Foundation.*
+import platform.UIKit.*
 
 fun main(args: Array<String>) {
     memScoped {


### PR DESCRIPTION
Also 

* Enable method signature checks when overriding Objective-C method;
* Make linkage issues more understandable in Objective-C interop;
* Do some refactoring.