### PR TITLE
sample/libcurl add body handler

### DIFF
--- a/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
+++ b/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
@@ -46,8 +46,8 @@ fun CPointer<ByteVar>.toKString(length: Int): String {
 
 fun header_callback(buffer: CPointer<ByteVar>?, size: size_t, nitems: size_t, userdata: COpaquePointer?): size_t {
     if (buffer == null) return 0
-    val header = buffer.toKString((size * nitems).toInt()).trim()
     if (userdata != null) {
+        val header = buffer.toKString((size * nitems).toInt()).trim()
         val curl = userdata.asStableRef<CUrl>().get()
         curl.header(header)
     }
@@ -57,8 +57,8 @@ fun header_callback(buffer: CPointer<ByteVar>?, size: size_t, nitems: size_t, us
 
 fun write_callback(buffer: CPointer<ByteVar>?, size: size_t, nitems: size_t, userdata: COpaquePointer?): size_t {
     if (buffer == null) return 0
-    val data = buffer.toKString((size * nitems).toInt()).trim()
     if (userdata != null) {
+        val data = buffer.toKString((size * nitems).toInt()).trim()
         val curl = userdata.asStableRef<CUrl>().get()
         curl.body(data)
     }

--- a/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
+++ b/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
@@ -19,6 +19,10 @@ class CUrl(val url: String)  {
     val header = Event<String>()
     val data = Event<String>()
 
+    fun nobody(){
+        curl_easy_setopt(curl, CURLOPT_NOBODY, 1L)
+    }
+
     fun fetch() {
         val res = curl_easy_perform(curl)
         if (res != CURLE_OK)

--- a/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
+++ b/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
@@ -2,6 +2,7 @@ package org.konan.libcurl
 
 import kotlinx.cinterop.*
 import platform.posix.*
+import platform.posix.size_t
 import libcurl.*
 
 class CUrl(val url: String)  {

--- a/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
+++ b/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
@@ -14,10 +14,13 @@ class CUrl(val url: String)  {
         val header = staticCFunction(::header_callback)
         curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header)
         curl_easy_setopt(curl, CURLOPT_HEADERDATA, stableRef.asCPointer())
+        val write_data = staticCFunction(::write_callback)
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data)
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, stableRef.asCPointer())
     }
 
     val header = Event<String>()
-    val data = Event<String>()
+    val body = Event<String>()
 
     fun nobody(){
         curl_easy_setopt(curl, CURLOPT_NOBODY, 1L)
@@ -50,13 +53,14 @@ fun header_callback(buffer: CPointer<ByteVar>?, size: size_t, nitems: size_t, us
     return size * nitems
 }
 
-/*
-fun write_callback(buffer: COpaquePointer?, size: size_t, nitems: size_t, userdata: COpaquePointer?): size_t {
+
+fun write_callback(buffer: CPointer<ByteVar>?, size: size_t, nitems: size_t, userdata: COpaquePointer?): size_t {
     if (buffer == null) return 0
+    val data = buffer.toKString((size * nitems).toInt()).trim()
     if (userdata != null) {
         val curl = userdata.asStableRef<CUrl>().get()
-        curl.data(buffer.)
+        curl.body(data)
     }
     return size * nitems
 }
-*/
+

--- a/samples/libcurl/src/main/kotlin/org/konan/libcurl/Program.kt
+++ b/samples/libcurl/src/main/kotlin/org/konan/libcurl/Program.kt
@@ -8,13 +8,15 @@ fun main(args: Array<String>) {
     curl.header += {
         println("[H] $it")
     }
+
+    curl.body += {
+        println("[B] $it")
+    }
+
     curl.fetch()
     curl.close()
 
-/*
-    val write_data = staticCFunction(::write_data)
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
-*/
+
 }
 
 fun help() {


### PR DESCRIPTION
this PR implements the handler of the body of the http call

implements `nobody()` method in case someone wants to use header only examples
added import for `import platform.posix.size_t` since fails on linux. Per [slack chat](https://kotlinlang.slack.com/archives/C3SGXARS6/p1516801844000029) maybe due multiple size_t available.

sample output to README.md of libcurl example:

```
$ build/bin/Curl.kexe https://raw.githubusercontent.com/JetBrains/kotlin-native/master/samples/libcurl/README.md
[H] HTTP/1.1 200 OK
[H] Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox
[H] Strict-Transport-Security: max-age=31536000
[H] X-Content-Type-Options: nosniff
[H] X-Frame-Options: deny
[H] X-XSS-Protection: 1; mode=block
[H] ETag: "ea858ff025ec4c69d467a855399b3b739df64115"
[H] Content-Type: text/plain; charset=utf-8
[H] Cache-Control: max-age=300
[H] X-Geo-Block-List:
[H] X-GitHub-Request-Id: 1D7E:366F:A0A40:A918F:5A69BF31
[H] Content-Length: 564
[H] Accept-Ranges: bytes
[H] Date: Thu, 25 Jan 2018 11:27:46 GMT
[H] Via: 1.1 varnish
[H] Connection: keep-alive
[H] X-Served-By: cache-ams4128-AMS
[H] X-Cache: MISS
[H] X-Cache-Hits: 0
[H] X-Timer: S1516879666.380145,VS0,VE80
[H] Vary: Authorization,Accept-Encoding
[H] Access-Control-Allow-Origin: *
[H] X-Fastly-Request-ID: c9ff9f3681fc819b3152ad643e8e49f70f1e6eff
[H] Expires: Thu, 25 Jan 2018 11:32:46 GMT
[H] Source-Age: 0
[H] 
[B] # HTTP client

 This example shows how to communicate with libcurl, HTTP/HTTPS/FTP/etc client library.
 Debian-like distros may need to `apt-get install libcurl4-openssl-dev`.

To build use `../gradlew build` or `./build.sh`.

To run use `../gradlew run`

To change run arguments, change property runArgs in gradle.propeties file 
or pass `-PrunArgs="https://www.jetbrains.com"` to gradle run. 

Alternatively you can run artifact directly 

    ./build/konan/bin/Curl/Curl.kexe https://www.jetbrains.com

It will perform HTTP get and print out the data obtained.
 $ 
```

