### PR TITLE
MinGW POSIX fixes

### DIFF
--- a/klib/src/platform/windows/posix.def
+++ b/klib/src/platform/windows/posix.def
@@ -57,9 +57,7 @@ static short posix_htons(short x) {
 #define RPC_NO_WINDOWS_H
 #define COM_NO_WINDOWS_H
 #define __INSIDE_CYGWIN__
-struct _OVERLAPPED;
-#define LPOVERLAPPED struct _OVERLAPPED*
-#include <winsock.h>
+#include <winsock2.h>
 
 // Wrapper to access h_errno variable.
 static int posix_h_errno() {

--- a/klib/src/platform/windows/posix.def
+++ b/klib/src/platform/windows/posix.def
@@ -1,9 +1,10 @@
 package = platform.posix
-headers = minwindef.h wtypesbase.h stdio.h io.h math.h
-compilerOpts = -DUNICODE -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DWINAPI_FAMILY=3 \
-   -D_INC_WINDOWS -DRPC_NO_WINDOWS_H -DCOM_NO_WINDOWS_H \
-   -Wno-incompatible-pointer-types -Wno-deprecated-declarations
-noStringConversion = send recv
+headers = assert.h complex.h dirent.h errno.h fcntl.h \
+    fenv.h float.h ftw.h getopt.h inttypes.h libgen.h limits.h \
+    locale.h math.h memory.h sched.h search.h semaphore.h \
+    setjmp.h signal.h stdint.h stdio.h stdlib.h string.h \
+    time.h uchar.h unistd.h utime.h wchar.h wctype.h
+noStringConversion = send sendto recv
 linkerOpts = -lWs2_32
 
 ---

--- a/klib/src/platform/windows/posix.def
+++ b/klib/src/platform/windows/posix.def
@@ -18,10 +18,47 @@ static short posix_htons(short x) {
 }
 
 // Hacks to make MinGW Windows headers look more modular than they are.
-typedef void* HWND;
-struct _OVERLAPPED;
-typedef struct _OVERLAPPED* LPOVERLAPPED;
+#ifdef _WIN64
+#define UINT_PTR    unsigned __int64
+#define ULONG_PTR   unsigned __int64
+#else
+#define UINT_PTR    unsigned int
+#define ULONG_PTR   unsigned long
+#endif
+#define DWORD_PTR   ULONG_PTR
+#define BYTE        unsigned char
+#define WORD        unsigned short
+#define DWORD       unsigned __LONG32
+#define ULONG       DWORD
+#define INT         int
+#define UINT        unsigned int
+#define CHAR        char
+#define WCHAR       WORD
+#define LPBYTE      BYTE*
+#define LPINT       INT*
+#define LPWORD      WORD*
+#define LPLONG      __LONG32*
+#define LPDWORD     DWORD*
+#define VOID        void
+#define PVOID       void*
+#define LPVOID      void*
+#define LPSTR       CHAR*
+#define LPWSTR      WCHAR*
+#define WINBOOL     int
+#define WPARAM      UINT_PTR
+#define HANDLE      LPVOID
+#define LPHANDLE    HANDLE*
+#define HWND        HANDLE
+#define FARPROC     void*
+#define WINAPI      __stdcall
+#define CALLBACK    __stdcall
+
+#define _INC_WINDOWS
+#define RPC_NO_WINDOWS_H
+#define COM_NO_WINDOWS_H
 #define __INSIDE_CYGWIN__
+struct _OVERLAPPED;
+#define LPOVERLAPPED struct _OVERLAPPED*
 #include <winsock.h>
 
 // Wrapper to access h_errno variable.
@@ -30,7 +67,7 @@ static int posix_h_errno() {
 }
 
 static int init_sockets() {
-    WORD wVersionRequested = MAKEWORD(2, 2);
+    WORD wVersionRequested = 0x202;
     WSADATA wsaData;
     return WSAStartup(wVersionRequested, &wsaData);
 }


### PR DESCRIPTION
Without this, any non-trivial windows programm require ```import platform.posix.*``` for types like BOOL, WORD etc.