### PR TITLE
[build][gradle][4.4] upgrade

### DIFF
--- a/Interop/Indexer/build.gradle
+++ b/Interop/Indexer/build.gradle
@@ -82,6 +82,16 @@ model {
         }
    }
 
+  /* HACK over gradle 4.4, it adds /usr/include, that affects our --sysroot flag */
+  toolChains {
+    clang(Clang) {
+      eachPlatform {
+        cppCompiler.withArguments { args ->
+          args.remove "/usr/include"
+        }
+      }
+    }
+  }
 }
 
 sourceSets {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/libclangext/build.gradle
+++ b/libclangext/build.gradle
@@ -39,4 +39,15 @@ model {
             }
         }
     }
+
+  /* HACK over gradle 4.4, it adds /usr/include, that affects our --sysroot flag */
+  toolChains {
+    clang(Clang) {
+      eachPlatform {
+        cppCompiler.withArguments { args ->
+          args.remove "/usr/include"
+        }
+      }
+    }
+  }
 }

--- a/llvmDebugInfoC/build.gradle
+++ b/llvmDebugInfoC/build.gradle
@@ -25,12 +25,23 @@ model {
         binaries.withType(StaticLibraryBinarySpec) { binary ->
           if (!project.parent.convention.plugins.platformInfo.isWindows())
              cppCompiler.args "-fPIC"
-          cppCompiler.args "--std=c++11", "-g", "-I${llvmDir}/include", "-I${projectDir}/src/main/include"
+          cppCompiler.args "--std=c++11", "-I${llvmDir}/include", "-I${projectDir}/src/main/include"
           linker.args "-L${llvmDir}/lib", "-lLLVMCore", "-lLLVMSupport"
         }
         binaries.withType(SharedLibraryBinarySpec) { binary ->
             buildable = false
         }
+    }
+  }
+
+  /* HACK over gradle 4.4, it adds /usr/include, that affects our --sysroot flag */
+  toolChains {
+    clang(Clang) {
+      eachPlatform {
+        cppCompiler.withArguments { args ->
+          args.remove "/usr/include"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Gradle native software plugins adds -I/usr/include that inroduce conflict with our --systemroot flags,
so we had to add following hack over it:

````
 /* HACK over gradle 4.4, it adds /usr/include, that affects our --sysroot flag */
toolChains {
  clang(Clang) {
    eachPlatform {
      cppCompiler.withArguments { args ->
        args.remove /usr/include
      }
    }
  }
}
````
links with #1167