### PR TITLE
Introduce environment variable to .konan parent dir

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -20,6 +20,9 @@ There are several gradle flags one can use for Konan build.
 
         ./gradlew -Pprefix=external_codegen_box_cast run_external
 
+ ## Compiler environment variables
+
+* **KONAN_DATA_DIR** changes `.konan` local data directory location (`$HOME/.konan` by default). Works both with cli compiler and gradle plugin
 
  ## Testing
 

--- a/LIBRARIES.md
+++ b/LIBRARIES.md
@@ -103,7 +103,7 @@ When given `-library foo` flag, the compiler searches the `foo`  library in the 
 
     * All repositories specified with `-repo` flag.
 
-    * Libraries installed in the default repository (For now the default is  `~/.konan` ).
+    * Libraries installed in the default repository (For now the default is  `~/.konan`, however it could be changed by setting **KONAN_DATA_DIR** environment variable).
 
     * Libraries installed in `$installation/klib` directory.
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/SearchPathResolver.kt
@@ -37,7 +37,7 @@ fun defaultResolver(repositories: List<String>, target: KonanTarget, distributio
                 repositories,
                 target,
                 distribution.klib,
-                distribution.localKonanDir
+                distribution.localKonanDir.absolutePath
         )
 
 fun SearchPathResolver.resolveImmediateLibraries(libraryNames: List<String>,

--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -171,5 +171,7 @@ task update(type: Copy) {
 }
 
 task rmDotKonan(type: Delete) {
-    delete "${System.getProperty("user.home")}/.konan"
+    def dir = System.getenv("KONAN_DATA_DIR") ?: "${System.getProperty("user.home")}/.konan"
+    delete dir
 }
+

--- a/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
+++ b/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.target.Distribution
 import org.jetbrains.kotlin.konan.target.PlatformManager
+import org.jetbrains.kotlin.konan.util.DependencyProcessor
 import org.jetbrains.kotlin.metadata.KonanLinkData
 import java.lang.System.out
 import kotlin.system.exitProcess
@@ -84,8 +85,7 @@ fun error(text: String) {
     exitProcess(1)
 }
 
-// TODO: Get rid of the hardcoded path.
-val defaultRepository = File(File.userHome, ".konan/klib")
+val defaultRepository = File(DependencyProcessor.localKonanDir.resolve("klib").absolutePath)
 
 open class ModuleDeserializer(val library: ByteArray) {
     protected val moduleHeader: KonanLinkData.LinkDataLibrary

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Distribution.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Distribution.kt
@@ -26,7 +26,7 @@ class Distribution(
         private val konanHomeOverride: String? = null,
         private val runtimeFileOverride: String? = null) {
 
-    val localKonanDir = "${File.userHome}/.konan"
+    val localKonanDir = DependencyProcessor.localKonanDir
 
     private fun findKonanHome(): String {
         if (konanHomeOverride != null) return konanHomeOverride
@@ -52,7 +52,7 @@ class Distribution(
         propertyFilesFromConfigDir(konanSubdir, genericName)
 
     private fun userPropertyFiles(genericName: String) =
-        propertyFilesFromConfigDir(localKonanDir, genericName)
+        propertyFilesFromConfigDir(localKonanDir.absolutePath, genericName)
 
     fun additionalPropertyFiles(genericName: String) =
             preconfiguredPropertyFiles(genericName) + userPropertyFiles(genericName)

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
@@ -53,6 +53,8 @@ sealed class KonanTarget(override val name: String, val family: Family, val arch
 
     // Tunable targets
     class ZEPHYR(val subName: String, val genericName: String = "zephyr") : KonanTarget("${genericName}_$subName", Family.ZEPHYR, Architecture.ARM32)
+
+    override fun toString() = name
 }
 
 fun hostTargetSuffix(host: KonanTarget, target: KonanTarget) =

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanPlugin.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.gradle.plugin.tasks.*
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.customerDistribution
+import org.jetbrains.kotlin.konan.util.*
 import java.io.File
 import java.util.*
 import javax.inject.Inject
@@ -129,7 +130,7 @@ internal fun Project.konanCompilerName(): String =
         "kotlin-native-${project.simpleOsName}-${this.konanVersion}"
 
 internal fun Project.konanCompilerDownloadDir(): String =
-        KonanCompilerDownloadTask.KONAN_PARENT_DIR + "/" + project.konanCompilerName()
+        DependencyProcessor.localKonanDir.resolve(project.konanCompilerName()).absolutePath
 
 // region Useful extensions and functions ---------------------------------------
 

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/tasks/KonanCompilerDownloadTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/tasks/KonanCompilerDownloadTask.kt
@@ -31,8 +31,6 @@ open class KonanCompilerDownloadTask : DefaultTask() {
 
     internal companion object {
         internal const val BASE_DOWNLOAD_URL = "https://download.jetbrains.com/kotlin/native/builds"
-
-        internal val KONAN_PARENT_DIR = "${System.getProperty("user.home")}/.konan"
     }
 
     /**
@@ -61,9 +59,10 @@ open class KonanCompilerDownloadTask : DefaultTask() {
                     append(project.simpleOsName)
                 }
                 val konanCompiler = project.konanCompilerName()
-                logger.info("Downloading Kotlin/Native compiler from $downloadUrlDirectory/$konanCompiler into $KONAN_PARENT_DIR")
+                val parentDir = DependencyProcessor.localKonanDir
+                logger.info("Downloading Kotlin/Native compiler from $downloadUrlDirectory/$konanCompiler into $parentDir")
                 DependencyProcessor(
-                        File(KONAN_PARENT_DIR),
+                        parentDir,
                         downloadUrlDirectory,
                         mapOf(konanCompiler to listOf(DependencySource.Remote.Public))
                 ).run()


### PR DESCRIPTION
It is important to be able to change ~/.konan dir location as user's home directory could have limited capacity or could be mounted via NFS (or both)

The environment variable name is still open question