### PR TITLE
Eliminate stack protection from the runtime.

### DIFF
--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
@@ -163,7 +163,7 @@ class ClangArgs(private val configurables: Configurables) : Configurables by con
                 emptyList()
             }
 
-    val commonClangArgs = listOf("-B$binDir") + extraHostClangArgs
+    val commonClangArgs = listOf("-B$binDir", "-fno-stack-protector") + extraHostClangArgs
 
     val clangPaths = listOf("$absoluteLlvmHome/bin", binDir)
 


### PR DESCRIPTION
There is some positive performance effect:
before: Average Ring score: absolute = 177,5160 us +- 0,5352 us, ratio = 8,68 +- 0,10
after:  Average Ring score: absolute = 171,3093 us +- 2,3758 us, ratio = 8,72 +- 0,23