### PR TITLE
Fix crash when producing framework with virtual suspend methods

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -790,8 +790,8 @@ private fun ObjCExportCodeGenerator.createTypeAdapter(
         }
     }
 
-    val virtualAdapters = descriptor.contributedMethods.
-            filter { mapper.isBaseMethod(it) && it.isOverridable }
+    val virtualAdapters = exposedMethods
+            .filter { mapper.isBaseMethod(it) && it.isOverridable }
             .map { createMethodVirtualAdapter(it) }
 
     val typeInfo = constPointer(codegen.typeInfoValue(descriptor))


### PR DESCRIPTION
Note: suspend methods aren't directly available through framework API