### PR TITLE
Enable missing checkers for frontend

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanPlatformConfigurator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanPlatformConfigurator.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.container.StorageComponentContainer
 import org.jetbrains.kotlin.container.useInstance
 import org.jetbrains.kotlin.platform.PlatformToKotlinClassMap
 import org.jetbrains.kotlin.resolve.*
+import org.jetbrains.kotlin.resolve.calls.checkers.ReifiedTypeParameterSubstitutionChecker
 import org.jetbrains.kotlin.resolve.calls.results.TypeSpecificityComparator
 import org.jetbrains.kotlin.resolve.checkers.ExpectedActualDeclarationChecker
 import org.jetbrains.kotlin.resolve.lazy.DelegationFilter
@@ -32,7 +33,10 @@ import org.jetbrains.kotlin.types.DynamicTypesSettings
 object KonanPlatformConfigurator : PlatformConfigurator(
         DynamicTypesSettings(),
         additionalDeclarationCheckers = listOf(ExpectedActualDeclarationChecker),
-        additionalCallCheckers = listOf(),
+        additionalCallCheckers = listOf(
+                org.jetbrains.kotlin.resolve.jvm.checkers.SuperCallWithDefaultArgumentsChecker(),
+                ReifiedTypeParameterSubstitutionChecker()
+        ),
         additionalTypeCheckers = listOf(),
         additionalClassifierUsageCheckers = listOf(),
         additionalAnnotationCheckers = listOf(),

--- a/runtime/src/main/kotlin/konan/internal/RuntimeUtils.kt
+++ b/runtime/src/main/kotlin/konan/internal/RuntimeUtils.kt
@@ -102,7 +102,7 @@ fun <T: Enum<T>> valueOfForEnum(name: String, values: Array<T>) : T
 
 fun <T: Enum<T>> valuesForEnum(values: Array<T>): Array<T>
 {
-    val result = Array<T?>(values.size)
+    val result = @Suppress("TYPE_PARAMETER_AS_REIFIED") Array<T?>(values.size)
     for (value in values)
         result[value.ordinal] = value
     @Suppress("UNCHECKED_CAST")

--- a/runtime/src/main/kotlin/kotlin/Array.kt
+++ b/runtime/src/main/kotlin/kotlin/Array.kt
@@ -23,6 +23,7 @@ import konan.internal.InlineConstructor
 public final class Array<T> {
     // Constructors are handled with compiler magic.
     @InlineConstructor
+    @Suppress("TYPE_PARAMETER_AS_REIFIED")
     public constructor(size: Int, init: (Int) -> T): this(size) {
         var index = 0
         while (index < size) {

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
@@ -24,6 +24,7 @@ package kotlin.collections
 @kotlin.internal.InlineExposed
 internal fun <E> arrayOfUninitializedElements(size: Int): Array<E> {
     // TODO: special case for size == 0?
+    @Suppress("TYPE_PARAMETER_AS_REIFIED")
     return Array<E>(size)
 }
 
@@ -51,7 +52,7 @@ fun <E> Array<E>.copyOfNulls(fromIndex: Int, toIndex: Int): Array<E?> {
     if (newSize < 0) {
         throw IllegalArgumentException("$fromIndex > $toIndex")
     }
-    val result = arrayOfNulls<E>(newSize)
+    val result = @Suppress("TYPE_PARAMETER_AS_REIFIED") arrayOfNulls<E>(newSize)
     copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
     return result
 }

--- a/runtime/src/main/kotlin/kotlin/collections/MutableCollections.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/MutableCollections.kt
@@ -282,7 +282,8 @@ public fun <T : Comparable<T>> MutableList<T>.sort(): Unit = sortWith(Comparator
 public fun <T> MutableList<T>.sortWith(comparator: Comparator<in T>): Unit {
     if (size > 1) {
         val it = listIterator()
-        for (v in toTypedArray().apply { sortWith(comparator) }) {
+        val sortedArray = @Suppress("TYPE_PARAMETER_AS_REIFIED") toTypedArray().apply { sortWith(comparator) }
+        for (v in sortedArray) {
             it.next()
             it.set(v)
         }


### PR DESCRIPTION
* Forbid super-calls with default arguments as in JVM;
* Forbid passing incorrect types for reified parameters.

Also suppress revealed errors with passing non-reified type to
array constructor