### PR TITLE
zephyr: win32 host

### DIFF
--- a/konan/platforms/zephyr/stm32f4_disco
+++ b/konan/platforms/zephyr/stm32f4_disco
@@ -34,3 +34,9 @@ dependencies.osx-zephyr_stm32f4_disco = \
     gcc-arm-none-eabi-7-2017-q4-major-mac \
     clang-llvm-5.0.0-darwin-macos \
     target-sysroot-2-wasm
+
+targetToolchain.mingw-zephyr_stm32f4_disco = gcc-arm-none-eabi-7-2017-q4-major-win32/arm-none-eabi
+dependencies.mingw-zephyr_stm32f4_disco = \
+    msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64 \
+    gcc-arm-none-eabi-7-2017-q4-major-win32 \
+    target-sysroot-2-wasm

--- a/samples/zephyr/build.bat
+++ b/samples/zephyr/build.bat
@@ -1,0 +1,55 @@
+::@echo off
+setlocal
+
+set BOARD=stm32f4_disco
+set ZEPHYR_BASE=%userprofile%\zephyr
+set TOOLCHAIN=gcc-arm-none-eabi-7-2017-q4-major-win32
+
+set DIR=%~dp0
+set KONAN_USER_DIR=%userprofile%/.konan
+set KONAN_DEPS=%KONAN_USER_DIR%/dependencies
+set GCC_ARM=%KONAN_DEPS%/%TOOLCHAIN%
+set ZEPHYR_TOOLCHAIN_VARIANT=gccarmemb
+set GCCARMEMB_TOOLCHAIN_PATH=%GCC_ARM%
+
+if defined KONAN_HOME (
+    set "PATH=%KONAN_HOME%\bin;%PATH%"
+) else (
+    set "PATH=%DIR%..\..\dist\bin;%DIR%..\..\bin;%PATH%"
+)
+
+if not exist build\ (mkdir build)
+cd build
+
+if not exist CMakeCache.txt (cmake -GNinja -DBOARD=%BOARD% .. || exit /b)
+
+:: We need generated headers to be consumed by `cinterop`,
+:: so we preconfigure the project with `make zephyr`.
+ninja zephyr
+
+call %DIR%\c_interop\platforms\%BOARD%.bat
+
+del program.o
+
+mkdir %DIR%\build\kotlin
+
+call konanc %DIR%/src/main.kt \
+        -target zephyr_%BOARD% \
+        -r %DIR%/c_interop/platforms/build \
+        -l %BOARD% \
+        -opt -g -o %DIR%/build/kotlin/program || exit 1
+
+ninja || exit /b
+
+# ninja flash
+#
+# For our STM32 boards the OpenOCD unable to flash the binary,
+# so we go with the following alternative utility:
+
+echo
+echo "Now run 'ninja flash' to flash the .bin to the card."
+echo
+echo "Or, if that doesn't work, like, for example if you have an stm32f4-disco,"
+echo "run the following command:"
+echo "st-flash --reset write build/zephyr/zephyr.bin 0x08000000"
+echo

--- a/samples/zephyr/c_interop/platforms/stm32f4_disco.bat
+++ b/samples/zephyr/c_interop/platforms/stm32f4_disco.bat
@@ -1,0 +1,46 @@
+:: Copyright 2010-2017 JetBrains s.r.o.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+:: http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+:: This is board specific.
+
+if "%BOARD%" == "" (
+    echo This script is to be included by build.bat
+    exit /b
+)
+
+:: TODO: we need a robust automated way to ask Zephyr for
+:: all these $ZEPHYR_BASE based paths and the proper defines.
+:: TODO: The D flag in `-copt -Dxxx` sequence is interpreted to be a jvm property,
+:: so we workaround the using -Xclang.
+
+call cinterop -def %DIR%/c_interop/platforms/%BOARD%.def ^
+        -pkg platform.zephyr.%BOARD% ^
+        -copt "-Xclang -DSTM32F407xx" ^
+        -copt -I%ZEPHYR_BASE%/kernel/include ^
+        -copt -I%ZEPHYR_BASE%/arch/arm/include ^
+        -copt -I%ZEPHYR_BASE%/arch/arm/soc/st_stm32/stm32f4 ^
+        -copt -I%ZEPHYR_BASE%/arch/arm/soc/st_stm32/stm32f4/include ^
+        -copt -I%ZEPHYR_BASE%/arch/arm/soc/st_stm32/include ^
+        -copt -I%ZEPHYR_BASE%/boards/arm/%BOARD% ^
+        -copt -I%ZEPHYR_BASE%/include ^
+        -copt -I%ZEPHYR_BASE%/include/drivers ^
+        -copt -I%ZEPHYR_BASE%/ext/hal/cmsis/Include ^
+        -copt -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/soc ^
+        -copt -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/drivers/include ^
+        -copt -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/drivers/include/Legacy ^
+        -copt -I%ZEPHYR_BASE%/drivers ^
+        -copt -I%DIR%/build/zephyr/include/generated ^
+        -copt -I%DIR%/build/zephyr/include/generated/syscalls ^
+        -o %DIR%/c_interop/platforms/build/%BOARD% ^
+        -target zephyr_%BOARD% || exit /b

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
@@ -164,7 +164,7 @@ open class HostManager(protected val distribution: Distribution = Distribution()
                 KonanTarget.MINGW -> listOf(
                     KonanTarget.MINGW,
                     KonanTarget.WASM32
-                ) 
+                ) + zephyrSubtargets
                 KonanTarget.MACBOOK -> listOf(
                     KonanTarget.MACBOOK,
                     KonanTarget.IPHONE,


### PR DESCRIPTION
Почти ЧАС думало, и в конце выдало:

```
 * Compiler version info: Konan: EAP 0.6.0.0 / Kotlin: 1.2.40
 * Output kind: PROGRAM

exception: org.jetbrains.kotlin.util.KotlinFrontEndException: Front-end Internal error: Failed to analyze declaration Engine
Cause: Should not parse a script without definition: F:/src/korlibs/build.gradle.kts
File being compiled at position: (50,1) in F:/$RECYCLE.BIN/S-1-5-21-3752340867-1742820832-3117743969-1000/$R3QYQT3.4/samples/androidNativeActivity/src/main/kotlin/engine.kt
The root cause was thrown at: Objects.java:290
        at org.jetbrains.kotlin.resolve.ExceptionWrappingKtVisitorVoid.visitDeclaration(ExceptionWrappingKtVisitorVoid.kt:43)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitDeclaration(KtVisitorVoid.java:453)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitDeclaration(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtVisitor.visitNamedDeclaration(KtVisitor.java:398)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitNamedDeclaration(KtVisitorVoid.java:381)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitNamedDeclaration(KtVisitorVoid.java:959)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitNamedDeclaration(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtVisitor.visitClassOrObject(KtVisitor.java:41)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitClassOrObject(KtVisitorVoid.java:37)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitClassOrObject(KtVisitorVoid.java:465)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitClassOrObject(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtVisitor.visitClass(KtVisitor.java:33)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitClass(KtVisitorVoid.java:33)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitClass(KtVisitorVoid.java:459)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitClass(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtClass.accept(KtClass.kt:34)
        at org.jetbrains.kotlin.psi.KtElementImplStub.accept(KtElementImplStub.java:59)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer$analyzeDeclarations$1.registerDeclarations(LazyTopDownAnalyzer.kt:77)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer$analyzeDeclarations$1.visitKtFile(LazyTopDownAnalyzer.kt:95)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitKtFile(KtVisitorVoid.java:513)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitKtFile(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtFile.accept(KtFile.kt:220)
        at org.jetbrains.kotlin.psi.KtFile.accept(KtFile.kt:207)
        at org.jetbrains.kotlin.resolve.ExceptionWrappingKtVisitorVoid.visitElement(ExceptionWrappingKtVisitorVoid.kt:27)
        at com.intellij.psi.PsiElementVisitor.visitFile(PsiElementVisitor.java:34)
        at org.jetbrains.kotlin.psi.KtVisitor.visitKtFile(KtVisitor.java:73)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitKtFile(KtVisitorVoid.java:69)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitKtFile(KtVisitorVoid.java:513)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitKtFile(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtFile.accept(KtFile.kt:220)
        at org.jetbrains.kotlin.psi.KtFile.accept(KtFile.kt:207)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer.analyzeDeclarations(LazyTopDownAnalyzer.kt:200)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer.analyzeDeclarations$default(LazyTopDownAnalyzer.kt:59)
        at org.jetbrains.kotlin.backend.konan.TopDownAnalyzerFacadeForKonan.analyzeFilesWithGivenTrace(TopDownAnalyzerFacadeForKonan.kt:71)
        at org.jetbrains.kotlin.backend.konan.TopDownAnalyzerFacadeForKonan.analyzeFiles(TopDownAnalyzerFacadeForKonan.kt:50)
        at org.jetbrains.kotlin.backend.konan.KonanDriverKt$runTopLevelPhases$1$1.invoke(KonanDriver.kt:58)
        at org.jetbrains.kotlin.backend.konan.KonanDriverKt$runTopLevelPhases$1$1.invoke(KonanDriver.kt)
        at org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport.analyzeAndReport(AnalyzerWithCompilerReport.kt:101)
        at org.jetbrains.kotlin.backend.konan.KonanDriverKt$runTopLevelPhases$1.invoke(KonanDriver.kt:57)
        at org.jetbrains.kotlin.backend.konan.KonanDriverKt$runTopLevelPhases$1.invoke(KonanDriver.kt)
        at org.jetbrains.kotlin.backend.konan.PhaseManager$phase$$inlined$with$lambda$1.invoke(KonanPhases.kt:140)
        at org.jetbrains.kotlin.backend.konan.PhaseManager$phase$$inlined$with$lambda$1.invoke(KonanPhases.kt:119)
        at org.jetbrains.kotlin.backend.konan.util.UtilKt.profileIf(util.kt:34)
        at org.jetbrains.kotlin.backend.konan.PhaseManager.phase$backend_native_compiler(KonanPhases.kt:139)
        at org.jetbrains.kotlin.backend.konan.KonanDriverKt.runTopLevelPhases(KonanDriver.kt:55)
        at org.jetbrains.kotlin.cli.bc.K2Native.doExecute(K2Native.kt:61)
        at org.jetbrains.kotlin.cli.bc.K2Native.doExecute(K2Native.kt:39)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.java:108)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.java:52)
        at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:92)
        at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:70)
        at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:36)
        at org.jetbrains.kotlin.cli.common.CLITool$Companion.doMainNoExit(CLITool.kt:157)
        at org.jetbrains.kotlin.cli.common.CLITool$Companion.doMain(CLITool.kt:148)
        at org.jetbrains.kotlin.cli.bc.K2Native$Companion$main$1.invoke(K2Native.kt:183)
        at org.jetbrains.kotlin.cli.bc.K2Native$Companion$main$1.invoke(K2Native.kt:174)
        at org.jetbrains.kotlin.backend.konan.util.UtilKt.profileIf(util.kt:34)
        at org.jetbrains.kotlin.backend.konan.util.UtilKt.profile(util.kt:29)
        at org.jetbrains.kotlin.cli.bc.K2Native$Companion.main(K2Native.kt:176)
        at org.jetbrains.kotlin.cli.bc.K2NativeKt.main(K2Native.kt:188)
        at org.jetbrains.kotlin.cli.utilities.MainKt.main(main.kt:27)
Caused by: java.lang.NullPointerException: Should not parse a script without definition: F:/src/korlibs/build.gradle.kts
        at java.util.Objects.requireNonNull(Objects.java:290)
        at org.jetbrains.kotlin.psi.KtScript.lambda$new$1(KtScript.java:36)
        at kotlin.SafePublicationLazyImpl.getValue(Lazy.kt:194)
        at org.jetbrains.kotlin.psi.KtScript.getFqName(KtScript.java:57)
        at org.jetbrains.kotlin.psi.KtScript.getName(KtScript.java:62)
        at org.jetbrains.kotlin.psi.KtNamedDeclarationStub.getNameAsName(KtNamedDeclarationStub.java:70)
        at org.jetbrains.kotlin.psi.KtScript.getNameAsName(KtScript.java:35)
        at org.jetbrains.kotlin.resolve.lazy.declarations.AbstractPsiBasedDeclarationProvider$Index.putToIndex(AbstractPsiBasedDeclarationProvider.kt:58)
        at org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedPackageMemberDeclarationProvider.doCreateIndex(FileBasedPackageMemberDeclarationProvider.kt:39)
        at org.jetbrains.kotlin.resolve.lazy.declarations.AbstractPsiBasedDeclarationProvider$index$1.invoke(AbstractPsiBasedDeclarationProvider.kt:85)
        at org.jetbrains.kotlin.resolve.lazy.declarations.AbstractPsiBasedDeclarationProvider$index$1.invoke(AbstractPsiBasedDeclarationProvider.kt:31)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:323)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:370)
        at org.jetbrains.kotlin.resolve.lazy.declarations.AbstractPsiBasedDeclarationProvider.getClassOrObjectDeclarations(AbstractPsiBasedDeclarationProvider.kt:104)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope.doGetClasses(AbstractLazyMemberScope.kt:59)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope.access$doGetClasses(AbstractLazyMemberScope.kt:39)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope$classDescriptors$1.invoke(Abstrac16:09MemberScope.kt:49)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope$classDescriptors$1.invoke(AbstractLazyMemberScope.kt:39)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke(LockBasedStorageManager.java:408)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke(LockBasedStorageManager.java:483)
        at org.jetbrains.kotlin.resolve.lazy.descriptors.AbstractLazyMemberScope.getContributedClassifier(AbstractLazyMemberScope.kt:74)
        at org.jetbrains.kotlin.resolve.lazy.LazyDeclarationResolver.findClassDescriptorIfAny(LazyDeclarationResolver.kt:77)
        at org.jetbrains.kotlin.resolve.lazy.LazyDeclarationResolver.findClassDescriptor(LazyDeclarationResolver.kt:87)

        at org.jetbrains.kotlin.resolve.lazy.LazyDeclarationResolver.getClassDescriptor(LazyDeclarationResolver.kt:62)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer$analyzeDeclarations$1.visitClassOrObject(LazyTopDownAnalyzer.kt:117)
        at org.jetbrains.kotlin.resolve.LazyTopDownAnalyzer$analyzeDeclarations$1.visitClass(LazyTopDownAnalyzer.kt:145)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitClass(KtVisitorVoid.java:459)
        at org.jetbrains.kotlin.psi.KtVisitorVoid.visitClass(KtVisitorVoid.java:21)
        at org.jetbrains.kotlin.psi.KtClass.accept(KtClass.kt:34)
        at org.jetbrains.kotlin.psi.KtElementImplStub.accept(KtElementImplStub.java:59)
        at org.jetbrains.kotlin.resolve.ExceptionWrappingKtVisitorVoid.visitDeclaration(ExceptionWrappingKtVisitorVoid.kt:32)
        ... 60 more
```