### PR TITLE
[codegen][DI][inline] generation debug info for inlined functions.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -658,13 +658,12 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
                 "${declaration.descriptor.containingDeclaration}::${ir2string(declaration)}")
     }
 
-    private fun IrFunction.location(line: Int, column:Int): LocationInfo? {
-        return if (context.shouldContainDebugInfo()) LocationInfo(
+    private fun IrFunction.location(line: Int, column:Int) =
+            if (context.shouldContainDebugInfo()) LocationInfo(
                 scope = scope()!!,
                 line = line,
                 column = column)
-        else null
-    }
+            else null
 
     //-------------------------------------------------------------------------//
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -209,6 +209,16 @@ internal interface CodeContext {
     fun classScope(): CodeContext?
 
     fun addResumePoint(bbLabel: LLVMBasicBlockRef): Int
+
+    /**
+     * Returns owning returnable block scope [ReturnableBlockScope].
+     *
+     * @returns the requested value if in the class scope or null.
+     */
+    fun returnableBlockScope(): CodeContext?
+
+    fun location(line:Int, column: Int): LocationInfo?
+    fun scope(): DIScopeOpaqueRef?
 }
 
 //-------------------------------------------------------------------------//
@@ -254,6 +264,12 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         override fun classScope(): CodeContext? = null
 
         override fun addResumePoint(bbLabel: LLVMBasicBlockRef) = unsupported(bbLabel)
+
+        override fun returnableBlockScope(): CodeContext? = null
+
+        override fun location(line: Int, column: Int): LocationInfo? = unsupported()
+
+        override fun scope(): DIScopeOpaqueRef? = unsupported()
     }
 
     /**
@@ -319,7 +335,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
     private fun createInitBody(initName: String): LLVMValueRef {
         val initFunction = LLVMAddFunction(context.llvmModule, initName, kInitFuncType)!!    // create LLVM function
         generateFunction(codegen, initFunction) {
-            using(FunctionScope(initFunction, it)) {
+            using(FunctionScope(initFunction, initName, it)) {
                 val bbInit = basicBlock("init", null)
                 val bbDeinit = basicBlock("deinit", null)
                 condBr(functionGenerationContext.icmpEq(LLVMGetParam(initFunction, 0)!!, kImmZero), bbDeinit, bbInit)
@@ -541,14 +557,16 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
     private inner class FunctionScope (val declaration: IrFunction?, val functionGenerationContext: FunctionGenerationContext) : InnerScopeImpl() {
 
 
-        constructor(llvmFunction:LLVMValueRef, functionGenerationContext: FunctionGenerationContext):this(null, functionGenerationContext) {
+        constructor(llvmFunction:LLVMValueRef, name:String, functionGenerationContext: FunctionGenerationContext):this(null, functionGenerationContext) {
             this.llvmFunction = llvmFunction
-
+            this.name = name
         }
 
         var llvmFunction:LLVMValueRef? = declaration?.let{
             codegen.llvmFunction(declaration.descriptor)
         }
+
+        private var name:String? = declaration?.descriptor?.name?.asString()
 
         override fun genReturn(target: CallableDescriptor, value: LLVMValueRef?) {
             if (declaration == null || target == declaration.descriptor) {
@@ -576,6 +594,18 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         }
 
         override fun functionScope(): CodeContext = this
+
+
+        override fun location(line: Int, column: Int) = scope()?.let {
+            @Suppress("UNCHECKED_CAST")
+            LocationInfo(declaration?.scope() ?:
+                    llvmFunction!!.scope(0, subroutineType(context, codegen.llvmTargetData, listOf(context.builtIns.intType)))!!, 0, 0)
+        }
+
+        override fun scope() = if (context.shouldContainDebugInfo())
+            declaration?.scope() ?:  llvmFunction!!.scope(0, subroutineType(context, codegen.llvmTargetData, listOf(context.builtIns.intType)))
+        else
+            null
     }
 
     private val functionGenerationContext
@@ -601,17 +631,9 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         if (declaration.descriptor.isExternal)                    return
         if (body == null)                                         return
 
-        val scope = declaration.scope()
-        val startLine = declaration.startLine()
-        val startLocationInfo = LocationInfo(
-                scope  = scope,
-                line   = startLine,
-                column = declaration.startColumn())
-        val endLocationInfo = LocationInfo(
-                scope  = scope,
-                line   = declaration.endLine(),
-                column = declaration.endColumn())
-        generateFunction(codegen, declaration.descriptor, startLocationInfo, endLocationInfo) {
+        generateFunction(codegen, declaration.descriptor,
+                declaration.location(declaration.startLine(), declaration.startColumn()),
+                declaration.location(declaration.endLine(), declaration.endColumn())) {
             using(FunctionScope(declaration, it)) {
                 val parameterScope = ParameterScope(declaration, functionGenerationContext)
                 using(parameterScope) {
@@ -635,6 +657,14 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         if (context.shouldVerifyBitCode())
             verifyModule(context.llvmModule!!,
                 "${declaration.descriptor.containingDeclaration}::${ir2string(declaration)}")
+    }
+
+    private fun IrFunction.location(line: Int, column:Int): LocationInfo? {
+        return if (context.shouldContainDebugInfo()) LocationInfo(
+                scope = scope()!!,
+                line = line,
+                column = column)
+        else null
     }
 
     //-------------------------------------------------------------------------//
@@ -863,13 +893,12 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
             }
         }
 
-        private inline fun endLocationInfoFromScope(): LocationInfo? {
+        private fun endLocationInfoFromScope(): LocationInfo? {
             val functionScope = currentCodeContext.functionScope()
             val irFunction = functionScope?.let {
                 (functionScope as FunctionScope).declaration
             }
-            val locationInfo = irFunction?.endLocation
-            return locationInfo
+            return irFunction?.endLocation
         }
 
         private fun jumpToHandler(exception: LLVMValueRef) {
@@ -1106,16 +1135,15 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
 
     //-------------------------------------------------------------------------//
     private fun debugInfoIfNeeded(function: IrFunction?, element: IrElement): VariableDebugLocation? {
-        if (function == null || element.startLocation == null || !context.shouldContainDebugInfo()) return null
-        val functionScope = function.scope()
-        if (functionScope == null || !element.needDebugInfo(context)) return null
-        val locationInfo = element.startLocation!!
+        if (function == null || !context.shouldContainDebugInfo() || currentCodeContext.scope() == null) return null
+        if (!element.needDebugInfo(context)) return null
+        val locationInfo = element.startLocation ?: return null
         val location = codegen.generateLocationInfo(locationInfo)
         val file = (currentCodeContext.fileScope() as FileScope).file.file()
         return when (element) {
             is IrVariable -> debugInfoLocalVariableLocation(
                     builder       = context.debugInfo.builder,
-                    functionScope = functionScope,
+                    functionScope = locationInfo.scope,
                     diType        = element.descriptor.type.diType(context, codegen.llvmTargetData),
                     name          = element.descriptor.name,
                     file          = file,
@@ -1123,7 +1151,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
                     location      = location)
             is IrValueParameter -> debugInfoParameterLocation(
                     builder       = context.debugInfo.builder,
-                    functionScope = functionScope,
+                    functionScope = locationInfo.scope,
                     diType        = element.descriptor.type.diType(context, codegen.llvmTargetData),
                     name          = element.descriptor.name,
                     argNo         = (element.descriptor as? ValueParameterDescriptor)?.index ?: 0,
@@ -1413,7 +1441,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
                 NaiveSourceBasedFileEntryImpl(sourceFileName)
             }
 
-    private inner class ReturnableBlockScope(val returnableBlock: IrReturnableBlockImpl) :
+    private inner class ReturnableBlockScope(val returnableBlock: IrReturnableBlock) :
             FileScope(IrFileImpl(getFileEntry(returnableBlock.sourceFileName))) {
 
         var bbExit : LLVMBasicBlockRef? = null
@@ -1446,12 +1474,39 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
                 functionGenerationContext.assignPhis(getResult() to value!!)                      // Assign return value to result PHI node.
             }
         }
+
+        override fun returnableBlockScope(): CodeContext? = this
+
+        override fun location(line: Int, column: Int): LocationInfo? {
+            return scope.let{
+                LocationInfo(
+                        scope,
+                        line,
+                        column)
+            }
+        }
+
+        /**
+         * Note: DILexicalBlocks aren't nested, they should be scoped with the parent function.
+         */
+        private val scope:DIScopeOpaqueRef by lazy {
+            val lexicalBlockFile = DICreateLexicalBlockFile(context.debugInfo.builder, functionScope()!!.scope(), super.file.file())
+            DICreateLexicalBlock(context.debugInfo.builder, lexicalBlockFile, super.file.file(), returnableBlock.startLine(), returnableBlock.startColumn())!!
+        }
+
+        override fun scope() = scope
+
     }
 
     //-------------------------------------------------------------------------//
 
     private open inner class FileScope(val file:IrFile) : InnerScopeImpl() {
         override fun fileScope(): CodeContext? = this
+
+        override fun location(line: Int, column: Int): LocationInfo? = LocationInfo(scope()!!, line, column)
+
+        @Suppress("UNCHECKED_CAST")
+        override fun scope() = file.file() as DIScopeOpaqueRef?
     }
 
     //-------------------------------------------------------------------------//
@@ -1466,7 +1521,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
             DICreateReplaceableCompositeType(
                     tag        = DwarfTag.DW_TAG_structure_type.value,
                     refBuilder = context.debugInfo.builder,
-                    refScope   = context.debugInfo.compilationModule as DIScopeOpaqueRef,
+                    refScope   = (currentCodeContext.fileScope() as FileScope)!!.file.file() as DIScopeOpaqueRef,
                     name       = clazz.descriptor.typeInfoSymbolName,
                     refFile    = file().file(),
                     line       = clazz.startLine()) as DITypeOpaqueRef
@@ -1476,7 +1531,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
 
     //-------------------------------------------------------------------------//
 
-    private fun evaluateReturnableBlock(value: IrReturnableBlockImpl): LLVMValueRef {
+    private fun evaluateReturnableBlock(value: IrReturnableBlock): LLVMValueRef {
         context.log{"evaluateReturnableBlock         : ${value.statements.forEach { ir2string(it) }}"}
 
         val returnableBlockScope = ReturnableBlockScope(value)
@@ -1635,28 +1690,17 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
     private fun file() = (currentCodeContext.fileScope() as FileScope).file
 
     //-------------------------------------------------------------------------//
-    private fun updateBuilderDebugLocation(element: IrElement?):DILocationRef? {
-        if (!context.shouldContainDebugInfo() || element == null) return null
+    private fun updateBuilderDebugLocation(element: IrElement):DILocationRef? {
+        if (!context.shouldContainDebugInfo() || currentCodeContext.functionScope() == null) return null
         @Suppress("UNCHECKED_CAST")
         return element.startLocation?.let{functionGenerationContext.debugLocation(it)}
     }
 
     private val IrElement.startLocation: LocationInfo?
-        get() = location(startLine(), startColumn())
+        get() = currentCodeContext.location(startLine(), startColumn())
 
     private val IrElement.endLocation: LocationInfo?
-        get() = location(endLine(), endColumn())
-
-    private inline fun location(line: Int, column: Int): LocationInfo? {
-        val functionScope = currentCodeContext.functionScope() as? FunctionScope ?: return null
-        val scope = functionScope.declaration ?: return null
-        val diScope = scope.scope() ?: return null
-        return LocationInfo(
-                line = line,
-                column = column,
-                scope = diScope)
-    }
-
+        get() = currentCodeContext.location(endLine(), endColumn())
 
     //-------------------------------------------------------------------------//
     private fun IrElement.startLine() = file().fileEntry.line(this.startOffset)
@@ -1697,37 +1741,62 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
 
     //-------------------------------------------------------------------------//
     private fun IrFile.file(): DIFileRef {
-        return context.debugInfo.files.getOrPut(this) {
+        return context.debugInfo.files.getOrPut(this.fileEntry.name) {
             val path = this.fileEntry.name.toFileAndFolder()
-            DICreateFile(context.debugInfo.builder, path.file, path.folder)!!
+            val file = DICreateFile(context.debugInfo.builder, path.file, path.folder)!!
+            DICreateCompilationUnit(
+                    builder     = context.debugInfo.builder,
+                    lang        = DwarfLanguage.DW_LANG_Kotlin.value,
+                    File        = path.file,
+                    dir         = path.folder,
+                    producer    = DWARF.producer,
+                    isOptimized = 0,
+                    flags       = "",
+                    rv          = DWARF.runtimeVersion)
+            file
+
         }
     }
 
     //-------------------------------------------------------------------------//
+
+    private fun IrFunction.scope():DIScopeOpaqueRef? = descriptor.scope(startLine())
+
     @Suppress("UNCHECKED_CAST")
-    private fun IrFunction.scope():DIScopeOpaqueRef? {
-        if (!context.shouldContainDebugInfo()) return null
-        return context.debugInfo.subprograms.getOrPut(descriptor) {
+    private fun FunctionDescriptor.scope(startLine:Int): DIScopeOpaqueRef? {
+        if (!context.llvmDeclarations.hasFunction(this) || !context.shouldContainDebugInfo())
+            return null
+        return context.debugInfo.subprograms.getOrPut(codegen.llvmFunction(this)) {
             memScoped {
-                val subroutineType = descriptor.subroutineType(context, codegen.llvmTargetData)
-                val functionLlvmValue = codegen.functionLlvmValue(descriptor)
-                val linkageName = LLVMGetValueName(functionLlvmValue)!!.toKString()
-                val diFunction = DICreateFunction(
-                        builder      = context.debugInfo.builder,
-                        scope        = context.debugInfo.compilationModule as DIScopeOpaqueRef,
-                        name         = descriptor.name.asString(),
-                        linkageName  = linkageName,
-                        file         = file().file(),
-                        lineNo       = startLine(),
-                        type         = subroutineType,
-                        //TODO: need more investigations.
-                        isLocal      = 0,
-                        isDefinition = 1,
-                        scopeLine    = 0)
-                DIFunctionAddSubprogram(functionLlvmValue , diFunction)
-                diFunction!!
+                val subroutineType = subroutineType(context, codegen.llvmTargetData)
+                val functionLlvmValue = codegen.llvmFunction(this@scope)
+                diFunctionScope(name.asString(), functionLlvmValue.name!!, startLine, subroutineType, functionLlvmValue)
             }
-        } as DIScopeOpaqueRef
+        }  as DIScopeOpaqueRef
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun LLVMValueRef.scope(startLine:Int, subroutineType: DISubroutineTypeRef): DIScopeOpaqueRef? {
+        return context.debugInfo.subprograms.getOrPut(this) {
+            diFunctionScope(name!!, name!!, startLine, subroutineType, this)
+        }  as DIScopeOpaqueRef
+    }
+    private fun diFunctionScope(name: String, linkageName: String, startLine: Int, subroutineType: DISubroutineTypeRef, functionLlvmValue: LLVMValueRef): DISubprogramRef {
+        @Suppress("UNCHECKED_CAST")
+        val diFunction = DICreateFunction(
+                builder = context.debugInfo.builder,
+                scope = (currentCodeContext.fileScope() as FileScope).file.file() as DIScopeOpaqueRef,
+                name = name,
+                linkageName = linkageName,
+                file = file().file(),
+                lineNo = startLine,
+                type = subroutineType,
+                //TODO: need more investigations.
+                isLocal = 0,
+                isDefinition = 1,
+                scopeLine = 0)
+        DIFunctionAddSubprogram(functionLlvmValue, diFunction)
+        return diFunction!!
     }
 
     //-------------------------------------------------------------------------//
@@ -2434,6 +2503,6 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
     }
 }
 
-internal data class LocationInfo(val scope:DIScopeOpaqueRef?,
+internal data class LocationInfo(val scope:DIScopeOpaqueRef,
                                  val line:Int,
                                  val column:Int)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1766,7 +1766,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
 
     @Suppress("UNCHECKED_CAST")
     private fun FunctionDescriptor.scope(startLine:Int): DIScopeOpaqueRef? {
-        if (!context.llvmDeclarations.hasFunction(this) || !context.shouldContainDebugInfo())
+        if (codegen.isExternal(this) || !context.shouldContainDebugInfo())
             return null
         return context.debugInfo.subprograms.getOrPut(codegen.llvmFunction(this)) {
             memScoped {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
@@ -54,6 +54,8 @@ internal class LlvmDeclarations(
     fun forFunction(descriptor: FunctionDescriptor) = functions[descriptor] ?:
             error(descriptor.toString())
 
+    fun hasFunction(descriptor: FunctionDescriptor) = functions.containsKey(descriptor)
+
     fun forClass(descriptor: ClassDescriptor) = classes[descriptor] ?:
             error(descriptor.toString())
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
@@ -54,8 +54,6 @@ internal class LlvmDeclarations(
     fun forFunction(descriptor: FunctionDescriptor) = functions[descriptor] ?:
             error(descriptor.toString())
 
-    fun hasFunction(descriptor: FunctionDescriptor) = functions.containsKey(descriptor)
-
     fun forClass(descriptor: ClassDescriptor) = classes[descriptor] ?:
             error(descriptor.toString())
 

--- a/llvmDebugInfoC/src/main/cpp/DebugInfoC.cpp
+++ b/llvmDebugInfoC/src/main/cpp/DebugInfoC.cpp
@@ -285,44 +285,5 @@ const char *DIGetSubprogramLinkName(DISubprogramRef sp) {
 int DISubprogramDescribesFunction(DISubprogramRef sp, LLVMValueRef fn) {
   return llvm::unwrap(sp)->describes(llvm::cast<llvm::Function>(llvm::unwrap(fn)));
 }
-
-int checkLocalVariable(DILocalVariableRef variable) {
-  auto var = llvm::unwrap(variable);
-  auto localScope = var->getScope();
-  auto subprogramScope = llvm::cast<llvm::DISubprogram>(localScope);
-  assert(subprogramScope);
-  auto scope = llvm::cast<llvm::DIScope>(localScope);
-  assert(scope);
-  fprintf(stderr, "-------->8--------\n");
-  while(scope) {
-    //scope->dump();
-    fprintf(stderr, "%p\n", scope);
-    if (llvm::isa<llvm::DICompileUnit>(scope))
-      return 1;
-    auto scopeRef = scope->getScope();
-    if (!scopeRef) {
-      fprintf(stderr, "variable: %s, directory:%s file:%s:%d\n", var->getName().data(), var->getDirectory().data(), var->getFilename().data(), var->getLine());
-    }
-    scope = llvm::cast<llvm::DIScope>(scopeRef);
-  }
-  return 0;
-}
-
-DIScopeOpaqueRef parentScope(DIScopeOpaqueRef scopeRef) {
-  return llvm::wrap(llvm::unwrap(scopeRef)->getScope().resolve());
-}
-
-void dumpScopeType(DIScopeOpaqueRef scopeRef) {
-  auto scope = llvm::unwrap(scopeRef);
-  #define _DUMP(type) do { \
-    if (llvm::isa<llvm::type>(scope)) {          \
-      fprintf(stderr, #type "\n");               \
-      return;                                    \
-    }                                            \
-  } while(0)
-  _DUMP(DICompileUnit);
-  _DUMP(DIFile);
-  _DUMP(DISubprogram);
-}
 } /* extern "C" */
 

--- a/llvmDebugInfoC/src/main/cpp/DebugInfoC.cpp
+++ b/llvmDebugInfoC/src/main/cpp/DebugInfoC.cpp
@@ -22,7 +22,6 @@
 #include <llvm/IR/Instruction.h>
 #include <llvm/Support/Casting.h>
 #include "DebugInfoC.h"
-#include <stdio.h>
 /**
  * c++ --std=c++11 llvmDebugInfoC/src/DebugInfoC.cpp -IllvmDebugInfoC/include/ -Idependencies/all/clang+llvm-3.9.0-darwin-macos/include -Ldependencies/all/clang+llvm-3.9.0-darwin-macos/lib  -lLLVMCore -lLLVMSupport -lncurses -shared -o libLLVMDebugInfoC.dylib
  */

--- a/llvmDebugInfoC/src/main/include/DebugInfoC.h
+++ b/llvmDebugInfoC/src/main/include/DebugInfoC.h
@@ -111,11 +111,6 @@ const char* LLVMBuilderGetCurrentBbName(LLVMBuilderRef builder);
 const char *DIGetSubprogramLinkName(DISubprogramRef sp);
 LLVMValueRef LLVMBuilderGetCurrentFunction(LLVMBuilderRef builder);
 int DISubprogramDescribesFunction(DISubprogramRef sp, LLVMValueRef fn);
-/* for debug needs */
-int checkLocalVariable(DILocalVariableRef variable);
-DIScopeOpaqueRef parentScope(DIScopeOpaqueRef scopeRef);
-void dumpScopeType(DIScopeOpaqueRef scopeRef);
-//void DIScopeDump(DIScopeOpaqueRef scope);
 # ifdef __cplusplus
 }
 # endif

--- a/llvmDebugInfoC/src/main/include/DebugInfoC.h
+++ b/llvmDebugInfoC/src/main/include/DebugInfoC.h
@@ -84,6 +84,10 @@ DIModuleRef DICreateModule(DIBuilderRef builder, DIScopeOpaqueRef scope,
                            const char* name, const char* configurationMacro,
                            const char* includePath, const char *iSysRoot);
 
+DIScopeOpaqueRef DICreateLexicalBlockFile(DIBuilderRef builderRef, DIScopeOpaqueRef scopeRef, DIFileRef fileRef);
+
+DIScopeOpaqueRef DICreateLexicalBlock(DIBuilderRef builderRef, DIScopeOpaqueRef scopeRef, DIFileRef fileRef, int line, int column);
+
 DISubprogramRef DICreateFunction(DIBuilderRef builder, DIScopeOpaqueRef scope,
                                  const char* name, const char *linkageName,
                                  DIFileRef file, unsigned lineNo,
@@ -107,6 +111,10 @@ const char* LLVMBuilderGetCurrentBbName(LLVMBuilderRef builder);
 const char *DIGetSubprogramLinkName(DISubprogramRef sp);
 LLVMValueRef LLVMBuilderGetCurrentFunction(LLVMBuilderRef builder);
 int DISubprogramDescribesFunction(DISubprogramRef sp, LLVMValueRef fn);
+/* for debug needs */
+int checkLocalVariable(DILocalVariableRef variable);
+DIScopeOpaqueRef parentScope(DIScopeOpaqueRef scopeRef);
+void dumpScopeType(DIScopeOpaqueRef scopeRef);
 //void DIScopeDump(DIScopeOpaqueRef scope);
 # ifdef __cplusplus
 }


### PR DESCRIPTION
- We use DILexicalBlock and DILexicalBlockFile for generation debug info for kotlin inline (macro substituion by nature).
-- Note: DILexicalBlock aren't nested in opposite to inline function in C meaning.
- Changed DICompileUnit generation practise, now it generated for each file.
- added DI LLVM bindings.