### PR TITLE
Replace some libstdc++ functions by simpler implementations

### DIFF
--- a/backend.native/konan.properties
+++ b/backend.native/konan.properties
@@ -141,7 +141,8 @@ llvmLtoOptFlags.linux = -O3 -function-sections
 llvmLtoNooptFlags.linux = -O1
 llvmLtoDynamicFlags.linux = -relocation-model=pic
 llvmLlcFlags.linux = -march=x86-64
-linkerKonanFlags.linux = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread
+linkerKonanFlags.linux = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread \
+  --defsym __cxa_demangle=Konan_cxa_demangle
 linkerOptimizationFlags.linux = --gc-sections
 linkerNoDebugFlags.linux = -S
 linkerDynamicFlags.linux = -shared
@@ -172,7 +173,8 @@ linkerOptimizationFlags.raspberrypi = --gc-sections
 targetSysRoot.raspberrypi = target-sysroot-1-raspberrypi
 # We could reuse host toolchain here.
 libffiDir.raspberrypi = libffi-3.2.1-2-raspberrypi
-linkerKonanFlags.raspberrypi = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread
+linkerKonanFlags.raspberrypi = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread \
+  --defsym __cxa_demangle=Konan_cxa_demangle
 # targetSysroot-relative.
 libGcc.raspberrypi = lib/gcc/arm-linux-gnueabihf/4.8.3
 llvmLtoFlags.raspberrypi = -float-abi=hard -mcpu=arm1136jf-s
@@ -201,7 +203,8 @@ linkerDynamicFlags.linux_mips32 = -shared
 targetSysRoot.linux_mips32 = target-sysroot-2-mips
 # We could reuse host toolchain here.
 libffiDir.linux_mips32 = libffi-3.2.1-2-linux-mips
-linkerKonanFlags.linux_mips32 = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread
+linkerKonanFlags.linux_mips32 = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread \
+  --defsym __cxa_demangle=Konan_cxa_demangle
 # targetSysroot-relative.
 libGcc.linux_mips32 = lib/gcc/mips-unknown-linux-gnu/4.9.4
 llvmLtoFlags.linux_mips32 =
@@ -227,7 +230,8 @@ linkerDynamicFlags.linux_mipsel32 = -shared
 targetSysRoot.linux_mipsel32 = target-sysroot-2-mipsel
 # We could reuse host toolchain here.
 libffiDir.linux_mipsel32 = libffi-3.2.1-2-linux-mipsel
-linkerKonanFlags.linux_mipsel32 = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread
+linkerKonanFlags.linux_mipsel32 = -Bstatic -lstdc++ -Bdynamic -ldl -lm -lpthread \
+  --defsym __cxa_demangle=Konan_cxa_demangle
 # targetSysroot-relative.
 libGcc.linux_mipsel32 = lib/gcc/mipsel-unknown-linux-gnu/4.9.4
 llvmLtoFlags.linux_mipsel32 =
@@ -298,7 +302,10 @@ llvmLtoOptFlags.mingw = -O3 -function-sections
 llvmLtoNooptFlags.mingw = -O1
 linkerNoDebugFlags.mingw = -Wl,-S
 linkerDynamicFlags.mingw = -shared
-linkerKonanFlags.mingw =-static-libgcc -static-libstdc++ -Xclang -flto-visibility-public-std -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic
+linkerKonanFlags.mingw =-static-libgcc -static-libstdc++ \
+  -Xclang -flto-visibility-public-std \
+  -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic \
+  -Wl,--defsym,__cxa_demangle=Konan_cxa_demangle
 linkerOptimizationFlags.mingw = -Wl,--gc-sections
 entrySelector.mingw = -Wl,--defsym,main=Konan_main
 dependencies.mingw = \

--- a/runtime/src/main/cpp/StdCppStubs.cpp
+++ b/runtime/src/main/cpp/StdCppStubs.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Assert.h"
+#include "Porting.h"
+#include "Common.h"
+
+// This function replaces `__cxa_demangle` defined in GNU libstdc++
+// by adding `--defsym` flag in `konan.properties`.
+// This allows to avoid linking `__cxa_demangle` and its dependencies, thus reducing binary size.
+RUNTIME_USED extern "C" char* Konan_cxa_demangle(
+    const char* __mangled_name, char* __output_buffer,
+    size_t* __length, int* __status
+) {
+  *__status = -2; // __mangled_name is not a valid name under the C++ ABI mangling rules.
+  return nullptr;
+}
+
+namespace std {
+  void __throw_length_error(const char* __s __attribute__((unused))) {
+    RuntimeAssert(false, __s);
+  }
+}


### PR DESCRIPTION
This helps to avoid linking large libstdc++ parts, thus reducing the binary size.