### PR TITLE
After combining all tests into a single binary,

### DIFF
--- a/backend.native/konan.properties
+++ b/backend.native/konan.properties
@@ -274,4 +274,5 @@ dependencies.osx-wasm32 = \
 quadruple.wasm32 = wasm32
 llvmLtoFlags.wasm32 =
 targetSysRoot.wasm32 = target-sysroot-1-wasm
-s2wasmFlags.wasm32 = --allocate-stack 1024 --import-memory
+# The stack size is in bytes.
+s2wasmFlags.wasm32 = --allocate-stack 1048576 --import-memory

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1422,7 +1422,6 @@ task string0(type: RunKonanTest) {
 }
 
 task parse0(type: RunKonanTest) {
-    disabled = (project.testTarget == 'wasm32') // KT-20862
     goldValue = "false\n" +
             "true\n" +
             "-1\n" +


### PR DESCRIPTION
we need to increase wasm32 stack size a little,
for the `parse0` test to pass.