### PR TITLE
 Add test for lambda class name clash (fixed in 610c9b5)

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
@@ -247,7 +247,12 @@ private class DeclarationsGeneratorVisitor(override val context: Context) :
                     typeInfoGlobal.pointer.getElementPtr(0).llvm,
                     typeInfoSymbolName)!!
 
-            if (!descriptor.isExported()) {
+            if (descriptor.isExported()) {
+                if (llvmTypeInfoPtr.name != typeInfoSymbolName) {
+                    // So alias name has been mangled by LLVM to avoid name clash.
+                    throw IllegalArgumentException("Global '$typeInfoSymbolName' already exists")
+                }
+            } else {
                 LLVMSetLinkage(llvmTypeInfoPtr, LLVMLinkage.LLVMInternalLinkage)
             }
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1958,6 +1958,11 @@ task lambda13(type: RunKonanTest) {
     source = "codegen/lambda/lambda13.kt"
 }
 
+task lambda14(type: RunStandaloneKonanTest) {
+    source = "codegen/lambda/lambda14.kt"
+    flags = ['-tr']
+}
+
 task objectExpression1(type: RunKonanTest) {
     goldValue = "aabb\n"
     source = "codegen/objectExpression/expr1.kt"

--- a/backend.native/tests/codegen/lambda/lambda14.kt
+++ b/backend.native/tests/codegen/lambda/lambda14.kt
@@ -1,0 +1,18 @@
+// FILE: 1.kt
+
+package codegen.lambda.lambda14
+
+import kotlin.test.*
+
+@Test fun runTest() {
+    assertEquals(foo()(), "foo1")
+    assertEquals(foo(0)(), "foo2")
+}
+
+fun foo() = { "foo1" }
+
+// FILE: 2.kt
+
+package codegen.lambda.lambda14
+
+fun foo(ignored: Int) = { "foo2" }


### PR DESCRIPTION
Also add internal check helping to detect such bugs on targets other than Mac.