### PR TITLE
gradle: allow only directories in DSL

### DIFF
--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanCompileConfig.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanCompileConfig.kt
@@ -44,9 +44,8 @@ abstract class KonanCompileConfig<T: KonanCompileTask>(name: String,
     override fun generateHostTaskDescription(task: Task, hostTarget: KonanTarget) =
             "Build the Kotlin/Native $typeForDescription '${task.name}' for current host"
 
-    override fun srcDir(dir: Any) = forEach { it.srcDir(dir) }
-    override fun srcFiles(vararg files: Any) = forEach { it.srcFiles(*files) }
-    override fun srcFiles(files: Collection<Any>) = forEach { it.srcFiles(files) }
+    override fun srcDirs(vararg dirs: Any) = forEach { it.srcDirs(*dirs) }
+    override fun srcDirs(dirs: Collection<Any>) = forEach { it.srcDirs(dirs) }
 
     override fun nativeLibrary(lib: Any) = forEach { it.nativeLibrary(lib) }
     override fun nativeLibraries(vararg libs: Any) = forEach { it.nativeLibraries(*libs) }

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
@@ -63,7 +63,7 @@ internal val Project.konanBitcodeBaseDir     get() = konanBuildRoot.resolve("bit
 
 internal fun File.targetSubdir(target: KonanTarget) = resolve(target.userName)
 
-internal val Project.konanDefaultSrcFiles         get() = fileTree("${projectDir.canonicalPath}/src/main/kotlin")
+internal val Project.konanDefaultSrcFiles get() = file("${projectDir.canonicalPath}/src/main/kotlin")
 internal fun Project.konanDefaultDefFile(libName: String)
         = file("${projectDir.canonicalPath}/src/main/c_interop/$libName.def")
 
@@ -163,13 +163,14 @@ internal fun MutableList<String>.addListArg(parameter: String, values: List<Stri
 internal fun dumpProperties(task: Task) {
     fun Iterable<String>.dump() = joinToString(prefix = "[", separator = ",\n${" ".repeat(22)}", postfix = "]")
     fun Collection<FileCollection>.dump() = flatMap { it.files }.map { it.canonicalPath }.dump()
+    fun Collection<File>.dump() = map { it.canonicalPath }.dump()
     when (task) {
         is KonanCompileTask -> with(task) {
             println()
             println("Compilation task: ${name}")
             println("destinationDir     : ${destinationDir}")
             println("artifact           : ${artifact.canonicalPath}")
-            println("srcFiles         : ${srcFiles.dump()}")
+            println("srcDirs            : ${srcDirs.dump()}")
             println("produce            : ${produce}")
             println("libraries          : ${libraries.files.dump()}")
             println("                   : ${libraries.artifacts.map {

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanSpecs.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanSpecs.kt
@@ -40,10 +40,8 @@ interface KonanBuildingSpec: KonanArtifactWithLibrariesSpec {
 }
 
 interface KonanCompileSpec: KonanBuildingSpec {
-    fun srcDir(dir: Any)
-
-    fun srcFiles(vararg files: Any)
-    fun srcFiles(files: Collection<Any>)
+    fun srcDirs(vararg dirs: Any)
+    fun srcDirs(dirs: Collection<Any>)
 
     // DSL. Native libraries.
 

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/tasks/KonanGenerateCMakeTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/tasks/KonanGenerateCMakeTask.kt
@@ -17,7 +17,6 @@
 package org.jetbrains.kotlin.gradle.plugin.tasks
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.plugin.KonanInteropLibrary
 import org.jetbrains.kotlin.gradle.plugin.KonanLibrary
@@ -64,7 +63,6 @@ open class KonanGenerateCMakeTask : DefaultTask() {
                 project($projectName Kotlin)
             """.trimIndent())
             appendln()
-
             for (interop in interops) {
                 val task = interop[TargetManager.host] ?: continue
                 appendln(
@@ -99,14 +97,11 @@ open class KonanGenerateCMakeTask : DefaultTask() {
 
     private val File.relativePath get() = relativeTo(project.projectDir)
 
-    private val FileCollection.asCMakeSourceList: List<String>
-        get() = files.map { it.relativePath.toString() }
-
     private val KonanInteropTask.cMakeCompilerOpts: String
         get() = compilerOpts.joinToString(" ")
 
     private val KonanCompileTask.cMakeSources: String
-        get() = srcFiles.flatMap { it.asCMakeSourceList }.joinToString(" ")
+        get() = srcDirs.joinToString(" ") { it.relativePath.toString() }
 
     private val KonanCompileTask.cMakeLibraries: String
         get() = mutableListOf<String>().apply {

--- a/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/CMakeSpecification.groovy
+++ b/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/CMakeSpecification.groovy
@@ -48,11 +48,11 @@ class CMakeSpecification extends BaseKonanSpecification {
             
             konanc_library(
                 NAME main_lib
-                SOURCES src/main/kotlin/main.kt)
+                SOURCES src/main/kotlin)
                 
             konanc_executable(
                 NAME Main
-                SOURCES src/main/kotlin/main.kt
+                SOURCES src/main/kotlin
                 LIBRARIES stdio main_lib
                 LINKER_OPTS -L/usr/lib/x86_64-linux-gnu)
             """.stripIndent().trim()

--- a/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/IncrementalSpecification.groovy
+++ b/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/IncrementalSpecification.groovy
@@ -119,7 +119,7 @@ class IncrementalSpecification extends BaseKonanSpecification {
         onlyRecompilationHappened(*results)
     }
 
-    def 'srcFiles change for a compilation task should cause only recompilation'() {
+    def 'srcDirs change for a compilation task should cause only recompilation'() {
         when:
         def project = KonanProject.createWithInterop(projectDirectory, ArtifactType.LIBRARY) { KonanProject it ->
             it.generateSrcFile(["src", "foo", "kotlin"], 'bar.kt', """
@@ -127,7 +127,7 @@ class IncrementalSpecification extends BaseKonanSpecification {
             """.stripIndent())
         }
         def results = buildTwice(project) { KonanProject it ->
-            it.addSetting("main", "srcFiles", "project.fileTree('src/foo/kotlin')")
+            it.addSetting("main", "srcDirs", "'src/foo/kotlin'")
         }
 
         then:
@@ -141,7 +141,7 @@ class IncrementalSpecification extends BaseKonanSpecification {
             it.buildFile.append("""
                 konanArtifacts {
                     library('lib') {
-                        srcFiles fileTree('src/lib/kotlin')
+                        srcDirs 'src/lib/kotlin'
                     }
                 }
             """.stripIndent())
@@ -161,7 +161,7 @@ class IncrementalSpecification extends BaseKonanSpecification {
             it.buildFile.append("""
                 konanArtifacts {
                     bitcode('lib') {
-                        srcFiles fileTree('src/lib/kotlin')
+                        srcDirs 'src/lib/kotlin'
                     }
                 }
             """.stripIndent())
@@ -241,7 +241,7 @@ class IncrementalSpecification extends BaseKonanSpecification {
             it.buildFile.append("""
                 konanArtifacts {
                     bitcode('lib') {
-                        srcFiles fileTree('src/lib/kotlin')
+                        srcDirs 'src/lib/kotlin'
                     }
                 }
             """.stripIndent())

--- a/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/KonanProject.groovy
+++ b/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/KonanProject.groovy
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlin.gradle.plugin.test
 
 import org.gradle.testkit.runner.GradleRunner
-import org.jetbrains.kotlin.konan.target.CompilerOutputKind
 import org.jetbrains.kotlin.konan.target.TargetManager
 
 import java.nio.file.Files
@@ -275,7 +274,7 @@ class KonanProject {
             interopTasks += newTasks
         } else {
             def src = generateSrcFile(projectPath.resolve("src/$name/kotlin"), "source.kt", content)
-            addSetting(name, "srcFiles", src)
+            addSetting(name, "srcDirs", "\"src/$name/kotlin\"")
             srcFiles += src
             compilationTasks += newTasks
         }


### PR DESCRIPTION
This changes grade DSL slightly, so that it is only possible to specify directories, and not arbitrary file collections. This should help with CMake generation and in general with IDE support.


Note that tests currently fail, but they should be fixed once #1081 is merged.

No changes to the samples were made, because all samples just use the default layout (which is great!). 