### PR TITLE
Fix minor typo

### DIFF
--- a/samples/calculator/calculator.xcodeproj/project.pbxproj
+++ b/samples/calculator/calculator.xcodeproj/project.pbxproj
@@ -165,7 +165,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "case \"$PLATFORM_NAME\" in\n    iphoneos)\n        TARGET=iphone\n        TASK=compileKonanKotlinArithmeticParserIphone\n        ;;\n    iphonesimulator)\n        TARGET=iphone_sim\n        TASK=compileKonanKotlinArithmeticParserIphone_sim\n        ;;\n    *)\n        echo \"Unknown platform: $PLATFORN_NAME\"\n        exit 1\n        ;;\nesac\n\nmkdir -p \"$SRCROOT/build/konan/bin/\"\nrm -f \"$SRCROOT/build/konan/bin/xcode\"\nln -s \"$TARGET\" \"$SRCROOT/build/konan/bin/xcode\"\n\n\"$SRCROOT/../gradlew\" -p \"$SRCROOT\" \"$TASK\"";
+			shellScript = "case \"$PLATFORM_NAME\" in\n    iphoneos)\n        TARGET=iphone\n        TASK=compileKonanKotlinArithmeticParserIphone\n        ;;\n    iphonesimulator)\n        TARGET=iphone_sim\n        TASK=compileKonanKotlinArithmeticParserIphone_sim\n        ;;\n    *)\n        echo \"Unknown platform: $PLATFORM_NAME\"\n        exit 1\n        ;;\nesac\n\nmkdir -p \"$SRCROOT/build/konan/bin/\"\nrm -f \"$SRCROOT/build/konan/bin/xcode\"\nln -s \"$TARGET\" \"$SRCROOT/build/konan/bin/xcode\"\n\n\"$SRCROOT/../gradlew\" -p \"$SRCROOT\" \"$TASK\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Just fixing a minor typo in the calculator sample xcode build script. Only changing a single character (`PLATFORN` -> `PLATFORM`) in `"Unknown platform: $PLATFORN_NAME"`. 