### PR TITLE
Explicitly declare public type of `konanArtifacts` extension

### DIFF
--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
@@ -263,7 +263,7 @@ class KonanPlugin @Inject constructor(private val registry: ToolingModelBuilderR
         project.tasks.create(KONAN_DOWNLOAD_TASK_NAME, KonanCompilerDownloadTask::class.java)
         project.tasks.create(KONAN_GENERATE_CMAKE_TASK_NAME, KonanGenerateCMakeTask::class.java)
         project.extensions.create(KONAN_EXTENSION_NAME, KonanExtension::class.java)
-        project.extensions.create(ARTIFACTS_CONTAINER_NAME, KonanArtifactContainer::class.java, project)
+        project.extensions.create(KonanArtifactContainer::class.java, ARTIFACTS_CONTAINER_NAME, KonanArtifactContainer::class.java, project)
 
         // Set additional project properties like konan.home, konan.build.targets etc.
         if (!project.hasProperty(ProjectProperty.KONAN_HOME)) {


### PR DESCRIPTION
Because `KonanArtifactContainer` inherits from Gradle's `DefaultPolymorphicDomainObjectContainer`, it inherits its implementation of [`HasPublicType`](https://github.com/gradle/gradle/blob/283a513257628b93a0b092f78385e2b42fec6da3/subprojects/model-core/src/main/java/org/gradle/api/reflect/HasPublicType.java#L29). This default implementation tells Gradle to expose the extension as a `NamedDomainObjectContainer<ElementType>` where `ElementType` is inferred in a best-effort manner. 

This means that any additional members of `KonanArtifactContainer` wouldn't be easily accessible in a Gradle Kotlin build script.

This commit explicitly declares the public extension type to be `KonanArtifactContainer` by using the appropriate [`ExtensionContainer#create` overload](https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/ExtensionContainer.html#create(java.lang.Class,%20java.lang.String,%20java.lang.Class,%20java.lang.Object...)).