### PR TITLE
Resolve name conflicts when present (dyn lib generation)

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CAdapterGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CAdapterGenerator.kt
@@ -220,8 +220,12 @@ private class ExportedElement(val kind: ElementKind,
                     TypeUtils.getClassDescriptor(owner.context.builtIns.nullableAnyType)!!
             else -> uniqueName(original) to TypeUtils.getClassDescriptor(original.returnType!!)!!
         }
+        val namesRecorded = mutableMapOf<String, Int>()
         val params = ArrayList(original.explicitParameters.mapIndexed() { index, it ->
-            "p$index /* ${it.name.asString()} */" to TypeUtils.getClassDescriptor(it.type)!!
+            val name = owner.translateName(it.name.asString())
+            val count = namesRecorded.getOrDefault(name, 0)
+            namesRecorded[name] = count + 1
+            "$name${count.toString().takeUnless { it == "0" } ?: ""}" to TypeUtils.getClassDescriptor(it.type)!!
         })
         return listOf(returned) + params
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CAdapterGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CAdapterGenerator.kt
@@ -391,7 +391,11 @@ internal class CAdapterGenerator(
             val name = translateName(it.name.asString()) 
             val count = paramNamesRecorded.getOrDefault(name, 0)
             paramNamesRecorded[name] = count + 1
-            "$name${count.toString().takeUnless { it == "0" } ?: ""}"
+            if (count == 0) {
+                name
+            } else {
+                "$name${count.toString()}"
+            }
         }
     }
 


### PR DESCRIPTION
2e07b3f resolved #1199 by replacing the parameter name with generic `p0, p1, ...` names. However, the original parameter names are useful to have in the generated header for people using an IDE.

This commit instead looks for name duplicates and appends a number when it finds one. For the original test case in #1199 it produces 

```c
        void (*hi)(testproj_kref_Foo thiz, const char* thiz1);
```

If no name conflicts are present on a given signature then the parameter names are not modified.