### PR TITLE
mingw tetris sample

### DIFF
--- a/samples/tetris/build.bat
+++ b/samples/tetris/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 set DIR=.
-set "PATH=..\..\dist\bin;..\..\bin;..\..\dist\dependencies\msys2-mingw-w64-x86_64-gcc-6.3.0-clang-llvm-3.9.1-windows-x86-64\bin;%PATH%"
+set "PATH=..\..\dist\bin;..\..\bin;%home%\.konan\dependencies\msys2-mingw-w64-x86_64-gcc-6.3.0-clang-llvm-3.9.1-windows-x86-64\bin;%PATH%"
 if "%TARGET%" == "" set TARGET=mingw
 rem Requires default mingw64 install path yet.
 set MINGW=\msys64\mingw64


### PR DESCRIPTION
А вообще я не очень понимаю политику партии.

Вот есть '%home%/.konan/dependencies/msys2-mingw-w64-x86_64-gcc-6.3.0-clang-llvm-3.9.1-windows-x86-64' с урезаной версией msys2, без менеджера пакетов.
Пакеты ставим в полноценный msys2, который юзер должен сам предварительно поставить.
В скриптах оно как-то работает, а с gradle и cmake не очень совместимо.

Как это сделано для других таргетов, например raspberrypi?