### PR TITLE
Added embedded bitcode support for ios

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.konan.target.Family
+
 /*
  * Copyright 2010-2018 JetBrains s.r.o.
  *
@@ -170,11 +172,12 @@ targetList.each { target ->
 
     def defaultArgs = ['-nopack', '-nostdlib', '-nodefaultlibs', '-ea' ]
     if (target != "wasm32") defaultArgs += '-g'
+    if (target == "ios_arm64") defaultArgs += "--embed_bitcode"
+    if (target == "ios_x64") defaultArgs += "--embed_bitcode_marker"
     def konanArgs = [*defaultArgs,
                      '-target', target,
                      '--runtime', project(':runtime').file("build/${target}/runtime.bc"),
                      *project.globalBuildArgs]
-
     task("${target}Stdlib", type: JavaExec) {
         main = 'org.jetbrains.kotlin.cli.bc.K2NativeKt'
         classpath = project.configurations.cli_bc

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -168,6 +168,12 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                     } else {
                         arguments.checkDependencies
                     })
+
+                put(EMBED_BITCODE, when {
+                    arguments.embedBitcode -> EmbedBitcode.ON
+                    arguments.embedBitcodeMarker -> EmbedBitcode.MARKER
+                    else -> EmbedBitcode.OFF
+                })
             }
         }
     }

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -139,5 +139,10 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     @Argument(value = "--verify_ir", description = "Verify IR")
     var verifyIr: Boolean = false
 
+    @Argument(value = "--embed_bitcode", description = "embed LLVM bitcode in object files")
+    var embedBitcode: Boolean = false
+
+    @Argument(value = "--embed_bitcode_marker", description = "embed LLVM bitcode marker in object files")
+    var embedBitcodeMarker: Boolean = false
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -389,6 +389,8 @@ internal class Context(config: KonanConfig) : KonanBackendContext(config) {
 
     fun shouldGenerateTestRunner(): Boolean = config.configuration.getBoolean(KonanConfigKeys.GENERATE_TEST_RUNNER)
 
+    fun shouldEmbedBitcode(): EmbedBitcode = config.configuration.get(KonanConfigKeys.EMBED_BITCODE, EmbedBitcode.OFF)
+
     override fun log(message: () -> String) {
         if (phase?.verbose ?: false) {
             println(message())

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -105,6 +105,12 @@ class KonanConfigKeys {
                 = CompilerConfigurationKey.create("verify ir")
         val VERBOSE_PHASES: CompilerConfigurationKey<List<String>> 
                 = CompilerConfigurationKey.create("verbose backend phases")
+        val EMBED_BITCODE: CompilerConfigurationKey<EmbedBitcode>
+                = CompilerConfigurationKey.create("embed_bitcode")
     }
+}
+
+enum class EmbedBitcode {
+    ON, OFF, MARKER
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -16,6 +16,8 @@
 
 package org.jetbrains.kotlin.backend.konan
 
+import llvm.*
+import org.jetbrains.kotlin.backend.konan.llvm.parseBitcodeFile
 import org.jetbrains.kotlin.konan.KonanExternalToolFailure
 import org.jetbrains.kotlin.konan.exec.Command
 import org.jetbrains.kotlin.konan.file.File
@@ -162,6 +164,7 @@ internal class LinkStage(val context: Context) {
     private fun link(objectFiles: List<ObjectFile>,
                      includedBinaries: List<String>,
                      libraryProvidedLinkerFlags: List<String>): ExecutableFile? {
+
         val frameworkLinkerArgs: List<String>
         val executable: String
 
@@ -176,7 +179,13 @@ internal class LinkStage(val context: Context) {
                 KonanTarget.MACOS_X64 -> "Versions/A/$dylibName"
                 else -> error(target)
             }
-            frameworkLinkerArgs = listOf("-install_name", "@rpath/${framework.name}/$dylibRelativePath")
+            val args = mutableListOf("-install_name", "@rpath/${framework.name}/$dylibRelativePath")
+            when (context.shouldEmbedBitcode()) {
+                EmbedBitcode.ON,
+                EmbedBitcode.MARKER -> args += "-bitcode_bundle"
+                EmbedBitcode.OFF -> {}
+            }
+            frameworkLinkerArgs = args
             val dylibPath = framework.child(dylibRelativePath)
             dylibPath.parentFile.mkdirs()
             executable = dylibPath.absolutePath

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
@@ -56,10 +56,10 @@ class ClangArgs(private val configurables: Configurables) : Configurables by con
                     listOf("--sysroot=$absoluteTargetSysRoot", "-mmacosx-version-min=10.11")
 
                 KonanTarget.IOS_ARM64 ->
-                    listOf("-stdlib=libc++", "-arch", "arm64", "-isysroot", absoluteTargetSysRoot, "-miphoneos-version-min=8.0.0")
+                    listOf("-stdlib=libc++", "-arch", "arm64", "-isysroot", absoluteTargetSysRoot, "-miphoneos-version-min=8.0.0", "-fembed-bitcode")
 
                 KonanTarget.IOS_X64 ->
-                    listOf("-stdlib=libc++", "-isysroot", absoluteTargetSysRoot, "-miphoneos-version-min=8.0.0")
+                    listOf("-stdlib=libc++", "-isysroot", absoluteTargetSysRoot, "-miphoneos-version-min=8.0.0", "-fembed-bitcode-marker")
 
                 KonanTarget.ANDROID_ARM32 ->
                     listOf("-target", targetArg!!,


### PR DESCRIPTION
This introduces the flags '--embed_bitcode' and '--embed_bitcode_marker' to
make it possible to build bitcode-enabled frameworks.

Fixes #1202, #1408