### PR TITLE
Rewrite backend.native tests to TestRunner

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1410,7 +1410,6 @@ task hash_set0(type: RunKonanTest) {
 
 task listof0(type: RunKonanTest) {
     goldValue = "abc\n[a, b, c, d]\n[n, s, a]\n"
-    arguments = ["a"]
     source = "runtime/collections/listof0.kt"
 }
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -252,6 +252,18 @@ task sum2(type: RunKonanTest) {
     source = "codegen/function/sum_imm.kt"
 }
 
+task sum_func(type: RunKonanTest) {
+    source = "codegen/function/sum_func.kt"
+}
+
+task sum_mixed(type: RunKonanTest) {
+    source = "codegen/function/sum_mixed.kt"
+}
+
+task sum_illy(type: RunKonanTest) {
+    source = "codegen/function/sum_silly.kt"
+}
+
 task function_defaults(type: RunKonanTest) {
     source = "codegen/function/defaults.kt"
 }
@@ -1173,6 +1185,10 @@ task cycle_do(type: RunKonanTest) {
     source = "codegen/cycles/cycle_do.kt"
 }
 
+task cycle_for(type: RunKonanTest) {
+    source = "codegen/cycles/cycle_for.kt"
+}
+
 task abstract_super(type: RunKonanTest) {
     source = "datagen/rtti/abstract_super.kt"
 }
@@ -1774,9 +1790,22 @@ task memory_throw_cleanup(type: RunKonanTest) {
     source = "runtime/memory/throw_cleanup.kt"
 }
 
+task memory_escape0(type: RunKonanTest) {
+    source = "runtime/memory/escape1.kt"
+}
+
 task memory_escape1(type: RunKonanTest) {
     goldValue = "zzz\n"
     source = "runtime/memory/escape1.kt"
+}
+
+task memory_cycles0(type: RunKonanTest) {
+    goldValue = "42\n"
+    source = "runtime/memory/cycles0.kt"
+}
+
+task memory_basic0(type: RunKonanTest) {
+    source = "runtime/memory/cycles0.kt"
 }
 
 task memory_escape2(type: RunKonanTest) {

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1265,7 +1265,7 @@ task link(type: LinkKonanTest) {
     goldValue = "0\n"
     source = "link/src/bar.kt"
     lib = "link/lib"
-}
+}(
 */
 
 task link_omit_unused(type: LinkKonanTest) {
@@ -1274,7 +1274,7 @@ task link_omit_unused(type: LinkKonanTest) {
     lib = "link/omit/lib.kt"
 }
 
-task link_default_libs(type: RunKonanTest) {
+task link_default_libs(type: RunStandaloneKonanTest) {
     disabled = (project.testTarget == 'wasm32') // there will be no posix.klib for wasm
     goldValue = "sizet = 0\n"
     source = "link/default/default.kt"
@@ -1761,17 +1761,17 @@ task lambda13(type: RunKonanTest) {
 
 task objectExpression1(type: RunKonanTest) {
     goldValue = "aabb\n"
-    source = "codegen/objectExpression/1.kt"
+    source = "codegen/objectExpression/expr1.kt"
 }
 
 task objectExpression2(type: RunKonanTest) {
     goldValue = "a\n"
-    source = "codegen/objectExpression/2.kt"
+    source = "codegen/objectExpression/expr2.kt"
 }
 
 task objectExpression3(type: RunKonanTest) {
     goldValue = "\n1\n2\n"
-    source = "codegen/objectExpression/3.kt"
+    source = "codegen/objectExpression/expr3.kt"
 }
 
 task initializers2(type: RunStandaloneKonanTest) {
@@ -1841,7 +1841,7 @@ task memory_cycles0(type: RunKonanTest) {
     source = "runtime/memory/cycles0.kt"
 }
 
-task memory_basic0(type: RunStandaloneKonanTest) {
+task memory_basic0(type: RunKonanTest) {
     source = "runtime/memory/basic0.kt"
 }
 
@@ -2036,7 +2036,7 @@ task deserialized_members(type: LinkKonanTest) {
     source = "serialization/deserialize_members.kt"
 }
 
-task testing_annotations(type: RunKonanTest) {
+task testing_annotations(type: RunStandaloneKonanTest) {
     source = "testing/annotations.kt"
     flags = ['-tr']
     arguments = ['--ktest_logger=SIMPLE']
@@ -2062,14 +2062,14 @@ task testing_annotations(type: RunKonanTest) {
             'Test suite finished: kotlin.test.tests.AnnotationsKt\nIteration finished: 1\nTesting finished\n'
 }
 
-task testing_assertions(type: RunKonanTest) {
+task testing_assertions(type: RunStandaloneKonanTest) {
     source = "testing/assertions.kt"
     flags = ['-tr']
     expectedFail = (project.testTarget == 'wasm32') // Uses exceptions.
     expectedExitStatus = 0
 }
 
-task testing_custom_main(type: RunKonanTest) {
+task testing_custom_main(type: RunStandaloneKonanTest) {
     source = "testing/custom_main.kt"
     flags = ['-tr', '-e', 'kotlin.test.tests.main']
     arguments = ['--ktest_logger=SIMPLE', '--ktest_repeat=2']

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -179,6 +179,43 @@ task slackReport(type:Reporter) {
     reportHome = rootProject.file("test.output").absoluteFile
 }
 
+task buildKonanTests(type: BuildKonanTest) {
+    compileList = [ "codegen",  "datagen", "lower", "runtime", "serialization"]
+    // TODO: move these tests into separate dirs or create this list during build
+    // These tests should not be built into the TestRunner's test executable
+    excludeList = [
+            // Driver tests
+            "runtime/basic/driver0.kt",
+            // Standalone tests
+            "runtime/basic/args0.kt",
+            "runtime/basic/exit.kt",
+            "runtime/basic/hello1.kt",
+            "runtime/basic/hello2.kt",
+            "runtime/basic/entry0.kt",
+            "runtime/basic/entry1.kt",
+            "runtime/basic/assert_failed.kt",
+            "runtime/basic/assert_passed.kt",
+            "runtime/basic/assert_failed.kt",
+            "runtime/basic/initializers2.kt",
+            "runtime/memory/basic0.kt",
+            // Link tests
+            "runtime/basic/entry2.kt",
+            "runtime/basic/libentry2.kt",
+            "codegen/enum/linkTest_main.kt",
+            "codegen/enum/linkTest_lib.kt",
+            "codegen/inline/defaultArgs_linkTest_main.kt",
+            "codegen/inline/defaultArgs_linkTest_lib.kt",
+            "serialization/serialize_members.kt",
+            "serialization/deserialize_members.kt",
+            "codegen/propertyCallableReference/linkTest_main.kt",
+            "codegen/propertyCallableReference/linkTest_lib.kt",
+            "codegen/bridges/linkTest_main.kt",
+            "codegen/bridges/linkTest_lib.kt",
+            "codegen/delegatedProperty/delegatedOverride_main.kt",
+            "codegen/delegatedProperty/delegatedOverride_lib.kt"
+    ]
+}
+
 task sum (type:RunKonanTest) {
     source = "codegen/function/sum.kt"
 }
@@ -419,7 +456,7 @@ task array_to_any(type: RunKonanTest) {
     source = "codegen/basics/array_to_any.kt"
 }
 
-task runtime_basic_exit(type: RunKonanTest) {
+task runtime_basic_exit(type: RunStandaloneKonanTest) {
     source = "runtime/basic/exit.kt"
     expectedExitStatus = 42
 }
@@ -429,13 +466,13 @@ task hello0(type: RunKonanTest) {
     source = "runtime/basic/hello0.kt"
 }
 
-task hello1(type: RunKonanTest) {
+task hello1(type: RunStandaloneKonanTest) {
     goldValue = "Hello World\n"
     testData = "Hello World\n"
     source = "runtime/basic/hello1.kt"
 }
 
-task hello2(type: RunKonanTest) {
+task hello2(type: RunStandaloneKonanTest) {
     goldValue = "you entered 'Hello World\n'"
     testData = "Hello World\n"
     source = "runtime/basic/hello2.kt"
@@ -451,13 +488,13 @@ task hello4(type: RunKonanTest) {
     source = "runtime/basic/hello4.kt"
 }
 
-task entry0(type: RunKonanTest) {
+task entry0(type: RunStandaloneKonanTest) {
     goldValue = "Hello.\n"
     source = "runtime/basic/entry0.kt"
-    flags = ["-entry", "koko.lala.main"] 
+    flags = ["-entry", "runtime.basic.entry0.main"]
 }
 
-task entry1(type: RunKonanTest) {
+task entry1(type: RunStandaloneKonanTest) {
     goldValue = "Hello.\n"
     source = "runtime/basic/entry1.kt"
     flags = ["-entry", "foo"] 
@@ -1590,7 +1627,7 @@ task range0(type: RunKonanTest) {
     source = "runtime/collections/range0.kt"
 }
 
-task args0(type: RunKonanTest) {
+task args0(type: RunStandaloneKonanTest) {
     arguments = ["AAA", "BB", "C"]
     goldValue = "AAA\nBB\nC\n"
     source = "runtime/basic/args0.kt"
@@ -1612,17 +1649,17 @@ task runtime_basic_standard(type: RunKonanTest) {
     source = "runtime/basic/standard.kt"
 }
 
-task runtime_basic_assert_failed(type: RunKonanTest) {
+task runtime_basic_assert_failed(type: RunStandaloneKonanTest) {
     expectedExitStatus = 1
     source = "runtime/basic/assert_failed.kt"
 }
 
-task runtime_basic_assert_passed(type: RunKonanTest) {
+task runtime_basic_assert_passed(type: RunStandaloneKonanTest) {
     expectedExitStatus = 0
     source = "runtime/basic/assert_passed.kt"
 }
 
-task runtime_basic_assert_disabled(type: RunKonanTest) {
+task runtime_basic_assert_disabled(type: RunStandaloneKonanTest) {
     expectedExitStatus = 0
     enableKonanAssertions = false
     source = "runtime/basic/assert_failed.kt"
@@ -1737,7 +1774,7 @@ task objectExpression3(type: RunKonanTest) {
     source = "codegen/objectExpression/3.kt"
 }
 
-task initializers2(type: RunKonanTest) {
+task initializers2(type: RunStandaloneKonanTest) {
     goldValue = "init globalValue2\n" +
                 "init globalValue3\n" +
                 "1\n" +
@@ -1791,7 +1828,7 @@ task memory_throw_cleanup(type: RunKonanTest) {
 }
 
 task memory_escape0(type: RunKonanTest) {
-    source = "runtime/memory/escape1.kt"
+    source = "runtime/memory/escape0.kt"
 }
 
 task memory_escape1(type: RunKonanTest) {
@@ -1804,8 +1841,8 @@ task memory_cycles0(type: RunKonanTest) {
     source = "runtime/memory/cycles0.kt"
 }
 
-task memory_basic0(type: RunKonanTest) {
-    source = "runtime/memory/cycles0.kt"
+task memory_basic0(type: RunStandaloneKonanTest) {
+    source = "runtime/memory/basic0.kt"
 }
 
 task memory_escape2(type: RunKonanTest) {
@@ -2058,12 +2095,12 @@ task testing_custom_main(type: RunKonanTest) {
 // Just check that the driver is able to produce runnable binaries.
 task driver0(type: RunDriverKonanTest) {
     goldValue = "Hello, world!\n"
-    source = "runtime/basic/hello0.kt"
+    source = "runtime/basic/driver0.kt"
 }
 
 task driver_opt(type: RunDriverKonanTest) {
     goldValue = "Hello, world!\n"
-    source = "runtime/basic/hello0.kt"
+    source = "runtime/basic/driver0.kt"
     flags = ["-opt"]
 }
 
@@ -2071,7 +2108,7 @@ task driver_opt(type: RunDriverKonanTest) {
 // binaries, but we verify that the compiler has been built, operational 
 // and accepts the -target flag, resulting in a successful compilation.
 task driver_cross(type: RunDriverKonanTest) {
-    source = "runtime/basic/hello0.kt"
+    source = "runtime/basic/driver0.kt"
     run = false
     if (isLinux()) {
         flags = ["-target", "raspberrypi"]

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2213,7 +2213,7 @@ task interop_echo_server(type: RunInteropKonanTest) {
 }
 
 if (isMac()) {
-    task interop_opengl_teapot(type: RunKonanTest) {
+    task interop_opengl_teapot(type: RunStandaloneKonanTest) {
     disabled = (project.testTarget == 'wasm32') // No interop for wasm yet.
         run = false
         source = "interop/basics/opengl_teapot.kt"

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1410,6 +1410,7 @@ task string0(type: RunKonanTest) {
 }
 
 task parse0(type: RunKonanTest) {
+    disabled = (project.testTarget == 'wasm32') // KT-20862
     goldValue = "false\n" +
             "true\n" +
             "-1\n" +

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -179,43 +179,6 @@ task slackReport(type:Reporter) {
     reportHome = rootProject.file("test.output").absoluteFile
 }
 
-task buildKonanTests(type: BuildKonanTest) {
-    compileList = [ "codegen",  "datagen", "lower", "runtime", "serialization"]
-    // TODO: move these tests into separate dirs or create this list during build
-    // These tests should not be built into the TestRunner's test executable
-    excludeList = [
-            // Driver tests
-            "runtime/basic/driver0.kt",
-            // Standalone tests
-            "runtime/basic/args0.kt",
-            "runtime/basic/exit.kt",
-            "runtime/basic/hello1.kt",
-            "runtime/basic/hello2.kt",
-            "runtime/basic/entry0.kt",
-            "runtime/basic/entry1.kt",
-            "runtime/basic/assert_failed.kt",
-            "runtime/basic/assert_passed.kt",
-            "runtime/basic/assert_failed.kt",
-            "runtime/basic/initializers2.kt",
-            "runtime/memory/basic0.kt",
-            // Link tests
-            "runtime/basic/entry2.kt",
-            "runtime/basic/libentry2.kt",
-            "codegen/enum/linkTest_main.kt",
-            "codegen/enum/linkTest_lib.kt",
-            "codegen/inline/defaultArgs_linkTest_main.kt",
-            "codegen/inline/defaultArgs_linkTest_lib.kt",
-            "serialization/serialize_members.kt",
-            "serialization/deserialize_members.kt",
-            "codegen/propertyCallableReference/linkTest_main.kt",
-            "codegen/propertyCallableReference/linkTest_lib.kt",
-            "codegen/bridges/linkTest_main.kt",
-            "codegen/bridges/linkTest_lib.kt",
-            "codegen/delegatedProperty/delegatedOverride_main.kt",
-            "codegen/delegatedProperty/delegatedOverride_lib.kt"
-    ]
-}
-
 task sum (type:RunKonanTest) {
     source = "codegen/function/sum.kt"
 }
@@ -2271,4 +2234,22 @@ if (isMac()) {
             }
         }
     }
+}
+
+task buildKonanTests(type: BuildKonanTest) {
+    compileList = [ "codegen",  "datagen", "lower", "runtime", "serialization"]
+
+    // These tests should not be built into the TestRunner's test executable
+    excludeList = []
+    project.tasks.withType(KonanTest)
+            .matching { ! (it instanceof RunKonanTest) }
+            .each {
+                // add library and source files
+                if (it instanceof LinkKonanTest) {
+                    excludeList += it.lib
+                }
+                if (it.source != null) {
+                    excludeList += it.source
+                }
+            }
 }

--- a/backend.native/tests/codegen/basics/array_to_any.kt
+++ b/backend.native/tests/codegen/basics/array_to_any.kt
@@ -1,4 +1,9 @@
-fun main(args: Array<String>) {
+package codegen.basics.array_to_any
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     foo().hashCode()
 }
 

--- a/backend.native/tests/codegen/basics/canonical_name.kt
+++ b/backend.native/tests/codegen/basics/canonical_name.kt
@@ -1,3 +1,7 @@
+package codegen.basics.canonical_name
+
+import kotlin.test.*
+
 interface I<U, T> {
   fun foo(a: U): T
   fun qux(a: T): U
@@ -24,10 +28,7 @@ fun <U, V> baz(i: I<U, V>, u: U, v:V) {
 
 //-----------------------------------------------------------------------------//
 
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
   baz<A1, A2>(A(), A1(), A2())
 }
-
-
-
-

--- a/backend.native/tests/codegen/basics/cast_null.kt
+++ b/backend.native/tests/codegen/basics/cast_null.kt
@@ -1,15 +1,20 @@
-fun main(args: Array<String>) {
+package codegen.basics.cast_null
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     testCast(null, false)
     testCastToNullable(null, true)
-    testCastToNullable(Test(), true)
+    testCastToNullable(TestKlass(), true)
     testCastToNullable("", false)
-    testCastNotNullableToNullable(Test(), true)
+    testCastNotNullableToNullable(TestKlass(), true)
     testCastNotNullableToNullable("", false)
 
     println("Ok")
 }
 
-class Test
+class TestKlass
 
 fun ensure(b: Boolean) {
     if (!b) {
@@ -19,7 +24,7 @@ fun ensure(b: Boolean) {
 
 fun testCast(x: Any?, expectSuccess: Boolean) {
     try {
-        x as Test
+        x as TestKlass
     } catch (e: Throwable) {
         ensure(!expectSuccess)
         return
@@ -29,7 +34,7 @@ fun testCast(x: Any?, expectSuccess: Boolean) {
 
 fun testCastToNullable(x: Any?, expectSuccess: Boolean) {
     try {
-        x as Test?
+        x as TestKlass?
     } catch (e: Throwable) {
         ensure(!expectSuccess)
         return
@@ -39,7 +44,7 @@ fun testCastToNullable(x: Any?, expectSuccess: Boolean) {
 
 fun testCastNotNullableToNullable(x: Any, expectSuccess: Boolean) {
     try {
-        x as Test?
+        x as TestKlass?
     } catch (e: Throwable) {
         ensure(!expectSuccess)
         return

--- a/backend.native/tests/codegen/basics/cast_simple.kt
+++ b/backend.native/tests/codegen/basics/cast_simple.kt
@@ -1,3 +1,7 @@
+package codegen.basics.cast_simple
+
+import kotlin.test.*
+
 open class A() {}
 class B(): A() {}
 
@@ -9,6 +13,7 @@ fun castTest(): Boolean {
   return true
 }
 
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
   if (!castTest()) throw Error()
 }

--- a/backend.native/tests/codegen/basics/check_type.kt
+++ b/backend.native/tests/codegen/basics/check_type.kt
@@ -1,4 +1,4 @@
-package codegen.basics
+package codegen.basics.check_type
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/basics/check_type.kt
+++ b/backend.native/tests/codegen/basics/check_type.kt
@@ -1,3 +1,7 @@
+package codegen.basics
+
+import kotlin.test.*
+
 interface I
 class A() : I {}
 class B() {}
@@ -28,8 +32,8 @@ fun isTypeOfInterface(a: Any) : Boolean {
 
 //-----------------------------------------------------------------------------//
 
-fun main(args: Array<String>) {
-
+@Test
+fun runTest() {
   println(isTypeOf(A()))
   println(isTypeOf(null))
   println(isTypeNullableOf(A()))

--- a/backend.native/tests/codegen/basics/concatenation.kt
+++ b/backend.native/tests/codegen/basics/concatenation.kt
@@ -1,4 +1,9 @@
-fun main(args: Array<String>) {
+package codegen.basics.concatenation
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     val s = "world"
     val i = 1
     println("Hello $s $i ${2*i}")
@@ -7,4 +12,3 @@ fun main(args: Array<String>) {
         println("Hello, $item")
     }
 }
-

--- a/backend.native/tests/codegen/basics/expression_as_statement.kt
+++ b/backend.native/tests/codegen/basics/expression_as_statement.kt
@@ -1,8 +1,13 @@
+package codegen.basics.expression_as_statement
+
+import kotlin.test.*
+
 fun foo() {
     Any() as String
 }
 
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
     try {
         foo()
     } catch (e: Throwable) {

--- a/backend.native/tests/codegen/basics/local_variable.kt
+++ b/backend.native/tests/codegen/basics/local_variable.kt
@@ -1,9 +1,14 @@
+package codegen.basics.local_variable
+
+import kotlin.test.*
+
 fun local_variable(a: Int) : Int {
   var b = 0
   b = a + 11
   return b
 }
 
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
   if (local_variable(3) != 14) throw Error()
 }

--- a/backend.native/tests/codegen/basics/null_check.kt
+++ b/backend.native/tests/codegen/basics/null_check.kt
@@ -1,3 +1,7 @@
+package codegen.basics.null_check
+
+import kotlin.test.*
+
 //--- Test "eqeq" -------------------------------------------------------------//
 
 fun check_eqeq(a: Any?) = a == null
@@ -22,7 +26,8 @@ fun null_check_eqeqeq2() : Boolean {
   return check_eqeqeq(null)
 }
 
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
   if (null_check_eqeq1())    throw Error()
   if (!null_check_eqeq2())   throw Error()
   if (null_check_eqeqeq1())  throw Error()

--- a/backend.native/tests/codegen/basics/safe_cast.kt
+++ b/backend.native/tests/codegen/basics/safe_cast.kt
@@ -1,3 +1,7 @@
+package codegen.basics.safe_cast
+
+import kotlin.test.*
+
 open class A
 class B : A()
 class C
@@ -14,8 +18,8 @@ fun safe_cast_negative(): Boolean {
   return foo(c) == null
 }
 
-
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
   val safeCastPositive = safe_cast_positive().toString()
   val safeCastNegative = safe_cast_negative().toString()
   println("safe_cast_positive: " + safeCastPositive)

--- a/backend.native/tests/codegen/basics/spread_operator_0.kt
+++ b/backend.native/tests/codegen/basics/spread_operator_0.kt
@@ -1,4 +1,9 @@
-fun main(arg:Array<String>) {
+package codegen.basics.spread_operator_0
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
   val list0 = _arrayOf("K", "o", "t", "l", "i", "n")
   val list1 = _arrayOf("l", "a","n", "g", "u", "a", "g", "e")
   val list = foo(list0, list1)

--- a/backend.native/tests/codegen/basics/superFunCall.kt
+++ b/backend.native/tests/codegen/basics/superFunCall.kt
@@ -1,3 +1,7 @@
+package codegen.basics.superFunCall
+
+import kotlin.test.*
+
 open class C {
     open fun f() = "<fun:C>"
 }
@@ -13,7 +17,8 @@ class C3: C2() {
     override fun f() = super<C2>.f() + "<fun:C3>"
 }
 
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
     println(C1().f())
     println(C3().f())
 }

--- a/backend.native/tests/codegen/basics/superGetterCall.kt
+++ b/backend.native/tests/codegen/basics/superGetterCall.kt
@@ -1,3 +1,7 @@
+package codegen.basics.superGetterCall
+
+import kotlin.test.*
+
 open class C {
     open val p1 = "<prop:C>"
 }
@@ -13,7 +17,8 @@ class C3: C2() {
     override val p1 = super<C2>.p1 + "<prop:C3>"
 }
 
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
     println(C1().p1)
     println(C3().p1)
 }

--- a/backend.native/tests/codegen/basics/superSetterCall.kt
+++ b/backend.native/tests/codegen/basics/superSetterCall.kt
@@ -1,3 +1,7 @@
+package codegen.basics.superSetterCall
+
+import kotlin.test.*
+
 open class C {
     open var p2 = "<prop:C>"
         set(value)  { field = "<prop:C>" + value }
@@ -22,7 +26,8 @@ class C3: C2() {
         }
 }
 
-fun main(args: Array<String>) {
+@Test
+fun runTest() {
     val c1 = C1()
     val c3 = C3()
     c1.p2 = "zzz"

--- a/backend.native/tests/codegen/basics/typealias1.kt
+++ b/backend.native/tests/codegen/basics/typealias1.kt
@@ -1,4 +1,9 @@
-fun main(args: Array<String>) {
+package codegen.basics.typealias1
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     println(Bar(42).x)
 }
 

--- a/backend.native/tests/codegen/basics/unchecked_cast1.kt
+++ b/backend.native/tests/codegen/basics/unchecked_cast1.kt
@@ -1,4 +1,9 @@
-fun main(args: Array<String>) {
+package codegen.basics.unchecked_cast1
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     foo<String>("17")
     bar<String>("17")
     foo<String>(42)

--- a/backend.native/tests/codegen/basics/unchecked_cast2.kt
+++ b/backend.native/tests/codegen/basics/unchecked_cast2.kt
@@ -1,4 +1,9 @@
-fun main(args: Array<String>) {
+package codegen.basics.unchecked_cast2
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     try {
         val x = cast<String>(Any())
         println(x.length)

--- a/backend.native/tests/codegen/basics/unchecked_cast3.kt
+++ b/backend.native/tests/codegen/basics/unchecked_cast3.kt
@@ -1,12 +1,17 @@
-fun main(args: Array<String>) {
-    testCast<Test>(Test(), true)
-    testCast<Test>(null, false)
-    testCastToNullable<Test>(null, true)
+package codegen.basics.unchecked_cast3
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
+    testCast<TestKlass>(TestKlass(), true)
+    testCast<TestKlass>(null, false)
+    testCastToNullable<TestKlass>(null, true)
 
     println("Ok")
 }
 
-class Test
+class TestKlass
 
 fun ensure(b: Boolean) {
     if (!b) {

--- a/backend.native/tests/codegen/basics/unit1.kt
+++ b/backend.native/tests/codegen/basics/unit1.kt
@@ -1,3 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.basics.unit1
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     println(println("First").toString())
 }

--- a/backend.native/tests/codegen/basics/unit2.kt
+++ b/backend.native/tests/codegen/basics/unit2.kt
@@ -1,4 +1,9 @@
-fun main(args: Array<String>) {
+package codegen.basics.unit2
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     val x = foo()
     println(x.toString())
 }

--- a/backend.native/tests/codegen/basics/unit3.kt
+++ b/backend.native/tests/codegen/basics/unit3.kt
@@ -1,4 +1,9 @@
-fun main(args: Array<String>) {
+package codegen.basics.unit3
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     foo(Unit)
 }
 

--- a/backend.native/tests/codegen/basics/unit4.kt
+++ b/backend.native/tests/codegen/basics/unit4.kt
@@ -1,4 +1,9 @@
-fun main(args: Array<String>) {
+package codegen.basics.unit4
+
+import kotlin.test.*
+
+@Test
+fun runTest() {
     for (x in 0 .. 8) {
         foo(x, Unit)
     }

--- a/backend.native/tests/codegen/boxing/boxing0.kt
+++ b/backend.native/tests/codegen/boxing/boxing0.kt
@@ -1,9 +1,12 @@
+package codegen.boxing.boxing0
+
+import kotlin.test.*
 
 class Box<T>(t: T) {
     var value = t
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val box: Box<Int> = Box<Int>(17)
     println(box.value)
 }

--- a/backend.native/tests/codegen/boxing/boxing1.kt
+++ b/backend.native/tests/codegen/boxing/boxing1.kt
@@ -1,8 +1,12 @@
+package codegen.boxing.boxing1
+
+import kotlin.test.*
+
 fun foo(arg: Any) {
     println(arg.toString())
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(1)
     foo(false)
     foo("Hello")

--- a/backend.native/tests/codegen/boxing/boxing10.kt
+++ b/backend.native/tests/codegen/boxing/boxing10.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.boxing.boxing10
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val FALSE: Boolean? = false
 
     if (FALSE != null) {

--- a/backend.native/tests/codegen/boxing/boxing11.kt
+++ b/backend.native/tests/codegen/boxing/boxing11.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.boxing11
+
+import kotlin.test.*
+
 fun printInt(x: Int) = println(x)
 
 class Foo(val value: Int?) {
@@ -6,7 +10,7 @@ class Foo(val value: Int?) {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     Foo(17).foo()
     Foo(null).foo()
 }

--- a/backend.native/tests/codegen/boxing/boxing12.kt
+++ b/backend.native/tests/codegen/boxing/boxing12.kt
@@ -1,7 +1,11 @@
+package codegen.boxing.boxing12
+
+import kotlin.test.*
+
 fun foo(x: Number) {
     println(x.toByte())
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(18)
 }

--- a/backend.native/tests/codegen/boxing/boxing13.kt
+++ b/backend.native/tests/codegen/boxing/boxing13.kt
@@ -1,9 +1,13 @@
+package codegen.boxing.boxing13
+
+import kotlin.test.*
+
 fun is42(x: Any?) {
     println(x == 42)
     println(42 == x)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     is42(16)
     is42(42)
     is42("42")

--- a/backend.native/tests/codegen/boxing/boxing14.kt
+++ b/backend.native/tests/codegen/boxing/boxing14.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.boxing.boxing14
+
+import kotlin.test.*
+
+@Test fun runTest() {
     42.println()
 }
 

--- a/backend.native/tests/codegen/boxing/boxing15.kt
+++ b/backend.native/tests/codegen/boxing/boxing15.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.boxing.boxing15
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(foo(17))
 }
 

--- a/backend.native/tests/codegen/boxing/boxing2.kt
+++ b/backend.native/tests/codegen/boxing/boxing2.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.boxing2
+
+import kotlin.test.*
+
 fun printInt(x: Int) = println(x)
 fun printBoolean(x: Boolean) = println(x)
 
@@ -10,7 +14,7 @@ fun foo(arg: Any) {
         println("other")
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(1)
     foo(true)
     foo("Hello")

--- a/backend.native/tests/codegen/boxing/boxing3.kt
+++ b/backend.native/tests/codegen/boxing/boxing3.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.boxing3
+
+import kotlin.test.*
+
 fun printInt(x: Int) = println(x)
 
 fun foo(arg: Int?) {
@@ -5,6 +9,6 @@ fun foo(arg: Int?) {
         printInt(arg)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(42)
 }

--- a/backend.native/tests/codegen/boxing/boxing4.kt
+++ b/backend.native/tests/codegen/boxing/boxing4.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.boxing4
+
+import kotlin.test.*
+
 fun printInt(x: Int) = println(x)
 
 fun foo(arg: Any?) {
@@ -5,6 +9,6 @@ fun foo(arg: Any?) {
         printInt(arg)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(16)
 }

--- a/backend.native/tests/codegen/boxing/boxing5.kt
+++ b/backend.native/tests/codegen/boxing/boxing5.kt
@@ -1,10 +1,14 @@
+package codegen.boxing.boxing5
+
+import kotlin.test.*
+
 fun printInt(x: Int) = println(x)
 
 fun foo(arg: Int?) {
     printInt(arg ?: 16)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(null)
     foo(42)
 }

--- a/backend.native/tests/codegen/boxing/boxing6.kt
+++ b/backend.native/tests/codegen/boxing/boxing6.kt
@@ -1,10 +1,14 @@
+package codegen.boxing.boxing6
+
+import kotlin.test.*
+
 fun printInt(x: Int) = println(x)
 
 fun foo(arg: Any) {
     printInt(arg as? Int ?: 16)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(42)
     foo("Hello")
 }

--- a/backend.native/tests/codegen/boxing/boxing7.kt
+++ b/backend.native/tests/codegen/boxing/boxing7.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.boxing7
+
+import kotlin.test.*
+
 fun printInt(x: Int) = println(x)
 
 fun foo(arg: Any) {
@@ -9,7 +13,7 @@ fun foo(arg: Any) {
     printInt(argAsInt)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(1)
     foo("Hello")
 }

--- a/backend.native/tests/codegen/boxing/boxing8.kt
+++ b/backend.native/tests/codegen/boxing/boxing8.kt
@@ -1,9 +1,13 @@
+package codegen.boxing.boxing8
+
+import kotlin.test.*
+
 fun foo(vararg args: Any?) {
     for (arg in args) {
         println(arg.toString())
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(1, null, true, "Hello")
 }

--- a/backend.native/tests/codegen/boxing/boxing9.kt
+++ b/backend.native/tests/codegen/boxing/boxing9.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.boxing9
+
+import kotlin.test.*
+
 fun foo(vararg args: Any?) {
     for (arg in args) {
         println(arg.toString())
@@ -8,6 +12,6 @@ fun bar(vararg args: Any?) {
     foo(1, *args, 2, *args, 3)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     bar(null, true, "Hello")
 }

--- a/backend.native/tests/codegen/branching/advanced_when2.kt
+++ b/backend.native/tests/codegen/branching/advanced_when2.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.advanced_when2
+
+import kotlin.test.*
+
 fun advanced_when2(i: Int): Int {
   var value = 1
   when (i) {
@@ -9,6 +13,6 @@ fun advanced_when2(i: Int): Int {
   return value
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (advanced_when2(10) != 42) throw Error()
 }

--- a/backend.native/tests/codegen/branching/advanced_when2.kt
+++ b/backend.native/tests/codegen/branching/advanced_when2.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.advanced_when2
+package codegen.branching.advanced_when2
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/advanced_when5.kt
+++ b/backend.native/tests/codegen/branching/advanced_when5.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.advanced_when5
+
+import kotlin.test.*
+
 fun advanced_when5(i: Int): Int {
   when (i) {
     0 -> { val v = 42; return v}
@@ -9,6 +13,6 @@ fun advanced_when5(i: Int): Int {
   }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (advanced_when5(5) != 24) throw Error()
 }

--- a/backend.native/tests/codegen/branching/advanced_when5.kt
+++ b/backend.native/tests/codegen/branching/advanced_when5.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.advanced_when5
+package codegen.branching.advanced_when5
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/if_else.kt
+++ b/backend.native/tests/codegen/branching/if_else.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.if_else
+package codegen.branching.if_else
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/if_else.kt
+++ b/backend.native/tests/codegen/branching/if_else.kt
@@ -1,8 +1,12 @@
+package codegen.boxing.if_else
+
+import kotlin.test.*
+
 fun if_else(b: Boolean): Int {
   if (b) return 42
   else   return 24
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (if_else(false) != 24) throw Error()
 }

--- a/backend.native/tests/codegen/branching/when2.kt
+++ b/backend.native/tests/codegen/branching/when2.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.when2
+
+import kotlin.test.*
+
 fun when2(i: Int): Int {
   when (i) {
     0 -> return 42
@@ -5,6 +9,6 @@ fun when2(i: Int): Int {
   }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (when2(0) != 42) throw Error()
 }

--- a/backend.native/tests/codegen/branching/when2.kt
+++ b/backend.native/tests/codegen/branching/when2.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.when2
+package codegen.branching.when2
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/when4.kt
+++ b/backend.native/tests/codegen/branching/when4.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.when4
+
+import kotlin.test.*
+
 fun when5(i: Int): Int {
   when (i) {
     0 -> return 42

--- a/backend.native/tests/codegen/branching/when4.kt
+++ b/backend.native/tests/codegen/branching/when4.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.when4
+package codegen.branching.when4
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/when5.kt
+++ b/backend.native/tests/codegen/branching/when5.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.when5
+package codegen.branching.when5
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/when5.kt
+++ b/backend.native/tests/codegen/branching/when5.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.when5
+
+import kotlin.test.*
+
 fun when5(i: Int): Int {
   when (i) {
     0 -> return 42
@@ -9,6 +13,6 @@ fun when5(i: Int): Int {
   }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (when5(2) != 3) throw Error()
 }

--- a/backend.native/tests/codegen/branching/when6.kt
+++ b/backend.native/tests/codegen/branching/when6.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.when6
+package codegen.branching.when6
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/when6.kt
+++ b/backend.native/tests/codegen/branching/when6.kt
@@ -1,6 +1,10 @@
+package codegen.boxing.when6
+
+import kotlin.test.*
+
 fun foo() {
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     if (true) foo() else foo()
 }

--- a/backend.native/tests/codegen/branching/when7.kt
+++ b/backend.native/tests/codegen/branching/when7.kt
@@ -1,3 +1,11 @@
+package codegen.boxing.when7
+
+import kotlin.test.*
+
+@Test fun runTest() {
+    main(emptyArray())
+}
+
 fun main(args: Array<String>) {
     val b = args.size < 1
     val x = if (b) Any() else throw Error()

--- a/backend.native/tests/codegen/branching/when7.kt
+++ b/backend.native/tests/codegen/branching/when7.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.when7
+package codegen.branching.when7
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/when8.kt
+++ b/backend.native/tests/codegen/branching/when8.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.boxing.when8
+
+import kotlin.test.*
+
+@Test fun runTest() {
     when (true) {
         true -> println("true")
         false -> println("false")

--- a/backend.native/tests/codegen/branching/when8.kt
+++ b/backend.native/tests/codegen/branching/when8.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.when8
+package codegen.branching.when8
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/when9.kt
+++ b/backend.native/tests/codegen/branching/when9.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.boxing.when9
+
+import kotlin.test.*
+
+@Test fun runTest() {
     foo(0)
     println("Ok")
 }

--- a/backend.native/tests/codegen/branching/when9.kt
+++ b/backend.native/tests/codegen/branching/when9.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.when9
+package codegen.branching.when9
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/when_through.kt
+++ b/backend.native/tests/codegen/branching/when_through.kt
@@ -1,4 +1,4 @@
-package codegen.boxing.when_through
+package codegen.branching.when_through
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/branching/when_through.kt
+++ b/backend.native/tests/codegen/branching/when_through.kt
@@ -1,3 +1,7 @@
+package codegen.boxing.when_through
+
+import kotlin.test.*
+
 fun when_through(i: Int): Int {
   var value = 1
   when (i) {
@@ -9,6 +13,6 @@ fun when_through(i: Int): Int {
   return value
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (when_through(2) != 1) throw Error()
 }

--- a/backend.native/tests/codegen/bridges/linkTest_lib.kt
+++ b/backend.native/tests/codegen/bridges/linkTest_lib.kt
@@ -1,4 +1,4 @@
-package codegen.bridges.linkTest.a
+package a
 
 interface A<T> {
     fun foo(): T

--- a/backend.native/tests/codegen/bridges/linkTest_lib.kt
+++ b/backend.native/tests/codegen/bridges/linkTest_lib.kt
@@ -1,4 +1,4 @@
-package a
+package codegen.bridges.linkTest.a
 
 interface A<T> {
     fun foo(): T

--- a/backend.native/tests/codegen/bridges/linkTest_main.kt
+++ b/backend.native/tests/codegen/bridges/linkTest_main.kt
@@ -1,8 +1,11 @@
-import a.*
+package codegen.bridges.linkTest_main
+
+import kotlin.test.*
+import codegen.bridges.linkTest.a.*
 
 class B: C()
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val b = B()
     println(b.foo())
     val c: C = b

--- a/backend.native/tests/codegen/bridges/linkTest_main.kt
+++ b/backend.native/tests/codegen/bridges/linkTest_main.kt
@@ -1,11 +1,8 @@
-package codegen.bridges.linkTest_main
-
-import kotlin.test.*
-import codegen.bridges.linkTest.a.*
+import a.*
 
 class B: C()
 
-@Test fun runTest() {
+fun main(args: Array<String>) {
     val b = B()
     println(b.foo())
     val c: C = b

--- a/backend.native/tests/codegen/bridges/test0.kt
+++ b/backend.native/tests/codegen/bridges/test0.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test0
+
+import kotlin.test.*
+
 // vtable call
 open class A {
     open fun foo(): Any = "A"
@@ -7,7 +11,7 @@ open class C : A() {
     override fun foo(): Int = 42
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val c = C()
     val a: A = c
     println(c.foo().toString())

--- a/backend.native/tests/codegen/bridges/test1.kt
+++ b/backend.native/tests/codegen/bridges/test1.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test1
+
+import kotlin.test.*
+
 // interface call, bridge overridden
 interface Z1 {
     fun foo(x: Int) : Any
@@ -11,7 +15,7 @@ open class B : A() {
     override fun foo(x: Int) : Int = 42
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val z1: A = B()
     println((z1.foo(1) + 1000).toString())
 }

--- a/backend.native/tests/codegen/bridges/test10.kt
+++ b/backend.native/tests/codegen/bridges/test10.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test10
+
+import kotlin.test.*
+
 open class A<T> {
     open fun foo(x: T) {
         println(x.toString())
@@ -19,7 +23,7 @@ fun zzz(a: A<Int>) {
     a.foo(42)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val b = B()
     zzz(b)
     val a = A<Int>()

--- a/backend.native/tests/codegen/bridges/test11.kt
+++ b/backend.native/tests/codegen/bridges/test11.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test11
+
+import kotlin.test.*
+
 interface I {
     fun foo(x: Int)
 }
@@ -10,7 +14,7 @@ class B : A<Int>(), I {
     override fun foo(x: Int) = println(x)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val b = B()
     val a: A<Int> = b
     val c: I = b

--- a/backend.native/tests/codegen/bridges/test12.kt
+++ b/backend.native/tests/codegen/bridges/test12.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test12
+
+import kotlin.test.*
+
 abstract class A<in T> {
     abstract fun foo(x: T)
 }
@@ -18,7 +22,7 @@ fun foo(arg: A<Int>) {
     arg.foo(42)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo(B())
     foo(C())
 }

--- a/backend.native/tests/codegen/bridges/test13.kt
+++ b/backend.native/tests/codegen/bridges/test13.kt
@@ -18,7 +18,7 @@ open class B: A<Int>() {
     }
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     val b = B()
     val a = A<Int>()
     b.bar(42)

--- a/backend.native/tests/codegen/bridges/test13.kt
+++ b/backend.native/tests/codegen/bridges/test13.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test13
+
+import kotlin.test.*
+
 open class A<T> {
     open fun T.foo() {
         println(this.toString())

--- a/backend.native/tests/codegen/bridges/test14.kt
+++ b/backend.native/tests/codegen/bridges/test14.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test14
+
+import kotlin.test.*
+
 open class A<T, U> {
     open fun foo(x: T, y: U) {
         println(x.toString())
@@ -26,7 +30,7 @@ fun zzz(a: A<Int, Int>) {
     a.foo(42, 56)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val b = B()
     zzz(b)
     val a = A<Int, Int>()

--- a/backend.native/tests/codegen/bridges/test15.kt
+++ b/backend.native/tests/codegen/bridges/test15.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test15
+
+import kotlin.test.*
+
 // non-generic interface, generic impl, vtable call + interface call
 open class A<T> {
     open var size: T = 56 as T
@@ -30,6 +34,6 @@ fun box(): String {
     return "OK"
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/bridges/test16.kt
+++ b/backend.native/tests/codegen/bridges/test16.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test16
+
+import kotlin.test.*
+
 interface A {
     fun foo(): String
 }
@@ -12,7 +16,7 @@ open class B: C() {
 
 fun bar(c: C) = c.foo()
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val b = B()
     val c: C = b
     println(bar(b))

--- a/backend.native/tests/codegen/bridges/test17.kt
+++ b/backend.native/tests/codegen/bridges/test17.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test17
+
+import kotlin.test.*
+
 // abstract bridge
 interface A<T> {
     fun foo(): T
@@ -13,7 +17,7 @@ class D: C() {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val d = D()
     val c: C = d
     val b: B<Int> = d

--- a/backend.native/tests/codegen/bridges/test18.kt
+++ b/backend.native/tests/codegen/bridges/test18.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test18
+
+import kotlin.test.*
+
 // overriden function returns Unit
 open class A {
     open fun foo(): Any = 42
@@ -7,7 +11,7 @@ open class B: A() {
     override fun foo(): Unit { }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val a: A = B()
     println(a.foo())
 }

--- a/backend.native/tests/codegen/bridges/test2.kt
+++ b/backend.native/tests/codegen/bridges/test2.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test2
+
+import kotlin.test.*
+
 // vtable call, bridge inherited
 open class A {
     open fun foo(): Any = "A"
@@ -9,7 +13,7 @@ open class C : A() {
 
 open class D: C()
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val c = D()
     val a: A = c
     println(c.foo().toString())

--- a/backend.native/tests/codegen/bridges/test3.kt
+++ b/backend.native/tests/codegen/bridges/test3.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test3
+
+import kotlin.test.*
+
 // non-generic interface, generic impl, non-virtual call + interface call
 open class A<T> {
     var size: T = 56 as T
@@ -25,6 +29,6 @@ fun box(): String {
     return "OK"
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/bridges/test4.kt
+++ b/backend.native/tests/codegen/bridges/test4.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test4
+
+import kotlin.test.*
+
 // vtable call + interface call
 interface Z {
     fun foo(): Any
@@ -13,7 +17,7 @@ open class A {
 
 open class B: A(), Z, Y
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val z: Z = B()
     val y: Y = z as Y
     println(z.foo().toString())

--- a/backend.native/tests/codegen/bridges/test5.kt
+++ b/backend.native/tests/codegen/bridges/test5.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test5
+
+import kotlin.test.*
+
 // non-generic interface, generic impl, vtable call + interface call
 open class A<T> {
     open var size: T = 56 as T
@@ -25,6 +29,6 @@ fun box(): String {
     return "OK"
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/bridges/test6.kt
+++ b/backend.native/tests/codegen/bridges/test6.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test6
+
+import kotlin.test.*
+
 // vtable call + interface call
 interface Z {
     fun foo(): Any
@@ -17,7 +21,7 @@ open class C : A() {
 
 open class D: C(), Y, Z
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val d = D()
     val y: Y = d
     val z: Z = d

--- a/backend.native/tests/codegen/bridges/test7.kt
+++ b/backend.native/tests/codegen/bridges/test7.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test7
+
+import kotlin.test.*
+
 // generic interface, non-generic impl, vtable call + interface call
 open class A {
     open var size: Int = 56
@@ -25,6 +29,6 @@ fun box(): String {
     return "OK"
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/bridges/test8.kt
+++ b/backend.native/tests/codegen/bridges/test8.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test8
+
+import kotlin.test.*
+
 // generic interface, non-generic impl, non-virtual call + interface call
 open class A {
     var size: Int = 56
@@ -25,6 +29,6 @@ fun box(): String {
     return "OK"
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/bridges/test9.kt
+++ b/backend.native/tests/codegen/bridges/test9.kt
@@ -1,3 +1,7 @@
+package codegen.bridges.test9
+
+import kotlin.test.*
+
 // abstract class vtable call
 abstract class A {
     abstract fun foo(): String
@@ -22,6 +26,6 @@ fun box(): String {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/classDelegation/generic.kt
+++ b/backend.native/tests/codegen/classDelegation/generic.kt
@@ -1,3 +1,7 @@
+package codegen.classDelegation.generic
+
+import kotlin.test.*
+
 open class Content() {
     override fun toString() = "OK"
 }
@@ -16,6 +20,6 @@ class ContentBoxDelegate<T : Content>() : ContentBox<T> by (Impl as ContentBox<T
 
 fun box() = ContentBoxDelegate<Content>().get().toString()
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/classDelegation/method.kt
+++ b/backend.native/tests/codegen/classDelegation/method.kt
@@ -1,3 +1,7 @@
+package codegen.classDelegation.method
+
+import kotlin.test.*
+
 interface A<T> {
     fun foo(): T
 }
@@ -14,6 +18,6 @@ fun box(): String {
     return c.foo() + a.foo()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/classDelegation/property.kt
+++ b/backend.native/tests/codegen/classDelegation/property.kt
@@ -1,3 +1,7 @@
+package codegen.classDelegation.property
+
+import kotlin.test.*
+
 interface A {
     val x: Int
 }
@@ -14,6 +18,6 @@ fun box(): String {
     return q.x.toString() + a.x.toString()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/classDelegation/withBridge.kt
+++ b/backend.native/tests/codegen/classDelegation/withBridge.kt
@@ -1,3 +1,7 @@
+package codegen.classDelegation.withBridge
+
+import kotlin.test.*
+
 interface A<T> {
     fun foo(t: T): String
 }
@@ -23,6 +27,6 @@ fun box(): String {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/controlflow/break.kt
+++ b/backend.native/tests/codegen/controlflow/break.kt
@@ -1,3 +1,7 @@
+package codegen.controlflow.`break`
+
+import kotlin.test.*
+
 fun foo() {
   var i = 0
   l1@while (true) {
@@ -45,7 +49,7 @@ fun qux() {
   }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   foo()
   bar()
   qux()

--- a/backend.native/tests/codegen/controlflow/break1.kt
+++ b/backend.native/tests/codegen/controlflow/break1.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.controlflow.break1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     loop@ while (true) {
         println("Body")
         break

--- a/backend.native/tests/codegen/controlflow/for_loops.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.controlflow.for_loops
+
+import kotlin.test.*
+
+@Test fun runTest() {
 
     // Simple loops
     for (i in 0..4) {

--- a/backend.native/tests/codegen/controlflow/for_loops_call_order.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_call_order.kt
@@ -1,9 +1,13 @@
+package codegen.controlflow.for_loops_call_order
+
+import kotlin.test.*
+
 fun f1(): Int { print("1"); return 0 }
 fun f2(): Int { print("2"); return 6 }
 fun f3(): Int { print("3"); return 2 }
 fun f4(): Int { print("4"); return 3 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     for (i in f1()..f2() step f3() step f4()) { }; println()
     for (i in f1() until f2() step f3() step f4()) {}; println()
     for (i in f2() downTo f1() step f3() step f4()) {}; println()

--- a/backend.native/tests/codegen/controlflow/for_loops_coroutines.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_coroutines.kt
@@ -1,6 +1,10 @@
+package codegen.controlflow.for_loops_coroutines
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val sq = buildSequence {
         for (i in 0..6 step 2) {
             print("before: $i ")

--- a/backend.native/tests/codegen/controlflow/for_loops_empty_range.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_empty_range.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.controlflow.for_loops_empty_range
+
+import kotlin.test.*
+
+@Test fun runTest() {
     // Simple loops
     for (i in 4..0) { print(i) }
     for (i in 4 until 0) { print(i) }

--- a/backend.native/tests/codegen/controlflow/for_loops_errors.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_errors.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.controlflow.for_loops_errors
+
+import kotlin.test.*
+
+@Test fun runTest() {
     // Negative step.
     try {
         for (i in 0 .. 4 step -2) print(i); println()

--- a/backend.native/tests/codegen/controlflow/for_loops_nested.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_nested.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.controlflow.for_loops_nested
+
+import kotlin.test.*
+
+@Test fun runTest() {
     // Simple
     for (i in 0..2) {
         for (j in 0..2) {

--- a/backend.native/tests/codegen/controlflow/for_loops_overflow.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_overflow.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.controlflow.for_loops_overflow
+
+import kotlin.test.*
+
+@Test fun runTest() {
     for (i in Int.MAX_VALUE - 1 .. Int.MAX_VALUE) { print(i); print(' ') }; println()
     for (i in Int.MAX_VALUE - 1 until Int.MAX_VALUE) { print(i); print(' ') }; println()
     for (i in Int.MIN_VALUE + 1 downTo Int.MIN_VALUE) { print(i); print(' ') }; println()

--- a/backend.native/tests/codegen/controlflow/for_loops_types.kt
+++ b/backend.native/tests/codegen/controlflow/for_loops_types.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.controlflow.for_loops_types
+
+import kotlin.test.*
+
+@Test fun runTest() {
     for (i in 0.toByte() .. 4.toByte()) print(i); println()
     for (i in 0.toByte() .. 4.toShort()) print(i); println()
     for (i in 0.toByte() .. 4.toInt()) print(i); println()

--- a/backend.native/tests/codegen/controlflow/unreachable1.kt
+++ b/backend.native/tests/codegen/controlflow/unreachable1.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.controlflow.unreachable1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(foo())
 }
 

--- a/backend.native/tests/codegen/coroutines/controlFlow_finally1.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_finally1.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_finally1
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_finally2.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_finally2.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_finally2
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_finally3.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_finally3.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_finally3
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_finally4.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_finally4.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_finally4
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_finally5.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_finally5.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_finally5
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_finally6.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_finally6.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_finally6
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_finally7.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_finally7.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_finally7
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -38,7 +42,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_if1.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_if1.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_if1
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_if2.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_if2.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_if2
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_inline1.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_inline1.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_inline1
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -21,7 +25,7 @@ inline suspend fun inline_s2(): Int {
     return 42
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_inline2.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_inline2.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_inline2
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -22,7 +26,7 @@ inline suspend fun inline_s2(): Int {
     return x
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_inline3.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_inline3.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_inline3
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -35,7 +39,7 @@ inline suspend fun inline_s2(): Int {
     return x
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_tryCatch1.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_tryCatch1.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_tryCatch1
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_tryCatch2.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_tryCatch2.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_tryCatch2
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -32,7 +36,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_tryCatch3.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_tryCatch3.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_tryCatch3
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -38,7 +42,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_tryCatch4.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_tryCatch4.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_tryCatch4
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -38,7 +42,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_tryCatch5.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_tryCatch5.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_tryCatch5
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -38,7 +42,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_while1.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_while1.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_while1
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -44,7 +48,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/controlFlow_while2.kt
+++ b/backend.native/tests/codegen/coroutines/controlFlow_while2.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.controlFlow_while2
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -44,7 +48,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/correctOrder1.kt
+++ b/backend.native/tests/codegen/coroutines/correctOrder1.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.correctOrder1
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -27,7 +31,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/degenerate1.kt
+++ b/backend.native/tests/codegen/coroutines/degenerate1.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.degenerate1
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -15,7 +19,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     builder {
         s1()
     }

--- a/backend.native/tests/codegen/coroutines/degenerate2.kt
+++ b/backend.native/tests/codegen/coroutines/degenerate2.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.degenerate2
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -22,7 +26,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     builder {
         s2()
     }

--- a/backend.native/tests/codegen/coroutines/returnsUnit1.kt
+++ b/backend.native/tests/codegen/coroutines/returnsUnit1.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.returnsUnit1
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -26,7 +30,7 @@ suspend fun s3(x: Int) {
     inline_s2(x)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/simple.kt
+++ b/backend.native/tests/codegen/coroutines/simple.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.simple
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -16,7 +20,7 @@ fun builder(c: suspend () -> Unit) {
     c.startCoroutine(EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/coroutines/withReceiver.kt
+++ b/backend.native/tests/codegen/coroutines/withReceiver.kt
@@ -1,3 +1,7 @@
+package codegen.coroutines.withReceiver
+
+import kotlin.test.*
+
 import kotlin.coroutines.experimental.*
 import kotlin.coroutines.experimental.intrinsics.*
 
@@ -18,7 +22,7 @@ fun builder(c: suspend Controller.() -> Unit) {
     c.startCoroutine(Controller(), EmptyContinuation)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var result = 0
 
     builder {

--- a/backend.native/tests/codegen/cycles/cycle.kt
+++ b/backend.native/tests/codegen/cycles/cycle.kt
@@ -1,3 +1,7 @@
+package codegen.cycles.cycle
+
+import kotlin.test.*
+
 fun cycle(cnt: Int): Int {
   var sum = 1
   while (sum == cnt) {
@@ -6,7 +10,7 @@ fun cycle(cnt: Int): Int {
   return sum
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (cycle(1) != 2) throw Error()
   if (cycle(0) != 1) throw Error()
 }

--- a/backend.native/tests/codegen/cycles/cycle_do.kt
+++ b/backend.native/tests/codegen/cycles/cycle_do.kt
@@ -1,3 +1,7 @@
+package codegen.cycles.cycle_do
+
+import kotlin.test.*
+
 fun cycle_do(cnt: Int): Int {
   var sum = 1
   do {
@@ -6,7 +10,7 @@ fun cycle_do(cnt: Int): Int {
   return sum
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (cycle_do(3) != 5) throw Error()
   if (cycle_do(0) != 3) throw Error()
 }

--- a/backend.native/tests/codegen/cycles/cycle_for.kt
+++ b/backend.native/tests/codegen/cycles/cycle_for.kt
@@ -1,7 +1,15 @@
+package codegen.cycles.cycle_for
+
+import kotlin.test.*
+
 fun cycle_for(arr: Array<Int>) : Int {
   var sum = 0
   for (i in arr) {
     sum += i
   }
   return sum
+}
+
+@Test fun main() {
+  if (cycle_for(Array(4, init = { it })) != 6) throw Error()
 }

--- a/backend.native/tests/codegen/cycles/cycle_for.kt
+++ b/backend.native/tests/codegen/cycles/cycle_for.kt
@@ -10,6 +10,6 @@ fun cycle_for(arr: Array<Int>) : Int {
   return sum
 }
 
-@Test fun main() {
+@Test fun runTest() {
   if (cycle_for(Array(4, init = { it })) != 6) throw Error()
 }

--- a/backend.native/tests/codegen/dataflow/scope1.kt
+++ b/backend.native/tests/codegen/dataflow/scope1.kt
@@ -1,6 +1,10 @@
+package codegen.dataflow.scope1
+
+import kotlin.test.*
+
 var b = true
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     var x = 1
     if (b) {
         var x = 2

--- a/backend.native/tests/codegen/dataflow/uninitialized_val.kt
+++ b/backend.native/tests/codegen/dataflow/uninitialized_val.kt
@@ -1,3 +1,7 @@
+package codegen.dataflow.uninitialized_val
+
+import kotlin.test.*
+
 fun foo(b: Boolean): Int {
     val x: Int
     if (b) {
@@ -9,7 +13,7 @@ fun foo(b: Boolean): Int {
     return x
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val uninitializedUnused: Int
 
     println(foo(true))

--- a/backend.native/tests/codegen/delegatedProperty/delegatedOverride_lib.kt
+++ b/backend.native/tests/codegen/delegatedProperty/delegatedOverride_lib.kt
@@ -1,4 +1,4 @@
-package a
+package codegen.delegatedProperty.delegatedOverride.a
 
 import kotlin.reflect.KProperty
 

--- a/backend.native/tests/codegen/delegatedProperty/delegatedOverride_lib.kt
+++ b/backend.native/tests/codegen/delegatedProperty/delegatedOverride_lib.kt
@@ -1,4 +1,4 @@
-package codegen.delegatedProperty.delegatedOverride.a
+package a
 
 import kotlin.reflect.KProperty
 

--- a/backend.native/tests/codegen/delegatedProperty/delegatedOverride_main.kt
+++ b/backend.native/tests/codegen/delegatedProperty/delegatedOverride_main.kt
@@ -1,8 +1,4 @@
-package codegen.delegatedProperty.delegatedOverride_main
-
-import kotlin.test.*
-
-import codegen.delegatedProperty.delegatedOverride.a.*
+import a.*
 
 open class C: B() {
     override val x: Int = 156
@@ -15,7 +11,7 @@ open class C: B() {
     }
 }
 
-@Test fun runTest() {
+fun main(args: Array<String>) {
     val c = C()
     c.foo()
 }

--- a/backend.native/tests/codegen/delegatedProperty/delegatedOverride_main.kt
+++ b/backend.native/tests/codegen/delegatedProperty/delegatedOverride_main.kt
@@ -1,4 +1,8 @@
-import a.*
+package codegen.delegatedProperty.delegatedOverride_main
+
+import kotlin.test.*
+
+import codegen.delegatedProperty.delegatedOverride.a.*
 
 open class C: B() {
     override val x: Int = 156
@@ -11,7 +15,7 @@ open class C: B() {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val c = C()
     c.foo()
 }

--- a/backend.native/tests/codegen/delegatedProperty/lazy.kt
+++ b/backend.native/tests/codegen/delegatedProperty/lazy.kt
@@ -1,9 +1,13 @@
+package codegen.delegatedProperty.lazy
+
+import kotlin.test.*
+
 val lazyValue: String by lazy {
     println("computed!")
     "Hello"
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(lazyValue)
     println(lazyValue)
 }

--- a/backend.native/tests/codegen/delegatedProperty/local.kt
+++ b/backend.native/tests/codegen/delegatedProperty/local.kt
@@ -1,3 +1,7 @@
+package codegen.delegatedProperty.local
+
+import kotlin.test.*
+
 import kotlin.reflect.KProperty
 
 fun foo(): Int {
@@ -13,6 +17,6 @@ fun foo(): Int {
     return x
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(foo())
 }

--- a/backend.native/tests/codegen/delegatedProperty/map.kt
+++ b/backend.native/tests/codegen/delegatedProperty/map.kt
@@ -1,9 +1,13 @@
+package codegen.delegatedProperty.map
+
+import kotlin.test.*
+
 class User(val map: Map<String, Any?>) {
     val name: String by map
     val age: Int     by map
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val user = User(mapOf(
             "name" to "John Doe",
             "age"  to 25

--- a/backend.native/tests/codegen/delegatedProperty/observable.kt
+++ b/backend.native/tests/codegen/delegatedProperty/observable.kt
@@ -1,3 +1,7 @@
+package codegen.delegatedProperty.observable
+
+import kotlin.test.*
+
 import kotlin.properties.Delegates
 
 class User {
@@ -7,7 +11,7 @@ class User {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val user = User()
     user.name = "first"
     user.name = "second"

--- a/backend.native/tests/codegen/delegatedProperty/packageLevel.kt
+++ b/backend.native/tests/codegen/delegatedProperty/packageLevel.kt
@@ -1,3 +1,7 @@
+package codegen.delegatedProperty.packageLevel
+
+import kotlin.test.*
+
 import kotlin.reflect.KProperty
 
 class Delegate {
@@ -9,6 +13,6 @@ class Delegate {
 
 val x: Int by Delegate()
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(x)
 }

--- a/backend.native/tests/codegen/delegatedProperty/simpleVal.kt
+++ b/backend.native/tests/codegen/delegatedProperty/simpleVal.kt
@@ -1,3 +1,7 @@
+package codegen.delegatedProperty.simpleVal
+
+import kotlin.test.*
+
 import kotlin.reflect.KProperty
 
 class Delegate {
@@ -11,6 +15,6 @@ class C {
     val x: Int by Delegate()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(C().x)
 }

--- a/backend.native/tests/codegen/delegatedProperty/simpleVar.kt
+++ b/backend.native/tests/codegen/delegatedProperty/simpleVar.kt
@@ -1,3 +1,7 @@
+package codegen.delegatedProperty.simpleVar
+
+import kotlin.test.*
+
 import kotlin.reflect.KProperty
 
 class Delegate {
@@ -18,7 +22,7 @@ class C {
     var x: Int by Delegate()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val c = C()
     println(c.x)
     c.x = 117

--- a/backend.native/tests/codegen/enum/companionObject.kt
+++ b/backend.native/tests/codegen/enum/companionObject.kt
@@ -1,3 +1,7 @@
+package codegen.enum.companionObject
+
+import kotlin.test.*
+
 enum class Game {
     ROCK,
     PAPER,
@@ -21,4 +25,4 @@ fun box(): String {
     return "OK"
 }
 
-fun main(args: Array<String>) = println(box())
+@Test fun runTest() = println(box())

--- a/backend.native/tests/codegen/enum/interfaceCallNoEntryClass.kt
+++ b/backend.native/tests/codegen/enum/interfaceCallNoEntryClass.kt
@@ -1,3 +1,7 @@
+package codegen.enum.interfaceCallNoEntryClass
+
+import kotlin.test.*
+
 interface A {
     fun foo(): String
 }
@@ -12,7 +16,7 @@ enum class Zzz(val zzz: String, val x: Int) : A {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(Zzz.Z3.foo())
     val a: A = Zzz.Z3
     println(a.foo())

--- a/backend.native/tests/codegen/enum/interfaceCallWithEntryClass.kt
+++ b/backend.native/tests/codegen/enum/interfaceCallWithEntryClass.kt
@@ -1,3 +1,7 @@
+package codegen.enum.interfaceCallWithEntryClass
+
+import kotlin.test.*
+
 interface A {
     fun f(): String
 }
@@ -14,7 +18,7 @@ enum class Zzz: A {
     override fun f() = ""
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(Zzz.Z1.f() + Zzz.Z2.f())
     val a1: A = Zzz.Z1
     val a2: A = Zzz.Z2

--- a/backend.native/tests/codegen/enum/linkTest_lib.kt
+++ b/backend.native/tests/codegen/enum/linkTest_lib.kt
@@ -1,4 +1,4 @@
-package codegen.enum.linkTest.a
+package a
 
 enum class A(val x: Int) {
     Z1(42),

--- a/backend.native/tests/codegen/enum/linkTest_lib.kt
+++ b/backend.native/tests/codegen/enum/linkTest_lib.kt
@@ -1,4 +1,4 @@
-package a
+package codegen.enum.linkTest.a
 
 enum class A(val x: Int) {
     Z1(42),

--- a/backend.native/tests/codegen/enum/linkTest_main.kt
+++ b/backend.native/tests/codegen/enum/linkTest_main.kt
@@ -1,6 +1,10 @@
-import a.*
+package codegen.enum.linkTest_main
 
-fun main(args: Array<String>) {
+import kotlin.test.*
+
+import codegen.enum.linkTest.a.*
+
+@Test fun runTest() {
     println(A.Z1.x)
     println(A.valueOf("Z2").x)
     println(A.values()[2].x)

--- a/backend.native/tests/codegen/enum/linkTest_main.kt
+++ b/backend.native/tests/codegen/enum/linkTest_main.kt
@@ -1,10 +1,6 @@
-package codegen.enum.linkTest_main
+import a.*
 
-import kotlin.test.*
-
-import codegen.enum.linkTest.a.*
-
-@Test fun runTest() {
+fun main(args: Array<String>) {
     println(A.Z1.x)
     println(A.valueOf("Z2").x)
     println(A.values()[2].x)

--- a/backend.native/tests/codegen/enum/test0.kt
+++ b/backend.native/tests/codegen/enum/test0.kt
@@ -1,9 +1,13 @@
+package codegen.enum.test0
+
+import kotlin.test.*
+
 val TOP_LEVEL = 5
 
 enum class MyEnum(value: Int) {
     VALUE(TOP_LEVEL)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(MyEnum.VALUE.toString())
 }

--- a/backend.native/tests/codegen/enum/test1.kt
+++ b/backend.native/tests/codegen/enum/test1.kt
@@ -1,8 +1,12 @@
+package codegen.enum.test1
+
+import kotlin.test.*
+
 enum class Zzz(val zzz: String, val x: Int) {
     Z1("z1", 1),
     Z2("z2", 2)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(Zzz.Z1.zzz + Zzz.Z2.x)
 }

--- a/backend.native/tests/codegen/enum/vCallNoEntryClass.kt
+++ b/backend.native/tests/codegen/enum/vCallNoEntryClass.kt
@@ -1,3 +1,7 @@
+package codegen.enum.vCallNoEntryClass
+
+import kotlin.test.*
+
 enum class Zzz(val zzz: String, val x: Int) {
     Z1("z1", 1),
     Z2("z2", 2),
@@ -8,6 +12,6 @@ enum class Zzz(val zzz: String, val x: Int) {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(Zzz.Z3.toString())
 }

--- a/backend.native/tests/codegen/enum/vCallWithEntryClass.kt
+++ b/backend.native/tests/codegen/enum/vCallWithEntryClass.kt
@@ -1,3 +1,7 @@
+package codegen.enum.vCallWithEntryClass
+
+import kotlin.test.*
+
 enum class Zzz {
     Z1 {
         override fun f() = "z1"
@@ -10,6 +14,6 @@ enum class Zzz {
     open fun f() = ""
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(Zzz.Z1.f() + Zzz.Z2.f())
 }

--- a/backend.native/tests/codegen/enum/valueOf.kt
+++ b/backend.native/tests/codegen/enum/valueOf.kt
@@ -1,10 +1,14 @@
+package codegen.enum.valueOf
+
+import kotlin.test.*
+
 enum class E {
     E3,
     E1,
     E2
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(E.valueOf("E1").toString())
     println(E.valueOf("E2").toString())
     println(E.valueOf("E3").toString())

--- a/backend.native/tests/codegen/enum/values.kt
+++ b/backend.native/tests/codegen/enum/values.kt
@@ -1,10 +1,14 @@
+package codegen.enum.values
+
+import kotlin.test.*
+
 enum class E {
     E3,
     E1,
     E2
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(E.values()[0].toString())
     println(E.values()[1].toString())
     println(E.values()[2].toString())

--- a/backend.native/tests/codegen/function/arithmetic.kt
+++ b/backend.native/tests/codegen/function/arithmetic.kt
@@ -1,10 +1,14 @@
+package codegen.function.arithmetic
+
+import kotlin.test.*
+
 fun square(a:Int):Int = a * a
 fun sumOfSquares(a:Int, b:Int):Int = square(a) + square(b)
 fun diffOfSquares(a:Int, b:Int):Int = square(a) - square(b)
 fun mod(a:Int,b:Int):Int = a / b
 fun remainder(a:Int, b:Int):Int = a % b
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
     if (square(2)             != 4)   throw Error()
     if (sumOfSquares(2, 4)    != 20)  throw Error()
     if (diffOfSquares(2, 4)   != -12) throw Error()

--- a/backend.native/tests/codegen/function/boolean.kt
+++ b/backend.native/tests/codegen/function/boolean.kt
@@ -1,5 +1,9 @@
+package codegen.function.boolean
+
+import kotlin.test.*
+
 fun bool_yes(): Boolean = true
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     if (!bool_yes()) throw Error()
 }

--- a/backend.native/tests/codegen/function/defaults.kt
+++ b/backend.native/tests/codegen/function/defaults.kt
@@ -1,3 +1,7 @@
+package codegen.function.defaults
+
+import kotlin.test.*
+
 /**
  * Created by minamoto on 12/26/16.
  */
@@ -14,9 +18,8 @@ open class A(val a:Int) {
         val one   =  A(1)
         val magic =  A(42)
     }
-
-
 }
+
 //     FUN public fun foo(a: defaults.A = ...): kotlin.Int
 //       a: EXPRESSION_BODY
 //         CALL '<get-magic>(): A' type=defaults.A origin=GET_PROPERTY
@@ -40,7 +43,7 @@ fun foo(a: A = A.magic, b:Int = 0xdeadbeef.toInt()) = a.a
 fun bar(a:A, inc:Int = 0) = A(a.a + inc)
 
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
 
 //  if: CALL 'NOT(Boolean): Boolean' type=kotlin.Boolean origin=EXCLEQ
 //    arg0: CALL 'EQEQ(Any?, Any?): Boolean' type=kotlin.Boolean origin=EXCLEQ
@@ -92,6 +95,3 @@ fun main(args:Array<String>) {
     }
     println("all tests passed")
 }
-
-
-

--- a/backend.native/tests/codegen/function/defaults1.kt
+++ b/backend.native/tests/codegen/function/defaults1.kt
@@ -1,6 +1,10 @@
+package codegen.function.defaults1
+
+import kotlin.test.*
+
 fun foo(x:Int = 0, y:Int = x + 1, z:Int = x + y + 1) = x + y + z
 
-fun main(arg:Array<String>) {
+@Test fun runTest() {
   val v = foo()
   if (v != 3) {
     println("test failed $v expected 3")

--- a/backend.native/tests/codegen/function/defaults10.kt
+++ b/backend.native/tests/codegen/function/defaults10.kt
@@ -1,7 +1,11 @@
+package codegen.function.defaults10
+
+import kotlin.test.*
+
 enum class A(one: Int, val two: Int = one) {
     FOO(42)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(A.FOO.two)
 }

--- a/backend.native/tests/codegen/function/defaults2.kt
+++ b/backend.native/tests/codegen/function/defaults2.kt
@@ -1,7 +1,11 @@
+package codegen.function.defaults2
+
+import kotlin.test.*
+
 
 fun Int.foo(inc0:Int, inc:Int = 0) = this + inc0 + inc
 
-fun main(arg:Array<String>) {
+@Test fun runTest() {
     val v = 42.foo(0)
     if (v != 42) {
         println("test failed v:$v expected:42")

--- a/backend.native/tests/codegen/function/defaults3.kt
+++ b/backend.native/tests/codegen/function/defaults3.kt
@@ -1,7 +1,11 @@
+package codegen.function.defaults3
+
+import kotlin.test.*
+
 fun foo(a:Int = 2, b:String = "Hello", c:Int = 4):String = "$b-$c$a"
 fun foo(a:Int = 3, b:Int = a + 1, c:Int = a + b) = a + b + c
 
-fun main(arg:Array<String>){
+@Test fun runTest() {
     val a = foo(b="Universe")
     if (a != "Universe-42")
         throw Error()

--- a/backend.native/tests/codegen/function/defaults4.kt
+++ b/backend.native/tests/codegen/function/defaults4.kt
@@ -1,3 +1,7 @@
+package codegen.function.defaults4
+
+import kotlin.test.*
+
 open class A {
     open fun foo(x: Int = 42) = println(x)
 }
@@ -8,6 +12,6 @@ class C : B() {
     override fun foo(x: Int) = println(x + 1)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     C().foo()
 }

--- a/backend.native/tests/codegen/function/defaults5.kt
+++ b/backend.native/tests/codegen/function/defaults5.kt
@@ -1,14 +1,18 @@
-class Test(val x: Int) {
+package codegen.function.defaults5
+
+import kotlin.test.*
+
+class TestClass(val x: Int) {
     fun foo(y: Int = x) {
         println(y)
     }
 }
 
-fun Test.bar(y: Int = x) {
+fun TestClass.bar(y: Int = x) {
     println(y)
 }
 
-fun main(args: Array<String>) {
-    Test(5).foo()
-    Test(6).bar()
+@Test fun runTest() {
+    TestClass(5).foo()
+    TestClass(6).bar()
 }

--- a/backend.native/tests/codegen/function/defaults6.kt
+++ b/backend.native/tests/codegen/function/defaults6.kt
@@ -1,6 +1,10 @@
+package codegen.function.defaults6
+
+import kotlin.test.*
+
 open class Foo(val x: Int = 42)
 class Bar : Foo()
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(Bar().x)
 }

--- a/backend.native/tests/codegen/function/defaults7.kt
+++ b/backend.native/tests/codegen/function/defaults7.kt
@@ -1,3 +1,7 @@
+package codegen.function.defaults7
+
+import kotlin.test.*
+
 /**
  * Test fails with code generation:
  * Call parameter type does not match function signature!
@@ -11,6 +15,6 @@ fun <T> foo(a : T, b : Int = 42){
     println(b)
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     foo(1)
 }

--- a/backend.native/tests/codegen/function/defaults8.kt
+++ b/backend.native/tests/codegen/function/defaults8.kt
@@ -1,3 +1,7 @@
+package codegen.function.defaults8
+
+import kotlin.test.*
+
 class Foo {
     fun test(x: Int = 1) = x
 }
@@ -6,6 +10,6 @@ class Bar {
     fun test(x: Int = 2) = x
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     println(Bar().test())
 }

--- a/backend.native/tests/codegen/function/defaults9.kt
+++ b/backend.native/tests/codegen/function/defaults9.kt
@@ -1,7 +1,11 @@
+package codegen.function.defaults9
+
+import kotlin.test.*
+
 class Foo {
     inner class Bar(x: Int, val y: Int = 1) {
         constructor() : this(42)
     }
 }
 
-fun main(arg:Array<String>) = println(Foo().Bar().y)
+@Test fun runTest() = println(Foo().Bar().y)

--- a/backend.native/tests/codegen/function/eqeq.kt
+++ b/backend.native/tests/codegen/function/eqeq.kt
@@ -1,3 +1,7 @@
+package codegen.function.eqeq
+
+import kotlin.test.*
+
 fun eqeqB  (a:Byte,   b:Byte  ) = a == b
 fun eqeqS  (a:Short,  b:Short ) = a == b
 fun eqeqI  (a:Int,    b:Int   ) = a == b
@@ -26,7 +30,7 @@ fun neF  (a:Float,  b:Float ) = a != b
 fun helloString()   =  "Hello"
 fun goodbyeString() =  "Goodbye"
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     if (!eqeqB(3   , 3   )) throw Error()
     if (!eqeqS(3   , 3   )) throw Error()
     if (!eqeqI(3   , 3   )) throw Error()

--- a/backend.native/tests/codegen/function/intrinsic.kt
+++ b/backend.native/tests/codegen/function/intrinsic.kt
@@ -1,3 +1,6 @@
+package codegen.function.intrinsic
+
+import kotlin.test.*
 
 // This code fails to link when bultins are taken from the 
 // frontend generated module, instead of our library.
@@ -10,6 +13,6 @@ fun intrinsic(b: Int): Int {
   return sum
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (intrinsic(3) != 4) throw Error()
 }

--- a/backend.native/tests/codegen/function/localFunction.kt
+++ b/backend.native/tests/codegen/function/localFunction.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.function.localFunction
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val x = 1
     fun local0() = println(x)
     fun local1() {

--- a/backend.native/tests/codegen/function/localFunction2.kt
+++ b/backend.native/tests/codegen/function/localFunction2.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.function.localFunction2
+
+import kotlin.test.*
+
+@Test fun runTest() {
     var a = 0
     fun local() {
         class A {

--- a/backend.native/tests/codegen/function/localFunction3.kt
+++ b/backend.native/tests/codegen/function/localFunction3.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.function.localFunction3
+
+import kotlin.test.*
+
+@Test fun runTest() {
     fun bar() {
         fun local1() {
             bar()

--- a/backend.native/tests/codegen/function/minus_eq.kt
+++ b/backend.native/tests/codegen/function/minus_eq.kt
@@ -1,9 +1,13 @@
+package codegen.function.minus_eq
+
+import kotlin.test.*
+
 fun minus_eq(a: Int): Int {
   var b = 11
   b -= a
   return b
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (minus_eq(23) != -12) throw Error()
 }

--- a/backend.native/tests/codegen/function/named.kt
+++ b/backend.native/tests/codegen/function/named.kt
@@ -1,5 +1,10 @@
+package codegen.function.named
+
+import kotlin.test.*
+
 fun foo(a:Int, b:Int) = a - b
-fun main(args:Array<String>) {
+
+@Test fun runTest() {
   if (foo(b = 24, a = 42) != 18)
       throw Error()
 }

--- a/backend.native/tests/codegen/function/plus_eq.kt
+++ b/backend.native/tests/codegen/function/plus_eq.kt
@@ -1,9 +1,13 @@
+package codegen.function.plus_eq
+
+import kotlin.test.*
+
 fun plus_eq(a: Int): Int {
   var b = 11
   b += a
   return b
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
   if (plus_eq(3) != 14) throw Error()
 }

--- a/backend.native/tests/codegen/function/sum.kt
+++ b/backend.native/tests/codegen/function/sum.kt
@@ -1,3 +1,7 @@
+package codegen.function.sum
+
+import kotlin.test.*
+
 fun sumIB(a:Int, b:Byte  ) = a + b
 fun sumIS(a:Int, b:Short ) = a + b
 fun sumII(a:Int, b:Int   ) = a + b
@@ -7,7 +11,7 @@ fun sumID(a:Int, b:Double) = a + b
 
 fun modID(a:Int, b:Double) = a % b
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
     if (sumIB(2, 3)    != 5)    throw Error()
     if (sumIS(2, 3)    != 5)    throw Error()
     if (sumII(2, 3)    != 5)    throw Error()

--- a/backend.native/tests/codegen/function/sum_3const.kt
+++ b/backend.native/tests/codegen/function/sum_3const.kt
@@ -1,6 +1,10 @@
+package codegen.function.sum_3const
+
+import kotlin.test.*
+
 fun sum3():Int = sum(1, 2, 33)
 fun sum(a:Int, b:Int, c:Int): Int = a + b + c
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     if (sum3() != 36) throw Error()
 }

--- a/backend.native/tests/codegen/function/sum_foo_bar.kt
+++ b/backend.native/tests/codegen/function/sum_foo_bar.kt
@@ -1,8 +1,12 @@
+package codegen.function.sum_foo_bar
+
+import kotlin.test.*
+
 fun foo(a:Int):Int = a
 fun bar(a:Int):Int = a
 
 fun sumFooBar(a:Int, b:Int):Int = foo(a) + bar(b)
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
     if (sumFooBar(2, 3) != 5) throw Error()
 }

--- a/backend.native/tests/codegen/function/sum_func.kt
+++ b/backend.native/tests/codegen/function/sum_func.kt
@@ -1,3 +1,9 @@
+package codegen.function.sum_func
+
+import kotlin.test.*
+
 fun foo():Int = 1
 //fun bar():Int = 2
 //fun sum():Int = foo() + bar()
+
+// FIXME: has no checks

--- a/backend.native/tests/codegen/function/sum_imm.kt
+++ b/backend.native/tests/codegen/function/sum_imm.kt
@@ -1,5 +1,9 @@
+package codegen.function.sum_imm
+
+import kotlin.test.*
+
 fun sum(a:Int): Int = a + 33
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
     if (sum(2) != 35) throw Error()
 }

--- a/backend.native/tests/codegen/function/sum_mixed.kt
+++ b/backend.native/tests/codegen/function/sum_mixed.kt
@@ -1,1 +1,6 @@
+package codegen.function.sum_mixed
+
+import kotlin.test.*
+
+// FIXME: has no checks
 fun sum(a:Float, b:Int) = a + b

--- a/backend.native/tests/codegen/function/sum_silly.kt
+++ b/backend.native/tests/codegen/function/sum_silly.kt
@@ -1,3 +1,9 @@
+package codegen.function.sum_silly
+
+import kotlin.test.*
+
+// FIXME: has no checks
+
 fun sum(a:Int, b:Int):Int {
  var c:Int
  c = a + b

--- a/backend.native/tests/codegen/initializers/correctOrder1.kt
+++ b/backend.native/tests/codegen/initializers/correctOrder1.kt
@@ -1,4 +1,8 @@
-class Test {
+package codegen.initializers.correctOrder1
+
+import kotlin.test.*
+
+class TestClass {
     val x: Int
 
     init {
@@ -8,6 +12,6 @@ class Test {
     val y = x
 }
 
-fun main(args: Array<String>) {
-    println(Test().y)
+@Test fun runTest() {
+    println(TestClass().y)
 }

--- a/backend.native/tests/codegen/initializers/correctOrder2.kt
+++ b/backend.native/tests/codegen/initializers/correctOrder2.kt
@@ -1,4 +1,8 @@
-class Test {
+package codegen.initializers.correctOrder2
+
+import kotlin.test.*
+
+class TestClass {
     val x: Int
 
     val y = 42
@@ -8,6 +12,6 @@ class Test {
     }
 }
 
-fun main(args: Array<String>) {
-    println(Test().x)
+@Test fun runTest() {
+    println(TestClass().x)
 }

--- a/backend.native/tests/codegen/inline/defaultArgs_linkTest_lib.kt
+++ b/backend.native/tests/codegen/inline/defaultArgs_linkTest_lib.kt
@@ -1,3 +1,3 @@
-package a
+package codegen.inline.defaultArgs_linkTest.a
 
 inline fun foo(x: Int, y: Int = 117) = x + y

--- a/backend.native/tests/codegen/inline/defaultArgs_linkTest_lib.kt
+++ b/backend.native/tests/codegen/inline/defaultArgs_linkTest_lib.kt
@@ -1,3 +1,3 @@
-package codegen.inline.defaultArgs_linkTest.a
+package a
 
 inline fun foo(x: Int, y: Int = 117) = x + y

--- a/backend.native/tests/codegen/inline/defaultArgs_linkTest_main.kt
+++ b/backend.native/tests/codegen/inline/defaultArgs_linkTest_main.kt
@@ -1,10 +1,6 @@
-package codegen.inline.defaultArgs_linkTest_main
+import a.*
 
-import kotlin.test.*
-
-import codegen.inline.defaultArgs_linkTest.a.*
-
-@Test fun runTest() {
+fun main(args: Array<String>) {
     println(foo(5))
     println(foo(5, 42))
 }

--- a/backend.native/tests/codegen/inline/defaultArgs_linkTest_main.kt
+++ b/backend.native/tests/codegen/inline/defaultArgs_linkTest_main.kt
@@ -1,6 +1,10 @@
-import a.*
+package codegen.inline.defaultArgs_linkTest_main
 
-fun main(args: Array<String>) {
+import kotlin.test.*
+
+import codegen.inline.defaultArgs_linkTest.a.*
+
+@Test fun runTest() {
     println(foo(5))
     println(foo(5, 42))
 }

--- a/backend.native/tests/codegen/inline/inline0.kt
+++ b/backend.native/tests/codegen/inline/inline0.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline0
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(i1: Int, j1: Int): Int {
     return i1 + j1
@@ -7,7 +11,7 @@ fun bar(i: Int, j: Int): Int {
     return i + foo(i, j)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(41, 2).toString())
 }
 

--- a/backend.native/tests/codegen/inline/inline1.kt
+++ b/backend.native/tests/codegen/inline/inline1.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline1
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(s4: String, s5: String): String {
     return s4 + s5
@@ -7,7 +11,7 @@ fun bar(s1: String, s2: String, s3: String): String {
     return s1 + foo(s2, s3)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar("Hello ", "wor", "ld"))
 }
 

--- a/backend.native/tests/codegen/inline/inline10.kt
+++ b/backend.native/tests/codegen/inline/inline10.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline10
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(i2: Int, body: () -> Int): Int {
     return i2 + body()
@@ -7,6 +11,6 @@ fun bar(i1: Int): Int {
     return foo(i1) { 1 }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(1).toString())
 }

--- a/backend.native/tests/codegen/inline/inline11.kt
+++ b/backend.native/tests/codegen/inline/inline11.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline11
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun <reified T> foo (i2: Any): Boolean {
     return i2 is T
@@ -7,6 +11,6 @@ fun bar(i1: Int): Boolean {
     return foo<Double>(i1)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(1).toString())
 }

--- a/backend.native/tests/codegen/inline/inline12.kt
+++ b/backend.native/tests/codegen/inline/inline12.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline12
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T> foo (): Boolean {
     return Any() is Any
@@ -7,6 +11,6 @@ fun bar(i1: Int): Boolean {
     return foo<Double>()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(1).toString())
 }

--- a/backend.native/tests/codegen/inline/inline13.kt
+++ b/backend.native/tests/codegen/inline/inline13.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline13
+
+import kotlin.test.*
+
 open class A<T1>()
 class B<T2>() : A<T2>()
 
@@ -10,6 +14,6 @@ fun bar(): Boolean {
     return foo<B<Int>>(B<Int>())
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar().toString())
 }

--- a/backend.native/tests/codegen/inline/inline14.kt
+++ b/backend.native/tests/codegen/inline/inline14.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline14
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo3(i3: Int): Int {
     return i3 + 3
@@ -17,6 +21,6 @@ fun bar(i0: Int): Int {
     return foo1(i0)  + foo3(i0)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(2).toString())
 }

--- a/backend.native/tests/codegen/inline/inline15.kt
+++ b/backend.native/tests/codegen/inline/inline15.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline15
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo2(i1: Int): Int {
     return i1 + 1
@@ -12,6 +16,6 @@ fun bar(i0: Int): Int {
     return foo1(i0) { foo2(it) + 1 }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(2).toString())
 }

--- a/backend.native/tests/codegen/inline/inline16.kt
+++ b/backend.native/tests/codegen/inline/inline16.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline16
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T, C : MutableCollection<in T>> foo(destination: C, predicate: (T) -> Boolean): C {
     for (element in destination) {
@@ -12,6 +16,6 @@ fun bar(): Boolean {
     return result.isEmpty()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar().toString())
 }

--- a/backend.native/tests/codegen/inline/inline17.kt
+++ b/backend.native/tests/codegen/inline/inline17.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline17
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T> foo(i1: T, i2: T): List<T> {
     val j1 = i1
@@ -9,6 +13,6 @@ fun bar(): List<Int> {
     return foo <Int> (1, 2)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar().toString())
 }

--- a/backend.native/tests/codegen/inline/inline18.kt
+++ b/backend.native/tests/codegen/inline/inline18.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline18
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T> foo2(i2: T, j2: T, p2: (T, T) -> Boolean): Boolean {
     return p2(i2, j2)
@@ -13,6 +17,6 @@ fun bar(): Boolean {
     return result
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar().toString())
 }

--- a/backend.native/tests/codegen/inline/inline19.kt
+++ b/backend.native/tests/codegen/inline/inline19.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline19
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline private fun foo(i: Int): Int {
     val result = i
@@ -8,7 +12,7 @@ fun bar(): Int {
     return foo(1) + foo(2)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar().toString())
 }
 

--- a/backend.native/tests/codegen/inline/inline2.kt
+++ b/backend.native/tests/codegen/inline/inline2.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline2
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(i4: Int, i5: Int) {
     println("hello $i4 $i5")
@@ -7,6 +11,6 @@ fun bar(i1: Int, i2: Int) {
     foo(i1, i2)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     bar(1, 8)
 }

--- a/backend.native/tests/codegen/inline/inline20.kt
+++ b/backend.native/tests/codegen/inline/inline20.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline20
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun bar(block: () -> String) : String {
     return block()
@@ -7,6 +11,6 @@ fun bar2() : String {
     return bar { return "def" }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar2())
 }

--- a/backend.native/tests/codegen/inline/inline21.kt
+++ b/backend.native/tests/codegen/inline/inline21.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline21
+
+import kotlin.test.*
+
 inline fun foo2(block2: () -> Int) : Int {
     println("foo2")
     return block2()
@@ -13,6 +17,6 @@ fun bar(block: () -> Int) : Int {
     return foo1(block)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar { 33 })
 }

--- a/backend.native/tests/codegen/inline/inline22.kt
+++ b/backend.native/tests/codegen/inline/inline22.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline22
+
+import kotlin.test.*
+
 inline fun foo2(i2: Int): Int {
     return i2 + 3
 }
@@ -10,6 +14,6 @@ fun bar(): Int {
     return foo1(11)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar().toString())
 }

--- a/backend.native/tests/codegen/inline/inline23.kt
+++ b/backend.native/tests/codegen/inline/inline23.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline23
+
+import kotlin.test.*
+
 inline fun <reified T> foo(i2: Any): T {
     return i2 as T
 }
@@ -6,6 +10,6 @@ fun bar(i1: Int): Int {
     return foo<Int>(i1)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(33))
 }

--- a/backend.native/tests/codegen/inline/inline24.kt
+++ b/backend.native/tests/codegen/inline/inline24.kt
@@ -1,8 +1,12 @@
+package codegen.inline.inline24
+
+import kotlin.test.*
+
 fun foo() = println("foo")
 fun bar() = println("bar")
 
 inline fun baz(x: Unit = foo(), y: Unit) {}
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     baz(y = bar())
 }

--- a/backend.native/tests/codegen/inline/inline25.kt
+++ b/backend.native/tests/codegen/inline/inline25.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline25
+
+import kotlin.test.*
+
 inline fun foo(block: String.() -> Unit) {
     "Ok".block()
 }
@@ -10,7 +14,7 @@ inline fun baz(block: String.() -> Unit) {
     block("Ok")
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     bar {
         println(it)
     }

--- a/backend.native/tests/codegen/inline/inline3.kt
+++ b/backend.native/tests/codegen/inline/inline3.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline3
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(i4: Int, i5: Int): Int {
     try {
@@ -11,6 +15,6 @@ fun bar(i1: Int, i2: Int, i3: Int): Int {
     return i1 + foo(i2, i3)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(1, 8, 2).toString())
 }

--- a/backend.native/tests/codegen/inline/inline4.kt
+++ b/backend.native/tests/codegen/inline/inline4.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline4
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(i4: Int, i5: Int): Int {
     if (i4 > 0) return i4
@@ -8,6 +12,6 @@ fun bar(i1: Int, i2: Int): Int {
     return foo(i1, i2)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(3, 8).toString())
 }

--- a/backend.native/tests/codegen/inline/inline5.kt
+++ b/backend.native/tests/codegen/inline/inline5.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline5
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(i2: Int, body: () -> Int): Int {
     return i2 + body()
@@ -7,7 +11,7 @@ fun bar(i1: Int): Int {
     return foo(i1) { return 33 }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(1).toString())
 }
 

--- a/backend.native/tests/codegen/inline/inline6.kt
+++ b/backend.native/tests/codegen/inline/inline6.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline6
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(body: () -> Unit) {
     println("hello1")
@@ -12,6 +16,6 @@ fun bar() {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     bar()
 }

--- a/backend.native/tests/codegen/inline/inline7.kt
+++ b/backend.native/tests/codegen/inline/inline7.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline7
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(vararg args: Int) {
     for (a in args) {
@@ -9,6 +13,6 @@ fun bar() {
     foo(1, 2, 3)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     bar()
 }

--- a/backend.native/tests/codegen/inline/inline8.kt
+++ b/backend.native/tests/codegen/inline/inline8.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline8
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(i3: Int, i4: Int) : Int {
     return i3 + i3 + i4
@@ -7,6 +11,6 @@ fun bar(i1: Int, i2: Int) : Int {
     return foo(i1 + i2, 2)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(1, 2).toString())
 }

--- a/backend.native/tests/codegen/inline/inline9.kt
+++ b/backend.native/tests/codegen/inline/inline9.kt
@@ -1,3 +1,7 @@
+package codegen.inline.inline9
+
+import kotlin.test.*
+
 @Suppress("NOTHING_TO_INLINE")
 inline fun foo(i3: Int, i4: Int): Int {
     return i3 + i3 + i4
@@ -12,6 +16,6 @@ fun bar(i1: Int, i2: Int): Int {
     return foo(quiz(i1), i2)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(bar(1, 2).toString())
 }

--- a/backend.native/tests/codegen/innerClass/doubleInner.kt
+++ b/backend.native/tests/codegen/innerClass/doubleInner.kt
@@ -1,3 +1,7 @@
+package codegen.innerClass.doubleInner
+
+import kotlin.test.*
+
 open class Father(val param: String) {
     abstract inner class InClass {
         fun work(): String {
@@ -16,6 +20,6 @@ fun box(): String {
     return Father("fail").Child("OK").Child2().work()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/innerClass/generic.kt
+++ b/backend.native/tests/codegen/innerClass/generic.kt
@@ -1,3 +1,7 @@
+package codegen.innerClass.generic
+
+import kotlin.test.*
+
 class Outer {
     inner class Inner<T>(val t: T) {
         fun box() = t
@@ -10,6 +14,6 @@ fun box(): String {
     return x.box()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/innerClass/getOuterVal.kt
+++ b/backend.native/tests/codegen/innerClass/getOuterVal.kt
@@ -1,3 +1,7 @@
+package codegen.innerClass.getOuterVal
+
+import kotlin.test.*
+
 class Outer(val s: String) {
     inner class Inner {
         fun box() = s
@@ -6,7 +10,7 @@ class Outer(val s: String) {
 
 fun box() = Outer("OK").Inner().box()
 
-fun main(args: Array<String>)
+@Test fun runTest()
 {
     println(box())
 }

--- a/backend.native/tests/codegen/innerClass/noPrimaryConstructor.kt
+++ b/backend.native/tests/codegen/innerClass/noPrimaryConstructor.kt
@@ -1,3 +1,7 @@
+package codegen.innerClass.noPrimaryConstructor
+
+import kotlin.test.*
+
 class Outer(val s: String) {
     inner class Inner {
         constructor(x: Int) {
@@ -15,7 +19,7 @@ class Outer(val s: String) {
 
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(Outer("OK").Inner(42).foo())
     println(Outer("OK").Inner("zzz").foo())
 }

--- a/backend.native/tests/codegen/innerClass/qualifiedThis.kt
+++ b/backend.native/tests/codegen/innerClass/qualifiedThis.kt
@@ -45,6 +45,6 @@ class A: ABase() { // implicit label @A
 
 fun box() = A().B().bar(D())
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/innerClass/qualifiedThis.kt
+++ b/backend.native/tests/codegen/innerClass/qualifiedThis.kt
@@ -1,3 +1,7 @@
+package codegen.innerClass.qualifiedThis
+
+import kotlin.test.*
+
 open class ABase
 {
     open fun zzz() = "a_base"

--- a/backend.native/tests/codegen/innerClass/secondaryConstructor.kt
+++ b/backend.native/tests/codegen/innerClass/secondaryConstructor.kt
@@ -1,3 +1,7 @@
+package codegen.innerClass.secondaryConstructor
+
+import kotlin.test.*
+
 class Outer(val x: Int) {
     inner class Inner() {
         inner class InnerInner() {

--- a/backend.native/tests/codegen/innerClass/secondaryConstructor.kt
+++ b/backend.native/tests/codegen/innerClass/secondaryConstructor.kt
@@ -19,6 +19,6 @@ class Outer(val x: Int) {
     }
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     Outer(42).Inner().InnerInner("zzz")
 }

--- a/backend.native/tests/codegen/innerClass/simple.kt
+++ b/backend.native/tests/codegen/innerClass/simple.kt
@@ -1,3 +1,7 @@
+package codegen.innerClass.simple
+
+import kotlin.test.*
+
 class Outer {
     inner class Inner {
         fun box() = "OK"
@@ -6,7 +10,7 @@ class Outer {
 
 fun box() = Outer().Inner().box()
 
-fun main(args: Array<String>)
+@Test fun runTest()
 {
     println(box())
 }

--- a/backend.native/tests/codegen/innerClass/superOuter.kt
+++ b/backend.native/tests/codegen/innerClass/superOuter.kt
@@ -12,6 +12,6 @@ open class Outer(val outer: String) {
 
 fun box() = Outer("Fail").value()
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/innerClass/superOuter.kt
+++ b/backend.native/tests/codegen/innerClass/superOuter.kt
@@ -1,3 +1,7 @@
+package codegen.innerClass.superOuter
+
+import kotlin.test.*
+
 open class Outer(val outer: String) {
     open inner class Inner(val inner: String): Outer(inner) {
         fun foo() = outer

--- a/backend.native/tests/codegen/kclass/kclass0.kt
+++ b/backend.native/tests/codegen/kclass/kclass0.kt
@@ -1,7 +1,10 @@
+package codegen.kclass.kclass0
+
+import kotlin.test.*
 import kotlin.reflect.KClass
 
 @Test fun runTest() {
-    main(emptyArray())
+    main(emptyArray<String>())
 }
 
 fun main(args: Array<String>) {

--- a/backend.native/tests/codegen/kclass/kclass0.kt
+++ b/backend.native/tests/codegen/kclass/kclass0.kt
@@ -11,8 +11,8 @@ fun main(args: Array<String>) {
     checkClass(Any::class, "kotlin.Any", "Any", Any(), null)
     checkClass(Int::class, "kotlin.Int", "Int", 42, "17")
     checkClass(String::class, "kotlin.String", "String", "17", 42)
-    checkClass(RootClass::class, "RootClass", "RootClass", RootClass(), Any())
-    checkClass(RootClass.Nested::class, "RootClass.Nested", "Nested", RootClass.Nested(), Any())
+    checkClass(RootClass::class, "codegen.kclass.kclass0.RootClass", "RootClass", RootClass(), Any())
+    checkClass(RootClass.Nested::class, "codegen.kclass.kclass0.RootClass.Nested", "Nested", RootClass.Nested(), Any())
 
     class Local {
         val captured = args
@@ -33,7 +33,7 @@ fun main(args: Array<String>) {
 
     // Interfaces:
     checkClass(Comparable::class, "kotlin.Comparable", "Comparable", 42, Any())
-    checkClass(Interface::class, "Interface", "Interface", object : Interface {}, Any())
+    checkClass(Interface::class, "codegen.kclass.kclass0.Interface", "Interface", object : Interface {}, Any())
 
     checkInstanceClass(Any(), Any::class)
     checkInstanceClass(42, Int::class)

--- a/backend.native/tests/codegen/kclass/kclass0.kt
+++ b/backend.native/tests/codegen/kclass/kclass0.kt
@@ -1,5 +1,9 @@
 import kotlin.reflect.KClass
 
+@Test fun runTest() {
+    main(emptyArray())
+}
+
 fun main(args: Array<String>) {
     checkClass(Any::class, "kotlin.Any", "Any", Any(), null)
     checkClass(Int::class, "kotlin.Int", "Int", 42, "17")

--- a/backend.native/tests/codegen/kclass/kclass1.kt
+++ b/backend.native/tests/codegen/kclass/kclass1.kt
@@ -40,9 +40,9 @@ class App(testQualified: Boolean) {
     }
 
     init {
-        assert(type.simpleName == "Test")
+        assert(type.simpleName == "TestClass")
         if (testQualified)
-            assert(type.qualifiedName == "com.github.salomonbrys.kmffkn.Test") // This is not really necessary, but always better :).
+            assert(type.qualifiedName == "codegen.kclass.kclass1.TestClass") // This is not really necessary, but always better :).
 
         assert(String::class == String::class)
         assert(String::class != Int::class)

--- a/backend.native/tests/codegen/kclass/kclass1.kt
+++ b/backend.native/tests/codegen/kclass/kclass1.kt
@@ -1,14 +1,16 @@
+package codegen.kclass.kclass1
+
+import kotlin.test.*
+
 // FILE: main.kt
-fun main(args: Array<String>) {
-    com.github.salomonbrys.kmffkn.App(testQualified = true)
+@Test fun runTest() {
+    App(testQualified = true)
 }
 
 // FILE: app.kt
 
 // Taken from:
 // https://github.com/SalomonBrys/kmffkn/blob/master/shared/main/kotlin/com/github/salomonbrys/kmffkn/app.kt
-
-package com.github.salomonbrys.kmffkn
 
 @DslMarker
 annotation class MyDsl
@@ -25,7 +27,7 @@ class KClassDsl {
 
 fun <T: Any> dsl(block: DslMain.() -> T): T = DslMain().block()
 
-class Test
+class TestClass
 
 class App(testQualified: Boolean) {
 
@@ -33,7 +35,7 @@ class App(testQualified: Boolean) {
     var type = dsl {
         kClass {
             //kClass {  } // This should error if uncommented because of `@DslMarker`.
-            of<Test>()
+            of<TestClass>()
         }
     }
 
@@ -45,8 +47,8 @@ class App(testQualified: Boolean) {
         assert(String::class == String::class)
         assert(String::class != Int::class)
 
-        assert(Test()::class == Test()::class)
-        assert(Test()::class == Test::class)
+        assert(TestClass()::class == TestClass()::class)
+        assert(TestClass()::class == TestClass::class)
 
         println("OK :D")
     }

--- a/backend.native/tests/codegen/lambda/lambda1.kt
+++ b/backend.native/tests/codegen/lambda/lambda1.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     run {
         println("lambda")
     }

--- a/backend.native/tests/codegen/lambda/lambda10.kt
+++ b/backend.native/tests/codegen/lambda/lambda10.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda10
+
+import kotlin.test.*
+
+@Test fun runTest() {
     var str = "original"
 
     val lambda = {

--- a/backend.native/tests/codegen/lambda/lambda11.kt
+++ b/backend.native/tests/codegen/lambda/lambda11.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda11
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val first = "first"
     val second = "second"
 

--- a/backend.native/tests/codegen/lambda/lambda12.kt
+++ b/backend.native/tests/codegen/lambda/lambda12.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda12
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val lambda = { s1: String, s2: String ->
         println(s1)
         println(s2)

--- a/backend.native/tests/codegen/lambda/lambda13.kt
+++ b/backend.native/tests/codegen/lambda/lambda13.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.lambda.lambda13
+
+import kotlin.test.*
+
+@Test fun runTest() {
     apply("foo") {
         println(this)
     }

--- a/backend.native/tests/codegen/lambda/lambda2.kt
+++ b/backend.native/tests/codegen/lambda/lambda2.kt
@@ -1,3 +1,11 @@
+package codegen.lambda.lambda2
+
+import kotlin.test.*
+
+@Test fun runTest() {
+    main(arrayOf("arg0"))
+}
+
 fun main(args : Array<String>) {
     run {
         println(args[0])

--- a/backend.native/tests/codegen/lambda/lambda3.kt
+++ b/backend.native/tests/codegen/lambda/lambda3.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda3
+
+import kotlin.test.*
+
+@Test fun runTest() {
     var str = "lambda"
     run {
         println(str)

--- a/backend.native/tests/codegen/lambda/lambda4.kt
+++ b/backend.native/tests/codegen/lambda/lambda4.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda4
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val lambda = bar()
     lambda()
     lambda()

--- a/backend.native/tests/codegen/lambda/lambda5.kt
+++ b/backend.native/tests/codegen/lambda/lambda5.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda5
+
+import kotlin.test.*
+
+@Test fun runTest() {
     foo {
         println(it)
     }

--- a/backend.native/tests/codegen/lambda/lambda6.kt
+++ b/backend.native/tests/codegen/lambda/lambda6.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda6
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val str = "captured"
     foo {
         println(it)

--- a/backend.native/tests/codegen/lambda/lambda7.kt
+++ b/backend.native/tests/codegen/lambda/lambda7.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda7
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val x = foo {
         it + 1
     }

--- a/backend.native/tests/codegen/lambda/lambda8.kt
+++ b/backend.native/tests/codegen/lambda/lambda8.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda8
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val lambda1 = bar("first")
     val lambda2 = bar("second")
 

--- a/backend.native/tests/codegen/lambda/lambda9.kt
+++ b/backend.native/tests/codegen/lambda/lambda9.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.lambda.lambda9
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val lambdas = ArrayList<() -> Unit>()
 
     for (i in 0..1) {

--- a/backend.native/tests/codegen/lateinit/inBaseClass.kt
+++ b/backend.native/tests/codegen/lateinit/inBaseClass.kt
@@ -1,3 +1,7 @@
+package codegen.lateinit.inBaseClass
+
+import kotlin.test.*
+
 class A(val a: Int)
 
 open class B {
@@ -8,7 +12,7 @@ class C: B() {
     fun foo() { a = A(42) }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val c = C()
     c.foo()
     println(c.a.a)

--- a/backend.native/tests/codegen/lateinit/initialized.kt
+++ b/backend.native/tests/codegen/lateinit/initialized.kt
@@ -1,10 +1,14 @@
+package codegen.lateinit.initialized
+
+import kotlin.test.*
+
 class A {
     lateinit var s: String
 
     fun foo() = s
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val a = A()
     a.s = "zzz"
     println(a.foo())

--- a/backend.native/tests/codegen/lateinit/notInitialized.kt
+++ b/backend.native/tests/codegen/lateinit/notInitialized.kt
@@ -1,10 +1,14 @@
+package codegen.lateinit.notInitialized
+
+import kotlin.test.*
+
 class A {
     lateinit var s: String
 
     fun foo() = s
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val a = A()
     try {
         println(a.foo())

--- a/backend.native/tests/codegen/localClass/innerTakesCapturedFromOuter.kt
+++ b/backend.native/tests/codegen/localClass/innerTakesCapturedFromOuter.kt
@@ -1,3 +1,7 @@
+package codegen.localClass.innerTakesCapturedFromOuter
+
+import kotlin.test.*
+
 fun box() {
     var previous: Any? = null
     for (i in 0 .. 2) {
@@ -13,6 +17,6 @@ fun box() {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     box()
 }

--- a/backend.native/tests/codegen/localClass/innerWithCapture.kt
+++ b/backend.native/tests/codegen/localClass/innerWithCapture.kt
@@ -1,3 +1,7 @@
+package codegen.localClass.innerWithCapture
+
+import kotlin.test.*
+
 fun box(s: String): String {
     class Local {
         open inner class Inner() {
@@ -8,6 +12,6 @@ fun box(s: String): String {
     return Local().Inner().result()
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     println(box("OK"))
 }

--- a/backend.native/tests/codegen/localClass/localFunctionCallFromLocalClass.kt
+++ b/backend.native/tests/codegen/localClass/localFunctionCallFromLocalClass.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.localClass.localFunctionCallFromLocalClass
+
+import kotlin.test.*
+
+@Test fun runTest() {
     var x = 1
     fun local1() {
         x++

--- a/backend.native/tests/codegen/localClass/localFunctionInLocalClass.kt
+++ b/backend.native/tests/codegen/localClass/localFunctionInLocalClass.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.localClass.localFunctionInLocalClass
+
+import kotlin.test.*
+
+@Test fun runTest() {
     var x = 0
     class A {
         fun bar() {

--- a/backend.native/tests/codegen/localClass/localHierarchy.kt
+++ b/backend.native/tests/codegen/localClass/localHierarchy.kt
@@ -1,3 +1,7 @@
+package codegen.localClass.localHierarchy
+
+import kotlin.test.*
+
 fun foo(s: String): String {
     open class Local {
         fun f() = s
@@ -10,6 +14,6 @@ fun foo(s: String): String {
     return Derived().g()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(foo("OK"))
 }

--- a/backend.native/tests/codegen/localClass/noPrimaryConstructor.kt
+++ b/backend.native/tests/codegen/localClass/noPrimaryConstructor.kt
@@ -1,3 +1,7 @@
+package codegen.localClass.noPrimaryConstructor
+
+import kotlin.test.*
+
 fun box(s: String): String {
     class Local {
         constructor(x: Int) {
@@ -16,6 +20,6 @@ fun box(s: String): String {
     return Local(42).result() + Local("zzz").result()
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     println(box("OK"))
 }

--- a/backend.native/tests/codegen/localClass/objectExpressionInInitializer.kt
+++ b/backend.native/tests/codegen/localClass/objectExpressionInInitializer.kt
@@ -1,3 +1,7 @@
+package codegen.localClass.objectExpressionInInitializer
+
+import kotlin.test.*
+
 abstract class Father {
     abstract inner class InClass {
         abstract fun work(): String
@@ -20,6 +24,6 @@ fun box(): String {
     return Child().ChildInClass.work()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/localClass/objectExpressionInProperty.kt
+++ b/backend.native/tests/codegen/localClass/objectExpressionInProperty.kt
@@ -1,3 +1,7 @@
+package codegen.localClass.objectExpressionInProperty
+
+import kotlin.test.*
+
 abstract class Father {
     abstract inner class InClass {
         abstract fun work(): String
@@ -16,6 +20,6 @@ fun box(): String {
     return Child().ChildInClass.work()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/localClass/tryCatch.kt
+++ b/backend.native/tests/codegen/localClass/tryCatch.kt
@@ -1,3 +1,7 @@
+package codegen.localClass.tryCatch
+
+import kotlin.test.*
+
 private fun foo() {
     val local =
             object {
@@ -11,6 +15,6 @@ private fun foo() {
     local.bar()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo()
 }

--- a/backend.native/tests/codegen/localClass/virtualCallFromConstructor.kt
+++ b/backend.native/tests/codegen/localClass/virtualCallFromConstructor.kt
@@ -1,3 +1,7 @@
+package codegen.localClass.virtualCallFromConstructor
+
+import kotlin.test.*
+
 abstract class WaitFor {
     init {
         condition()
@@ -20,6 +24,6 @@ fun box(): String {
     return result;
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(box())
 }

--- a/backend.native/tests/codegen/object/constructor.kt
+++ b/backend.native/tests/codegen/object/constructor.kt
@@ -1,3 +1,5 @@
+package codegen.`object`.constructor
+
 class A()
 
 class B(val a:Int)

--- a/backend.native/tests/codegen/object/constructor0.kt
+++ b/backend.native/tests/codegen/object/constructor0.kt
@@ -1,3 +1,7 @@
+package codegen.`object`.constructor0
+
+import kotlin.test.*
+
 class A {
     var field0:Int = 0;
     constructor(arg0:Int) {

--- a/backend.native/tests/codegen/object/fields.kt
+++ b/backend.native/tests/codegen/object/fields.kt
@@ -1,3 +1,7 @@
+package codegen.`object`.fields
+
+import kotlin.test.*
+
 private var globalValue = 1
 var global:Int
     get() = globalValue
@@ -9,7 +13,7 @@ fun globalTest(i:Int):Int {
 }
 
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
     if (global != 1)          throw Error()
     if (globalTest(41) != 42) throw Error()
     if (global != 42)         throw Error()

--- a/backend.native/tests/codegen/object/fields1.kt
+++ b/backend.native/tests/codegen/object/fields1.kt
@@ -1,3 +1,7 @@
+package codegen.`object`.fields1
+
+import kotlin.test.*
+
 class B(val a:Int, b:Int) {
     constructor(pos:Int):this(1, pos) {}
     val pos = b + 1
@@ -7,7 +11,7 @@ fun primaryConstructorCall(a:Int, b:Int) = B(a, b).pos
 
 fun secondaryConstructorCall(a:Int) = B(a).pos
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
     if (primaryConstructorCall(0xdeadbeef.toInt(), 41) != 42) throw Error()
     if (secondaryConstructorCall(41)                   != 42) throw Error()
 }

--- a/backend.native/tests/codegen/object/fields2.kt
+++ b/backend.native/tests/codegen/object/fields2.kt
@@ -1,3 +1,7 @@
+package codegen.`object`.fields2
+
+import kotlin.test.*
+
 var global: Int = 0
     get() {
         println("Get global = $field")
@@ -8,7 +12,7 @@ var global: Int = 0
         field = value
     }
 
-class Test {
+class TestClass {
     var member: Int = 0
         get() {
             println("Get member = $field")
@@ -20,10 +24,10 @@ class Test {
         }
 }
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
     global = 1
 
-    val test = Test()
+    val test = TestClass()
     test.member = 42
 
     global = test.member

--- a/backend.native/tests/codegen/object/init0.kt
+++ b/backend.native/tests/codegen/object/init0.kt
@@ -1,3 +1,7 @@
+package codegen.`object`.init0
+
+import kotlin.test.*
+
 class A(a:Int) {
   var i:Int = 0
   init {

--- a/backend.native/tests/codegen/object/initialization.kt
+++ b/backend.native/tests/codegen/object/initialization.kt
@@ -1,3 +1,7 @@
+package codegen.`object`.initialization
+
+import kotlin.test.*
+
 open class A(val a:Int, val b:Int)
 
 open class B(val c:Int, d:Int):A(c, d)
@@ -19,6 +23,6 @@ fun foo(i:Int, j:Int):Int {
    return c.c
 }
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
    if (foo(2, 3) != 5) throw Error()
 }

--- a/backend.native/tests/codegen/object/initialization1.kt
+++ b/backend.native/tests/codegen/object/initialization1.kt
@@ -1,4 +1,8 @@
-class Test {
+package codegen.`object`.initialization1
+
+import kotlin.test.*
+
+class TestClass {
     constructor() {
         println("constructor1")
     }
@@ -14,7 +18,7 @@ class Test {
     val f = println("field")
 }
 
-fun main(args: Array<String>) {
-    Test()
-    Test(1)
+@Test fun runTest() {
+    TestClass()
+    TestClass(1)
 }

--- a/backend.native/tests/codegen/object/method_call.kt
+++ b/backend.native/tests/codegen/object/method_call.kt
@@ -1,9 +1,13 @@
+package codegen.`object`.method_call
+
+import kotlin.test.*
+
 class A(val a:Int) {
   fun foo(i:Int) = a + i
 }
 
 fun fortyTwo() = A(41).foo(1)
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
   if (fortyTwo() != 42) throw Error()
 }

--- a/backend.native/tests/codegen/objectExpression/1.kt
+++ b/backend.native/tests/codegen/objectExpression/1.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.objectExpression_1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val a = "a"
 
     val x = object {

--- a/backend.native/tests/codegen/objectExpression/2.kt
+++ b/backend.native/tests/codegen/objectExpression/2.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.objectExpression_2
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val a = "a"
 
     val x = object {

--- a/backend.native/tests/codegen/objectExpression/3.kt
+++ b/backend.native/tests/codegen/objectExpression/3.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package codegen.objectExpression_3
+
+import kotlin.test.*
+
+@Test fun runTest() {
     var cnt = 0
 
     var x: Any = ""

--- a/backend.native/tests/codegen/objectExpression/expr1.kt
+++ b/backend.native/tests/codegen/objectExpression/expr1.kt
@@ -1,4 +1,4 @@
-package codegen.objectExpression_1
+package codegen.objectExpression.expr1
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/objectExpression/expr2.kt
+++ b/backend.native/tests/codegen/objectExpression/expr2.kt
@@ -1,5 +1,4 @@
-package codegen.objectExpression_2
-
+package codegen.objectExpression.expr2
 import kotlin.test.*
 
 @Test fun runTest() {

--- a/backend.native/tests/codegen/objectExpression/expr3.kt
+++ b/backend.native/tests/codegen/objectExpression/expr3.kt
@@ -1,4 +1,4 @@
-package codegen.objectExpression_3
+package codegen.objectExpression.expr3
 
 import kotlin.test.*
 

--- a/backend.native/tests/codegen/propertyCallableReference/dynamicReceiver.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/dynamicReceiver.kt
@@ -1,12 +1,16 @@
-class Test {
+package codegen.propertyCallableReference.dynamicReceiver
+
+import kotlin.test.*
+
+class TestClass {
     var x: Int = 42
 }
 
-fun foo(): Test {
+fun foo(): TestClass {
     println(42)
-    return Test()
+    return TestClass()
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     foo()::x
 }

--- a/backend.native/tests/codegen/propertyCallableReference/linkTest_lib.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/linkTest_lib.kt
@@ -1,3 +1,3 @@
-package a
+package codegen.propertyCallableReference.linkTest.a
 
 class A(val x: Int)

--- a/backend.native/tests/codegen/propertyCallableReference/linkTest_lib.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/linkTest_lib.kt
@@ -1,3 +1,3 @@
-package codegen.propertyCallableReference.linkTest.a
+package a
 
 class A(val x: Int)

--- a/backend.native/tests/codegen/propertyCallableReference/linkTest_main.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/linkTest_main.kt
@@ -1,6 +1,10 @@
-import a.A
+package codegen.propertyCallableReference.linkTest_main
 
-fun main(args: Array<String>) {
+import kotlin.test.*
+
+import codegen.propertyCallableReference.linkTest.a.A
+
+@Test fun runTest() {
     val p1 = A::x
     println(p1.get(A(42)))
     val a = A(117)

--- a/backend.native/tests/codegen/propertyCallableReference/linkTest_main.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/linkTest_main.kt
@@ -1,10 +1,6 @@
-package codegen.propertyCallableReference.linkTest_main
+import a.A
 
-import kotlin.test.*
-
-import codegen.propertyCallableReference.linkTest.a.A
-
-@Test fun runTest() {
+fun main(args: Array<String>) {
     val p1 = A::x
     println(p1.get(A(42)))
     val a = A(117)

--- a/backend.native/tests/codegen/propertyCallableReference/valClass.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/valClass.kt
@@ -1,6 +1,10 @@
+package codegen.propertyCallableReference.valClass
+
+import kotlin.test.*
+
 class A(val x: Int)
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val p1 = A::x
     println(p1.get(A(42)))
     val a = A(117)

--- a/backend.native/tests/codegen/propertyCallableReference/valExtension.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/valExtension.kt
@@ -1,10 +1,14 @@
+package codegen.propertyCallableReference.valExtension
+
+import kotlin.test.*
+
 class A(y: Int) {
     var x = y
 }
 
 val A.z get() = this.x
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val p1 = A::z
     println(p1.get(A(42)))
     val a = A(117)

--- a/backend.native/tests/codegen/propertyCallableReference/valModule.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/valModule.kt
@@ -1,6 +1,10 @@
+package codegen.propertyCallableReference.valModule
+
+import kotlin.test.*
+
 val x = 42
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val p = ::x
     println(p.get())
 }

--- a/backend.native/tests/codegen/propertyCallableReference/varClass.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/varClass.kt
@@ -1,6 +1,10 @@
+package codegen.propertyCallableReference.varClass
+
+import kotlin.test.*
+
 class A(var x: Int)
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val p1 = A::x
     val a = A(42)
     p1.set(a, 117)

--- a/backend.native/tests/codegen/propertyCallableReference/varExtension.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/varExtension.kt
@@ -1,3 +1,7 @@
+package codegen.propertyCallableReference.varExtension
+
+import kotlin.test.*
+
 class A(y: Int) {
     var x = y
 }
@@ -8,7 +12,7 @@ var A.z: Int
         this.x = value
     }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val p1 = A::z
     val a = A(42)
     p1.set(a, 117)

--- a/backend.native/tests/codegen/propertyCallableReference/varModule.kt
+++ b/backend.native/tests/codegen/propertyCallableReference/varModule.kt
@@ -1,6 +1,10 @@
+package codegen.propertyCallableReference.varModule
+
+import kotlin.test.*
+
 var x = 42
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val p = ::x
     p.set(117)
     println(x)

--- a/backend.native/tests/codegen/try/catch3.kt
+++ b/backend.native/tests/codegen/try/catch3.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.catch3
+
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         println("Before")
         throw Error("Error happens")

--- a/backend.native/tests/codegen/try/catch4.kt
+++ b/backend.native/tests/codegen/try/catch4.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.catch4
+
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         println("Before")
         throw Error("Error happens")

--- a/backend.native/tests/codegen/try/catch5.kt
+++ b/backend.native/tests/codegen/try/catch5.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.catch5
+
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         try {
             println("Before")

--- a/backend.native/tests/codegen/try/catch6.kt
+++ b/backend.native/tests/codegen/try/catch6.kt
@@ -1,5 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.catch6
 
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         println("Before")
         foo()

--- a/backend.native/tests/codegen/try/catch8.kt
+++ b/backend.native/tests/codegen/try/catch8.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.catch8
+
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         throw Error("Error happens")
     } catch (e: Throwable) {

--- a/backend.native/tests/codegen/try/finally1.kt
+++ b/backend.native/tests/codegen/try/finally1.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally1
+
+import kotlin.test.*
+
+@Test fun runTest() {
 
     try {
         println("Try")

--- a/backend.native/tests/codegen/try/finally10.kt
+++ b/backend.native/tests/codegen/try/finally10.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally10
+
+import kotlin.test.*
+
+@Test fun runTest() {
     while (true) {
         try {
             continue

--- a/backend.native/tests/codegen/try/finally11.kt
+++ b/backend.native/tests/codegen/try/finally11.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally11
+
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         try {
             return

--- a/backend.native/tests/codegen/try/finally2.kt
+++ b/backend.native/tests/codegen/try/finally2.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally2
+
+import kotlin.test.*
+
+@Test fun runTest() {
 
     try {
         println("Try")

--- a/backend.native/tests/codegen/try/finally3.kt
+++ b/backend.native/tests/codegen/try/finally3.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally3
+
+import kotlin.test.*
+
+@Test fun runTest() {
 
     try {
         try {

--- a/backend.native/tests/codegen/try/finally4.kt
+++ b/backend.native/tests/codegen/try/finally4.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally4
+
+import kotlin.test.*
+
+@Test fun runTest() {
 
     try {
         try {

--- a/backend.native/tests/codegen/try/finally5.kt
+++ b/backend.native/tests/codegen/try/finally5.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally5
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(foo())
 }
 

--- a/backend.native/tests/codegen/try/finally6.kt
+++ b/backend.native/tests/codegen/try/finally6.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally6
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(foo())
 }
 

--- a/backend.native/tests/codegen/try/finally7.kt
+++ b/backend.native/tests/codegen/try/finally7.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally7
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(foo())
 }
 

--- a/backend.native/tests/codegen/try/finally8.kt
+++ b/backend.native/tests/codegen/try/finally8.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally8
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(foo())
 }
 

--- a/backend.native/tests/codegen/try/finally9.kt
+++ b/backend.native/tests/codegen/try/finally9.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.finally9
+
+import kotlin.test.*
+
+@Test fun runTest() {
     do {
         try {
             break

--- a/backend.native/tests/codegen/try/try1.kt
+++ b/backend.native/tests/codegen/try/try1.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.try1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val x = try {
         5
     } catch (e: Throwable) {

--- a/backend.native/tests/codegen/try/try2.kt
+++ b/backend.native/tests/codegen/try/try2.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.try2
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val x = try {
         throw Error()
         5

--- a/backend.native/tests/codegen/try/try3.kt
+++ b/backend.native/tests/codegen/try/try3.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.try3
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val x = try {
         throw Error()
     } catch (e: Throwable) {

--- a/backend.native/tests/codegen/try/try4.kt
+++ b/backend.native/tests/codegen/try/try4.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package codegen.`try`.try4
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val x = try {
         println("Try")
         5

--- a/backend.native/tests/datagen/literals/empty_string.kt
+++ b/backend.native/tests/datagen/literals/empty_string.kt
@@ -1,3 +1,7 @@
-fun main(args : Array<String>) {
+package datagen.literals.empty_string
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println("")
 }

--- a/backend.native/tests/datagen/literals/listof1.kt
+++ b/backend.native/tests/datagen/literals/listof1.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package datagen.literals.listof1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val list = foo()
     println(list === foo())
     println(list.toString())

--- a/backend.native/tests/datagen/literals/strdedup1.kt
+++ b/backend.native/tests/datagen/literals/strdedup1.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package datagen.literals.strdedup1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val str1 = "Hello"
     val str2 = "Hello"
     println(str1 == str2)

--- a/backend.native/tests/datagen/literals/strdedup2.kt
+++ b/backend.native/tests/datagen/literals/strdedup2.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package datagen.literals.strdedup2
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val str1 = ""
     val str2 = "hello".subSequence(2, 2)
     println(str1 == str2)

--- a/backend.native/tests/datagen/rtti/abstract_super.kt
+++ b/backend.native/tests/datagen/rtti/abstract_super.kt
@@ -1,8 +1,12 @@
+package datagen.rtti.abstract_super
+
+import kotlin.test.*
+
 abstract class Super
 
 class Foo : Super()
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     // This test now checks that the source can be successfully compiled and linked;
     // TODO: check the contents of TypeInfo?
 }

--- a/backend.native/tests/datagen/rtti/vtable1.kt
+++ b/backend.native/tests/datagen/rtti/vtable1.kt
@@ -1,3 +1,7 @@
+package datagen.rtti.vtable1
+
+import kotlin.test.*
+
 abstract class Super {
     abstract fun bar()
 }
@@ -6,7 +10,7 @@ class Foo : Super() {
     final override fun bar() {}
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     // This test now checks that the source can be successfully compiled and linked;
     // TODO: check the contents of TypeInfo?
 }

--- a/backend.native/tests/lower/tailrec.kt
+++ b/backend.native/tests/lower/tailrec.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package lower.tailrec
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(add(5, 7))
     println(add(100000000, 0))
 

--- a/backend.native/tests/lower/vararg.kt
+++ b/backend.native/tests/lower/vararg.kt
@@ -1,6 +1,10 @@
+package lower.vararg
+
+import kotlin.test.*
+
 fun foo(vararg x: Any?) {}
 fun bar() = foo()
 
-fun main(arg:Array<String>) {
+@Test fun runTest() {
   bar()
 }

--- a/backend.native/tests/lower/vararg_of_literals.kt
+++ b/backend.native/tests/lower/vararg_of_literals.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package lower.vararg_of_literals
+
+import kotlin.test.*
+
+@Test fun runTest() {
     foo()
     foo()
 }

--- a/backend.native/tests/mangling/mangling.kt
+++ b/backend.native/tests/mangling/mangling.kt
@@ -1,3 +1,7 @@
+package mangling.mangling
+
+import kotlin.test.*
+
 fun test_direct() {
     val mutListInt = mutableListOf<Int>(1, 2, 3, 4)
     val mutListNum = mutableListOf<Number>(9, 10, 11, 12)
@@ -28,7 +32,7 @@ fun test_multiple_constructors() {
     mangle3(number)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     test_direct()
     test_param()
     test_multiple_constructors()

--- a/backend.native/tests/mangling/mangling.kt
+++ b/backend.native/tests/mangling/mangling.kt
@@ -1,7 +1,3 @@
-package mangling.mangling
-
-import kotlin.test.*
-
 fun test_direct() {
     val mutListInt = mutableListOf<Int>(1, 2, 3, 4)
     val mutListNum = mutableListOf<Number>(9, 10, 11, 12)
@@ -32,7 +28,7 @@ fun test_multiple_constructors() {
     mangle3(number)
 }
 
-@Test fun runTest() {
+fun main(args: Array<String>) {
     test_direct()
     test_param()
     test_multiple_constructors()

--- a/backend.native/tests/mangling/manglinglib.kt
+++ b/backend.native/tests/mangling/manglinglib.kt
@@ -1,5 +1,3 @@
-package mangling.mangling
-
 public fun mangle1(l: List<Int>) {
     println("Int direct $l")
 }

--- a/backend.native/tests/mangling/manglinglib.kt
+++ b/backend.native/tests/mangling/manglinglib.kt
@@ -1,3 +1,5 @@
+package mangling.mangling
+
 public fun mangle1(l: List<Int>) {
     println("Int direct $l")
 }

--- a/backend.native/tests/runtime/basic/driver0.kt
+++ b/backend.native/tests/runtime/basic/driver0.kt
@@ -1,0 +1,4 @@
+// TODO: remove kotlin_native.io once overrides are in place.
+fun main(args : Array<String>) {
+    println("Hello, world!")
+}

--- a/backend.native/tests/runtime/basic/empty_substring.kt
+++ b/backend.native/tests/runtime/basic/empty_substring.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.empty_substring
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val hello = "Hello world"
     println(hello.subSequence(1, 1).toString())
 }

--- a/backend.native/tests/runtime/basic/entry0.kt
+++ b/backend.native/tests/runtime/basic/entry0.kt
@@ -1,4 +1,4 @@
-package koko.lala
+package runtime.basic.entry0
 
 fun fail() {
     println("Test failed, this is a wrong main() function.")

--- a/backend.native/tests/runtime/basic/entry1.kt
+++ b/backend.native/tests/runtime/basic/entry1.kt
@@ -1,5 +1,3 @@
-package runtime.basic.entry1
-
 fun fail() {
     println("Test failed, this is a wrong main() function.")
 }

--- a/backend.native/tests/runtime/basic/entry1.kt
+++ b/backend.native/tests/runtime/basic/entry1.kt
@@ -1,3 +1,5 @@
+package runtime.basic.entry1
+
 fun fail() {
     println("Test failed, this is a wrong main() function.")
 }

--- a/backend.native/tests/runtime/basic/entry2.kt
+++ b/backend.native/tests/runtime/basic/entry2.kt
@@ -1,5 +1,3 @@
-package runtime.basic.entry2
-
 fun main(args: Array<String>) {
     fail()
 }

--- a/backend.native/tests/runtime/basic/entry2.kt
+++ b/backend.native/tests/runtime/basic/entry2.kt
@@ -1,3 +1,5 @@
+package runtime.basic.entry2
+
 fun main(args: Array<String>) {
     fail()
 }

--- a/backend.native/tests/runtime/basic/for0.kt
+++ b/backend.native/tests/runtime/basic/for0.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.for0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val byteArray = ByteArray(3)
     byteArray[0] = 2
     byteArray[1] = 3

--- a/backend.native/tests/runtime/basic/hash0.kt
+++ b/backend.native/tests/runtime/basic/hash0.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.hash0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(239.hashCode())
     println((-1L).hashCode())
     println('a'.hashCode())

--- a/backend.native/tests/runtime/basic/hello0.kt
+++ b/backend.native/tests/runtime/basic/hello0.kt
@@ -1,3 +1,7 @@
-fun main(args : Array<String>) {
+package runtime.basic.hello0
+
+import kotlin.test.*
+
+@Test fun runTest() {
   println("Hello, world!")
 }

--- a/backend.native/tests/runtime/basic/hello1.kt
+++ b/backend.native/tests/runtime/basic/hello1.kt
@@ -1,3 +1,4 @@
+// TODO: TestRuner should be able to pass input to stdin
 // TODO: remove kotlin_native.io once overrides are in place.
 fun main(args : Array<String>) {
   print(readLine().toString())

--- a/backend.native/tests/runtime/basic/hello2.kt
+++ b/backend.native/tests/runtime/basic/hello2.kt
@@ -1,3 +1,4 @@
+// TODO: TestRuner should be able to pass input to stdin
 // TODO: remove kotlin_native.io once overrides are in place.
 fun main(args : Array<String>) {
   print("you entered '" + readLine() + "'")

--- a/backend.native/tests/runtime/basic/hello3.kt
+++ b/backend.native/tests/runtime/basic/hello3.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.hello3
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(239)
     // TODO: enable, once override by name is implemented.
     println(true)

--- a/backend.native/tests/runtime/basic/hello4.kt
+++ b/backend.native/tests/runtime/basic/hello4.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.hello4
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val x = 2
     println(if (x == 2) "Hello" else "Привет")
     println(if (x == 3) "Bye" else "Пока")

--- a/backend.native/tests/runtime/basic/initializers0.kt
+++ b/backend.native/tests/runtime/basic/initializers0.kt
@@ -1,3 +1,7 @@
+package runtime.basic.initializers0
+
+import kotlin.test.*
+
 class A {
     init{
         println ("A::init")
@@ -25,7 +29,7 @@ class A {
     }
 }
 
-fun main(args:Array<String>) {
+@Test fun runTest() {
     println("main")
     A.foo()
     A.foo()

--- a/backend.native/tests/runtime/basic/initializers1.kt
+++ b/backend.native/tests/runtime/basic/initializers1.kt
@@ -1,4 +1,8 @@
-class Test {
+package runtime.basic.initializers1
+
+import kotlin.test.*
+
+class TestClass {
     companion object {
         init {
             println("Init Test")
@@ -6,8 +10,8 @@ class Test {
     }
 }
 
-fun main(args : Array<String>) {
-    val t1 = Test()
-    val t2 = Test()
+@Test fun runTest() {
+    val t1 = TestClass()
+    val t2 = TestClass()
     println("Done")
 }

--- a/backend.native/tests/runtime/basic/initializers2.kt
+++ b/backend.native/tests/runtime/basic/initializers2.kt
@@ -1,7 +1,3 @@
-package runtime.basic.initializers2
-
-import kotlin.test.*
-
 class A(val msg: String) {
     init {
         println("init $msg")
@@ -13,7 +9,7 @@ val globalValue1 = 1
 val globalValue2 = A("globalValue2")
 val globalValue3 = A("globalValue3")
 
-@Test fun runTest() {
+fun main(args: Array<String>) {
     println(globalValue1.toString())
     println(globalValue2.toString())
     println(globalValue3.toString())

--- a/backend.native/tests/runtime/basic/initializers2.kt
+++ b/backend.native/tests/runtime/basic/initializers2.kt
@@ -1,3 +1,7 @@
+package runtime.basic.initializers2
+
+import kotlin.test.*
+
 class A(val msg: String) {
     init {
         println("init $msg")
@@ -9,7 +13,7 @@ val globalValue1 = 1
 val globalValue2 = A("globalValue2")
 val globalValue3 = A("globalValue3")
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(globalValue1.toString())
     println(globalValue2.toString())
     println(globalValue3.toString())

--- a/backend.native/tests/runtime/basic/initializers3.kt
+++ b/backend.native/tests/runtime/basic/initializers3.kt
@@ -1,7 +1,11 @@
+package runtime.basic.initializers3
+
+import kotlin.test.*
+
 class Foo(val bar: Int)
 
 var x = Foo(42)
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(x.bar)
 }

--- a/backend.native/tests/runtime/basic/initializers4.kt
+++ b/backend.native/tests/runtime/basic/initializers4.kt
@@ -1,7 +1,11 @@
+package runtime.basic.initializers4
+
+import kotlin.test.*
+
 const val INT_MAX_POWER_OF_TWO: Int = Int.MAX_VALUE / 2 + 1
 val DOUBLE = Double.MAX_VALUE - 1.0
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(INT_MAX_POWER_OF_TWO)
     println(DOUBLE > 0.0)
 }

--- a/backend.native/tests/runtime/basic/initializers5.kt
+++ b/backend.native/tests/runtime/basic/initializers5.kt
@@ -1,8 +1,12 @@
+package runtime.basic.initializers5
+
+import kotlin.test.*
+
 object A {
     val a = 42
     val b = A.a
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     println(A.b)
 }

--- a/backend.native/tests/runtime/basic/interface0.kt
+++ b/backend.native/tests/runtime/basic/interface0.kt
@@ -1,3 +1,6 @@
+package runtime.basic.interface0
+
+import kotlin.test.*
 
 interface A {
     fun b() = c()
@@ -10,7 +13,7 @@ class B(): A {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val a:A = B()
     a.b()
 }

--- a/backend.native/tests/runtime/basic/libentry2.kt
+++ b/backend.native/tests/runtime/basic/libentry2.kt
@@ -1,3 +1,5 @@
+package runtime.basic.entry2
+
 fun fail() {
     println("Test failed, this is a wrong main() function.")
 }

--- a/backend.native/tests/runtime/basic/libentry2.kt
+++ b/backend.native/tests/runtime/basic/libentry2.kt
@@ -1,5 +1,3 @@
-package runtime.basic.entry2
-
 fun fail() {
     println("Test failed, this is a wrong main() function.")
 }

--- a/backend.native/tests/runtime/basic/main_exception.kt
+++ b/backend.native/tests/runtime/basic/main_exception.kt
@@ -1,3 +1,7 @@
-fun main(args: Array<String>) {
+package runtime.basic.main_exception
+
+import kotlin.test.*
+
+@Test fun runTest() {
     throw Error("Hello!")
 }

--- a/backend.native/tests/runtime/basic/standard.kt
+++ b/backend.native/tests/runtime/basic/standard.kt
@@ -1,10 +1,14 @@
+package runtime.basic.standard
+
+import kotlin.test.*
+
 class Foo(val bar: Int)
 
 fun <T> assertEquals(actual: T, expected: T) {
     if (actual != expected) throw AssertionError("Assertion failed. Expected value: $expected, actual value: $actual")
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     try {
         TODO()
         throw AssertionError("TODO() doesn't throw an exception")

--- a/backend.native/tests/runtime/basic/statements0.kt
+++ b/backend.native/tests/runtime/basic/statements0.kt
@@ -1,3 +1,7 @@
+package runtime.basic.statements0
+
+import kotlin.test.*
+
 fun simple() {
     var a = 238
     a++
@@ -27,7 +31,7 @@ fun fields() {
     println(foo.i)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     simple()
     fields()
 }

--- a/backend.native/tests/runtime/basic/throw0.kt
+++ b/backend.native/tests/runtime/basic/throw0.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.throw0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val cond = 1
     if (cond == 2) throw RuntimeException()
     if (cond == 3) throw NoSuchElementException("no such element")

--- a/backend.native/tests/runtime/basic/tostring0.kt
+++ b/backend.native/tests/runtime/basic/tostring0.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.tostring0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(127.toByte().toString())
     println(255.toByte().toString())
     println(239.toShort().toString())

--- a/backend.native/tests/runtime/basic/tostring1.kt
+++ b/backend.native/tests/runtime/basic/tostring1.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.tostring1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val hello = "Hello world"
     println(hello.subSequence(1, 5).toString())
 }

--- a/backend.native/tests/runtime/basic/tostring2.kt
+++ b/backend.native/tests/runtime/basic/tostring2.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.basic.tostring2
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val hello = "Hello"
     val array = hello.toCharArray()
     for (ch in array) {

--- a/backend.native/tests/runtime/basic/tostring3.kt
+++ b/backend.native/tests/runtime/basic/tostring3.kt
@@ -1,3 +1,7 @@
+package runtime.basic.tostring3
+
+import kotlin.test.*
+
 fun testByte() {
     val values = ByteArray(2)
     values[0] = Byte.MIN_VALUE
@@ -58,7 +62,7 @@ fun testDouble() {
     }
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     testByte()
     testShort()
     testInt()

--- a/backend.native/tests/runtime/collections/AbstractMutableCollection.kt
+++ b/backend.native/tests/runtime/collections/AbstractMutableCollection.kt
@@ -1,3 +1,7 @@
+package runtime.collections.AbstractMutableCollection
+
+import kotlin.test.*
+
 class TestCollection(): AbstractMutableCollection<Int>() {
     companion object {
         const val SIZE = 7
@@ -48,7 +52,7 @@ fun assertEquals(a: TestCollection, b: List<Int>) {
     }
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val c = TestCollection()
     if (!c.addAll(listOf(1, 2, 3, 2, 4, 5, 4))) throw AssertionError("addAll is false when it must be true.")
     if (c.addAll(listOf(1, 2)) != false) throw AssertionError("addAll is true when it must be false.")

--- a/backend.native/tests/runtime/collections/BitSet.kt
+++ b/backend.native/tests/runtime/collections/BitSet.kt
@@ -1,3 +1,7 @@
+package runtime.collections.BitSet
+
+import kotlin.test.*
+
 fun assertContainsOnly(bitSet: BitSet, trueBits: Set<Int>, size: Int) {
     for (i in 0 until size) {
         val expectedBit = i in trueBits
@@ -437,7 +441,7 @@ fun testEqualsHashCode() {
     assertTrue("Different sized BitSet with higher bits not set returned false", b1 == b3)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     testConstructor()
     testSet()
     testFlip()

--- a/backend.native/tests/runtime/collections/array0.kt
+++ b/backend.native/tests/runtime/collections/array0.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.collections.array0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     // Create instances of all array types.
     val byteArray = ByteArray(5)
     println(byteArray.size.toString())

--- a/backend.native/tests/runtime/collections/array1.kt
+++ b/backend.native/tests/runtime/collections/array1.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.collections.array1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val byteArray = ByteArray(5)
     byteArray[1] = 2
     byteArray[3] = 4

--- a/backend.native/tests/runtime/collections/array2.kt
+++ b/backend.native/tests/runtime/collections/array2.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.collections.array2
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val byteArray = Array<Byte>(5, { i -> (i * 2).toByte() })
     byteArray.map { println(it) }
 

--- a/backend.native/tests/runtime/collections/array3.kt
+++ b/backend.native/tests/runtime/collections/array3.kt
@@ -1,6 +1,10 @@
+package runtime.collections.array3
+
+import kotlin.test.*
+
 import konan.*
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     val data = immutableBinaryBlobOf(0x1, 0x2, 0x3, 0x7, 0x8, 0x9, 0x80, 0xff)
     for (b in data) {
         print("$b ")

--- a/backend.native/tests/runtime/collections/array_list1.kt
+++ b/backend.native/tests/runtime/collections/array_list1.kt
@@ -1,3 +1,7 @@
+package runtime.collections.array_list1
+
+import kotlin.test.*
+
 fun assertTrue(cond: Boolean) {
     if (!cond)
        println("FAIL")
@@ -342,7 +346,7 @@ fun testIteratorAdd() {
     assertEquals(listOf("1", "2", "-2", "3", "4", "-4", "5"), a)
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     testBasic()
     testIterator()
     testRemove()

--- a/backend.native/tests/runtime/collections/hash_map0.kt
+++ b/backend.native/tests/runtime/collections/hash_map0.kt
@@ -1,3 +1,7 @@
+package runtime.collections.hash_map0
+
+import kotlin.test.*
+
 fun assertTrue(cond: Boolean) {
     if (!cond)
         println("FAIL")
@@ -247,7 +251,7 @@ fun testEntriesIteratorSet() {
     assertEquals(mapOf("a" to "1!", "b" to "2!", "c" to "3!"), m)
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     testBasic()
     testRehashAndCompact()
     testClear()

--- a/backend.native/tests/runtime/collections/hash_set0.kt
+++ b/backend.native/tests/runtime/collections/hash_set0.kt
@@ -1,3 +1,7 @@
+package runtime.collections.hash_set0
+
+import kotlin.test.*
+
 fun assertTrue(cond: Boolean) {
     if (!cond)
         println("FAIL")
@@ -118,7 +122,7 @@ fun testRetainAll() {
     assertEquals(setOf("1", "3", "5"), s)
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     testBasic()
     testIterator()
     testEquals()

--- a/backend.native/tests/runtime/collections/listof0.kt
+++ b/backend.native/tests/runtime/collections/listof0.kt
@@ -1,3 +1,11 @@
+package runtime.collections.listof0
+
+import kotlin.test.*
+
+@Test fun runTest() {
+    main(arrayOf("a"))
+}
+
 fun main(args : Array<String>) {
     val nonConstStr = args[0]
     val list = arrayListOf(nonConstStr, "b", "c")

--- a/backend.native/tests/runtime/collections/moderately_large_array.kt
+++ b/backend.native/tests/runtime/collections/moderately_large_array.kt
@@ -1,5 +1,8 @@
+package runtime.collections.moderately_large_array
 
-fun main(args: Array<String>) {
+import kotlin.test.*
+
+@Test fun runTest() {
     val a = ByteArray(1000000)
 
     var sum = 0

--- a/backend.native/tests/runtime/collections/moderately_large_array1.kt
+++ b/backend.native/tests/runtime/collections/moderately_large_array1.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package runtime.collections.moderately_large_array1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val a = Array<Byte>(100000, { i -> i.toByte()})
 
     var sum = 0

--- a/backend.native/tests/runtime/collections/range0.kt
+++ b/backend.native/tests/runtime/collections/range0.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.collections.range0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     for (i in 1..3) print(i)
     println()
     for (i in 'a'..'d') print(i)

--- a/backend.native/tests/runtime/collections/sort0.kt
+++ b/backend.native/tests/runtime/collections/sort0.kt
@@ -1,4 +1,8 @@
-fun main(a: Array<String>) {
+package runtime.collections.sort0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println(arrayOf("x", "a", "b").sorted().toString())
     println(intArrayOf(239, 42, -1, 100500, 0).sorted().toString());
 }

--- a/backend.native/tests/runtime/collections/sort1.kt
+++ b/backend.native/tests/runtime/collections/sort1.kt
@@ -1,4 +1,8 @@
-fun main(a: Array<String>) {
+package runtime.collections.sort1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val foo = mutableListOf("x", "a", "b")
     foo.sort()
     println(foo.toString())

--- a/backend.native/tests/runtime/exceptions/catch1.kt
+++ b/backend.native/tests/runtime/exceptions/catch1.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.exceptions.catch1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         println("Before")
         foo()

--- a/backend.native/tests/runtime/exceptions/catch2.kt
+++ b/backend.native/tests/runtime/exceptions/catch2.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.exceptions.catch2
+
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         println("Before")
         foo()

--- a/backend.native/tests/runtime/exceptions/catch7.kt
+++ b/backend.native/tests/runtime/exceptions/catch7.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.exceptions.catch7
+
+import kotlin.test.*
+
+@Test fun runTest() {
     try {
         foo()
     } catch (e: Throwable) {

--- a/backend.native/tests/runtime/exceptions/extend0.kt
+++ b/backend.native/tests/runtime/exceptions/extend0.kt
@@ -1,6 +1,10 @@
+package runtime.exceptions.extend0
+
+import kotlin.test.*
+
 class C : Exception("OK")
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     try {
         throw C()
     } catch (e: Throwable) {

--- a/backend.native/tests/runtime/memory/basic0.kt
+++ b/backend.native/tests/runtime/memory/basic0.kt
@@ -1,10 +1,14 @@
+package runtime.memory.basic0
+
+import kotlin.test.*
+
 class A {
     var field: B? = null
 }
 
 class B(var field: Int)
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     val a = A()
     a.field = B(2)
 }

--- a/backend.native/tests/runtime/memory/cycles0.kt
+++ b/backend.native/tests/runtime/memory/cycles0.kt
@@ -1,3 +1,7 @@
+package runtime.memory.cycles0
+
+import kotlin.test.*
+
 data class Node(val data: Int, var next: Node?, var prev: Node?, val outer: Node?)
 
 fun makeCycle(len: Int, outer: Node?): Node {
@@ -35,7 +39,7 @@ fun createCycles(junk: Node) {
 
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     // Create outer link from cyclic garbage.
     val outer = Node(42, null, null, null)
     createCycles(outer)

--- a/backend.native/tests/runtime/memory/escape0.kt
+++ b/backend.native/tests/runtime/memory/escape0.kt
@@ -1,3 +1,7 @@
+package runtime.memory.escape0
+
+import kotlin.test.*
+
 //fun foo1(arg: String) : String = foo0(arg)
 fun foo1(arg: Any) : Any = foo0(arg)
 
@@ -46,7 +50,7 @@ fun zoo7(arg1: Any, arg2: Any, selector: Int) : Any {
     return if (selector < 2) arg1 else arg2;
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     //val z = zoo7(Any(), Any(), 1)
     val x = zoo5(Any())
     //println(bar(foo1(foo2("")), foo2(foo1(""))))

--- a/backend.native/tests/runtime/memory/escape1.kt
+++ b/backend.native/tests/runtime/memory/escape1.kt
@@ -1,3 +1,7 @@
+package runtime.memory.escape1
+
+import kotlin.test.*
+
 class B(val s: String)
 
 class A {
@@ -9,6 +13,6 @@ fun foo(): B {
     return a.b
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     println(foo().s)
 }

--- a/backend.native/tests/runtime/memory/escape2.kt
+++ b/backend.native/tests/runtime/memory/escape2.kt
@@ -1,3 +1,7 @@
+package runtime.memory.escape2
+
+import kotlin.test.*
+
 class A(val s: String)
 
 class B {
@@ -17,7 +21,7 @@ fun bar(b: B) {
 
 val global = B()
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     bar(global)
     println(global.a!!.s)
 }

--- a/backend.native/tests/runtime/memory/throw_cleanup.kt
+++ b/backend.native/tests/runtime/memory/throw_cleanup.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package runtime.memory.throw_cleanup
+
+import kotlin.test.*
+
+@Test fun runTest() {
     foo(false)
     try {
         foo(true)

--- a/backend.native/tests/runtime/memory/var1.kt
+++ b/backend.native/tests/runtime/memory/var1.kt
@@ -1,3 +1,7 @@
+package runtime.memory.var1
+
+import kotlin.test.*
+
 class Integer(val value: Int) {
     operator fun inc() = Integer(value + 1)
 }
@@ -7,7 +11,7 @@ fun foo(x: Any, y: Any) {
     y.use()
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     var x = Integer(0)
 
     for (i in 0..1) {

--- a/backend.native/tests/runtime/memory/var2.kt
+++ b/backend.native/tests/runtime/memory/var2.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.memory.var2
+
+import kotlin.test.*
+
+@Test fun runTest() {
     var x = Any()
 
     for (i in 0..1) {

--- a/backend.native/tests/runtime/memory/var3.kt
+++ b/backend.native/tests/runtime/memory/var3.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.memory.var3
+
+import kotlin.test.*
+
+@Test fun runTest() {
     foo().use()
 }
 

--- a/backend.native/tests/runtime/memory/var4.kt
+++ b/backend.native/tests/runtime/memory/var4.kt
@@ -1,4 +1,8 @@
-fun main(args : Array<String>) {
+package runtime.memory.var4
+
+import kotlin.test.*
+
+@Test fun runTest() {
     var x = Error()
 
     for (i in 0..1) {

--- a/backend.native/tests/runtime/text/chars0.kt
+++ b/backend.native/tests/runtime/text/chars0.kt
@@ -1,3 +1,7 @@
+package runtime.text.chars0
+
+import kotlin.test.*
+
 fun assertTrue(v: Boolean) = if (!v) throw AssertionError() else Unit
 fun assertFalse(v: Boolean) = if (v) throw AssertionError() else Unit
 fun assertEquals(a: Int, b: Int) { if (a != b) throw AssertionError() }
@@ -103,7 +107,7 @@ fun testCategory() {
     } catch (e: IllegalArgumentException) {}
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     testIsSurrogatePair()
     testToChars()
     testToCodePoint()

--- a/backend.native/tests/runtime/text/parse0.kt
+++ b/backend.native/tests/runtime/text/parse0.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package runtime.text.parse0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     println("false".toBoolean())
     println("true".toBoolean())
     println("-1".toByte())

--- a/backend.native/tests/runtime/text/string0.kt
+++ b/backend.native/tests/runtime/text/string0.kt
@@ -1,4 +1,8 @@
-fun main(args: Array<String>) {
+package runtime.text.string0
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val str = "hello"
     println(str.equals("HElLo", true))
     val strI18n = "Привет"

--- a/backend.native/tests/runtime/text/string_builder0.kt
+++ b/backend.native/tests/runtime/text/string_builder0.kt
@@ -1,3 +1,7 @@
+package runtime.text.string_builder0
+
+import kotlin.test.*
+
 // Utils ====================================================================================================
 fun assertTrue(cond: Boolean) {
     if (!cond)
@@ -262,7 +266,7 @@ fun testBasic() {
     assertEquals("", sb.toString())
 }
 
-fun main(args : Array<String>) {
+@Test fun runTest() {
     testBasic()
     testInsert()
     testReverse()

--- a/backend.native/tests/runtime/text/string_builder1.kt
+++ b/backend.native/tests/runtime/text/string_builder1.kt
@@ -1,4 +1,8 @@
-fun main(arg:Array<String>) {
+package runtime.text.string_builder1
+
+import kotlin.test.*
+
+@Test fun runTest() {
     val a = StringBuilder()
     a.append("Hello").appendln("Kotlin").appendln(42).appendln(0.1).appendln(true)
     println(a.toString())	

--- a/backend.native/tests/runtime/text/to_string0.kt
+++ b/backend.native/tests/runtime/text/to_string0.kt
@@ -1,3 +1,7 @@
+package runtime.text.to_string0
+
+import kotlin.test.*
+
 // Based on Apache Harmony tests.
 
 fun assertEquals(actual: String, expected: String, msg: String) {
@@ -34,7 +38,7 @@ fun testLongToStringWithRadix() {
 
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     testIntToStringWithRadix()
     testLongToStringWithRadix()
     println("OK")

--- a/backend.native/tests/runtime/workers/worker0.kt
+++ b/backend.native/tests/runtime/workers/worker0.kt
@@ -1,6 +1,10 @@
+package runtime.workers.worker0
+
+import kotlin.test.*
+
 import konan.worker.*
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val worker = startWorker()
     val future = worker.schedule(TransferMode.CHECKED, { "Input".shallowCopy()}) {
         input -> input + " processed"

--- a/backend.native/tests/runtime/workers/worker1.kt
+++ b/backend.native/tests/runtime/workers/worker1.kt
@@ -1,6 +1,10 @@
+package runtime.workers.worker1
+
+import kotlin.test.*
+
 import konan.worker.*
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val COUNT = 5
     val workers = Array(COUNT, { _ -> startWorker()})
 

--- a/backend.native/tests/runtime/workers/worker2.kt
+++ b/backend.native/tests/runtime/workers/worker2.kt
@@ -1,9 +1,13 @@
+package runtime.workers.worker2
+
+import kotlin.test.*
+
 import konan.worker.*
 
 data class WorkerArgument(val intParam: Int, val stringParam: String)
 data class WorkerResult(val intResult: Int, val stringResult: String)
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     val COUNT = 5
     val workers = Array(COUNT, { _ -> startWorker()})
 

--- a/backend.native/tests/runtime/workers/worker3.kt
+++ b/backend.native/tests/runtime/workers/worker3.kt
@@ -1,7 +1,15 @@
+package runtime.workers.worker3
+
+import kotlin.test.*
+
 import konan.worker.*
 
 data class WorkerArgument(val intParam: Int, val stringParam: String)
 data class WorkerResult(val intResult: Int, val stringResult: String)
+
+@Test fun runTest() {
+    main(emptyArray())
+}
 
 fun main(args: Array<String>) {
     val worker = startWorker()

--- a/backend.native/tests/serialization/deserialize_members.kt
+++ b/backend.native/tests/serialization/deserialize_members.kt
@@ -1,6 +1,10 @@
-import foo.bar.*
+package serialization.deserialize_members
 
-fun main(args: Array<String>) {
+import kotlin.test.*
+
+import serialization.serialize_members.*
+
+@Test fun runTest() {
     val c = C()
     val d = C.D()
     val e = C.D.E()

--- a/backend.native/tests/serialization/deserialize_members.kt
+++ b/backend.native/tests/serialization/deserialize_members.kt
@@ -1,10 +1,6 @@
-package serialization.deserialize_members
+import foo.bar.*
 
-import kotlin.test.*
-
-import serialization.serialize_members.*
-
-@Test fun runTest() {
+fun main(args: Array<String>) {
     val c = C()
     val d = C.D()
     val e = C.D.E()

--- a/backend.native/tests/serialization/deserialized_inline0.kt
+++ b/backend.native/tests/serialization/deserialized_inline0.kt
@@ -1,3 +1,7 @@
+package serialization.deserialized_inline0
+
+import kotlin.test.*
+
 
 fun inline_todo() {
     try {
@@ -28,7 +32,7 @@ fun inline_areEqual() {
     println(konan.internal.areEqual(b, b))
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     inline_todo()
     inline_assert()
     inline_maxof()

--- a/backend.native/tests/serialization/deserialized_listof0.kt
+++ b/backend.native/tests/serialization/deserialized_listof0.kt
@@ -1,3 +1,6 @@
+package serialization.deserialized_listof0
+
+import kotlin.test.*
 
 fun test_arrayList() {
     val l = listOf(1, 2, 3)
@@ -20,7 +23,7 @@ fun test_arrayList3() {
     println(n)
 }
 
-fun main(args: Array<String>) {
+@Test fun runTest() {
     test_arrayList()
     test_arrayList2<Int>(5, 6, 7)
     test_arrayList2<String>("a", "b", "c")

--- a/backend.native/tests/serialization/serialize_members.kt
+++ b/backend.native/tests/serialization/serialize_members.kt
@@ -1,4 +1,4 @@
-package foo.bar
+package serialization.serialize_members
 
 class R<T> {
     inline fun bar(t: T) {

--- a/backend.native/tests/serialization/serialize_members.kt
+++ b/backend.native/tests/serialization/serialize_members.kt
@@ -1,4 +1,4 @@
-package serialization.serialize_members
+package foo.bar
 
 class R<T> {
     inline fun bar(t: T) {

--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -295,6 +295,7 @@ class TestFailedException extends RuntimeException {
         super(s)
     }
 }
+
 class RunKonanTest extends KonanTest {
     void compileTest(List<String> filesToCompile, String exe) {
         runCompiler(filesToCompile, exe, flags?:[])

--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -377,7 +377,7 @@ class RunKonanTest extends ExtKonanTest {
 
     RunKonanTest() {
         super()
-        dependsOn(project.tasks['buildKonanTests'])
+        dependsOn('buildKonanTests')
     }
 
     @Override

--- a/runtime/src/main/kotlin/konan/test/TestLogger.kt
+++ b/runtime/src/main/kotlin/konan/test/TestLogger.kt
@@ -33,6 +33,7 @@ open class TestLoggerWithStatistics: BaseTestLogger() {
 class SilentTestLogger: BaseTestLogger() {
     override fun logTestList(runner: TestRunner, suites: Collection<TestSuite>) {}
     override fun log(message: String) {}
+    override fun fail(testCase: TestCase, e: Throwable, timeMillis: Long) = e.printStackTrace()
 }
 
 class SimpleTestLogger: BaseTestLogger() {
@@ -56,5 +57,3 @@ class SimpleTestLogger: BaseTestLogger() {
     }
     override fun ignore(testCase: TestCase) = println("Ignore: $testCase")
 }
-
-

--- a/runtime/src/main/kotlin/konan/test/TestRunner.kt
+++ b/runtime/src/main/kotlin/konan/test/TestRunner.kt
@@ -48,8 +48,8 @@ object TestRunner {
      *  --gtest_list_tests
      *  --ktest_list_tests                                  - Show all available tests.
      *
-     *  --gtest_filter=POSTIVE_PATTERNS[-NEGATIVE_PATTERNS]
-     *  --ktest_filter=POSTIVE_PATTERNS[-NEGATIVE_PATTERNS] - Run only the tests whose name matches one of the
+     *  --gtest_filter=POSITIVE_PATTERNS[-NEGATIVE_PATTERNS]
+     *  --ktest_filter=POSITIVE_PATTERNS[-NEGATIVE_PATTERNS] - Run only the tests whose name matches one of the
      *                                                        positive patterns but none of the negative patterns.
      *                                                        '?' matches any single character; '*' matches any
      *                                                        substring; ':' separates two patterns.


### PR DESCRIPTION
### Changes
- Make tests use @Test (kotlin.test.Test) annotation. Such tests will be build with konan's TestRunner enabled (-tr option).
- Each test has it's own package name and it's entry point now is a runTest() marked with @Test
- Tests are built with BuildKonanTest before the execution into the single binary. Each run is an invocation of this executable with TestRunner's options to select the test to execute
- Tests that could not be run within a single-binary (use exitProcess or have initialization with side-effects) run the same way as previously, but Gradle's task was renamed
- small fixes to test runner

### Testing
`master` branch build: 1h:49m. Tests run for about 1h
`backend-tests-port`: 49m:12s. Tests run for 12m

- `backend-tests-port`: https://buildserver.labs.intellij.net/viewLog.html?buildId=22914254&buildTypeId=Kotlin_KotlinNativeLinux&tab=buildResultsDiv

- `master`: https://buildserver.labs.intellij.net/viewLog.html?buildId=22906458&buildTypeId=Kotlin_KotlinNativeLinux&tab=buildResultsDiv