### PR TITLE
A set of library tweaks

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Distribution.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Distribution.kt
@@ -44,7 +44,7 @@ class Distribution(val targetManager: TargetManager,
     val properties = File(propertyFileName).loadProperties()
 
     val klib = "$konanHome/klib"
-    val stdlib = "$klib/stdlib"
+    val stdlib = "$klib/common/stdlib"
     val runtime = runtimeFileOverride ?: "$stdlib/targets/${targetName}/native/runtime.bc"
 
     val dependenciesDir = "$konanHome/dependencies"

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -89,14 +89,15 @@ class KonanConfig(val project: Project, val configuration: CompilerConfiguration
                 false
         ).let {
             warnOnLibraryDuplicates(it.map { it.libraryFile })
-            it.distinctBy { it.libraryFile.absolutePath }
+            val result = it.distinctBy { it.libraryFile.absolutePath }
+            resolver.resolveLibrariesRecursive(result, targetManager.target, currentAbiVersion)
+            result
         }
     }
 
     fun librariesWithDependencies(moduleDescriptor: ModuleDescriptor?): List<KonanLibraryReader> {
         if (moduleDescriptor == null) error("purgeUnneeded() only works correctly after resolve is over, and we have successfully marked package files as needed or not needed.")
 
-        resolver.resolveLibrariesRecursive(immediateLibraries, targetManager.target, currentAbiVersion)
         return immediateLibraries.purgeUnneeded().withResolvedDependencies()
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -117,7 +117,7 @@ class KonanConfig(val project: Project, val configuration: CompilerConfiguration
         for (klib in libraries) {
             profile("Loading ${klib.libraryName}") {
                 // MutableModuleContext needs ModuleDescriptorImpl, rather than ModuleDescriptor.
-                val moduleDescriptor = klib.moduleDescriptor(specifics) as ModuleDescriptorImpl
+                val moduleDescriptor = klib.moduleDescriptor(specifics)
                 allMetadata.add(moduleDescriptor)
             }
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibraryReader.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibraryReader.kt
@@ -28,7 +28,7 @@ interface KonanLibraryReader {
     val linkerOpts: List<String>
     val unresolvedDependencies: List<String>
     val escapeAnalysis: ByteArray?
-    val isDefaultLink: Boolean get() = false
+    val isDefaultLibrary: Boolean get() = false
     val isNeededForLink: Boolean get() = true
     val manifestProperties: Properties
     val moduleHeaderData: ByteArray

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibraryReader.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibraryReader.kt
@@ -28,6 +28,7 @@ interface KonanLibraryReader {
     val linkerOpts: List<String>
     val unresolvedDependencies: List<String>
     val escapeAnalysis: ByteArray?
+    val isDefaultLink: Boolean get() = false
     val isNeededForLink: Boolean get() = true
     val manifestProperties: Properties
     val moduleHeaderData: ByteArray

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
@@ -130,10 +130,10 @@ class KonanLibrarySearchPathResolver(
         get() = localKonanDir?.File()?.klib
 
     val distHead: File?
-        get() = distributionKlib?.File()
+        get() = distributionKlib?.File()?.child("common")
 
     val distPlatformHead: File?
-        get() = targetManager?.let { distHead?.child(targetManager.targetName) }
+        get() = targetManager?.let { distributionKlib?.File()?.child("platform")?.child(targetManager.targetName) }
 
     val currentDirHead: File?
         get() = if (!skipCurrentDir) File.userDir else null
@@ -176,11 +176,13 @@ class KonanLibrarySearchPathResolver(
         get() = File(this, "klib")
 
     // The libraries from the default root are linked automatically.
-    val defaultRoot: File?
-        get() = if (distPlatformHead?.exists ?: false) distPlatformHead else null
+    val defaultRoots: List<File>
+        get() = listOf(distHead, distPlatformHead)
+                .filterNotNull()
+                .filter{ it.exists }
 
     override fun defaultLinks(nostdlib: Boolean, noDefaultLibs: Boolean): List<File> {
-        val defaultLibs = defaultRoot?.listFiles.orEmpty()
+        val defaultLibs = defaultRoots.flatMap{ it.listFiles }
             .filterNot { it.name.removeSuffixIfPresent(".klib") == "stdlib" }
             .map { File(it.absolutePath) }
         val result = mutableListOf<File>()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
@@ -49,7 +49,7 @@ fun SearchPathResolver.resolveImmediateLibraries(libraryNames: List<String>,
                                                  removeDuplicates: Boolean = true): List<LibraryReaderImpl> {
 
     val defaultLibraries = defaultLinks(nostdlib = noStdLib, noDefaultLibs = noDefaultLibs).map {
-        LibraryReaderImpl(it, abiVersion, target)
+        LibraryReaderImpl(it, abiVersion, target, isDefaultLink = true)
     }
 
     val userProvidedLibraries = libraryNames

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
@@ -52,7 +52,7 @@ fun SearchPathResolver.resolveImmediateLibraries(libraryNames: List<String>,
             .map{ LibraryReaderImpl(it, abiVersion, target) }
 
     val defaultLibraries = defaultLinks(nostdlib = noStdLib, noDefaultLibs = noDefaultLibs).map {
-        LibraryReaderImpl(it, abiVersion, target, isDefaultLink = true)
+        LibraryReaderImpl(it, abiVersion, target, isDefaultLibrary = true)
     }
 
     // Make sure the user provided ones appear first, so that 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
 class LibraryReaderImpl(var libraryFile: File, val currentAbiVersion: Int,
-    val target: KonanTarget? = null)
+    val target: KonanTarget? = null, override val isDefaultLink: Boolean = false)
     : KonanLibraryReader {
 
     // For the zipped libraries inPlace gives files from zip file system
@@ -98,4 +98,5 @@ class LibraryReaderImpl(var libraryFile: File, val currentAbiVersion: Int,
 
 }
 
-internal fun <T: KonanLibraryReader> List<T>.purgeUnneeded(): List<T> = this.filter{ it.isNeededForLink }
+internal fun <T: KonanLibraryReader> List<T>.purgeUnneeded(): List<T> = this.filter{ !it.isDefaultLink || it.isNeededForLink }
+

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/KonanLibraryReaderImpl.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
 class LibraryReaderImpl(var libraryFile: File, val currentAbiVersion: Int,
-    val target: KonanTarget? = null, override val isDefaultLink: Boolean = false)
+    val target: KonanTarget? = null, override val isDefaultLibrary: Boolean = false)
     : KonanLibraryReader {
 
     // For the zipped libraries inPlace gives files from zip file system
@@ -98,5 +98,5 @@ class LibraryReaderImpl(var libraryFile: File, val currentAbiVersion: Int,
 
 }
 
-internal fun <T: KonanLibraryReader> List<T>.purgeUnneeded(): List<T> = this.filter{ !it.isDefaultLink || it.isNeededForLink }
+internal fun <T: KonanLibraryReader> List<T>.purgeUnneeded(): List<T> = this.filter{ !it.isDefaultLibrary || it.isNeededForLink }
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1245,7 +1245,7 @@ task link_default_libs(type: RunStandaloneKonanTest) {
 
 task link_testLib_explicitly(type: RunKonanTest) {
     dependsOn ':klib:installTestLibrary'
-    goldValue = "This is a side effect of a test library linked into the binary.\nYou should not be seing this.\n\nHello\n"
+    goldValue = "This is a side effect of a test library linked into the binary.\nYou should not be seeing this.\n\nHello\n"
     source = "link/omit/hello.kt"
     // We force library inclusion, so need to see the warning banner.
     flags = ['-l', 'testLibrary'] 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1244,6 +1244,9 @@ task link_default_libs(type: RunStandaloneKonanTest) {
 }
 
 task link_testLib_explicitly(type: RunStandaloneKonanTest) {
+    // there are no testLibrary for cross targets yet.
+    disabled = (project.testTarget != null && project.testTarget != project.hostName) 
+
     dependsOn ':klib:installTestLibrary'
     goldValue = "This is a side effect of a test library linked into the binary.\nYou should not be seeing this.\n\nHello\n"
     source = "link/omit/hello.kt"

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1243,7 +1243,7 @@ task link_default_libs(type: RunStandaloneKonanTest) {
     source = "link/default/default.kt"
 }
 
-task link_testLib_explicitly(type: RunKonanTest) {
+task link_testLib_explicitly(type: RunStandaloneKonanTest) {
     dependsOn ':klib:installTestLibrary'
     goldValue = "This is a side effect of a test library linked into the binary.\nYou should not be seeing this.\n\nHello\n"
     source = "link/omit/hello.kt"

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1243,6 +1243,15 @@ task link_default_libs(type: RunStandaloneKonanTest) {
     source = "link/default/default.kt"
 }
 
+task link_testLib_explicitly(type: RunKonanTest) {
+    dependsOn ':klib:installTestLibrary'
+    goldValue = "Hello\n"
+    source = "link/omit/hello.kt"
+    // We force library inclusion, so need to see the warning banner.
+    flags = ['-l', 'testLibrary'] 
+
+}
+
 task no_purge_for_dependencies(type: LinkKonanTest) {
     disabled = (project.testTarget == 'wasm32') // there will be no posix.klib for wasm
     goldValue = "linked library\nand symbols from posix available: 17; 1.0\n"

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1245,7 +1245,7 @@ task link_default_libs(type: RunStandaloneKonanTest) {
 
 task link_testLib_explicitly(type: RunKonanTest) {
     dependsOn ':klib:installTestLibrary'
-    goldValue = "Hello\n"
+    goldValue = "This is a side effect of a test library linked into the binary.\nYou should not be seing this.\n\nHello\n"
     source = "link/omit/hello.kt"
     // We force library inclusion, so need to see the warning banner.
     flags = ['-l', 'testLibrary'] 

--- a/build.gradle
+++ b/build.gradle
@@ -231,13 +231,15 @@ task distRuntime(type: Copy) {
     dependsOn('commonDistRuntime')
 }
 
+def stdlib = 'klib/common/stdlib'
+
 task commonDistRuntime(type: Copy) {
     destinationDir file('dist')
 
     // Target independant common part.
     from(project(':runtime').file("build/${hostName}Stdlib")) {
         include('**')
-        into('klib/stdlib')
+        into(stdlib)
     }
 }
 
@@ -260,19 +262,19 @@ targetList.each { target ->
 
         from(project(':runtime').file("build/$target")) {
             include("*.bc")
-            into("klib/stdlib/targets/$target/native")
+            into("$stdlib/targets/$target/native")
         }
         from(project(':runtime').file("build/${target}Stdlib")) {
             include('**')
-            into('klib/stdlib')
+            into(stdlib)
         }
         from(project(':runtime').file("build/${target}Start.bc")) {
             rename("${target}Start.bc", 'start.bc')
-            into("klib/stdlib/targets/$target/native")
+            into("$stdlib/targets/$target/native")
         }
         if (target == 'wasm32') {
             from(project(':runtime').file('src/launcher/js')) {
-                into('klib/stdlib/targets/wasm32/included')
+                into('$stdlib/targets/wasm32/included')
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -353,6 +353,7 @@ task bundle(type: (isWindows()) ? Zip : Tar) {
     from("$project.rootDir/dist") {
         include '**'
         exclude 'dependencies'
+        exclude 'klib/testLibrary'
         into baseName
     }
     from(project.rootDir) {

--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,7 @@ targetList.each { target ->
         }
         if (target == 'wasm32') {
             from(project(':runtime').file('src/launcher/js')) {
-                into('$stdlib/targets/wasm32/included')
+                into("$stdlib/targets/wasm32/included")
             }
         }
     }

--- a/klib/build.gradle
+++ b/klib/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 }
 
 def dist = rootProject.file('dist').absolutePath
+def suffix = isWindows() ? ".bat" : ""
 
 // TODO: Ideally we want to write just konanArtifacts{} clause here,
 // but we need to make Kotlin/Native Gradle Plugin a dependence
@@ -33,7 +34,7 @@ def dist = rootProject.file('dist').absolutePath
 task compileKonanTestLibrary(type: Exec) {
     dependsOn ':dist'
 
-    def compiler = "$dist/bin/konanc"
+    def compiler = "$dist/bin/konanc$suffix"
     def source = 'src/testLibrary'
     def artifact = 'build/konan/bin/testLibrary'
 
@@ -44,8 +45,8 @@ task compileKonanTestLibrary(type: Exec) {
 task installTestLibrary(type: Exec) {
     dependsOn 'compileKonanTestLibrary'
 
+    def tool = "$dist/bin/klib$suffix"
     def repo = "$dist/klib/common"
-    def tool = "$dist/bin/klib"
     def library = 'build/konan/bin/testLibrary.klib'
 
     executable tool

--- a/klib/build.gradle
+++ b/klib/build.gradle
@@ -24,3 +24,31 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile project(path: ':backend.native', configuration: 'cli_bc')
 }
+
+def dist = rootProject.file('dist').absolutePath
+
+// TODO: Ideally we want to write just konanArtifacts{} clouse here,
+// but we need to make Kotlin Native Gradle Plugin a dependence
+// of our buildScripts first.
+task compileKonanTestLibrary(type: Exec) {
+    dependsOn ':dist'
+
+    def compiler = "$dist/bin/konanc"
+    def source = 'src/testLibrary'
+    def artifact = 'build/konan/bin/testLibrary'
+
+    executable compiler
+    args source, '-o', artifact, '-p', 'library'
+}
+
+task installTestLibrary(type: Exec) {
+    dependsOn 'compileKonanTestLibrary'
+
+    def repo = "$dist/klib/common"
+    def tool = "$dist/bin/klib"
+    def library = 'build/konan/bin/testLibrary.klib'
+
+    executable tool
+    args 'install', library, '-repository', repo
+}
+

--- a/klib/build.gradle
+++ b/klib/build.gradle
@@ -27,8 +27,8 @@ dependencies {
 
 def dist = rootProject.file('dist').absolutePath
 
-// TODO: Ideally we want to write just konanArtifacts{} clouse here,
-// but we need to make Kotlin Native Gradle Plugin a dependence
+// TODO: Ideally we want to write just konanArtifacts{} clause here,
+// but we need to make Kotlin/Native Gradle Plugin a dependence
 // of our buildScripts first.
 task compileKonanTestLibrary(type: Exec) {
     dependsOn ':dist'

--- a/klib/platform.gradle
+++ b/klib/platform.gradle
@@ -20,7 +20,7 @@ konanArtifacts {
         defFile gradle.startParameter.projectProperties.defFile
         noDefaultLibs true
         libraries {
-            files libs.collect { "$konanHome/klib/$targetName/$it" }
+            files libs.collect { "$konanHome/klib/platform/$targetName/$it" }
         }
     }
 }
@@ -29,7 +29,7 @@ def suffix = gradle.startParameter.projectProperties['suffix']
 def klibProgram = suffix?"$konanHome/bin/klib.$suffix" : "$konanHome/bin/klib"
 
 task klibInstall(type:Exec) {
-    String repo = "$konanHome/klib/$targetName"
+    String repo = "$konanHome/klib/platform/$targetName"
     doFirst {
         new File(repo).mkdirs()
     }

--- a/klib/src/testLibrary/kotlin/test_platform_lib.kt
+++ b/klib/src/testLibrary/kotlin/test_platform_lib.kt
@@ -1,0 +1,9 @@
+package test.konan.platform
+
+fun produceMessage() {
+    println("""This is a side effect of a test library linked into the binary.
+You should not be seing this.
+""")
+}
+
+val x: Unit = produceMessage()

--- a/klib/src/testLibrary/kotlin/test_platform_lib.kt
+++ b/klib/src/testLibrary/kotlin/test_platform_lib.kt
@@ -2,7 +2,7 @@ package test.konan.platform
 
 fun produceMessage() {
     println("""This is a side effect of a test library linked into the binary.
-You should not be seing this.
+You should not be seeing this.
 """)
 }
 


### PR DESCRIPTION
   * A `testLibrary.klib` has been introduced to check library purging is not broken.
   * The libraries in `dist/klib` have been separated into `dist/klib/common` and `dist/klib/platform`.
   * User provided libraries have precedence over default lined libraries in case of duplicate inclusion.