### PR TITLE
Instead of execClang we now have execKonanClang which properly invokes

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2286,7 +2286,7 @@ if (isMac()) {
         interop = 'objcSmoke'
 
         doFirst {
-            execClang {
+            execKonanClang(project.testTarget) {
                 args "$projectDir/interop/objc/smoke.m"
                 args "-lobjc", '-fobjc-arc'
                 args '-fPIC', '-shared', '-o', "$buildDir/libobjcsmoke.dylib"

--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/CompileToBitcode.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/CompileToBitcode.groovy
@@ -98,11 +98,6 @@ class CompileCppToBitcode extends DefaultTask {
         linkerArgs.addAll(args)
     }
 
-    List<String> targetArgs(String target) {
-        def result = project.rootProject.targetClangArgs(KonanTarget.valueOf(target.toUpperCase()))
-        return result
-    }
-
     @TaskAction
     void compile() {
         // the strange code below seems to be required due to some Gradle (Groovy?) behaviour
@@ -113,12 +108,11 @@ class CompileCppToBitcode extends DefaultTask {
         File objDir = this.getObjDir()
         objDir.mkdirs()
 
-        project.execClang {
+        project.execKonanClang(this.target) {
             workingDir objDir
             executable "clang++"
             args '-std=c++11'
 
-            args targetArgs(this.target)
             args compilerArgs
 
             args "-I$headersDir"


### PR DESCRIPTION
the distribution clang able to utilize distributed sysroots etc.
And execBareClang which just invokes the distribution clang with system sysroot.