### PR TITLE
[gradle-plugin] Use HostManager instead of PlatformManager

### DIFF
--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
@@ -112,7 +112,7 @@ private class TargetManagerImpl(val userRequest: String?, val hostManager: HostM
     override val targetSuffix get() = target.detailedName
 }
 
-open class HostManager internal constructor(protected val distribution: Distribution = Distribution()) {
+open class HostManager(protected val distribution: Distribution = Distribution()) {
 
     fun targetManager(userRequest: String? = null): TargetManager = TargetManagerImpl(userRequest, this)
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Platform.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Platform.kt
@@ -39,9 +39,9 @@ class PlatformManager(distribution: Distribution = Distribution()) : HostManager
         it.key to Platform(it.value)
     }.toMap()
 
-    fun platform(target: KonanTarget) = platforms[target]!!
-    val hostPlatform = platforms[host]!!
+    fun platform(target: KonanTarget) = platforms.getValue(target)
+    val hostPlatform = platforms.getValue(host)
 
-    fun loader(target: KonanTarget) = loaders[target]!!
+    fun loader(target: KonanTarget) = loaders.getValue(target)
 }
 

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanBuildingConfig.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanBuildingConfig.kt
@@ -46,11 +46,11 @@ abstract class KonanBuildingConfig<T: KonanBuildingTask>(private val name_: Stri
     internal val aggregateBuildTask: Task
 
     private val konanTargets: Iterable<KonanTarget>
-        get() = project.platformManager.toKonanTargets(targets).distinct()
+        get() = project.hostManager.toKonanTargets(targets).distinct()
 
     init {
         for (target in konanTargets) {
-            if (!project.platformManager.isEnabled(target)) {
+            if (!project.hostManager.isEnabled(target)) {
                 project.logger.warn("The target is not enabled on the current host: ${target.visibleName}")
                 continue
             }
@@ -119,7 +119,7 @@ abstract class KonanBuildingConfig<T: KonanBuildingTask>(private val name_: Stri
     internal operator fun get(target: KonanTarget) = targetToTask[target]
 
     fun getByTarget(target: String) = findByTarget(target) ?: throw NoSuchElementException("No such target for artifact $name: ${target}")
-    fun findByTarget(target: String) = this[project.platformManager.targetByName(target)]
+    fun findByTarget(target: String) = this[project.hostManager.targetByName(target)]
 
     fun getArtifactByTarget(target: String) = getByTarget(target).artifact
     fun findArtifactByTarget(target: String) = findByTarget(target)?.artifact
@@ -144,9 +144,9 @@ abstract class KonanBuildingConfig<T: KonanBuildingTask>(private val name_: Stri
     fun dependsOn(vararg dependencies: Any?) = forEach { it.dependsOn(*dependencies) }
 
     fun target(targetString: String, configureAction: T.() -> Unit) {
-        val target = project.platformManager.targetByName(targetString)
+        val target = project.hostManager.targetByName(targetString)
 
-        if (!project.platformManager.isEnabled(target)) {
+        if (!project.hostManager.isEnabled(target)) {
             project.logger.warn("Target '$targetString' of artifact '$name' is not supported on the current host")
             return
         }

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
@@ -23,8 +23,8 @@ import org.gradle.api.plugins.BasePlugin
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.jetbrains.kotlin.gradle.plugin.KonanPlugin.Companion.COMPILE_ALL_TASK_NAME
 import org.jetbrains.kotlin.gradle.plugin.tasks.*
+import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
-import org.jetbrains.kotlin.konan.target.PlatformManager
 import org.jetbrains.kotlin.konan.target.customerDistribution
 import java.io.File
 import java.util.*
@@ -74,13 +74,13 @@ internal val Project.konanArtifactsContainer: NamedDomainObjectContainer<KonanBu
     get() = extensions.getByName(KonanPlugin.ARTIFACTS_CONTAINER_NAME)
             as NamedDomainObjectContainer<KonanBuildingConfig<*>>
 
-internal val Project.platformManager: PlatformManager
-    get() = findProperty("platformManager") as PlatformManager? ?:
-            PlatformManager(customerDistribution(konanHome))
+internal val Project.hostManager: HostManager
+    get() = findProperty("hostManager") as HostManager? ?:
+        HostManager(customerDistribution(konanHome))
 
 internal val Project.konanTargets: List<KonanTarget>
-    get() = platformManager.toKonanTargets(konanExtension.targets)
-                .filter{ platformManager.isEnabled(it) }
+    get() = hostManager.toKonanTargets(konanExtension.targets)
+                .filter{ hostManager.isEnabled(it) }
                 .distinct()
 
 @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Gradle plugin uses PlatformManager to initialize tasks
when the compiler is not downloaded yet. In this case
PlatformManager cannot read konan.properties file.
This patch replaces PlatformManager with HostManager