### PR TITLE
Minor improvements in gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,6 +287,7 @@ targetList.each { target ->
     targetDefFiles(target).forEach{
         defFile ->
             def taskName = defFileToTaskName(target, defFile.name)
+            def jvmArgs = project.findProperty("platfromLibsJvmArgs") ?: "-Xmx3G"
             def suffix = null
             if (new PlatformInfo().isWindows())
                 suffix = 'bat'
@@ -298,6 +299,7 @@ targetList.each { target ->
                 buildFile project('klib').file('platform.gradle')
                 dir project(':klib').projectDir
                 startParameter.projectProperties = [
+                        'konan.jvmArgs'  : jvmArgs,
                         'kotlin_version' : kotlin_version,
                         'name'           : defFile.name,
                         'defFile'        : defFile.file.absolutePath,

--- a/samples/gradle.properties
+++ b/samples/gradle.properties
@@ -1,1 +1,2 @@
 konan.home=../../dist
+konan.jvmArgs=-Xmx3G

--- a/samples/gradle.properties.for_bundle
+++ b/samples/gradle.properties.for_bundle
@@ -1,1 +1,2 @@
 konan.home=../..
+konan.jvmArgs=-Xmx3G

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
@@ -34,6 +34,7 @@ import javax.inject.Inject
  *      konan.home          - directory where compiler is located (aka dist in konan project output).
  *      konan.version       - a konan compiler version for downloading.
  *      konan.build.targets - list of targets to build (by default all the declared targets are built).
+ *      konan.jvmArgs       - additional args to be passed to a JVM executing the compiler/cinterop tool.
  */
 
 internal fun Project.hasProperty(property: KonanPlugin.ProjectProperty) = hasProperty(property.propertyName)
@@ -89,6 +90,9 @@ internal val Project.requestedTargets
     get() = findProperty(KonanPlugin.ProjectProperty.KONAN_BUILD_TARGETS)?.let {
         it.toString().trim().split("\\s+".toRegex())
     }.orEmpty()
+
+internal val Project.jvmArgs
+    get() = (findProperty(KonanPlugin.ProjectProperty.KONAN_JVM_ARGS) as String?)?.split("\\s+".toRegex()).orEmpty()
 
 internal val Project.compileAllTask
     get() = getOrCreateTask(COMPILE_ALL_TASK_NAME)
@@ -223,6 +227,8 @@ open class KonanExtension {
     var languageVersion: String? = null
     var apiVersion: String? = null
 
+    val jvmArgs = mutableListOf<String>()
+
     internal val konanTargets: List<KonanTarget>
         get() = targets.map { TargetManager(it).target }.distinct()
 }
@@ -234,6 +240,7 @@ class KonanPlugin @Inject constructor(private val registry: ToolingModelBuilderR
         KONAN_HOME          ("konan.home"),
         KONAN_VERSION       ("konan.version"),
         KONAN_BUILD_TARGETS ("konan.build.targets"),
+        KONAN_JVM_ARGS      ("konan.jvmArgs"),
         DOWNLOAD_COMPILER   ("download.compiler")
     }
 

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanToolRunner.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanToolRunner.kt
@@ -50,9 +50,11 @@ internal abstract class KonanCliRunner(val toolName: String, val fullName: Strin
 
     override val jvmArgs = mutableListOf(
             "-ea",
-            "-Xmx3G",
             "-Dkonan.home=${project.konanHome}",
-            "-Djava.library.path=${project.konanHome}/konan/nativelib")
+            "-Djava.library.path=${project.konanHome}/konan/nativelib").apply {
+        addAll(project.konanExtension.jvmArgs)
+        addAll(project.jvmArgs)
+    }
 
     override val environment = mutableMapOf("LIBCLANG_DISABLE_CRASH_RECOVERY" to "1")
 

--- a/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/CMakeSpecification.groovy
+++ b/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/CMakeSpecification.groovy
@@ -1,9 +1,12 @@
 package org.jetbrains.kotlin.gradle.plugin.test
 
-class CMakeSpecification extends BaseKonanSpecification {
+import org.jetbrains.kotlin.konan.target.Family
+import org.jetbrains.kotlin.konan.target.TargetManager
 
+class CMakeSpecification extends BaseKonanSpecification {
     def 'Plugin should generate CMake from project without additional settings'() {
         when:
+        def sdlIncludePath = (TargetManager.host.family == Family.WINDOWS) ? "C:/SDL2/include" : "/usr/include/SDL2"
         def project = KonanProject.createEmpty(projectDirectory) { KonanProject it ->
             it.buildFile.write("""
             plugins { id 'konan' }
@@ -11,7 +14,7 @@ class CMakeSpecification extends BaseKonanSpecification {
                 interop('stdio')
                 interop('sdl') {
                     defFile 'src/main/c_interop/sdl.def'
-                    includeDirs '/usr/include/SDL2'
+                    includeDirs '$sdlIncludePath'
                 }
                 library('main_lib')
                 program('Main') {
@@ -40,7 +43,7 @@ class CMakeSpecification extends BaseKonanSpecification {
             cinterop(
                 NAME sdl
                 DEF_FILE src/main/c_interop/sdl.def
-                COMPILER_OPTS -I/usr/include/SDL2)
+                COMPILER_OPTS -I$sdlIncludePath)
             
             cinterop(
                 NAME stdio
@@ -61,7 +64,7 @@ class CMakeSpecification extends BaseKonanSpecification {
         cMakeModule.exists()
         cMakeLists.exists()
 
-        def actualCMakeLists = cMakeLists.text.trim()
+        def actualCMakeLists = cMakeLists.text.trim().replace('\r\n', '\n')
         actualCMakeLists == expectedCMakeLists
     }
 

--- a/tools/publish-release.sh
+++ b/tools/publish-release.sh
@@ -107,8 +107,9 @@ if [ "$UPLOAD" == "true" ]; then
     ./gradlew build --refresh-dependencies
 
     # 6. Upload the bundle to the CDN
-    stage "Uploading the bundle to CDN: $BUNDLE_TAR -> ftp://uploadcds.labs.intellij.net/kotlin/native/"
-    curl --upload-file "$BUNDLE_TAR" "ftp://$CDN_USER:$CDN_PASS@uploadcds.labs.intellij.net/kotlin/native/"
+    stage "Uploading the bundle to CDN: $BUNDLE_TAR -> ftp://uploadcds.labs.intellij.net/builds/releases/$VERSION/$OS"
+    curl --upload-file "$BUNDLE_TAR" "ftp://$CDN_USER:$CDN_PASS@uploadcds.labs.intellij.net/builds/releases/$VERSION/$OS"
+    echo "Available at https://download.jetbrains.com/kotlin/native/builds/releases/$VERSION/$OS/$BUNDLE_TAR"
 
     echo "Wait ${WAIT_TIME} seconds to ensure that the bundle can be downloaded."
     sleep ${WAIT_TIME}


### PR DESCRIPTION
- Use new CDN paths for compiler bundles.
- Allow setting additional JVM arguments for compiler/cinterop.
- Fix `includeDir` processing in CMake project generation.