### PR TITLE
Pass -O2 to clang when compiling runtime

### DIFF
--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/CompileToBitcode.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/CompileToBitcode.groovy
@@ -112,7 +112,7 @@ class CompileCppToBitcode extends DefaultTask {
             workingDir objDir
             executable "clang++"
             args '-std=c++11'
-
+            args '-O2'
             args compilerArgs
 
             args "-I$headersDir"

--- a/runtime/src/main/cpp/Memory.cpp
+++ b/runtime/src/main/cpp/Memory.cpp
@@ -84,6 +84,12 @@ struct FrameOverlay {
   ArenaContainer* arena;
 };
 
+// A little hack that allows to enable -O2 optimizations
+// Prevents clang from replacing FrameOverlay struct
+// with single pointer.
+// Can be removed when FrameOverlay will become more complex
+FrameOverlay exportFrameOverlay;
+
 // Current number of allocated containers.
 int allocCount = 0;
 int aliveMemoryStatesCount = 0;


### PR DESCRIPTION
This fixes performance regression that appeared after migration to LLVM 5.0. The downside is that link_stage became slower (approximately by a factor of 2).