### PR TITLE
[gradle-plugin] Use dev plugin

### DIFF
--- a/tools/kotlin-native-gradle-plugin/build.gradle
+++ b/tools/kotlin-native-gradle-plugin/build.gradle
@@ -37,7 +37,7 @@ buildscript {
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
     }
 }
-apply plugin: 'java'
+apply plugin: 'java-gradle-plugin'
 apply plugin: 'kotlin'
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
@@ -80,11 +80,9 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
     compile "org.jetbrains.kotlin:kotlin-stdlib:$buildKotlinVersion"
     compile "org.jetbrains.kotlin:kotlin-gradle-plugin:$buildKotlinVersion"
-    compile gradleApi()
 
     bundleDependencies "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
 
-    testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'
     testCompile "org.jetbrains.kotlin:kotlin-test:$buildKotlinVersion"
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$buildKotlinVersion"

--- a/tools/kotlin-native-gradle-plugin/build.gradle
+++ b/tools/kotlin-native-gradle-plugin/build.gradle
@@ -170,3 +170,12 @@ bintray {
     }
     publications = ['gradlePlugin']
 }
+
+gradlePlugin {
+    plugins {
+        create("konan") {
+            id = 'konan'
+            implementationClass = 'org.jetbrains.kotlin.gradle.plugin.KonanPlugin'
+        }
+    }
+}

--- a/tools/kotlin-native-gradle-plugin/src/main/resources/META-INF/gradle-plugins/konan.properties
+++ b/tools/kotlin-native-gradle-plugin/src/main/resources/META-INF/gradle-plugins/konan.properties
@@ -1,2 +1,1 @@
-implementation-class=org.jetbrains.kotlin.gradle.plugin.KonanPlugin
 default-konan-version=$konanVersion

--- a/tools/kotlin-native-gradle-plugin/src/main/resources/META-INF/gradle-plugins/konan.properties
+++ b/tools/kotlin-native-gradle-plugin/src/main/resources/META-INF/gradle-plugins/konan.properties
@@ -1,1 +1,0 @@
-default-konan-version=$konanVersion


### PR DESCRIPTION
I've just replaced the java plugin with the [gradle plugin development plugin](https://docs.gradle.org/current/userguide/java_gradle_plugin.html).

I've also replaced the konan.properties with the `gradlePlugins` block.
It seems the `default-konan-version` inside was a relict from old days and isn't used anymore.

