### PR TITLE
[gradle-plugin] Remove pluginMetadata left over

### DIFF
--- a/tools/kotlin-native-gradle-plugin/build.gradle
+++ b/tools/kotlin-native-gradle-plugin/build.gradle
@@ -54,22 +54,6 @@ repositories {
     }
 }
 
-task pluginMetadata {
-    def outputDir = file("$buildDir/$name")
-
-    inputs.files sourceSets.main.runtimeClasspath
-    outputs.dir outputDir
-
-    doLast {
-        outputDir.mkdirs()
-        def metadata = new Properties()
-        metadata.put("implementation-classpath", sourceSets.main.runtimeClasspath.join(File.pathSeparator))
-        file("$outputDir/plugin-under-test-metadata.properties").withPrintWriter {
-            metadata.store(it, "Plugin metadata")
-        }
-    }
-}
-
 configurations {
     bundleDependencies {
         transitive = false
@@ -90,7 +74,6 @@ dependencies {
     testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude module: 'groovy-all'
     }
-    testRuntime files(pluginMetadata)
 }
 
 shadowJar {


### PR DESCRIPTION
In #1579 we've switched to the `java-gradle-plugin`.
With that it is not needed anymore to inject these properties file manually.
See https://docs.gradle.org/current/userguide/test_kit.html#sub:test-kit-classpath-injection

I've just forgot to delete this in #1579 😅 