### PR TITLE
samples/videoplayer: migrate from libavresample to libswresample

### DIFF
--- a/samples/videoplayer/README.md
+++ b/samples/videoplayer/README.md
@@ -7,7 +7,7 @@ ffmpeg and SDL2 is needed for that to work, i.e.
      port install ffmpeg-devel
      brew install ffmpeg sdl2
      apt install libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
-                 libavresample-dev
+                 libswresample-dev
      apt install libsdl2-dev
      pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-ffmpeg
 

--- a/samples/videoplayer/src/main/c_interop/ffmpeg.def
+++ b/samples/videoplayer/src/main/c_interop/ffmpeg.def
@@ -1,9 +1,9 @@
 package = ffmpeg
 headers = libavcodec/avcodec.h libavformat/avformat.h libavutil/pixfmt.h libavutil/opt.h \
-          libswscale/swscale.h libavresample/avresample.h
+          libswscale/swscale.h libswresample/swresample.h
 headerFilter = libavcodec/** libavformat/** libavutil/** \
-          libswscale/** libavresample/**
-linkerOpts = -lavutil -lavformat -lavcodec -lswscale -lavresample
+          libswscale/** libswresample/**
+linkerOpts = -lavutil -lavformat -lavcodec -lswscale -lswresample
 ---
 
 static void av_buffer_unref2(AVBufferRef* ref) {
@@ -21,7 +21,7 @@ static void avformat_free_context2(AVFormatContext* ref) {
     avformat_free_context(&copy);
 }
 
-static void avresample_free2(AVAudioResampleContext* ref) {
-    AVAudioResampleContext* copy = ref;
-    avresample_free(&copy);
+static void swr_free2(SwrContext* ref) {
+    SwrContext* copy = ref;
+    swr_free(&copy);
 }


### PR DESCRIPTION
libavresample is deprecated, and even already removed in some distros.