### PR TITLE
Fix enableDebug() option not working in build.gradle

### DIFF
--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanCompileTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanCompileTask.kt
@@ -22,6 +22,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.tasks.*
 import java.io.File
+import java.lang.IllegalArgumentException
 
 /**
  * A task compiling the target executable/library using Kotlin/Native compiler
@@ -285,6 +286,10 @@ open class KonanCompileConfig(
 
     fun enableAssertions() = with(compilationTask) {
         enableAssertions = true
+    }
+
+    fun enableDebug() = with(compilationTask) {
+        enableDebug = true
     }
 
     fun noDefaultLibs(flag: Boolean) = with(compilationTask) {


### PR DESCRIPTION
The GRADLE_PLUGIN.md mentions enableDebug() option in the plugin dsl but that options doesn't work (the command line one does).

This pull request adds that option.