### PR TITLE
Fix override conflicts with different return types

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BinaryInterface.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BinaryInterface.kt
@@ -160,7 +160,7 @@ private val FunctionDescriptor.signature: String
                 when {
                     this.typeParameters.isNotEmpty() -> "Generic"
                     returnType.let { it != null && it.isValueType() } -> "ValueType"
-                    returnType.let { it != null && !KotlinBuiltIns.isUnitOrNullableUnit(it) } -> "Reference"
+                    returnType.let { it != null && !KotlinBuiltIns.isUnitOrNullableUnit(it) } -> typeToHashString(returnType!!)
                     else -> ""
                 }
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -907,6 +907,10 @@ task bridges_special(type: RunKonanTest) {
     source = "codegen/bridges/special.kt"
 }
 
+task returnTypeSignature(type: RunKonanTest) {
+    source = "codegen/bridges/returnTypeSignature.kt"
+}
+
 task classDelegation_method(type: RunKonanTest) {
     goldValue = "OKOK\n"
     source = "codegen/classDelegation/method.kt"

--- a/backend.native/tests/codegen/bridges/returnTypeSignature.kt
+++ b/backend.native/tests/codegen/bridges/returnTypeSignature.kt
@@ -1,0 +1,29 @@
+package codegen.bridges.signature
+
+import kotlin.test.*
+
+class A { }
+
+class B { }
+
+class C { }
+
+interface Parser<in IN: Any, out OUT: Any> {
+    fun parse(source: IN): OUT
+}
+
+interface MultiParser<in IN: Any, out OUT: Any> {
+    fun parse(source: IN): Collection<OUT>
+}
+
+interface ExtendsInterface<T: Any>: Parser<A, T>, MultiParser<B, T> {
+    override fun parse(source: B): Collection<T> = ArrayList<T>()
+}
+
+abstract class AbstractClass(): ExtendsInterface<C> {
+    public override fun parse(source: A): C = C()
+}
+
+@Test fun runTest() {
+    val array = object : AbstractClass() { }.parse(B())
+}


### PR DESCRIPTION
The test in the change fails on master before the fix with:
```
exception: java.lang.AssertionError: Duplicate method table entry: functionName = 'parse(#GENERIC_kotlin.Any)Reference', hash = '-3826397110773062389', entry1 = (descriptor=public open fun parse(source: A): C defined in main.<no name provided>[SimpleFunctionDescriptorImpl@1859e2a4], overriddenDescriptor=public abstract fun parse(source: IN): OUT defined in Parser[SimpleFunctionDescriptorImpl@40e60ece]), entry2 = (descriptor=public open fun parse(source: B): kotlin.collections.Collection<C> defined in main.<no name provided>[SimpleFunctionDescriptorImpl@46349b95], overriddenDescriptor=public abstract fun parse(source: IN): kotlin.collections.Collection<OUT> defined in MultiParser[SimpleFunctionDescriptorImpl@4b3fe06e])
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGenerator.methodTableRecords(RTTIGenerator.kt:215)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGenerator.generate(RTTIGenerator.kt:161)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGeneratorVisitor.visitClass(IrToBitcode.kt:140)
	at org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid$DefaultImpls.visitClass(IrElementVisitorVoid.kt:44)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGeneratorVisitor.visitClass(IrToBitcode.kt:122)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGeneratorVisitor.visitClass(IrToBitcode.kt:122)
	at org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl.accept(IrClassImpl.kt:77)
	at org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl.acceptChildren(IrFileImpl.kt:69)
	at org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoidKt.acceptChildrenVoid(IrElementVisitorVoid.kt:245)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGeneratorVisitor.visitElement(IrToBitcode.kt:128)
	at org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid$DefaultImpls.visitPackageFragment(IrElementVisitorVoid.kt:30)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGeneratorVisitor.visitPackageFragment(IrToBitcode.kt:122)
	at org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid$DefaultImpls.visitFile(IrElementVisitorVoid.kt:37)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGeneratorVisitor.visitFile(IrToBitcode.kt:122)
	at org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid$DefaultImpls.visitFile(IrElementVisitorVoid.kt:38)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGeneratorVisitor.visitFile(IrToBitcode.kt:122)
	at org.jetbrains.kotlin.backend.konan.llvm.RTTIGeneratorVisitor.visitFile(IrToBitcode.kt:122)
	at org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl.accept(IrFileImpl.kt:66)
```