### PR TITLE
Don't unwrap fake overrides in `deserializeDescriptor()`.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/IrDescriptorSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/IrDescriptorSerializer.kt
@@ -125,14 +125,6 @@ internal class IrDescriptorSerializer(
     }
 
     fun serializeDescriptor(descriptor: DeclarationDescriptor): KonanIr.KotlinDescriptor {
-
-        if (descriptor is CallableMemberDescriptor &&  
-            descriptor.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE) {
-            // TODO: It seems rather braindead. 
-            // Do we need to do anything more than that?
-            return serializeDescriptor(DescriptorUtils.unwrapFakeOverride(descriptor))
-        }
-
         val classOrPackage = descriptor.classOrPackage
         val parentFqNameIndex = if (classOrPackage is ClassOrPackageFragmentDescriptor) {
             stringTable.getClassOrPackageFqNameIndex(classOrPackage)


### PR DESCRIPTION
It is not needed for newly declare descriptors and it is harmful to (potentially substituted) uses.