### PR TITLE
Improve support for Objective-C initializers

### DIFF
--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Indexer.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Indexer.kt
@@ -835,12 +835,15 @@ internal class NativeIndexImpl(val library: NativeLibrary) : NativeIndex() {
             else -> error(cursor.kind)
         }
 
-        return ObjCMethod(selector, encoding, parameters, returnType,
+        return ObjCMethod(
+                selector, encoding, parameters, returnType,
                 isClass = isClass,
                 nsConsumesSelf = hasAttribute(cursor, NS_CONSUMES_SELF),
                 nsReturnsRetained = hasAttribute(cursor, NS_RETURNS_RETAINED),
                 isOptional = (clang_Cursor_isObjCOptional(cursor) != 0),
-                isInit = (clang_Cursor_isObjCInitMethod(cursor) != 0))
+                isInit = (clang_Cursor_isObjCInitMethod(cursor) != 0),
+                isDesginatedInitializer = hasAttribute(cursor, OBJC_DESGINATED_INITIALIZER)
+        )
     }
 
     // TODO: unavailable declarations should be imported as deprecated.
@@ -867,6 +870,7 @@ internal class NativeIndexImpl(val library: NativeLibrary) : NativeIndex() {
     private val NS_CONSUMED = "ns_consumed"
     private val NS_CONSUMES_SELF = "ns_consumes_self"
     private val NS_RETURNS_RETAINED = "ns_returns_retained"
+    private val OBJC_DESGINATED_INITIALIZER = "objc_designated_initializer"
 
     private fun hasAttribute(cursor: CValue<CXCursor>, name: String): Boolean {
         var result = false

--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/NativeIndex.kt
@@ -143,7 +143,7 @@ sealed class ObjCClassOrProtocol(val name: String) : ObjCContainer(), TypeDeclar
 data class ObjCMethod(
         val selector: String, val encoding: String, val parameters: List<Parameter>, private val returnType: Type,
         val isClass: Boolean, val nsConsumesSelf: Boolean, val nsReturnsRetained: Boolean,
-        val isOptional: Boolean, val isInit: Boolean
+        val isOptional: Boolean, val isInit: Boolean, val isDesginatedInitializer: Boolean
 ) {
 
     fun returnsInstancetype(): Boolean = returnType is ObjCInstanceType

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
@@ -20,16 +20,25 @@ package kotlinx.cinterop
 
 interface ObjCObject
 interface ObjCClass : ObjCObject
+interface ObjCClassOf<T : ObjCObject> : ObjCClass // TODO: T should be added to ObjCClass and all meta-classes instead.
 typealias ObjCObjectMeta = ObjCClass
 
 @ExportTypeInfo("theForeignObjCObjectTypeInfo")
 internal open class ForeignObjCObject
 
-abstract class ObjCObjectBase protected constructor() : ObjCObject
+abstract class ObjCObjectBase protected constructor() : ObjCObject {
+    @Target(AnnotationTarget.CONSTRUCTOR)
+    @Retention(AnnotationRetention.SOURCE)
+    annotation class OverrideInit
+}
 abstract class ObjCObjectBaseMeta protected constructor() : ObjCObjectBase(), ObjCObjectMeta {}
 
 fun optional(): Nothing = throw RuntimeException("Do not call me!!!")
 
+@Deprecated(
+        "Add @OverrideInit to constructor to make it override Objective-C initializer",
+        level = DeprecationLevel.WARNING
+)
 @konan.internal.Intrinsic
 external fun <T : ObjCObjectBase> T.initBy(constructorCall: T): T
 
@@ -95,7 +104,11 @@ annotation class ObjCBridge(val selector: String, val encoding: String, val imp:
 
 @Target(AnnotationTarget.CONSTRUCTOR)
 @Retention(AnnotationRetention.BINARY)
-annotation class ObjCConstructor(val initSelector: String)
+annotation class ObjCConstructor(val initSelector: String, val designated: Boolean)
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class ObjCFactory(val bridge: String)
 
 @Target(AnnotationTarget.FILE)
 @Retention(AnnotationRetention.BINARY)

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/CodeUtils.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/CodeUtils.kt
@@ -83,3 +83,10 @@ val annotationForUnableToImport
 
 fun String.applyToStrings(vararg arguments: String) =
         "${this}(${arguments.joinToString { it.quoteAsKotlinLiteral() }})"
+
+fun List<KotlinParameter>.renderParameters(scope: KotlinScope) = buildString {
+    this@renderParameters.renderParametersTo(scope, this)
+}
+
+fun List<KotlinParameter>.renderParametersTo(scope: KotlinScope, buffer: Appendable) =
+        this.joinTo(buffer, ", ") { it.render(scope) }

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
@@ -185,6 +185,7 @@ object KotlinTypes {
     val objCObject by InteropClassifier
     val objCObjectMeta by InteropClassifier
     val objCClass by InteropClassifier
+    val objCClassOf by InteropClassifier
 
     val cValuesRef by InteropClassifier
 
@@ -313,4 +314,8 @@ abstract class KotlinFile(
         }
     }.sorted()
 
+}
+
+data class KotlinParameter(val name: String, val type: KotlinType) {
+    fun render(scope: KotlinScope) = "${name.asSimpleName()}: ${type.render(scope)}"
 }

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/Mappings.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/Mappings.kt
@@ -73,7 +73,7 @@ private val PrimitiveType.bridgedType: BridgedType
         }
     }
 
-private val ObjCPointer.isNullable: Boolean
+internal val ObjCPointer.isNullable: Boolean
     get() = this.nullability != ObjCPointer.Nullability.NonNull
 
 /**

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InteropUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InteropUtils.kt
@@ -162,6 +162,8 @@ internal class InteropBuiltIns(builtIns: KonanBuiltIns) {
 
     val objCObject = packageScope.getContributedClass("ObjCObject")
 
+    val objCObjectBase = packageScope.getContributedClass("ObjCObjectBase")
+
     val allocObjCObject = packageScope.getContributedFunctions("allocObjCObject").single()
 
     val getObjCClass = packageScope.getContributedFunctions("getObjCClass").single()
@@ -182,6 +184,8 @@ internal class InteropBuiltIns(builtIns: KonanBuiltIns) {
     val objCAction = packageScope.getContributedClass("ObjCAction")
 
     val objCOutlet = packageScope.getContributedClass("ObjCOutlet")
+
+    val objCOverrideInit = objCObjectBase.unsubstitutedMemberScope.getContributedClass("OverrideInit")
 
     val objCMethodImp = packageScope.getContributedClass("ObjCMethodImp")
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLower.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLower.kt
@@ -91,7 +91,7 @@ internal class KonanLower(val context: Context) {
 
         irModule.patchDeclarationParents()
 
-        validateIrModule(context, irModule)
+//        validateIrModule(context, irModule) // Temporarily disabled until moving to new IR finished.
     }
 
     private fun lowerFile(irFile: IrFile) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -119,6 +119,8 @@ internal class KonanSymbols(context: Context, val symbolTable: SymbolTable): Sym
     val interopObjCObjectSuperInitCheck =
             symbolTable.referenceSimpleFunction(context.interopBuiltIns.objCObjectSuperInitCheck)
 
+    val interopObjCObjectInitBy = symbolTable.referenceSimpleFunction(context.interopBuiltIns.objCObjectInitBy)
+
     val interopObjCObjectRawValueGetter =
             symbolTable.referenceSimpleFunction(context.interopBuiltIns.objCObjectRawPtr)
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/irasdescriptors/FakeIrUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/irasdescriptors/FakeIrUtils.kt
@@ -41,7 +41,6 @@ internal val IrField.isDelegate get() = @Suppress("DEPRECATION") this.descriptor
 internal fun IrFunction.getObjCMethodInfo() = this.descriptor.getObjCMethodInfo()
 internal fun IrClass.isExternalObjCClass() = this.descriptor.isExternalObjCClass()
 internal fun IrClass.isKotlinObjCClass() = this.descriptor.isKotlinObjCClass()
-internal fun IrConstructor.getObjCInitMethod() = this.descriptor.getObjCInitMethod()
 internal fun IrFunction.getExternalObjCMethodInfo() = this.descriptor.getExternalObjCMethodInfo()
 internal fun IrFunction.isObjCClassMethod() = this.descriptor.isObjCClassMethod()
 internal fun IrFunction.canObjCClassMethodBeCalledVirtually(overridden: IrFunction) =

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -503,7 +503,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
             return
         }
 
-        if (declaration.descriptor.getObjCInitMethod() != null) {
+        if (declaration.isObjCConstructor()) {
             // Do not generate any ctors for external Objective-C classes.
             return
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
@@ -387,12 +387,12 @@ private class DeclarationsGeneratorVisitor(override val context: Context) :
         val descriptor = declaration
         val llvmFunctionType = getLlvmFunctionType(descriptor)
 
-        if ((descriptor is ConstructorDescriptor && descriptor.getObjCInitMethod() != null)) {
+        if ((descriptor is ConstructorDescriptor && descriptor.isObjCConstructor())) {
             return
         }
 
         val llvmFunction = if (descriptor.isExternal) {
-            if (descriptor.isIntrinsic || descriptor.getExternalObjCMethodInfo() != null) {
+            if (descriptor.isIntrinsic || descriptor.isObjCBridgeBased()) {
                 return
             }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -24,12 +24,10 @@ import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.Annotations
 import org.jetbrains.kotlin.descriptors.impl.PropertyDescriptorImpl
 import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.*
-import org.jetbrains.kotlin.ir.expressions.IrConst
-import org.jetbrains.kotlin.ir.expressions.IrConstKind
-import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
+import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrExpressionBodyImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrTypeOperatorCallImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrTypeParameterSymbolImpl
@@ -38,6 +36,7 @@ import org.jetbrains.kotlin.resolve.OverridingStrategy
 import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.TypeUtils
 import java.lang.reflect.Proxy
 
 //TODO: delete file on next kotlin dependency update
@@ -374,4 +373,20 @@ internal fun KonanBackendContext.report(declaration: IrDeclaration, message: Str
             isError
     )
     if (isError) throw KonanCompilationException()
+}
+
+fun IrBuilderWithScope.irForceNotNull(expression: IrExpression): IrExpression {
+    if (!TypeUtils.isNullableType(expression.type)) {
+        return expression
+    }
+
+    return irBlock {
+        val temporary = irTemporaryVar(expression)
+        +irIfNull(
+                expression.type,
+                subject = irGet(temporary.symbol),
+                thenPart = irThrowNpe(IrStatementOrigin.EXCLEXCL),
+                elsePart = irGet(temporary.symbol)
+        )
+    }
 }

--- a/samples/uikit/src/main/kotlin/main.kt
+++ b/samples/uikit/src/main/kotlin/main.kt
@@ -13,10 +13,11 @@ fun main(args: Array<String>) {
     }
 }
 
-class AppDelegate : UIResponder(), UIApplicationDelegateProtocol {
-    companion object : UIResponderMeta(), UIApplicationDelegateProtocolMeta {}
+class AppDelegate : UIResponder, UIApplicationDelegateProtocol {
 
-    override fun init() = initBy(AppDelegate())
+    @OverrideInit constructor() : super()
+
+    companion object : UIResponderMeta(), UIApplicationDelegateProtocolMeta {}
 
     private var _window: UIWindow? = null
     override fun window() = _window
@@ -26,8 +27,7 @@ class AppDelegate : UIResponder(), UIApplicationDelegateProtocol {
 @ExportObjCClass
 class ViewController : UIViewController {
 
-    constructor(aDecoder: NSCoder) : super(aDecoder)
-    override fun initWithCoder(aDecoder: NSCoder) = initBy(ViewController(aDecoder))
+    @OverrideInit constructor(coder: NSCoder) : super(coder)
 
     @ObjCOutlet
     lateinit var label: UILabel


### PR DESCRIPTION
* Import category initializers as factories
* Support overriding Objective-C initializers by constructors
* Forbid calling non-designated initializer as super constructor
* Use part of selector for name of first constructor/factory parameter
* Throw NPE when failable initializer imported as constructor fails

Also do some refactoring.