### PR TITLE
 Support IEEE754 floating point comparisons

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.backend.konan.serialization.markBackingFields
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.kotlinSourceRoots
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi2ir.Psi2IrConfiguration
 import org.jetbrains.kotlin.psi2ir.Psi2IrTranslator
 
@@ -46,7 +47,8 @@ fun runTopLevelPhases(konanConfig: KonanConfig, environment: KotlinCoreEnvironme
 
     val context = Context(konanConfig)
 
-    val analyzerWithCompilerReport = AnalyzerWithCompilerReport(context.messageCollector)
+    val analyzerWithCompilerReport = AnalyzerWithCompilerReport(context.messageCollector,
+            environment.configuration.languageVersionSettings)
 
     val phaser = PhaseManager(context)
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/DescriptorUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/DescriptorUtils.kt
@@ -28,11 +28,13 @@ import org.jetbrains.kotlin.builtins.isFunctionType
 import org.jetbrains.kotlin.builtins.isSuspendFunctionType
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.descriptorUtil.*
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.SimpleType
 import org.jetbrains.kotlin.types.typeUtil.isUnit
 import org.jetbrains.kotlin.util.OperatorNameConventions
 
@@ -70,13 +72,7 @@ internal fun <T : CallableMemberDescriptor> T.resolveFakeOverride(): T {
 private val intrinsicAnnotation = FqName("konan.internal.Intrinsic")
 
 internal val CallableDescriptor.isIntrinsic: Boolean
-    get() = when {
-        this.annotations.hasAnnotation(intrinsicAnnotation) -> {
-        //    check(isExternal, { "Intrinsic function $name should be external" })
-            true
-        }
-        else -> false
-    }
+    get() = this.annotations.hasAnnotation(intrinsicAnnotation)
 
 private val intrinsicTypes = setOf(
         "kotlin.Boolean", "kotlin.Char",
@@ -345,3 +341,6 @@ val ClassDescriptor.enumEntries: List<ClassDescriptor>
 
 internal val DeclarationDescriptor.isExpectMember: Boolean
     get() = this is MemberDescriptor && this.isExpect
+
+fun FunctionDescriptor.isComparisonDescriptor(map: Map<SimpleType, IrSimpleFunction>): Boolean =
+        map.values.any { it.descriptor == this }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/DescriptorUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/DescriptorUtils.kt
@@ -74,9 +74,14 @@ internal fun <T : CallableMemberDescriptor> T.resolveFakeOverride(): T {
 
 private val intrinsicAnnotation = FqName("konan.internal.Intrinsic")
 
-// TODO: check it is external?
-internal val CallableDescriptor.isIntrinsic: Boolean
-    get() = this.annotations.findAnnotation(intrinsicAnnotation) != null
+internal val FunctionDescriptor.isIntrinsic: Boolean
+    get() = when {
+        this.annotations.hasAnnotation(intrinsicAnnotation) -> {
+            check(isExternal, { "Intrinsic function $name should be external" })
+            true
+        }
+        else -> false
+    }
 
 private val intrinsicTypes = setOf(
         "kotlin.Boolean", "kotlin.Char",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/DescriptorUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/DescriptorUtils.kt
@@ -18,8 +18,6 @@ package org.jetbrains.kotlin.backend.konan.descriptors
 
 import org.jetbrains.kotlin.backend.common.atMostOne
 import org.jetbrains.kotlin.backend.konan.KonanBuiltIns
-import org.jetbrains.kotlin.backend.konan.ValueType
-import org.jetbrains.kotlin.backend.konan.isRepresentedAs
 import org.jetbrains.kotlin.backend.konan.isValueType
 import org.jetbrains.kotlin.backend.konan.llvm.functionName
 import org.jetbrains.kotlin.backend.konan.llvm.localHash
@@ -30,10 +28,7 @@ import org.jetbrains.kotlin.builtins.isFunctionType
 import org.jetbrains.kotlin.builtins.isSuspendFunctionType
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
-import org.jetbrains.kotlin.incremental.components.NoLookupLocation
-import org.jetbrains.kotlin.ir.descriptors.IrBuiltinOperatorDescriptorBase
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.descriptorUtil.*
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
@@ -74,10 +69,10 @@ internal fun <T : CallableMemberDescriptor> T.resolveFakeOverride(): T {
 
 private val intrinsicAnnotation = FqName("konan.internal.Intrinsic")
 
-internal val FunctionDescriptor.isIntrinsic: Boolean
+internal val CallableDescriptor.isIntrinsic: Boolean
     get() = when {
         this.annotations.hasAnnotation(intrinsicAnnotation) -> {
-            check(isExternal, { "Intrinsic function $name should be external" })
+        //    check(isExternal, { "Intrinsic function $name should be external" })
             true
         }
         else -> false

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -121,6 +121,10 @@ internal class KonanSymbols(context: Context, val symbolTable: SymbolTable): Sym
         symbolTable.referenceSimpleFunction(it)
     }
 
+    val ieee754Equals = context.getInternalFunctions("ieee754Equals").map {
+        symbolTable.referenceSimpleFunction(it)
+    }
+
     override val areEqual = symbolTable.referenceSimpleFunction(context.getInternalFunctions("areEqual").single())
 
     override val ThrowNullPointerException = symbolTable.referenceSimpleFunction(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
@@ -458,6 +458,10 @@ internal class FunctionGenerationContext(val function: LLVMValueRef,
 
     /* floating-point comparisons */
     fun fcmpEq(arg0: LLVMValueRef, arg1: LLVMValueRef, name: String = ""): LLVMValueRef = LLVMBuildFCmp(builder, LLVMRealPredicate.LLVMRealOEQ, arg0, arg1, name)!!
+    fun fcmpGt(arg0: LLVMValueRef, arg1: LLVMValueRef, name: String = ""): LLVMValueRef = LLVMBuildFCmp(builder, LLVMRealPredicate.LLVMRealOGT, arg0, arg1, name)!!
+    fun fcmpGe(arg0: LLVMValueRef, arg1: LLVMValueRef, name: String = ""): LLVMValueRef = LLVMBuildFCmp(builder, LLVMRealPredicate.LLVMRealOGE, arg0, arg1, name)!!
+    fun fcmpLt(arg0: LLVMValueRef, arg1: LLVMValueRef, name: String = ""): LLVMValueRef = LLVMBuildFCmp(builder, LLVMRealPredicate.LLVMRealOLT, arg0, arg1, name)!!
+    fun fcmpLe(arg0: LLVMValueRef, arg1: LLVMValueRef, name: String = ""): LLVMValueRef = LLVMBuildFCmp(builder, LLVMRealPredicate.LLVMRealOLE, arg0, arg1, name)!!
 
     fun bitcast(type: LLVMTypeRef?, value: LLVMValueRef, name: String = "") = LLVMBuildBitCast(builder, value, type, name)!!
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -46,7 +46,6 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.SimpleType
 import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.types.typeUtil.isNothing
 import org.jetbrains.kotlin.types.typeUtil.isPrimitiveNumberType
@@ -2343,27 +2342,25 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         val ib = context.irModule!!.irBuiltins
 
         with(functionGenerationContext) {
-            val arg0 = args[0]
-            val arg1 = args[1]
             return when {
-                descriptor == ib.eqeqeq -> icmpEq(arg0, arg1)
-                descriptor == ib.booleanNot -> icmpNe(arg0, kTrue)
+                descriptor == ib.eqeqeq -> icmpEq(args[0], args[1])
+                descriptor == ib.booleanNot -> icmpNe(args[0], kTrue)
 
                 descriptor.isComparisonDescriptor(ib.greaterFunByOperandType) -> {
-                    if (arg0.type.isFloatingPoint()) fcmpGt(arg0, arg1)
-                    else icmpGt(arg0, arg1)
+                    if (args[0].type.isFloatingPoint()) fcmpGt(args[0], args[1])
+                    else icmpGt(args[0], args[1])
                 }
                 descriptor.isComparisonDescriptor(ib.greaterOrEqualFunByOperandType) -> {
-                    if (arg0.type.isFloatingPoint()) fcmpGe(arg0, arg1)
-                    else icmpGe(arg0, arg1)
+                    if (args[0].type.isFloatingPoint()) fcmpGe(args[0], args[1])
+                    else icmpGe(args[0], args[1])
                 }
                 descriptor.isComparisonDescriptor(ib.lessFunByOperandType) -> {
-                    if (arg0.type.isFloatingPoint()) fcmpLt(arg0, arg1)
-                    else icmpLt(arg0, arg1)
+                    if (args[0].type.isFloatingPoint()) fcmpLt(args[0], args[1])
+                    else icmpLt(args[0], args[1])
                 }
                 descriptor.isComparisonDescriptor(ib.lessOrEqualFunByOperandType) -> {
-                    if (arg0.type.isFloatingPoint()) fcmpLe(arg0, arg1)
-                    else icmpLe(arg0, arg1)
+                    if (args[0].type.isFloatingPoint()) fcmpLe(args[0], args[1])
+                    else icmpLe(args[0], args[1])
                 }
                 else -> TODO(descriptor.name.toString())
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
@@ -307,3 +307,8 @@ internal fun String.mdString() = LLVMMDString(this, this.length)!!
 internal fun node(vararg it:LLVMValueRef) = LLVMMDNode(it.toList().toCValues(), it.size)
 
 internal fun LLVMValueRef.setUnaligned() = apply { LLVMSetAlignment(this, 1) }
+
+fun LLVMTypeRef.isFloatingPoint(): Boolean = when (llvm.LLVMGetTypeKind(this)) {
+    LLVMTypeKind.LLVMFloatTypeKind, LLVMTypeKind.LLVMDoubleTypeKind -> true
+    else -> false
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DefaultArgumentsStubGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DefaultArgumentsStubGenerator.kt
@@ -47,7 +47,7 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
-import org.jetbrains.kotlin.resolve.descriptorUtil.hasDefaultValue
+import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.builtIns
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ForLoopsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ForLoopsLowering.kt
@@ -441,7 +441,7 @@ private class ForLoopsTransformer(val context: Context) : IrElementTransformerVo
                 putValueArgument(0, minConst)
             }
             putValueArgument(0, compareToCall)
-            putValueArgument(1, IrConstImpl.int(startOffset, endOffset, context.builtIns.intType, 0))
+            putValueArgument(1, irInt(0))
         }
     }
 
@@ -459,7 +459,7 @@ private class ForLoopsTransformer(val context: Context) : IrElementTransformerVo
 
         val check: IrExpression = irCall(comparingBuiltIn!!).apply {
             putValueArgument(0, irCallOp(compareTo, irGet(forLoopInfo.inductionVariable), irGet(forLoopInfo.last)))
-            putValueArgument(1, IrConstImpl.int(startOffset, endOffset, context.builtIns.intType, 0))
+            putValueArgument(1, irInt(0))
         }
 
         // Process closed and open ranges in different manners.

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FunctionInlining.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FunctionInlining.kt
@@ -45,7 +45,7 @@ import org.jetbrains.kotlin.ir.symbols.impl.createValueSymbol
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
-import org.jetbrains.kotlin.resolve.descriptorUtil.hasDefaultValue
+import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
 import org.jetbrains.kotlin.resolve.inline.InlineUtil
 import org.jetbrains.kotlin.types.TypeProjectionImpl
 import org.jetbrains.kotlin.types.TypeSubstitutor

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/DescriptorTable.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/DescriptorTable.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.backend.konan.llvm.isExported
 import org.jetbrains.kotlin.backend.konan.llvm.typeInfoSymbolName
 import org.jetbrains.kotlin.backend.konan.llvm.symbolName
 import org.jetbrains.kotlin.backend.konan.llvm.localHash
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 
 internal fun DeclarationDescriptor.symbolName(): String = when (this) {
     is FunctionDescriptor 
@@ -81,16 +82,12 @@ class IrDeserializationDescriptorIndex(irBuiltIns: IrBuiltIns) {
 }
 
 val IrBuiltIns.irBuiltInDescriptors
-    get() = listOf<FunctionDescriptor>(
-        this.eqeqeq,
-        this.eqeq,
-        this.lt0,
-        this.lteq0,
-        this.gt0,
-        this.gteq0,
-        this.throwNpe,
-        this.booleanNot,
-        this.noWhenBranchMatchedException,
-        this.enumValueOf)
+    get() = (lessFunByOperandType.values +
+                lessOrEqualFunByOperandType.values +
+                greaterOrEqualFunByOperandType.values +
+                greaterFunByOperandType.values +
+                ieee754equalsFunByOperandType.values +
+                eqeqeqFun + eqeqFun + throwNpeFun + booleanNotFun + noWhenBranchMatchedExceptionFun + enumValueOfFun)
+                .map(IrSimpleFunction::descriptor)
 
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanDescriptorSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanDescriptorSerializer.kt
@@ -74,7 +74,7 @@ class KonanDescriptorSerializer private constructor(
         val flags = Flags.getClassFlags(
                 hasAnnotations(classDescriptor), classDescriptor.visibility, classDescriptor.modality, classDescriptor.kind,
                 classDescriptor.isInner, classDescriptor.isCompanionObject, classDescriptor.isData, classDescriptor.isExternal,
-                classDescriptor.isExpect
+                classDescriptor.isExpect, classDescriptor.isInline
         )
         if (flags != builder.flags) {
             builder.flags = flags

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUnboundSymbolReplacer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUnboundSymbolReplacer.kt
@@ -40,9 +40,12 @@ internal fun IrModuleFragment.replaceUnboundSymbols(context: Context) {
     val collector = DeclarationSymbolCollector()
     with(collector) {
         with(irBuiltins) {
-            for (op in arrayOf(eqeqeqFun, eqeqFun, lt0Fun, lteq0Fun, gt0Fun, gteq0Fun, throwNpeFun, booleanNotFun,
-                    noWhenBranchMatchedExceptionFun)) {
-
+            for (op in arrayOf(eqeqeqFun, eqeqFun, throwNpeFun, booleanNotFun, noWhenBranchMatchedExceptionFun) +
+                    lessFunByOperandType.values +
+                    lessOrEqualFunByOperandType.values +
+                    greaterOrEqualFunByOperandType.values +
+                    greaterFunByOperandType.values +
+                    ieee754equalsFunByOperandType.values) {
                 register(op.symbol)
             }
         }

--- a/backend.native/tests/external/codegen/box/ieee754/dataClass.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/dataClass.kt
@@ -1,5 +1,3 @@
-// IGNORE_BACKEND: NATIVE
-
 data class Test(val z1: Double, val z2: Double?)
 
 fun box(): String {

--- a/backend.native/tests/external/codegen/box/ieee754/equalsNaN.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/equalsNaN.kt
@@ -1,4 +1,3 @@
-// IGNORE_BACKEND: NATIVE
 // WITH_RUNTIME
 
 import kotlin.test.*

--- a/backend.native/tests/external/codegen/box/ieee754/explicitCompareCall.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/explicitCompareCall.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JS, NATIVE
+// IGNORE_BACKEND: JS
 fun less1(a: Double, b: Double) = a.compareTo(b) == -1
 
 fun less2(a: Double?, b: Double?) = a!!.compareTo(b!!) == -1

--- a/backend.native/tests/external/codegen/box/ieee754/explicitEqualsCall.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/explicitEqualsCall.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JS, NATIVE
+// IGNORE_BACKEND: JS
 
 fun equals1(a: Double, b: Double) = a.equals(b)
 

--- a/backend.native/tests/external/codegen/box/ieee754/inline.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/inline.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JS, NATIVE
+// IGNORE_BACKEND: JS!
 
 inline fun less(a: Comparable<Double>, b: Double): Boolean {
     return a < b

--- a/backend.native/tests/external/codegen/box/ieee754/inline.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/inline.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JS!
+// IGNORE_BACKEND: JS
 
 inline fun less(a: Comparable<Double>, b: Double): Boolean {
     return a < b

--- a/backend.native/tests/external/codegen/box/ieee754/safeCall.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/safeCall.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JS, NATIVE
+// IGNORE_BACKEND: JS
 fun box(): String {
     val plusZero: Double? = 0.0
     val minusZero: Double = -0.0

--- a/backend.native/tests/external/codegen/box/ieee754/smartCastToDifferentTypes.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/smartCastToDifferentTypes.kt
@@ -1,4 +1,4 @@
-// IGNORE_BACKEND: JS, NATIVE
+// IGNORE_BACKEND: JS
 fun box(): String {
     val zero: Any = 0.0
     val floatZero: Any = -0.0F

--- a/backend.native/tests/external/codegen/box/primitiveTypes/comparisonWithNaN.kt
+++ b/backend.native/tests/external/codegen/box/primitiveTypes/comparisonWithNaN.kt
@@ -1,5 +1,5 @@
 // TODO: muted automatically, investigate should it be ran for JS or not
-// IGNORE_BACKEND: JS, NATIVE
+// IGNORE_BACKEND: JS
 
 // This test checks that our bytecode is consistent with javac bytecode
 
@@ -10,8 +10,8 @@ fun _assert(condition: Boolean) {
 fun _assertFalse(condition: Boolean) = _assert(!condition)
 
 fun box(): String {
-    var dnan = java.lang.Double.NaN
-    if (System.nanoTime() < 0) dnan = 3.14 // To avoid possible compile-time const propagation
+    var dnan = Double.NaN
+//    if (System.nanoTime() < 0) dnan = 3.14 // To avoid possible compile-time const propagation
 
     _assertFalse(0.0 < dnan)
     _assertFalse(0.0 > dnan)
@@ -34,8 +34,8 @@ fun box(): String {
     _assert(dnan.compareTo(0.0) == 1)
     _assert(dnan.compareTo(dnan) == 0)
 
-    var fnan = java.lang.Float.NaN
-    if (System.nanoTime() < 0) fnan = 3.14f
+    var fnan = Float.NaN
+//    if (System.nanoTime() < 0) fnan = 3.14f
 
     _assertFalse(0.0f < fnan)
     _assertFalse(0.0f > fnan)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,10 +23,10 @@ testDataVersion=1226829:id
 kotlinCompilerRepo=https://dl.bintray.com/jetbrains/kotlin-native-dependencies
 #kotlinCompilerRepo=http://oss.sonatype.org/content/repositories/snapshots
 #kotlinCompilerRepo=http://dl.bintray.com/kotlin/kotlin-dev
-kotlinCompilerVersion=1.2-20180202.233511-207
-kotlinScriptRuntimeVersion=1.2-20180202.233541-207
-kotlinStdLibVersion=1.2-20180202.233544-207
-kotlinReflectVersion=1.2-20180205.090650-208
+kotlinCompilerVersion=1.2-20180212.074217-235
+kotlinScriptRuntimeVersion=1.2-20180212.074236-235
+kotlinStdLibVersion=1.2-20180212.074248-235
+kotlinReflectVersion=1.2-20180212.074230-235
 konanVersion=0.6
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 
@@ -34,8 +34,8 @@ org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 # required for performance mesuarement tasks
 
 kotlinStdLibJdk7Version=1.2-20180211.161219-234
-kotlinStdLibJdk8Version=1.2-20180205.090723-208
-kotlinGradlePluginVersion=1.2-20180205.090645-208
+kotlinStdLibJdk8Version=1.2-20180209.103010-228
+kotlinGradlePluginVersion=1.2-20180209.102945-228
 
 kotlinGradlePluginApiVersion=1.2-20180208.144029-227
 kotlinCompilerEmbeddableVersion=1.2-20180208.144022-227

--- a/runtime/src/main/cpp/Operator.cpp
+++ b/runtime/src/main/cpp/Operator.cpp
@@ -324,13 +324,6 @@ KDouble Kotlin_Long_toDouble         (KLong a           ) { return a; }
 
 //--- Float -------------------------------------------------------------------//
 
-KInt    Kotlin_Float_compareTo_Byte   (KFloat a, KByte   b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Float_compareTo_Short  (KFloat a, KShort  b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Float_compareTo_Int    (KFloat a, KInt    b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Float_compareTo_Long   (KFloat a, KLong   b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Float_compareTo_Float  (KFloat a, KFloat  b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Float_compareTo_Double (KFloat a, KDouble b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-
 KFloat  Kotlin_Float_plus_Byte        (KFloat a, KByte   b) { return a + b; }
 KFloat  Kotlin_Float_plus_Short       (KFloat a, KShort  b) { return a + b; }
 KFloat  Kotlin_Float_plus_Int         (KFloat a, KInt    b) { return a + b; }
@@ -412,13 +405,6 @@ KBoolean Kotlin_Float_isFinite        (KFloat a)          { return isfinite(a); 
 
   //--- Double ------------------------------------------------------------------//
 
-KInt    Kotlin_Double_compareTo_Byte   (KDouble a, KByte   b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Double_compareTo_Short  (KDouble a, KShort  b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Double_compareTo_Int    (KDouble a, KInt    b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Double_compareTo_Long   (KDouble a, KLong   b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Double_compareTo_Float  (KDouble a, KFloat  b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-KInt    Kotlin_Double_compareTo_Double (KDouble a, KDouble b) { if (a == b) return 0; return (a < b) ? -1 : 1; }
-
 KDouble Kotlin_Double_plus_Byte        (KDouble a, KByte   b) { return a + b; }
 KDouble Kotlin_Double_plus_Short       (KDouble a, KShort  b) { return a + b; }
 KDouble Kotlin_Double_plus_Int         (KDouble a, KInt    b) { return a + b; }
@@ -471,8 +457,7 @@ KLong   Kotlin_Double_toLong           (KDouble a           ) {
   if (a <= (KDouble) INT64_MIN) return INT64_MIN;
   return a;
 }
-KByte   Kotlin_Double_toByte           (KDouble a           ) { return (KByte)  Kotlin_Double_toInt(a); }
-KShort  Kotlin_Double_toShort          (KDouble a           ) { return (KShort) Kotlin_Double_toInt(a); }
+
 KFloat  Kotlin_Double_toFloat          (KDouble a           ) { return a; }
 KDouble Kotlin_Double_toDouble         (KDouble a           ) { return a; }
 

--- a/runtime/src/main/kotlin/konan/internal/Boxing.kt
+++ b/runtime/src/main/kotlin/konan/internal/Boxing.kt
@@ -170,7 +170,7 @@ class FloatBox(val value: Float) : Number(), Comparable<Float> {
             return false
         }
 
-        return this.value == other.value
+        return this.value.equals(other.value)
     }
 
     override fun hashCode() = value.hashCode()
@@ -197,7 +197,7 @@ class DoubleBox(val value: Double) : Number(), Comparable<Double> {
             return false
         }
 
-        return this.value == other.value
+        return this.value.equals(other.value)
     }
 
     override fun hashCode() = value.hashCode()

--- a/runtime/src/main/kotlin/konan/internal/Coroutines.kt
+++ b/runtime/src/main/kotlin/konan/internal/Coroutines.kt
@@ -21,12 +21,11 @@ import kotlin.coroutines.experimental.intrinsics.*
 
 @Intrinsic
 @PublishedApi
-internal external fun <T> getContinuation(): Continuation<T> = throw AssertionError("Call to getContinuation should've been lowered")
+internal external fun <T> getContinuation(): Continuation<T>
 
 @Intrinsic
 @PublishedApi
 internal external suspend fun <T> returnIfSuspended(@Suppress("UNUSED_PARAMETER") argument: Any?): T
-        = throw AssertionError("Call to returnIfSuspended should've been lowered")
 
 // Single-threaded continuation.
 class SafeContinuation<in T>

--- a/runtime/src/main/kotlin/konan/internal/Coroutines.kt
+++ b/runtime/src/main/kotlin/konan/internal/Coroutines.kt
@@ -21,11 +21,11 @@ import kotlin.coroutines.experimental.intrinsics.*
 
 @Intrinsic
 @PublishedApi
-internal fun <T> getContinuation(): Continuation<T> = throw AssertionError("Call to getContinuation should've been lowered")
+internal external fun <T> getContinuation(): Continuation<T> = throw AssertionError("Call to getContinuation should've been lowered")
 
 @Intrinsic
 @PublishedApi
-internal suspend fun <T> returnIfSuspended(@Suppress("UNUSED_PARAMETER") argument: Any?): T
+internal external suspend fun <T> returnIfSuspended(@Suppress("UNUSED_PARAMETER") argument: Any?): T
         = throw AssertionError("Call to returnIfSuspended should've been lowered")
 
 // Single-threaded continuation.

--- a/runtime/src/main/kotlin/konan/internal/Intrinsics.kt
+++ b/runtime/src/main/kotlin/konan/internal/Intrinsics.kt
@@ -26,8 +26,9 @@ import kotlinx.cinterop.NativePtr
 @Intrinsic external fun areEqualByValue(first: Short, second: Short): Boolean
 @Intrinsic external fun areEqualByValue(first: Int, second: Int): Boolean
 @Intrinsic external fun areEqualByValue(first: Long, second: Long): Boolean
-@Intrinsic external fun areEqualByValue(first: Float, second: Float): Boolean
-@Intrinsic external fun areEqualByValue(first: Double, second: Double): Boolean
+
+@Intrinsic external fun ieee754Equals(first: Float, second: Float): Boolean
+@Intrinsic external fun ieee754Equals(first: Double, second: Double): Boolean
 
 @Intrinsic external fun areEqualByValue(first: NativePtr, second: NativePtr): Boolean
 @Intrinsic external fun areEqualByValue(first: NativePointed?, second: NativePointed?): Boolean

--- a/runtime/src/main/kotlin/kotlin/Primitives.kt
+++ b/runtime/src/main/kotlin/kotlin/Primitives.kt
@@ -983,43 +983,52 @@ public final class Float : Number(), Comparable<Float> {
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Float_compareTo_Byte")
-    external public operator fun compareTo(other: Byte): Int
+    public operator fun compareTo(other: Byte): Int = compareTo(other.toFloat())
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Float_compareTo_Short")
-    external public operator fun compareTo(other: Short): Int
+    public operator fun compareTo(other: Short): Int = compareTo(other.toFloat())
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Float_compareTo_Int")
-    external public operator fun compareTo(other: Int): Int
+    public operator fun compareTo(other: Int): Int = compareTo(other.toFloat())
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Float_compareTo_Long")
-    external public operator fun compareTo(other: Long): Int
+    public operator fun compareTo(other: Long): Int = compareTo(other.toFloat())
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Float_compareTo_Float")
-    external public override operator fun compareTo(other: Float): Int
+    public override operator fun compareTo(other: Float): Int {
+        // if any of values in NaN both comparisons return false
+        if (this > other) return 1
+        if (this < other) return -1
+
+        val thisBits = this.toBits()
+        val otherBits = other.toBits()
+
+        // Canonical NaN bits representation higher than any other bit representvalue
+        return when {
+            (thisBits > otherBits) -> 1
+            (thisBits < otherBits) -> -1
+            else -> 0
+        }
+    }
+
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Float_compareTo_Double")
-    external public operator fun compareTo(other: Double): Int
+    public operator fun compareTo(other: Double): Int = - other.toDouble().compareTo(this)
 
     /** Adds the other value to this value. */
     @SymbolName("Kotlin_Float_plus_Byte")
@@ -1129,11 +1138,12 @@ public final class Float : Number(), Comparable<Float> {
     @SymbolName("Kotlin_Float_unaryMinus")
     external public operator fun unaryMinus(): Float
 
-    @SymbolName("Kotlin_Float_toByte")
-    external public override fun toByte(): Byte
+    public override fun toByte(): Byte = this.toInt().toByte()
+
     public override fun toChar(): Char = this.toInt().toChar()
-    @SymbolName("Kotlin_Float_toShort")
-    external public override fun toShort(): Short
+
+    public override fun toShort(): Short = this.toInt().toShort()
+
     @SymbolName("Kotlin_Float_toInt")
     external public override fun toInt(): Int
     @SymbolName("Kotlin_Float_toLong")
@@ -1143,14 +1153,9 @@ public final class Float : Number(), Comparable<Float> {
     @SymbolName("Kotlin_Float_toDouble")
     external public override fun toDouble(): Double
 
-    // Konan-specific.
-    // We intentionally provide this overload to equals() to avoid artifical boxing.
-    // Note that here we intentionally deviate from JVM Kotlin, where this method would be
-    // this.bits() == other.bits().
-    public fun equals(other: Float): Boolean = konan.internal.areEqualByValue(this, other)
+    public fun equals(other: Float): Boolean = toBits() == other.toBits()
 
-    public override fun equals(other: Any?): Boolean =
-            other is Float && konan.internal.areEqualByValue(this, other)
+    public override fun equals(other: Any?): Boolean = other is Float && this.equals(other)
 
     public override fun toString() = NumberConverter.convert(this)
 
@@ -1201,43 +1206,56 @@ public final class Double : Number(), Comparable<Double> {
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Double_compareTo_Byte")
-    external public operator fun compareTo(other: Byte): Int
+    public operator fun compareTo(other: Byte): Int = compareTo(other.toDouble())
+
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Double_compareTo_Short")
-    external public operator fun compareTo(other: Short): Int
+    public operator fun compareTo(other: Short): Int = compareTo(other.toDouble())
+
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Double_compareTo_Int")
-    external public operator fun compareTo(other: Int): Int
+    public operator fun compareTo(other: Int): Int = compareTo(other.toDouble())
+
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Double_compareTo_Long")
-    external public operator fun compareTo(other: Long): Int
+    public operator fun compareTo(other: Long): Int = compareTo(other.toDouble())
+
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Double_compareTo_Float")
-    external public operator fun compareTo(other: Float): Int
+    public operator fun compareTo(other: Float): Int = compareTo(other.toDouble())
+
     /**
      * Compares this value with the specified value for order.
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    @SymbolName("Kotlin_Double_compareTo_Double")
-    external public override operator fun compareTo(other: Double): Int
+    public override operator fun compareTo(other: Double): Int {
+        // if any of values in NaN both comparisons return false
+        if (this > other) return 1
+        if (this < other) return -1
+
+        val thisBits = this.toBits()
+        val otherBits = other.toBits()
+
+        // Canonical NaN bits representation higher than any other bit representvalue
+        return when {
+            (thisBits > otherBits) -> 1
+            (thisBits < otherBits) -> -1
+            else -> 0
+        }
+    }
 
     /** Adds the other value to this value. */
     @SymbolName("Kotlin_Double_plus_Byte")
@@ -1347,14 +1365,14 @@ public final class Double : Number(), Comparable<Double> {
     @SymbolName("Kotlin_Double_unaryMinus")
     external public operator fun unaryMinus(): Double
 
+    public override fun toByte(): Byte = this.toInt().toByte()
 
-    @SymbolName("Kotlin_Double_toByte")
-    external public override fun toByte(): Byte
     public override fun toChar(): Char = this.toInt().toChar()
-    @SymbolName("Kotlin_Double_toShort")
-    external public override fun toShort(): Short
-    @SymbolName("Kotlin_Double_toInt")
-    external public override fun toInt(): Int
+
+    public override fun toShort(): Short = this.toInt().toShort()
+
+    public override fun toInt(): Int = this.toLong().toInt()
+
     @SymbolName("Kotlin_Double_toLong")
     external public override fun toLong(): Long
     @SymbolName("Kotlin_Double_toFloat")
@@ -1362,19 +1380,13 @@ public final class Double : Number(), Comparable<Double> {
     @SymbolName("Kotlin_Double_toDouble")
     external public override fun toDouble(): Double
 
-    // Konan-specific.
-    // Note that here we intentionally deviate from JVM Kotlin, where this method would be
-    // this.bits() == other.bits().
-    public fun equals(other: Double): Boolean = konan.internal.areEqualByValue(this, other)
+    public fun equals(other: Double): Boolean = toBits() == other.toBits()
 
-    public override fun equals(other: Any?): Boolean =
-            other is Double && konan.internal.areEqualByValue(this, other)
+    public override fun equals(other: Any?): Boolean = other is Double && this.equals(other)
 
     public override fun toString() = NumberConverter.convert(this)
 
-    public override fun hashCode(): Int {
-        return bits().hashCode()
-    }
+    public override fun hashCode(): Int = bits().hashCode()
 
     @SymbolName("Kotlin_Double_bits")
     external public fun bits(): Long

--- a/runtime/src/main/kotlin/kotlin/Primitives.kt
+++ b/runtime/src/main/kotlin/kotlin/Primitives.kt
@@ -1016,11 +1016,7 @@ public final class Float : Number(), Comparable<Float> {
         val otherBits = other.toBits()
 
         // Canonical NaN bits representation higher than any other bit representvalue
-        return when {
-            (thisBits > otherBits) -> 1
-            (thisBits < otherBits) -> -1
-            else -> 0
-        }
+        return thisBits.compareTo(otherBits)
     }
 
     /**
@@ -1028,7 +1024,7 @@ public final class Float : Number(), Comparable<Float> {
      * Returns zero if this value is equal to the specified other value, a negative number if its less than other,
      * or a positive number if its greater than other.
      */
-    public operator fun compareTo(other: Double): Int = - other.toDouble().compareTo(this)
+    public operator fun compareTo(other: Double): Int = - other.compareTo(this)
 
     /** Adds the other value to this value. */
     @SymbolName("Kotlin_Float_plus_Byte")
@@ -1250,11 +1246,7 @@ public final class Double : Number(), Comparable<Double> {
         val otherBits = other.toBits()
 
         // Canonical NaN bits representation higher than any other bit representvalue
-        return when {
-            (thisBits > otherBits) -> 1
-            (thisBits < otherBits) -> -1
-            else -> 0
-        }
+        return thisBits.compareTo(otherBits)
     }
 
     /** Adds the other value to this value. */
@@ -1371,8 +1363,8 @@ public final class Double : Number(), Comparable<Double> {
 
     public override fun toShort(): Short = this.toInt().toShort()
 
-    public override fun toInt(): Int = this.toLong().toInt()
-
+    @SymbolName("Kotlin_Double_toInt")
+    external public override fun toInt(): Int
     @SymbolName("Kotlin_Double_toLong")
     external public override fun toLong(): Long
     @SymbolName("Kotlin_Double_toFloat")

--- a/runtime/src/main/kotlin/kotlin/comparisons/Comparisons.kt
+++ b/runtime/src/main/kotlin/kotlin/comparisons/Comparisons.kt
@@ -266,7 +266,7 @@ public inline fun <T: Comparable<T>> nullsFirst(): Comparator<T?> = nullsFirst(n
  * considering `null` value greater than any other value.
  */
 public fun <T: Any> nullsLast(comparator: Comparator<in T>): Comparator<T?> {
-    return object: Comparator<T?> {
+   return object: Comparator<T?> {
         override fun compare(a: T?, b: T?): Int {
             if (a === b) return 0
             if (a == null) return 1

--- a/runtime/src/main/kotlin/kotlin/comparisons/Comparisons.kt
+++ b/runtime/src/main/kotlin/kotlin/comparisons/Comparisons.kt
@@ -266,7 +266,7 @@ public inline fun <T: Comparable<T>> nullsFirst(): Comparator<T?> = nullsFirst(n
  * considering `null` value greater than any other value.
  */
 public fun <T: Any> nullsLast(comparator: Comparator<in T>): Comparator<T?> {
-   return object: Comparator<T?> {
+    return object: Comparator<T?> {
         override fun compare(a: T?, b: T?): Int {
             if (a === b) return 0
             if (a == null) return 1


### PR DESCRIPTION
1. Update Compiler 

2. Support IEEE754
- Add an intrinsic that performs check according to the standard
- Add floating point compare methods from LLVM
- Support new IR builtins, symbols and descriptors
- Rewrite compareTo floating point checks to Kotlin
- Rewrite equals to be the same as in JVM

3. Unignore several tests