### PR TITLE
win32 curl sample

### DIFF
--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -42,9 +42,9 @@ task buildSamplesWithPlatformLibs() {
     dependsOn ':globalState:assemble'
     dependsOn ':html5Canvas:assemble'
     dependsOn ':workers:assemble'
+    dependsOn ':curl:assemble'
 
     if (MPPTools.isMacos() || MPPTools.isLinux()) {
-        dependsOn ':curl:assemble'
         dependsOn ':nonBlockingEchoServer:assemble'
         dependsOn ':tensorflow:assemble'
     }

--- a/samples/curl/build.gradle
+++ b/samples/curl/build.gradle
@@ -9,13 +9,17 @@ repositories {
 }
 
 // Determine host preset.
-def hostPreset = MPPTools.defaultHostPreset(project, [kotlin.presets.macosX64, kotlin.presets.linuxX64])
+def hostPreset = MPPTools.defaultHostPreset(project, [kotlin.presets.macosX64, kotlin.presets.linuxX64, kotlin.presets.mingwX64])
 
 kotlin {
     targets {
         fromPreset(hostPreset, 'curl') {
             compilations.main.outputKinds 'EXECUTABLE'
             compilations.main.entryPoint 'sample.curl.main'
+            if (hostPreset == presets.mingwX64) {
+                // Add lib path to `libcurl` and its dependencies:
+                compilations.main.linkerOpts "-L${MPPTools.mingwPath()}/lib"
+            }
         }
     }
 
@@ -29,6 +33,9 @@ kotlin {
 }
 
 MPPTools.createRunTask(project, 'runProgram', kotlin.targets.curl) {
+    if (hostPreset == kotlin.presets.mingwX64) {
+        environment 'PATH': "${MPPTools.mingwPath()}/bin;${System.getenv('PATH')}"
+    }
     args 'https://www.jetbrains.com/'
 }
 

--- a/samples/libcurl/README.md
+++ b/samples/libcurl/README.md
@@ -1,7 +1,12 @@
 # Curl interop library
 
 This example shows how to build and publish an interop library to communicate with the libcurl,
-HTTP/HTTPS/FTP/etc client library. Debian-like distros may need to `apt-get install libcurl4-openssl-dev`.
+HTTP/HTTPS/FTP/etc client library.
+
+Install libcurl development files. For Mac - `brew install curl`.
+For Debian-like Linux - use `apt-get install libcurl4-openssl-dev` or `apt-get install libcurl4-gnutls-dev`.
+For Windows - `pacman -S mingw-w64-x86_64-curl` in MinGW64 console, if you do
+not have MSYS2-MinGW64 installed - install it first as described in http://www.msys2.org
 
 To build use `../gradlew assemble`.
 

--- a/samples/libcurl/build.gradle
+++ b/samples/libcurl/build.gradle
@@ -21,7 +21,7 @@ task cleanLocalRepo(type: Delete) {
 }
 
 // Determine host preset.
-def hostPreset = MPPTools.defaultHostPreset(project, [kotlin.presets.macosX64, kotlin.presets.linuxX64])
+def hostPreset = MPPTools.defaultHostPreset(project, [kotlin.presets.macosX64, kotlin.presets.linuxX64, kotlin.presets.mingwX64])
 
 kotlin {
     targets {
@@ -34,6 +34,9 @@ kotlin {
                             break
                         case presets.linuxX64:
                             includeDirs.headerFilterOnly '/usr/include', '/usr/include/x86_64-linux-gnu'
+                            break
+                        case presets.mingwX64:
+                            includeDirs.headerFilterOnly "${MPPTools.mingwPath()}/include"
                             break
                     }
                 }

--- a/samples/libcurl/src/nativeInterop/cinterop/libcurl.def
+++ b/samples/libcurl/src/nativeInterop/cinterop/libcurl.def
@@ -2,3 +2,4 @@ headers = curl/curl.h
 headerFilter = curl/*
 linkerOpts.osx = -L/opt/local/lib -L/usr/local/opt/curl/lib -lcurl
 linkerOpts.linux = -L/usr/lib64 -L/usr/lib/x86_64-linux-gnu -lcurl
+linkerOpts.mingw = -lcurl

--- a/samples/settings.gradle
+++ b/samples/settings.gradle
@@ -27,13 +27,13 @@ if (MPPTools.isMacos() || MPPTools.isLinux() || MPPTools.isWindows()) {
     include ':tetris'
     include ':videoplayer'
     include ':workers'
+    include ':curl'
+    include ':libcurl'
 }
 
 if (MPPTools.isMacos() || MPPTools.isLinux()) {
-    include ':curl'
     include ':gitchurn'
     include ':gtk'
-    include ':libcurl'
     include ':nonBlockingEchoServer'
     include ':tensorflow'
     include ':torch'


### PR DESCRIPTION
Trying new repository publishing on Windows:

```
gradlew :libcurl:build :libcurl:publish

BUILD SUCCESSFUL in 24s
```

```
gradlew :curl:build

F:\TEMP\konan_temp1272759987503012476\combined.o:(.text+0xcdabf): undefined reference to `__imp_curl_easy_strerror'
F:\TEMP\konan_temp1272759987503012476\combined.o:F:\src\kotlin-native-msink\Interop\Runtime\src\native\kotlin\kotlinx\cinterop/NativeUtils.kt:21: undefined reference to `__imp_curl_easy_init'
F:\TEMP\konan_temp1272759987503012476\combined.o:F:\src\kotlin-native-msink\Interop\Runtime\src\native\kotlin\kotlinx\cinterop/NativeUtils.kt:21: undefined reference to `__imp_curl_easy_setopt'
F:\TEMP\konan_temp1272759987503012476\combined.o:F:\src\kotlin-native-msink\Interop\Runtime\src\native\kotlin\kotlinx\cinterop/NativeUtils.kt:21: undefined reference to `__imp_curl_easy_perform'
F:\TEMP\konan_temp1272759987503012476\combined.o:F:\src\kotlin-native-msink\Interop\Runtime\src\native\kotlin\kotlinx\cinterop/NativeUtils.kt:21: undefined reference to `__imp_curl_easy_cleanup'
clang++.exe: error: linker command failed with exit code 1 (use -v to see invocation)
error: f:\Work\.konan\dependencies\msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64/bin/clang++ invocation reported errors
```

What I did wrong?

I guess it's something related not to repository, but to static linkage: `libcurl.a` contains that functions without `__imp_` prefix.