### PR TITLE
unit-tests: multiple positive patterns are ORed together

### DIFF
--- a/runtime/src/main/kotlin/konan/test/TestRunner.kt
+++ b/runtime/src/main/kotlin/konan/test/TestRunner.kt
@@ -142,7 +142,7 @@ object TestRunner {
         val negativePatterns = filters.getOrNull(1)?.toGTestPatterns() ?: emptyList()
 
         this.filters.add { testCase ->
-            positivePatterns.all { testCase.prettyName.matches(it) } &&
+            positivePatterns.any { testCase.prettyName.matches(it) } &&
             negativePatterns.none { testCase.prettyName.matches(it) }
         }
     }


### PR DESCRIPTION
This matches behavior of Google Test:

https://github.com/google/googletest/blob/7684db32712ea4fdb56e8d6f784c51d6f39e5e2c/googletest/docs/AdvancedGuide.md#running-a-subset-of-the-tests

cc @ilmat192 