### PR TITLE
Objective-C names with '$' in them were blowing up

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/CodeUtils.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/CodeUtils.kt
@@ -38,7 +38,7 @@ typealias KotlinExpression = String
  * For this identifier constructs the string to be parsed by Kotlin as `SimpleName`
  * defined [here](https://kotlinlang.org/docs/reference/grammar.html#SimpleName).
  */
-fun String.asSimpleName(): String = if (this in kotlinKeywords) {
+fun String.asSimpleName(): String = if (this in kotlinKeywords || this.contains("$")) {
     "`$this`"
 } else {
     this


### PR DESCRIPTION
Not sure if this has test coverage anywhere. Didn't see it. Also, I'm not sure if other characters in Objc names are problematic. However, this fully solved my problem, and we're wrapping quite a lot of autogen Objc.