### PR TITLE
Cross testing

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2421,19 +2421,6 @@ task driver_opt(type: RunDriverKonanTest) {
     flags = ["-opt"]
 }
 
-// Check that cross-compilation completes successfully. We can't run such 
-// binaries, but we verify that the compiler has been built, operational 
-// and accepts the -target flag, resulting in a successful compilation.
-task driver_cross(type: RunDriverKonanTest) {
-    source = "runtime/basic/driver0.kt"
-    run = false
-    if (isLinux()) {
-        flags = ["-target", "raspberrypi"]
-    } else if (isMac()) {
-        flags = ["-target", "iphone"]
-    }
-}
-
 // Enable when deserialization for default arguments is fixed.
 task inline_defaultArgs_linkTest(type: LinkKonanTest) {
     goldValue = "122\n47\n"

--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -77,6 +77,11 @@ abstract class KonanTest extends JavaExec {
         // We don't build the compiler if a custom dist path is specified.
         if (!project.ext.useCustomDist) {
             dependsOn(project.rootProject.tasks['dist'])
+            if (project.testTarget) {
+                // if a test_target property is set then tests should depend on a crossDist
+                // otherwise runtime components would not be build for a target
+                dependsOn(project.rootProject.tasks['crossDist'])
+            }
         }
     }
 


### PR DESCRIPTION
- Removes driver_cross test as it is not needed because there is a standalone crosstargets testing
- Add `crossDist` dependency for a tests executed with -Ptest_target