### PR TITLE
Supported recursive references in enums

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -160,11 +160,23 @@ internal class KonanSymbols(context: Context, val symbolTable: SymbolTable): Sym
         symbol.descriptor to symbolTable.referenceSimpleFunction(functionDescriptor)
     }.toMap()
 
-     val valuesForEnum = symbolTable.referenceSimpleFunction(
+    val valuesForEnum = symbolTable.referenceSimpleFunction(
             context.getInternalFunctions("valuesForEnum").single())
 
     val valueOfForEnum = symbolTable.referenceSimpleFunction(
             context.getInternalFunctions("valueOfForEnum").single())
+
+    val enumValues = symbolTable.referenceSimpleFunction(
+             builtInsPackage("kotlin").getContributedFunctions(Name.identifier("enumValues"), NoLookupLocation.FROM_BACKEND).single())
+
+    val enumValueOf = symbolTable.referenceSimpleFunction(
+            builtInsPackage("kotlin").getContributedFunctions(Name.identifier("enumValueOf"), NoLookupLocation.FROM_BACKEND).single())
+
+    val createUninitializedInstance = symbolTable.referenceSimpleFunction(
+            context.getInternalFunctions("createUninitializedInstance").single())
+
+    val initInstance = symbolTable.referenceSimpleFunction(
+            context.getInternalFunctions("initInstance").single())
 
     val getContinuation = symbolTable.referenceSimpleFunction(
             context.getInternalFunctions("getContinuation").single())

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -2044,6 +2044,20 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
                 }
             }
 
+            context.ir.symbols.createUninitializedInstance.descriptor -> {
+                val typeParameterT = context.ir.symbols.createUninitializedInstance.descriptor.typeParameters[0]
+                val enumClass = callee.getTypeArgument(typeParameterT)!!
+                val enumClassDescriptor = enumClass.constructor.declarationDescriptor as ClassDescriptor
+                functionGenerationContext.allocInstance(typeInfoForAllocation(enumClassDescriptor), lifetimes[callee]!!)
+            }
+
+            context.ir.symbols.initInstance.descriptor -> {
+                val initializer = callee.getValueArgument(1) as IrCall
+                val thiz = evaluateExpression(callee.getValueArgument(0)!!)
+                evaluateSimpleFunctionCall(initializer.descriptor, listOf(thiz) + evaluateExplicitArgs(initializer), lifetimes[initializer]!!)
+                codegen.theUnitInstanceRef.llvm
+            }
+
             else -> TODO(callee.descriptor.original.toString())
         }
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DataFlowIR.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DataFlowIR.kt
@@ -406,6 +406,8 @@ internal object DataFlowIR {
             return parent.child(localName)
         }
 
+        private val FunctionDescriptor.internalName get() = getFqName(this).asString() + "#internal"
+
         fun mapFunction(descriptor: CallableDescriptor) = descriptor.original.let {
             functionMap.getOrPut(it) {
                 when (it) {
@@ -413,8 +415,9 @@ internal object DataFlowIR {
                         FunctionSymbol.Private(privateFunIndex++, module, -1, takeName { "${it.symbolName}_init" })
 
                     is FunctionDescriptor -> {
+                        val name = if (it.isExported()) it.symbolName else it.internalName
                         if (it.module != irModule.descriptor || it.externalOrIntrinsic())
-                            FunctionSymbol.External(it.symbolName.localHash.value, takeName { it.symbolName })
+                            FunctionSymbol.External(name.localHash.value, takeName { name })
                         else {
                             val isAbstract = it.modality == Modality.ABSTRACT
                             val classDescriptor = it.containingDeclaration as? ClassDescriptor
@@ -425,9 +428,9 @@ internal object DataFlowIR {
                                 ++module.numberOfFunctions
                             val symbolTableIndex = if (!placeToFunctionsTable) -1 else couldBeCalledVirtuallyIndex++
                             if (it.isExported())
-                                FunctionSymbol.Public(it.symbolName.localHash.value, module, symbolTableIndex, takeName { it.symbolName })
+                                FunctionSymbol.Public(name.localHash.value, module, symbolTableIndex, takeName { name })
                             else
-                                FunctionSymbol.Private(privateFunIndex++, module, symbolTableIndex, takeName { getFqName(it).asString() + "#internal" })
+                                FunctionSymbol.Private(privateFunIndex++, module, symbolTableIndex, takeName { name })
                         }
                     }
 

--- a/runtime/src/main/kotlin/konan/internal/RuntimeUtils.kt
+++ b/runtime/src/main/kotlin/konan/internal/RuntimeUtils.kt
@@ -105,6 +105,16 @@ fun <T: Enum<T>> valuesForEnum(values: Array<T>): Array<T>
     return result as Array<T>
 }
 
+@Intrinsic
+internal fun <T> createUninitializedInstance(): T {
+    throw Exception("Call to this function should've been lowered")
+}
+
+@Intrinsic
+internal fun initInstance(thiz: Any, constructorCall: Any): Unit {
+    throw Exception("Call to this function should've been lowered")
+}
+
 fun checkProgressionStep(step: Int)  = if (step > 0) step else throw IllegalArgumentException("Step must be positive, was: $step.")
 fun checkProgressionStep(step: Long) = if (step > 0) step else throw IllegalArgumentException("Step must be positive, was: $step.")
 


### PR DESCRIPTION
Split enum entries initialization onto two steps:
1. Allocation of all instances and storing them in the array;
2. Calling constructors on each instance.