### PR TITLE
Added missing /iphone subpath to source path of replace binary script…

### DIFF
--- a/samples/uikit/konan.xcodeproj/project.pbxproj
+++ b/samples/uikit/konan.xcodeproj/project.pbxproj
@@ -169,7 +169,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp \"$SRCROOT/build/konan/bin/app.kexe\" \"$TARGET_BUILD_DIR/$EXECUTABLE_PATH\"";
+			shellScript = "cp \"$SRCROOT/build/konan/bin/iphone/app.kexe\" \"$TARGET_BUILD_DIR/$EXECUTABLE_PATH\"";
 		};
 		2C901F991F59928A004412FA /* Build Binary From Kotlin Sources */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Source path in "replace binary" script phase was invalid. When building app.kexe is really in **/build/konan/bin/iphone** not in /build/konan/bin.

Tested on my device. Sample launches fine now.

I also was struggling to find a proper introduction step by step how to run the sample. I finally got some understanding by reading a few readme files on github but I think it should be in one readme for a sample - talking about gradle.properties change to point to valid distro.