### PR TITLE
Add 'disableDesignatedInitializerChecks' .def file flag

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -85,7 +85,8 @@ class ObjCMethodStub(private val stubGenerator: StubGenerator,
                     when (container) {
                         is ObjCClass -> {
                             // TODO: consider generating non-designated initializers as factories.
-                            val designated = method.isDesginatedInitializer
+                            val designated = method.isDesginatedInitializer ||
+                                    stubGenerator.configuration.disableDesignatedInitializerChecks
 
                             result.add("")
                             result.add("@ObjCConstructor(${method.selector.quoteAsKotlinLiteral()}, $designated)")

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/InteropConfiguration.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/InteropConfiguration.kt
@@ -28,5 +28,6 @@ class InteropConfiguration(
         val strictEnums: Set<String>,
         val nonStrictEnums: Set<String>,
         val noStringConversion: Set<String>,
-        val exportForwardDeclarations: List<String>
+        val exportForwardDeclarations: List<String>,
+        val disableDesignatedInitializerChecks: Boolean
 )

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -276,7 +276,8 @@ private fun processCLib(args: Array<String>): Array<String>? {
             strictEnums = def.config.strictEnums.toSet(),
             nonStrictEnums = def.config.nonStrictEnums.toSet(),
             noStringConversion = def.config.noStringConversion.toSet(),
-            exportForwardDeclarations = def.config.exportForwardDeclarations
+            exportForwardDeclarations = def.config.exportForwardDeclarations,
+            disableDesignatedInitializerChecks = def.config.disableDesignatedInitializerChecks
     )
 
     val nativeIndex = buildNativeIndex(library)

--- a/OBJC_INTEROP.md
+++ b/OBJC_INTEROP.md
@@ -216,6 +216,12 @@ The overriding constructor must have the same parameter names and types as the o
 To override different methods with clashing Kotlin signatures, one can add
 `@Suppress("CONFLICTING_OVERLOADS")` annotation to the class.
 
+By default Kotlin/Native compiler doesn't allow to call non-designated
+Objective-C initializer as `super(...)` constructor. This behaviour can be
+inconvenient if designated initializers aren't marked properly in the Objective-C
+library. Adding `disableDesignatedInitializerChecks = true` to `.def` file for
+this library would disable these compiler checks.
+
 ## C features
 
 See [INTEROP.md](INTEROP.md) for the case when library uses some plain C features

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DefFile.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DefFile.kt
@@ -99,6 +99,10 @@ class DefFile(val file:File?, val config:DefFileConfig, val manifestAddendProper
         val exportForwardDeclarations by lazy {
             properties.getSpaceSeparated("exportForwardDeclarations")
         }
+
+        val disableDesignatedInitializerChecks by lazy {
+            properties.getProperty("disableDesignatedInitializerChecks")?.toBoolean() ?: false
+        }
     }
 }
 


### PR DESCRIPTION
When enabled for an Objective-C library, compiler would permit to call
a constructor of a class from this library as super-constructor even if
it is not marked as designated.

Fix #1539