### PR TITLE
Minor bugfix to correct error handling.

### DIFF
--- a/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
+++ b/samples/libcurl/src/main/kotlin/org/konan/libcurl/CUrl.kt
@@ -22,7 +22,7 @@ class CUrl(val url: String)  {
     fun fetch() {
         val res = curl_easy_perform(curl)
         if (res != CURLE_OK)
-            println("curl_easy_perform() failed: ${curl_easy_strerror(res)}")
+            println("curl_easy_perform() failed: ${curl_easy_strerror(res)?.toKString()}")
     }
 
     fun close() {


### PR DESCRIPTION
Without this tweak the raw pointer from curl_easy_strerror() is returned as the error message masking what is truly wrong.