### PR TITLE
Rework objc-export

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
@@ -1,0 +1,62 @@
+package org.jetbrains.kotlin.backend.konan.objcexport
+
+import org.jetbrains.kotlin.builtins.getReceiverTypeFromFunctionType
+import org.jetbrains.kotlin.builtins.getReturnTypeFromFunctionType
+import org.jetbrains.kotlin.builtins.getValueParameterTypesFromFunctionType
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.TypeUtils
+
+internal interface CustomTypeMapper {
+    val mappedClassDescriptor: ClassDescriptor
+    fun mapType(mappedSuperType: KotlinType): ObjCNonNullReferenceType
+
+    class Simple(
+            override val mappedClassDescriptor: ClassDescriptor,
+            private val objCClassName: String
+    ) : CustomTypeMapper {
+
+        override fun mapType(mappedSuperType: KotlinType): ObjCNonNullReferenceType =
+                ObjCClassType(objCClassName)
+    }
+
+    class Collection(
+            private val generator: ObjCExportHeaderGenerator,
+            override val mappedClassDescriptor: ClassDescriptor,
+            private val objCClassName: String
+    ) : CustomTypeMapper {
+        override fun mapType(mappedSuperType: KotlinType): ObjCNonNullReferenceType {
+            val typeArguments = mappedSuperType.arguments.map {
+                val argument = it.type
+                if (TypeUtils.isNullableType(argument)) {
+                    // Kotlin `null` keys and values are represented as `NSNull` singleton.
+                    ObjCIdType
+                } else {
+                    generator.mapReferenceTypeIgnoringNullability(argument)
+                }
+            }
+
+            return ObjCClassType(objCClassName, typeArguments)
+        }
+    }
+
+    class Function(
+            private val generator: ObjCExportHeaderGenerator,
+            parameterCount: Int
+    ) : CustomTypeMapper {
+        override val mappedClassDescriptor = generator.builtIns.getFunction(parameterCount)
+
+        override fun mapType(mappedSuperType: KotlinType): ObjCNonNullReferenceType {
+            val functionType = mappedSuperType
+
+            val returnType = functionType.getReturnTypeFromFunctionType()
+            val parameterTypes = listOfNotNull(functionType.getReceiverTypeFromFunctionType()) +
+                    functionType.getValueParameterTypesFromFunctionType().map { it.type }
+
+            return ObjCBlockPointerType(
+                    generator.mapReferenceType(returnType),
+                    parameterTypes.map { generator.mapReferenceType(it) }
+            )
+        }
+    }
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/MethodBridge.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/MethodBridge.kt
@@ -4,7 +4,9 @@ import org.jetbrains.kotlin.backend.common.descriptors.allParameters
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.ParameterDescriptor
 
-// TODO: generalize type bridges to support such things as selectors, ignored class method receivers etc.
+internal sealed class TypeBridge
+internal object ReferenceBridge : TypeBridge()
+internal data class ValueTypeBridge(val objCValueType: ObjCValueType) : TypeBridge()
 
 internal sealed class MethodBridgeParameter
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/MethodBridge.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/MethodBridge.kt
@@ -1,0 +1,100 @@
+package org.jetbrains.kotlin.backend.konan.objcexport
+
+import org.jetbrains.kotlin.backend.common.descriptors.allParameters
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.ParameterDescriptor
+
+// TODO: generalize type bridges to support such things as selectors, ignored class method receivers etc.
+
+internal sealed class MethodBridgeParameter
+
+internal sealed class MethodBridgeReceiver : MethodBridgeParameter() {
+    object Static : MethodBridgeReceiver()
+    object Factory : MethodBridgeReceiver()
+    object Instance : MethodBridgeReceiver()
+}
+
+internal object MethodBridgeSelector : MethodBridgeParameter()
+
+internal sealed class MethodBridgeValueParameter : MethodBridgeParameter() {
+    data class Mapped(val bridge: TypeBridge) : MethodBridgeValueParameter()
+    object ErrorOutParameter : MethodBridgeValueParameter()
+    data class KotlinResultOutParameter(val bridge: TypeBridge) : MethodBridgeValueParameter()
+}
+
+internal data class MethodBridge(
+        val returnBridge: ReturnValue,
+        val receiver: MethodBridgeReceiver,
+        val valueParameters: List<MethodBridgeValueParameter>
+) {
+
+    sealed class ReturnValue {
+        object Void : ReturnValue()
+        object HashCode : ReturnValue()
+        data class Mapped(val bridge: TypeBridge) : ReturnValue()
+        sealed class Instance : ReturnValue() {
+            object InitResult : Instance()
+            object FactoryResult : Instance()
+        }
+
+        sealed class WithError : ReturnValue() {
+            object Success : WithError()
+            data class RefOrNull(val successBridge: ReturnValue) : WithError()
+        }
+    }
+
+    val paramBridges: List<MethodBridgeParameter> =
+            listOf(receiver) + MethodBridgeSelector + valueParameters
+
+    // TODO: it is not exactly true in potential future cases.
+    val isInstance: Boolean get() = when (receiver) {
+        MethodBridgeReceiver.Static,
+        MethodBridgeReceiver.Factory -> false
+
+        MethodBridgeReceiver.Instance -> true
+    }
+}
+
+internal fun MethodBridge.valueParametersAssociated(
+        descriptor: FunctionDescriptor
+): List<Pair<MethodBridgeValueParameter, ParameterDescriptor?>> {
+    val kotlinParameters = descriptor.allParameters.iterator()
+    val skipFirstKotlinParameter = when (this.receiver) {
+        MethodBridgeReceiver.Static -> false
+        MethodBridgeReceiver.Factory, MethodBridgeReceiver.Instance -> true
+    }
+    if (skipFirstKotlinParameter) {
+        kotlinParameters.next()
+    }
+
+    return this.valueParameters.map {
+        when (it) {
+            is MethodBridgeValueParameter.Mapped -> it to kotlinParameters.next()
+
+            is MethodBridgeValueParameter.ErrorOutParameter,
+            is MethodBridgeValueParameter.KotlinResultOutParameter -> it to null
+        }
+    }.also { assert(!kotlinParameters.hasNext()) }
+}
+
+internal fun MethodBridge.parametersAssociated(
+        descriptor: FunctionDescriptor
+): List<Pair<MethodBridgeParameter, ParameterDescriptor?>> {
+    val kotlinParameters = descriptor.allParameters.iterator()
+
+    return this.paramBridges.map {
+        when (it) {
+            is MethodBridgeValueParameter.Mapped, MethodBridgeReceiver.Instance ->
+                it to kotlinParameters.next()
+
+            MethodBridgeReceiver.Static, MethodBridgeSelector, MethodBridgeValueParameter.ErrorOutParameter,
+            is MethodBridgeValueParameter.KotlinResultOutParameter ->
+                it to null
+
+            MethodBridgeReceiver.Factory -> {
+                kotlinParameters.next()
+                it to null
+            }
+        }
+    }.also { assert(!kotlinParameters.hasNext()) }
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -46,7 +46,7 @@ internal class ObjCExport(val codegen: CodeGenerator) {
         val topLevelDeclarations: Map<FqName, List<CallableMemberDescriptor>>
 
         if (context.config.produce == CompilerOutputKind.FRAMEWORK) {
-            val headerGenerator = ObjCExportHeaderGenerator(context)
+            val headerGenerator = ObjCExportHeaderGeneratorImpl(context)
             produceFrameworkSpecific(headerGenerator)
 
             generatedClasses = headerGenerator.generatedClasses
@@ -63,7 +63,7 @@ internal class ObjCExport(val codegen: CodeGenerator) {
 
             }
 
-            val namer = ObjCExportNamer(context, mapper)
+            val namer = ObjCExportNamer(context.moduleDescriptor, context.builtIns, mapper)
             objCCodeGenerator = ObjCExportCodeGenerator(codegen, namer, mapper)
 
             generatedClasses = emptySet()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -98,7 +98,7 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
     private val extensions = mutableMapOf<ClassDescriptor, MutableList<CallableMemberDescriptor>>()
     private val extraClassesToTranslate = mutableSetOf<ClassDescriptor>()
 
-    fun translateModule() {
+    fun translateModule(): List<Stub<*>> {
         // TODO: make the translation order stable
         // to stabilize name mangling.
 
@@ -177,6 +177,8 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
                 translateClass(descriptor)
             }
         }
+
+        return stubs
     }
 
     private fun translateClassName(descriptor: ClassDescriptor): String = classOrInterfaceToName.getOrPut(descriptor) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -316,7 +316,7 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
         }
 
         methods.forEach { method ->
-            val superSignatures = method.overriddenDescriptors
+            val superSignatures: Set<String> = method.overriddenDescriptors
                     .filter { mapper.shouldBeExposed(it) }
                     .flatMap { getSignatures(it.original) }
                     .toSet()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -281,7 +281,6 @@ abstract class ObjCExportHeaderGenerator(
                     descriptor.enumEntries.forEach {
                         val entryName = namer.getEnumEntrySelector(it)
                         +ObjcProperty(entryName, null, type, listOf("class", "readonly"))
-//                        +"@property (class, readonly) ${type.render(entryName)};"
                     }
                 }
                 else -> {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -88,7 +88,7 @@ abstract class ObjCExportHeaderGenerator(
                 .asSequence()
                 .flatMap { it.getAllSuperClassifiers().asSequence() }
                 .map { it as ClassDescriptor }
-                .filter { customMappedTypes.contains(it) }
+                .filter { !customMappedTypes.contains(it) }
                 .toSet()
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -264,7 +264,6 @@ abstract class ObjCExportHeaderGenerator(
 
                         +buildMethod(it, it)
                         if (selector == "init") {
-                            //todo no swift name here???
                             +ObjcMethod(it, false, ObjCInstanceType, listOf("new"), emptyList(),
                                         listOf("availability(swift, unavailable, message=\"use object initializers instead\")"))
                         }
@@ -302,7 +301,6 @@ abstract class ObjCExportHeaderGenerator(
                     ?.forEach {
                         val selector = getSelector(it)
                         if (selector !in presentConstructors) {
-                            //todo attach attributes???
                             val c = buildMethod(it, it)
                             +ObjcMethod(c.descriptor, c.isInstanceMethod, c.returnType, c.selectors, c.parameters, c.attributes + "unavailable")
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -194,18 +194,17 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
         val members = buildMembers {
             translateMembers(declarations)
         }
-        stubs.add(ObjcInterface(name, null, null, emptyList(), "Extensions", members))
+        stubs.add(ObjcInterface(name, categoryName = "Extensions", members = members))
     }
 
     private fun translateTopLevel(packageFqName: FqName, declarations: List<CallableMemberDescriptor>) {
         val name = namer.getPackageName(packageFqName)
 
         // TODO: stop inheriting KotlinBase.
-        //todo add "__attribute__((objc_subclassing_restricted))"
         val members = buildMembers {
             translateMembers(declarations)
         }
-        stubs.add(ObjcInterface(name, null, namer.kotlinAnyName, emptyList(), null, members))
+        stubs.add(ObjcInterface(name, superClass = namer.kotlinAnyName, members = members, attributes = listOf("objc_subclassing_restricted")))
     }
 
     private fun translateClass(descriptor: ClassDescriptor) {
@@ -290,7 +289,8 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
             translateClassOrInterfaceMembers(descriptor)
         }
 
-        val interfaceStub = ObjcInterface(name, descriptor, superName, superProtocols, null, members)
+        val interfaceStub = ObjcInterface(name, descriptor = descriptor, superClass = superName,
+                superProtocols = superProtocols, members = members)
         stubs.add(interfaceStub)
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -107,21 +107,21 @@ abstract class ObjCExportHeaderGenerator(
         // TODO: make the translation order stable
         // to stabilize name mangling.
 
-        stubs.add(ObjcInterface(kotlinAnyName, superClass = "NSObject", members = buildMembers {
-            +ObjcMethod(null, true, ObjCInstanceType, listOf("init"), emptyList(), listOf("unavailable"))
-            +ObjcMethod(null, false, ObjCInstanceType, listOf("new"), emptyList(), listOf("unavailable"))
-            +ObjcMethod(null, false, ObjCVoidType, listOf("initialize"), emptyList(), listOf("objc_requires_super"))
+        stubs.add(ObjCInterface(kotlinAnyName, superClass = "NSObject", members = buildMembers {
+            +ObjCMethod(null, true, ObjCInstanceType, listOf("init"), emptyList(), listOf("unavailable"))
+            +ObjCMethod(null, false, ObjCInstanceType, listOf("new"), emptyList(), listOf("unavailable"))
+            +ObjCMethod(null, false, ObjCVoidType, listOf("initialize"), emptyList(), listOf("objc_requires_super"))
         }))
 
         // TODO: add comment to the header.
-        stubs.add(ObjcInterface(
+        stubs.add(ObjCInterface(
                 kotlinAnyName,
                 superProtocols = listOf("NSCopying"),
                 categoryName = "${kotlinAnyName}Copying"
         ))
 
         // TODO: only if appears
-        stubs.add(ObjcInterface(
+        stubs.add(ObjCInterface(
                 namer.mutableSetName,
                 generics = listOf("ObjectType"),
                 superClass = "NSMutableSet<ObjectType>",
@@ -129,15 +129,15 @@ abstract class ObjCExportHeaderGenerator(
         ))
 
         // TODO: only if appears
-        stubs.add(ObjcInterface(
+        stubs.add(ObjCInterface(
                 namer.mutableMapName,
                 generics = listOf("KeyType", "ObjectType"),
                 superClass = "NSMutableDictionary<KeyType, ObjectType>",
                 attributes = listOf("objc_runtime_name(\"KotlinMutableDictionary\")")
         ))
 
-        stubs.add(ObjcInterface("NSError", categoryName = "NSErrorKotlinException", members = buildMembers {
-            +ObjcProperty("kotlinException", null, ObjCNullableReferenceType(ObjCIdType), listOf("readonly"))
+        stubs.add(ObjCInterface("NSError", categoryName = "NSErrorKotlinException", members = buildMembers {
+            +ObjCProperty("kotlinException", null, ObjCNullableReferenceType(ObjCIdType), listOf("readonly"))
         }))
 
         val packageFragments = moduleDescriptor.getPackageFragments()
@@ -213,7 +213,7 @@ abstract class ObjCExportHeaderGenerator(
         val members: List<Stub<*>> = buildMembers { translateClassOrInterfaceMembers(descriptor) }
         val superProtocols: List<String> = descriptor.superProtocols
 
-        val protocolStub = ObjcProtocol(name, descriptor, superProtocols, members)
+        val protocolStub = ObjCProtocol(name, descriptor, superProtocols, members)
 
         stubs.add(protocolStub)
     }
@@ -236,7 +236,7 @@ abstract class ObjCExportHeaderGenerator(
         val members = buildMembers {
             translateMembers(declarations)
         }
-        stubs.add(ObjcInterface(name, categoryName = "Extensions", members = members))
+        stubs.add(ObjCInterface(name, categoryName = "Extensions", members = members))
     }
 
     private fun translateTopLevel(packageFqName: FqName, declarations: List<CallableMemberDescriptor>) {
@@ -246,7 +246,7 @@ abstract class ObjCExportHeaderGenerator(
         val members = buildMembers {
             translateMembers(declarations)
         }
-        stubs.add(ObjcInterface(
+        stubs.add(ObjCInterface(
                 name,
                 superClass = namer.kotlinAnyName,
                 members = members,
@@ -280,22 +280,22 @@ abstract class ObjCExportHeaderGenerator(
 
                         +buildMethod(it, it)
                         if (selector == "init") {
-                            +ObjcMethod(it, false, ObjCInstanceType, listOf("new"), emptyList(),
+                            +ObjCMethod(it, false, ObjCInstanceType, listOf("new"), emptyList(),
                                         listOf("availability(swift, unavailable, message=\"use object initializers instead\")"))
                         }
                     }
 
             if (descriptor.isArray || descriptor.kind == ClassKind.OBJECT || descriptor.kind == ClassKind.ENUM_CLASS) {
-                +ObjcMethod(null, false, ObjCInstanceType, listOf("alloc"), emptyList(), listOf("unavailable"))
+                +ObjCMethod(null, false, ObjCInstanceType, listOf("alloc"), emptyList(), listOf("unavailable"))
 
-                val parameter = ObjcParameter("zone", null, ObjcRawType("struct _NSZone *"))
-                +ObjcMethod(descriptor, false, ObjCInstanceType, listOf("allocWithZone:"), listOf(parameter), listOf("unavailable"))
+                val parameter = ObjCParameter("zone", null, ObjCRawType("struct _NSZone *"))
+                +ObjCMethod(descriptor, false, ObjCInstanceType, listOf("allocWithZone:"), listOf(parameter), listOf("unavailable"))
             }
 
             // TODO: consider adding exception-throwing impls for these.
             when (descriptor.kind) {
                 ClassKind.OBJECT -> {
-                    +ObjcMethod(
+                    +ObjCMethod(
                             null, false, ObjCInstanceType,
                             listOf(namer.getObjectInstanceSelector(descriptor)), emptyList(),
                             listOf(swiftNameAttribute("init()"))
@@ -306,7 +306,7 @@ abstract class ObjCExportHeaderGenerator(
 
                     descriptor.enumEntries.forEach {
                         val entryName = namer.getEnumEntrySelector(it)
-                        +ObjcProperty(entryName, null, type, listOf("class", "readonly"))
+                        +ObjCProperty(entryName, null, type, listOf("class", "readonly"))
                     }
                 }
                 else -> {
@@ -322,10 +322,10 @@ abstract class ObjCExportHeaderGenerator(
                         val selector = getSelector(it)
                         if (selector !in presentConstructors) {
                             val c = buildMethod(it, it)
-                            +ObjcMethod(c.descriptor, c.isInstanceMethod, c.returnType, c.selectors, c.parameters, c.attributes + "unavailable")
+                            +ObjCMethod(c.descriptor, c.isInstanceMethod, c.returnType, c.selectors, c.parameters, c.attributes + "unavailable")
 
                             if (selector == "init") {
-                                +ObjcMethod(null, false, ObjCInstanceType, listOf("new"), emptyList(), listOf("unavailable"))
+                                +ObjCMethod(null, false, ObjCInstanceType, listOf("new"), emptyList(), listOf("unavailable"))
                             }
 
                             // TODO: consider adding exception-throwing impls for these.
@@ -337,7 +337,7 @@ abstract class ObjCExportHeaderGenerator(
 
         val attributes = if (descriptor.isFinalOrEnum) listOf("objc_subclassing_restricted") else emptyList()
 
-        val interfaceStub = ObjcInterface(
+        val interfaceStub = ObjCInterface(
                 name,
                 descriptor = descriptor,
                 superClass = superName,
@@ -418,10 +418,10 @@ abstract class ObjCExportHeaderGenerator(
         }
     }
 
-    private val methodToSignatures = mutableMapOf<FunctionDescriptor, Set<RenderedStub<ObjcMethod>>>()
-    private val propertyToSignatures = mutableMapOf<PropertyDescriptor, Set<RenderedStub<ObjcProperty>>>()
+    private val methodToSignatures = mutableMapOf<FunctionDescriptor, Set<RenderedStub<ObjCMethod>>>()
+    private val propertyToSignatures = mutableMapOf<PropertyDescriptor, Set<RenderedStub<ObjCProperty>>>()
 
-    private fun buildMethods(method: FunctionDescriptor): Set<RenderedStub<ObjcMethod>> = methodToSignatures.getOrPut(method) {
+    private fun buildMethods(method: FunctionDescriptor): Set<RenderedStub<ObjCMethod>> = methodToSignatures.getOrPut(method) {
         mapper.getBaseMethods(method)
                 .asSequence()
                 .distinctBy { namer.getSelector(it) }
@@ -430,7 +430,7 @@ abstract class ObjCExportHeaderGenerator(
                 .toSet()
     }
 
-    private fun buildProperties(property: PropertyDescriptor): Set<RenderedStub<ObjcProperty>> = propertyToSignatures.getOrPut(property) {
+    private fun buildProperties(property: PropertyDescriptor): Set<RenderedStub<ObjCProperty>> = propertyToSignatures.getOrPut(property) {
         mapper.getBaseProperties(property)
                 .asSequence()
                 .distinctBy { namer.getName(it) }
@@ -445,7 +445,7 @@ abstract class ObjCExportHeaderGenerator(
         return namer.getSelector(method)
     }
 
-    private fun buildProperty(property: PropertyDescriptor, baseProperty: PropertyDescriptor): ObjcProperty {
+    private fun buildProperty(property: PropertyDescriptor, baseProperty: PropertyDescriptor): ObjCProperty {
         assert(mapper.isBaseProperty(baseProperty))
         assert(mapper.isObjCProperty(baseProperty))
 
@@ -472,11 +472,11 @@ abstract class ObjCExportHeaderGenerator(
         val getterSelector = getSelector(baseProperty.getter!!)
         val getterName: String? = if (getterSelector != name) getterSelector else null
 
-        return ObjcProperty(name, property, type, attributes, setterName, getterName)
+        return ObjCProperty(name, property, type, attributes, setterName, getterName)
     }
 
-    private fun buildMethod(method: FunctionDescriptor, baseMethod: FunctionDescriptor): ObjcMethod {
-        fun collectParameters(baseMethodBridge: MethodBridge, method: FunctionDescriptor): List<ObjcParameter> {
+    private fun buildMethod(method: FunctionDescriptor, baseMethod: FunctionDescriptor): ObjCMethod {
+        fun collectParameters(baseMethodBridge: MethodBridge, method: FunctionDescriptor): List<ObjCParameter> {
             fun unifyName(initialName: String, usedNames: Set<String>): String {
                 var unique = initialName
                 while (unique in usedNames) {
@@ -487,7 +487,7 @@ abstract class ObjCExportHeaderGenerator(
 
             val valueParametersAssociated = baseMethodBridge.valueParametersAssociated(method)
 
-            val parameters = mutableListOf<ObjcParameter>()
+            val parameters = mutableListOf<ObjCParameter>()
 
             val usedNames = mutableSetOf<String>()
             valueParametersAssociated.forEach { (bridge: MethodBridgeValueParameter, p: ParameterDescriptor?) ->
@@ -516,7 +516,7 @@ abstract class ObjCExportHeaderGenerator(
                         ObjCPointerType(mapType(method.returnType!!, bridge.bridge), nullable = true)
                 }
 
-                parameters += ObjcParameter(uniqueName, p, type)
+                parameters += ObjCParameter(uniqueName, p, type)
             }
             return parameters
         }
@@ -541,7 +541,7 @@ abstract class ObjCExportHeaderGenerator(
             attributes += "objc_designated_initializer"
         }
 
-        return ObjcMethod(method, isInstanceMethod, returnType, selectorParts, parameters, attributes)
+        return ObjCMethod(method, isInstanceMethod, returnType, selectorParts, parameters, attributes)
     }
 
     private fun splitSelector(selector: String): List<String> {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -399,22 +399,20 @@ abstract class ObjCExportHeaderGenerator(
             attributes += "class"
         }
 
-        val getterSelector = getSelector(baseProperty.getter!!)
-        if (getterSelector != name) {
-            attributes += "getter=$getterSelector"
-        }
-
+        val setterName: String?
         val propertySetter = property.setter
         if (propertySetter != null && mapper.shouldBeExposed(propertySetter)) {
             val setterSelector = mapper.getBaseMethods(propertySetter).map { namer.getSelector(it) }.distinct().single()
-            if (setterSelector != "set" + name.capitalize() + ":") {
-                attributes += "setter=$setterSelector"
-            }
+            setterName = if (setterSelector != "set" + name.capitalize() + ":") setterSelector else null
         } else {
             attributes += "readonly"
+            setterName = null
         }
 
-        return ObjcProperty(name, property, type, attributes)
+        val getterSelector = getSelector(baseProperty.getter!!)
+        val getterName: String? = if (getterSelector != name) getterSelector else null
+
+        return ObjcProperty(name, property, type, attributes, setterName, getterName)
     }
 
     private fun buildMethod(method: FunctionDescriptor, baseMethod: FunctionDescriptor): ObjcMethod {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -232,24 +232,32 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
                 val selector = getSelector(it)
                 if (!descriptor.isArray) presentConstructors += selector
 
-                +"${buildMethod(it, it)};"
+                +buildMethod(it, it)
                 if (selector == "init") {
-                    +"+ (instancetype)new OBJC_SWIFT_UNAVAILABLE(\"use object initializers instead\");"
+                    //todo no swift name here???
+                    +ObjcMethod(it, false, ObjCInstanceType, listOf("new"), emptyList(), "" , true, false)
+                    //+"+ (instancetype)new OBJC_SWIFT_UNAVAILABLE(\"use object initializers instead\");"
                 }
-                +""
             }
 
             if (descriptor.isArray || descriptor.kind == ClassKind.OBJECT || descriptor.kind == ClassKind.ENUM_CLASS) {
-                +"+(instancetype)alloc __attribute__((unavailable));"
-                +"+(instancetype)allocWithZone:(struct _NSZone *)zone __attribute__((unavailable));"
-                +""
+                //todo attach attributes???
+                +ObjcMethod(null, false, ObjCInstanceType, listOf("alloc"), emptyList(), "init", true, false)
+                //+"+(instancetype)alloc __attribute__((unavailable));"
+
+
+                //todo attributes???
+                val parameter = ObjcParameter("zone", null, ObjcRawType("struct _NSZone *"))
+                +ObjcMethod(descriptor, false, ObjCInstanceType, listOf("allocWithZone"), listOf(parameter), "init", true, false)
+//                +"+(instancetype)allocWithZone:(struct _NSZone *)zone __attribute__((unavailable));"
+
             }
 
             // TODO: consider adding exception-throwing impls for these.
             when (descriptor.kind) {
                 ClassKind.OBJECT -> {
-                    +"+(instancetype)${namer.getObjectInstanceSelector(descriptor)} NS_SWIFT_NAME(init());"
-                    +""
+                    +ObjcMethod(null, false, ObjCInstanceType, listOf(namer.getObjectInstanceSelector(descriptor)), emptyList(), "init", true, false)
+//                    +"+(instancetype)${namer.getObjectInstanceSelector(descriptor)} NS_SWIFT_NAME(init());"
                 }
                 ClassKind.ENUM_CLASS -> {
                     val type = mapType(descriptor.defaultType, ReferenceBridge)
@@ -269,12 +277,15 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
             superClass?.constructors?.filter { mapper.shouldBeExposed(it) }?.forEach {
                 val selector = getSelector(it)
                 if (selector !in presentConstructors) {
-                    +"${buildMethod(it, it)} __attribute__((unavailable));"
+                    //todo attach attributes???
+//                    +"${buildMethod(it, it)} __attribute__((unavailable));"
+
                     if (selector == "init") {
-                        +"+(instancetype) new __attribute__((unavailable));"
+                        //todo attach attributes
+                        +ObjcMethod(null, false, ObjCInstanceType, listOf("new"), emptyList(), "init", true, false)
+//                        +"+(instancetype) new __attribute__((unavailable));"
                     }
 
-                    +""
                     // TODO: consider adding exception-throwing impls for these.
                 }
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -267,7 +267,7 @@ abstract class ObjCExportHeaderGenerator(
                 +ObjcMethod(null, false, ObjCInstanceType, listOf("alloc"), emptyList(), listOf("unavailable"))
 
                 val parameter = ObjcParameter("zone", null, ObjcRawType("struct _NSZone *"))
-                +ObjcMethod(descriptor, false, ObjCInstanceType, listOf("allocWithZone"), listOf(parameter), listOf("unavailable"))
+                +ObjcMethod(descriptor, false, ObjCInstanceType, listOf("allocWithZone:"), listOf(parameter), listOf("unavailable"))
             }
 
             // TODO: consider adding exception-throwing impls for these.
@@ -470,7 +470,8 @@ abstract class ObjCExportHeaderGenerator(
         val isInstanceMethod: Boolean = baseMethodBridge.isInstance
         val returnType: ObjCType = mapReturnType(baseMethodBridge.returnBridge, method)
         val parameters = collectParameters(baseMethodBridge, method)
-        val selectorParts: List<String> = getSelector(baseMethod).trimEnd(':').split(':')
+        val selector = getSelector(baseMethod)
+        val selectorParts: List<String> = splitSelector(selector)
         val swiftName = namer.getSwiftName(baseMethod)
         val attributes = mutableListOf<String>()
 
@@ -481,6 +482,14 @@ abstract class ObjCExportHeaderGenerator(
         }
 
         return ObjcMethod(method, isInstanceMethod, returnType, selectorParts, parameters, attributes)
+    }
+
+    private fun splitSelector(selector: String): List<String> {
+        return if (!selector.endsWith(":")) {
+            listOf(selector)
+        } else {
+            selector.trimEnd(':').split(':').map { "$it:" }
+        }
     }
 
     private val methodsWithThrowAnnotationConsidered = mutableSetOf<FunctionDescriptor>()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -190,13 +190,11 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
     private fun translateExtensions(classDescriptor: ClassDescriptor, declarations: List<CallableMemberDescriptor>) {
         translateClass(classDescriptor)
 
-        stubs.addBuiltBy {
-            +"@interface ${translateClassName(classDescriptor)} (Extensions)"
-
+        val name = translateClassName(classDescriptor)
+        val members = buildMembers {
             translateMembers(declarations)
-
-            +"@end;"
         }
+        stubs.add(ObjcInterface(name, null, null, emptyList(), "Extensions", members))
     }
 
     private fun translateTopLevel(packageFqName: FqName, declarations: List<CallableMemberDescriptor>) {
@@ -293,7 +291,7 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
             translateClassOrInterfaceMembers(descriptor)
         }
 
-        val interfaceStub = ObjcInterface(name, descriptor, superName, superProtocols, members)
+        val interfaceStub = ObjcInterface(name, descriptor, superName, superProtocols, null, members)
         stubs.add(interfaceStub)
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -369,7 +369,6 @@ abstract class ObjCExportHeaderGenerator(
         }
     }
 
-    //todo hashCode&equals for ObjcMethod???
     private val methodToSignatures = mutableMapOf<FunctionDescriptor, Set<ObjcMethod>>()
 
     private fun buildMethods(method: FunctionDescriptor): Set<ObjcMethod> = methodToSignatures.getOrPut(method) {
@@ -380,7 +379,6 @@ abstract class ObjCExportHeaderGenerator(
                 .toSet()
     }
 
-    //todo hashCode&equals for ObjcProperty???
     private val propertyToSignatures = mutableMapOf<PropertyDescriptor, Set<ObjcProperty>>()
 
     private fun buildProperties(property: PropertyDescriptor): Set<ObjcProperty> = propertyToSignatures.getOrPut(property) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -47,10 +47,10 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
 
     internal val namer = ObjCExportNamer(moduleDescriptor, builtIns, mapper)
 
-    val generatedClasses = mutableSetOf<ClassDescriptor>()
-    val topLevel = mutableMapOf<FqName, MutableList<CallableMemberDescriptor>>()
+    internal val generatedClasses = mutableSetOf<ClassDescriptor>()
+    internal val topLevel = mutableMapOf<FqName, MutableList<CallableMemberDescriptor>>()
 
-    internal val customTypeMappers: Map<ClassDescriptor, CustomTypeMapper> = with(builtIns) {
+    private val customTypeMappers: Map<ClassDescriptor, CustomTypeMapper> = with(builtIns) {
         val result = mutableListOf<CustomTypeMapper>()
 
         val generator = this@ObjCExportHeaderGenerator
@@ -558,9 +558,9 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
         add("NS_ASSUME_NONNULL_END")
     }
 
-    abstract fun reportCompilationWarning(text: String)
+    protected abstract fun reportCompilationWarning(text: String)
 
-    abstract fun reportError(method: FunctionDescriptor, text: String)
+    protected abstract fun reportError(method: FunctionDescriptor, text: String)
 
     internal fun mapReferenceType(kotlinType: KotlinType): ObjCReferenceType =
             mapReferenceTypeIgnoringNullability(kotlinType).let {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -551,7 +551,7 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
         add("")
 
         stubs.forEach {
-            addAll(it.lines)
+            addAll(StubRenderer.render(it))
             add("")
         }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -199,14 +199,13 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
 
     private fun translateTopLevel(packageFqName: FqName, declarations: List<CallableMemberDescriptor>) {
         val name = namer.getPackageName(packageFqName)
-        stubs.addBuiltBy {
-            +"__attribute__((objc_subclassing_restricted))"
-            +"@interface $name : ${namer.kotlinAnyName}" // TODO: stop inheriting KotlinBase.
 
+        // TODO: stop inheriting KotlinBase.
+        //todo add "__attribute__((objc_subclassing_restricted))"
+        val members = buildMembers {
             translateMembers(declarations)
-
-            +"@end;"
         }
+        stubs.add(ObjcInterface(name, null, namer.kotlinAnyName, emptyList(), null, members))
     }
 
     private fun translateClass(descriptor: ClassDescriptor) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -32,8 +32,11 @@ import org.jetbrains.kotlin.types.TypeUtils
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 import org.jetbrains.kotlin.utils.addIfNotNull
 
-abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
-                                         val builtIns: KotlinBuiltIns) {
+abstract class ObjCExportHeaderGenerator(
+        val moduleDescriptor: ModuleDescriptor,
+        val builtIns: KotlinBuiltIns,
+        topLevelNamePrefix: String = moduleDescriptor.namePrefix
+) {
     internal val mapper: ObjCExportMapper = object : ObjCExportMapper() {
         override fun getCategoryMembersFor(descriptor: ClassDescriptor) =
                 extensions[descriptor].orEmpty()
@@ -45,7 +48,7 @@ abstract class ObjCExportHeaderGenerator(val moduleDescriptor: ModuleDescriptor,
         }
     }
 
-    internal val namer = ObjCExportNamer(moduleDescriptor, builtIns, mapper)
+    internal val namer = ObjCExportNamer(moduleDescriptor, builtIns, mapper, topLevelNamePrefix)
 
     internal val generatedClasses = mutableSetOf<ClassDescriptor>()
     internal val topLevel = mutableMapOf<FqName, MutableList<CallableMemberDescriptor>>()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -466,7 +466,7 @@ abstract class ObjCExportHeaderGenerator(
                         ObjCPointerType(mapType(method.returnType!!, bridge.bridge), nullable = true)
                 }
 
-                parameters += ObjcParameter(uniqueName, p!!, type) //todo get rid of !!
+                parameters += ObjcParameter(uniqueName, p, type)
             }
             return parameters
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGeneratorImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGeneratorImpl.kt
@@ -8,11 +8,11 @@ import org.jetbrains.kotlin.ir.util.report
 internal class ObjCExportHeaderGeneratorImpl(val context: Context)
     : ObjCExportHeaderGenerator(context.moduleDescriptor, context.builtIns) {
 
-    override fun reportCompilationWarning(text: String) {
+    override fun reportWarning(text: String) {
         context.reportCompilationWarning(text)
     }
 
-    override fun reportError(method: FunctionDescriptor, text: String) {
+    override fun reportWarning(method: FunctionDescriptor, text: String) {
         context.report(
                 context.ir.get(method),
                 text,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGeneratorImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGeneratorImpl.kt
@@ -1,0 +1,22 @@
+package org.jetbrains.kotlin.backend.konan.objcexport
+
+import org.jetbrains.kotlin.backend.konan.Context
+import org.jetbrains.kotlin.backend.konan.reportCompilationWarning
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.ir.util.report
+
+internal class ObjCExportHeaderGeneratorImpl(val context: Context)
+    : ObjCExportHeaderGenerator(context.moduleDescriptor, context.builtIns) {
+
+    override fun reportCompilationWarning(text: String) {
+        context.reportCompilationWarning(text)
+    }
+
+    override fun reportError(method: FunctionDescriptor, text: String) {
+        context.report(
+                context.ir.get(method),
+                text,
+                isError = false
+        )
+    }
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt
@@ -36,7 +36,7 @@ internal abstract class ObjCExportMapper {
 
     private val methodBridgeCache = mutableMapOf<FunctionDescriptor, MethodBridge>()
 
-    fun bridgeMethod(descriptor: FunctionDescriptor) = methodBridgeCache.getOrPut(descriptor) {
+    fun bridgeMethod(descriptor: FunctionDescriptor): MethodBridge = methodBridgeCache.getOrPut(descriptor) {
         bridgeMethodImpl(descriptor)
     }
 }
@@ -108,105 +108,6 @@ internal fun ObjCExportMapper.isObjCProperty(property: PropertyDescriptor): Bool
 
 internal fun ObjCExportMapper.doesThrow(method: FunctionDescriptor): Boolean = method.allOverriddenDescriptors.any {
     it.overriddenDescriptors.isEmpty() && it.annotations.hasAnnotation(KonanBuiltIns.FqNames.throws)
-}
-
-// TODO: generalize type bridges to support such things as selectors, ignored class method receivers etc.
-
-internal sealed class TypeBridge
-internal object ReferenceBridge : TypeBridge()
-internal data class ValueTypeBridge(val objCValueType: ObjCValueType) : TypeBridge()
-
-internal sealed class MethodBridgeParameter
-
-internal sealed class MethodBridgeReceiver : MethodBridgeParameter() {
-    object Static : MethodBridgeReceiver()
-    object Factory : MethodBridgeReceiver()
-    object Instance : MethodBridgeReceiver()
-}
-
-internal object MethodBridgeSelector : MethodBridgeParameter()
-
-internal sealed class MethodBridgeValueParameter : MethodBridgeParameter() {
-    data class Mapped(val bridge: TypeBridge) : MethodBridgeValueParameter()
-    object ErrorOutParameter : MethodBridgeValueParameter()
-    data class KotlinResultOutParameter(val bridge: TypeBridge) : MethodBridgeValueParameter()
-}
-
-internal data class MethodBridge(
-        val returnBridge: ReturnValue,
-        val receiver: MethodBridgeReceiver,
-        val valueParameters: List<MethodBridgeValueParameter>
-) {
-
-    sealed class ReturnValue {
-        object Void : ReturnValue()
-        object HashCode : ReturnValue()
-        data class Mapped(val bridge: TypeBridge) : ReturnValue()
-        sealed class Instance : ReturnValue() {
-            object InitResult : Instance()
-            object FactoryResult : Instance()
-        }
-
-        sealed class WithError : ReturnValue() {
-            object Success : WithError()
-            data class RefOrNull(val successBridge: ReturnValue) : WithError()
-        }
-    }
-
-    val paramBridges: List<MethodBridgeParameter> =
-            listOf(receiver) + MethodBridgeSelector + valueParameters
-
-    // TODO: it is not exactly true in potential future cases.
-    val isInstance: Boolean get() = when (receiver) {
-        MethodBridgeReceiver.Static,
-        MethodBridgeReceiver.Factory -> false
-
-        MethodBridgeReceiver.Instance -> true
-    }
-}
-
-internal fun MethodBridge.valueParametersAssociated(
-        descriptor: FunctionDescriptor
-): List<Pair<MethodBridgeValueParameter, ParameterDescriptor?>> {
-    val kotlinParameters = descriptor.allParameters.iterator()
-    val skipFirstKotlinParameter = when (this.receiver) {
-        MethodBridgeReceiver.Static -> false
-        MethodBridgeReceiver.Factory, MethodBridgeReceiver.Instance -> true
-    }
-    if (skipFirstKotlinParameter) {
-        kotlinParameters.next()
-    }
-
-    return this.valueParameters.map {
-        when (it) {
-            is MethodBridgeValueParameter.Mapped -> it to kotlinParameters.next()
-
-            is MethodBridgeValueParameter.ErrorOutParameter,
-            is MethodBridgeValueParameter.KotlinResultOutParameter -> it to null
-        }
-    }.also { assert(!kotlinParameters.hasNext()) }
-}
-
-internal fun MethodBridge.parametersAssociated(
-        descriptor: FunctionDescriptor
-): List<Pair<MethodBridgeParameter, ParameterDescriptor?>> {
-    val kotlinParameters = descriptor.allParameters.iterator()
-
-    return this.paramBridges.map {
-        when (it) {
-            is MethodBridgeValueParameter.Mapped, MethodBridgeReceiver.Instance ->
-                it to kotlinParameters.next()
-
-            MethodBridgeReceiver.Static, MethodBridgeSelector, MethodBridgeValueParameter.ErrorOutParameter,
-            is MethodBridgeValueParameter.KotlinResultOutParameter ->
-                it to null
-
-            MethodBridgeReceiver.Factory -> {
-                kotlinParameters.next()
-                it to null
-            }
-        }
-    }.also { assert(!kotlinParameters.hasNext()) }
 }
 
 private fun ObjCExportMapper.bridgeType(kotlinType: KotlinType): TypeBridge {
@@ -305,30 +206,4 @@ internal fun ObjCExportMapper.bridgePropertyType(descriptor: PropertyDescriptor)
     assert(isBaseProperty(descriptor))
 
     return bridgeType(descriptor.type)
-}
-
-internal enum class ObjCValueType(
-        val kotlinValueType: ValueType, // It is here for simplicity.
-        val encoding: String
-) {
-
-    BOOL(ValueType.BOOLEAN, "c"),
-    CHAR(ValueType.BYTE, "c"),
-    UNSIGNED_SHORT(ValueType.CHAR, "S"),
-    SHORT(ValueType.SHORT, "s"),
-    INT(ValueType.INT, "i"),
-    LONG_LONG(ValueType.LONG, "q"),
-    FLOAT(ValueType.FLOAT, "f"),
-    DOUBLE(ValueType.DOUBLE, "d")
-
-    ;
-
-    // UNSIGNED_SHORT -> unsignedShort
-    val nsNumberName = this.name.split('_').mapIndexed { index, s ->
-        val lower = s.toLowerCase()
-        if (index > 0) lower.capitalize() else lower
-    }.joinToString("")
-
-    val nsNumberValueSelector get() = "${nsNumberName}Value"
-    val nsNumberFactorySelector get() = "numberWith${nsNumberName.capitalize()}:"
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -29,12 +29,13 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
 
 internal class ObjCExportNamer(val moduleDescriptor: ModuleDescriptor,
-                               val builtIns: KotlinBuiltIns,
-                               val mapper: ObjCExportMapper) {
+        val builtIns: KotlinBuiltIns,
+        val mapper: ObjCExportMapper,
+        private val topLevelNamePrefix: String = moduleDescriptor.namePrefix
+    ) {
     val kotlinAnyName = "KotlinBase"
 
     private val commonPackageSegments = moduleDescriptor.guessMainPackage().pathSegments()
-    private val topLevelNamePrefix = moduleDescriptor.namePrefix
 
     val mutableSetName = "${topLevelNamePrefix}MutableSet"
     val mutableMapName = "${topLevelNamePrefix}MutableDictionary"
@@ -441,7 +442,7 @@ private fun ObjCExportMapper.canHaveSameName(first: PropertyDescriptor, second: 
     return bridgePropertyType(first) == bridgePropertyType(second)
 }
 
-private val ModuleDescriptor.namePrefix: String get() {
+internal val ModuleDescriptor.namePrefix: String get() {
     // <fooBar> -> FooBar
     val moduleName = this.name.asString().let { it.substring(1, it.lastIndex) }.capitalize()
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -16,9 +16,9 @@
 
 package org.jetbrains.kotlin.backend.konan.objcexport
 
-import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.backend.konan.descriptors.isArray
 import org.jetbrains.kotlin.backend.konan.descriptors.isInterface
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.name.FqName
@@ -28,11 +28,13 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.isSubclassOf
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
 
-internal class ObjCExportNamer(val context: Context, val mapper: ObjCExportMapper) {
+internal class ObjCExportNamer(val moduleDescriptor: ModuleDescriptor,
+                               val builtIns: KotlinBuiltIns,
+                               val mapper: ObjCExportMapper) {
     val kotlinAnyName = "KotlinBase"
 
-    private val commonPackageSegments = context.moduleDescriptor.guessMainPackage().pathSegments()
-    private val topLevelNamePrefix = context.moduleDescriptor.namePrefix
+    private val commonPackageSegments = moduleDescriptor.guessMainPackage().pathSegments()
+    private val topLevelNamePrefix = moduleDescriptor.namePrefix
 
     val mutableSetName = "${topLevelNamePrefix}MutableSet"
     val mutableMapName = "${topLevelNamePrefix}MutableDictionary"
@@ -116,7 +118,7 @@ internal class ObjCExportNamer(val context: Context, val mapper: ObjCExportMappe
             StringBuilder().apply {
                 append(topLevelNamePrefix)
 
-                if (descriptor.module != context.moduleDescriptor) {
+                if (descriptor.module != moduleDescriptor) {
                     append(descriptor.module.namePrefix)
                 }
 
@@ -246,11 +248,11 @@ internal class ObjCExportNamer(val context: Context, val mapper: ObjCExportMappe
     }
 
     init {
-        val any = context.builtIns.any
+        val any = builtIns.any
 
         classNames.forceAssign(any, kotlinAnyName)
-        classNames.forceAssign(context.builtIns.mutableSet, mutableSetName)
-        classNames.forceAssign(context.builtIns.mutableMap, mutableMapName)
+        classNames.forceAssign(builtIns.mutableSet, mutableSetName)
+        classNames.forceAssign(builtIns.mutableMap, mutableMapName)
 
         fun ClassDescriptor.method(name: String) =
                 this.unsubstitutedMemberScope.getContributedFunctions(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubBuilder.kt
@@ -7,6 +7,14 @@ internal class StubBuilder {
         children.add(this)
     }
 
+    operator fun Stub<*>.unaryPlus() {
+        children.add(this)
+    }
+
+    operator fun plusAssign(set: Set<Stub<*>>) {
+        children += set
+    }
+
     fun build() = children
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubBuilder.kt
@@ -1,0 +1,20 @@
+package org.jetbrains.kotlin.backend.konan.objcexport
+
+internal class StubBuilder {
+    private val children = mutableListOf<Stub<*>>()
+
+    operator fun String.unaryPlus() {
+        children.add(this)
+    }
+
+    fun build() = children
+}
+
+internal inline fun buildMembers(block: StubBuilder.() -> Unit): List<Stub<*>> = StubBuilder().let {
+    it.block()
+    it.build()
+}
+
+internal inline fun MutableCollection<Stub<*>>.addBuiltBy(block: StubBuilder.() -> Unit) {
+    this.addAll(buildMembers(block))
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubBuilder.kt
@@ -7,7 +7,7 @@ internal class StubBuilder {
         children.add(this)
     }
 
-    operator fun plusAssign(set: Set<Stub<*>>) {
+    operator fun plusAssign(set: Collection<Stub<*>>) {
         children += set
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubBuilder.kt
@@ -3,10 +3,6 @@ package org.jetbrains.kotlin.backend.konan.objcexport
 internal class StubBuilder {
     private val children = mutableListOf<Stub<*>>()
 
-    operator fun String.unaryPlus() {
-        children.add(this)
-    }
-
     operator fun Stub<*>.unaryPlus() {
         children.add(this)
     }
@@ -21,8 +17,4 @@ internal class StubBuilder {
 internal inline fun buildMembers(block: StubBuilder.() -> Unit): List<Stub<*>> = StubBuilder().let {
     it.block()
     it.build()
-}
-
-internal inline fun MutableCollection<Stub<*>>.addBuiltBy(block: StubBuilder.() -> Unit) {
-    this.addAll(buildMembers(block))
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
@@ -1,0 +1,170 @@
+package org.jetbrains.kotlin.backend.konan.objcexport
+
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+
+object StubRenderer {
+    fun render(stub: Stub<*>): List<String> = collect {
+        stub.run {
+            when (this) {
+                is ObjcProtocol -> {
+                    +renderProtocolHeader()
+                    +"@required"
+                    renderMembers(this)
+                    +"@end;"
+                }
+                is ObjcInterface -> {
+                    attributes.forEach {
+                        +renderAttribute(it)
+                    }
+                    +renderInterfaceHeader()
+                    renderMembers(this)
+                    +"@end;"
+                }
+                is ObjcMethod -> {
+                    +renderMethod(this)
+                }
+                is ObjcProperty -> {
+                    +renderProperty(this)
+                }
+                else -> throw IllegalArgumentException("unsupported stub: " + stub::class)
+            }
+        }
+    }
+
+    private fun renderProperty(property: ObjcProperty): String = buildString {
+        fun StringBuilder.appendType() {
+            append(' ')
+            append(property.type.render())
+        }
+
+        fun StringBuilder.appendAttributes() {
+            if (property.attributes.isNotEmpty()) {
+                append(' ')
+                property.attributes.joinTo(this, prefix = "(", postfix = ")")
+            }
+        }
+
+        append("@property")
+        appendAttributes()
+        appendType()
+        append(property.name)
+        append(';')
+    }
+
+    private fun renderMethod(method: ObjcMethod): String = buildString {
+        fun appendStaticness() {
+            if (method.isInstanceMethod) {
+                append('-')
+            } else {
+                append('+')
+            }
+        }
+
+        fun appendReturnType() {
+            append(" (")
+            append(method.returnType.render())
+            append(')')
+        }
+
+        fun appendParameters() {
+            append(' ')
+            assert(method.selectors.size == method.parameters.size ||
+                   method.selectors.size == 1 && method.parameters.size == 0)
+
+            if (method.selectors.size == 1 && method.parameters.size == 0) {
+                append(method.selectors[0])
+            } else {
+                for (i in 0 until method.selectors.size) {
+                    if (i > 0) append(' ')
+
+                    val parameter = method.parameters[i]
+                    val selector = method.selectors[i]
+                    append(selector)
+                    append(": (")
+                    append(parameter.type.render())
+                    append(") ")
+                    append(parameter.name)
+                }
+            }
+        }
+
+        fun appendAttributes() {
+            method.attributes.joinTo(this, separator = " ", transform = ::renderAttribute)
+        }
+
+        appendStaticness()
+        appendReturnType()
+        appendParameters()
+        appendAttributes()
+        append(';')
+    }
+
+    private fun ObjcProtocol.renderProtocolHeader() = buildString {
+        append("@protocol ")
+        append(name)
+        appendSuperProtocols(this@renderProtocolHeader)
+    }
+
+    private fun StringBuilder.appendSuperProtocols(clazz: ClassStubBase<ClassDescriptor>) {
+        val protocols = clazz.superProtocols
+        if (protocols.isNotEmpty()) {
+            protocols.joinTo(this, separator = ", ", prefix = " <", postfix = ">")
+        }
+    }
+
+    private fun ObjcInterface.renderInterfaceHeader() = buildString {
+        fun appendSuperClass() {
+            if (superClass != null) append(superClass)
+        }
+
+        fun appendGenerics() {
+            val generics = generics
+            if (generics.isNotEmpty()) {
+                generics.joinTo(this, separator = ", ", prefix = " <", postfix = ">")
+            }
+        }
+
+        fun appendCategoryName() {
+            if (categoryName != null) {
+                append(" (")
+                append(categoryName)
+                append(')')
+            }
+        }
+
+        append("@interface ")
+        append(name)
+        appendGenerics()
+        appendSuperClass()
+        appendCategoryName()
+        appendSuperProtocols(this@renderInterfaceHeader)
+    }
+
+    private fun Collector.renderMembers(clazz: ClassStubBase<*>) {
+        clazz.members.forEach {
+            +render(it)
+        }
+    }
+
+    private fun renderAttribute(attribute: String) = "__attribute__(($attribute))"
+
+    private fun collect(p: Collector.() -> Unit): List<String> {
+        val collector = Collector()
+        collector.p()
+        return collector.build()
+    }
+
+    private class Collector {
+        private val collection: MutableList<String> = mutableListOf()
+        fun build(): List<String> = collection
+
+        operator fun String.unaryPlus() {
+            collection += this
+        }
+
+        operator fun List<String>.unaryPlus() {
+            collection += this
+        }
+    }
+}
+

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
@@ -6,13 +6,13 @@ object StubRenderer {
     fun render(stub: Stub<*>): List<String> = collect {
         stub.run {
             when (this) {
-                is ObjcProtocol -> {
+                is ObjCProtocol -> {
                     +renderProtocolHeader()
                     +"@required"
                     renderMembers(this)
                     +"@end;"
                 }
-                is ObjcInterface -> {
+                is ObjCInterface -> {
                     attributes.forEach {
                         +renderAttribute(it)
                     }
@@ -20,10 +20,10 @@ object StubRenderer {
                     renderMembers(this)
                     +"@end;"
                 }
-                is ObjcMethod -> {
+                is ObjCMethod -> {
                     +renderMethod(this)
                 }
-                is ObjcProperty -> {
+                is ObjCProperty -> {
                     +renderProperty(this)
                 }
                 else -> throw IllegalArgumentException("unsupported stub: " + stub::class)
@@ -31,13 +31,13 @@ object StubRenderer {
         }
     }
 
-    private fun renderProperty(property: ObjcProperty): String = buildString {
+    private fun renderProperty(property: ObjCProperty): String = buildString {
         fun StringBuilder.appendTypeAndName() {
             append(' ')
             append(property.type.render(property.name))
         }
 
-        fun ObjcProperty.getAllAttributes(): List<String> {
+        fun ObjCProperty.getAllAttributes(): List<String> {
             if (getterName == null && setterName == null) return attributes
 
             val allAttributes = attributes.toMutableList()
@@ -60,7 +60,7 @@ object StubRenderer {
         append(';')
     }
 
-    private fun renderMethod(method: ObjcMethod): String = buildString {
+    private fun renderMethod(method: ObjCMethod): String = buildString {
         fun appendStaticness() {
             if (method.isInstanceMethod) {
                 append('-')
@@ -109,20 +109,20 @@ object StubRenderer {
         append(';')
     }
 
-    private fun ObjcProtocol.renderProtocolHeader() = buildString {
+    private fun ObjCProtocol.renderProtocolHeader() = buildString {
         append("@protocol ")
         append(name)
         appendSuperProtocols(this@renderProtocolHeader)
     }
 
-    private fun StringBuilder.appendSuperProtocols(clazz: ObjcClass<ClassDescriptor>) {
+    private fun StringBuilder.appendSuperProtocols(clazz: ObjCClass<ClassDescriptor>) {
         val protocols = clazz.superProtocols
         if (protocols.isNotEmpty()) {
             protocols.joinTo(this, separator = ", ", prefix = " <", postfix = ">")
         }
     }
 
-    private fun ObjcInterface.renderInterfaceHeader() = buildString {
+    private fun ObjCInterface.renderInterfaceHeader() = buildString {
         fun appendSuperClass() {
             if (superClass != null) append(" : $superClass")
         }
@@ -150,7 +150,7 @@ object StubRenderer {
         appendSuperProtocols(this@renderInterfaceHeader)
     }
 
-    private fun Collector.renderMembers(clazz: ObjcClass<*>) {
+    private fun Collector.renderMembers(clazz: ObjCClass<*>) {
         clazz.members.forEach {
             +render(it)
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
@@ -90,7 +90,7 @@ object StubRenderer {
                     val parameter = method.parameters[i]
                     val selector = method.selectors[i]
                     append(selector)
-                    append(": (")
+                    append(" (")
                     append(parameter.type.render())
                     append(") ")
                     append(parameter.name)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
@@ -76,7 +76,6 @@ object StubRenderer {
         }
 
         fun appendParameters() {
-            append(' ')
             assert(method.selectors.size == method.parameters.size ||
                    method.selectors.size == 1 && method.parameters.size == 0)
 
@@ -89,9 +88,9 @@ object StubRenderer {
                     val parameter = method.parameters[i]
                     val selector = method.selectors[i]
                     append(selector)
-                    append(" (")
+                    append("(")
                     append(parameter.type.render())
-                    append(") ")
+                    append(")")
                     append(parameter.name)
                 }
             }
@@ -130,7 +129,7 @@ object StubRenderer {
         fun appendGenerics() {
             val generics = generics
             if (generics.isNotEmpty()) {
-                generics.joinTo(this, separator = ", ", prefix = " <", postfix = ">")
+                generics.joinTo(this, separator = ", ", prefix = "<", postfix = ">")
             }
         }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
@@ -32,9 +32,9 @@ object StubRenderer {
     }
 
     private fun renderProperty(property: ObjcProperty): String = buildString {
-        fun StringBuilder.appendType() {
+        fun StringBuilder.appendTypeAndName() {
             append(' ')
-            append(property.type.render())
+            append(property.type.render(property.name))
         }
 
         fun ObjcProperty.getAllAttributes(): List<String> {
@@ -56,8 +56,7 @@ object StubRenderer {
 
         append("@property")
         appendAttributes()
-        appendType()
-        append(property.name)
+        appendTypeAndName()
         append(';')
     }
 
@@ -99,6 +98,7 @@ object StubRenderer {
         }
 
         fun appendAttributes() {
+            if (method.attributes.isNotEmpty()) append(' ')
             method.attributes.joinTo(this, separator = " ", transform = ::renderAttribute)
         }
 
@@ -124,7 +124,7 @@ object StubRenderer {
 
     private fun ObjcInterface.renderInterfaceHeader() = buildString {
         fun appendSuperClass() {
-            if (superClass != null) append(superClass)
+            if (superClass != null) append(" : $superClass")
         }
 
         fun appendGenerics() {
@@ -145,8 +145,8 @@ object StubRenderer {
         append("@interface ")
         append(name)
         appendGenerics()
-        appendSuperClass()
         appendCategoryName()
+        appendSuperClass()
         appendSuperProtocols(this@renderInterfaceHeader)
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
@@ -37,10 +37,20 @@ object StubRenderer {
             append(property.type.render())
         }
 
+        fun ObjcProperty.getAllAttributes(): List<String> {
+            if (getterName == null && setterName == null) return attributes
+
+            val allAttributes = attributes.toMutableList()
+            getterName?.let { allAttributes += "getter=$it" }
+            setterName?.let { allAttributes += "setter=$it" }
+            return allAttributes
+        }
+
         fun StringBuilder.appendAttributes() {
-            if (property.attributes.isNotEmpty()) {
+            val attributes = property.getAllAttributes()
+            if (attributes.isNotEmpty()) {
                 append(' ')
-                property.attributes.joinTo(this, prefix = "(", postfix = ")")
+                attributes.joinTo(this, prefix = "(", postfix = ")")
             }
         }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/StubRenderer.kt
@@ -115,7 +115,7 @@ object StubRenderer {
         appendSuperProtocols(this@renderProtocolHeader)
     }
 
-    private fun StringBuilder.appendSuperProtocols(clazz: ClassStubBase<ClassDescriptor>) {
+    private fun StringBuilder.appendSuperProtocols(clazz: ObjcClass<ClassDescriptor>) {
         val protocols = clazz.superProtocols
         if (protocols.isNotEmpty()) {
             protocols.joinTo(this, separator = ", ", prefix = " <", postfix = ">")
@@ -150,7 +150,7 @@ object StubRenderer {
         appendSuperProtocols(this@renderInterfaceHeader)
     }
 
-    private fun Collector.renderMembers(clazz: ClassStubBase<*>) {
+    private fun Collector.renderMembers(clazz: ObjcClass<*>) {
         clazz.members.forEach {
             +render(it)
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
@@ -18,7 +18,7 @@ package org.jetbrains.kotlin.backend.konan.objcexport
 
 import org.jetbrains.kotlin.backend.konan.ValueType
 
-internal sealed class ObjCType {
+sealed class ObjCType {
     final override fun toString(): String = this.render()
 
     abstract fun render(attrsAndName: String): String

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2010-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.kotlin.backend.konan.objcexport
+
+internal sealed class ObjCType {
+    final override fun toString(): String = this.render()
+
+    abstract fun render(attrsAndName: String): String
+
+    fun render() = render("")
+
+    protected fun String.withAttrsAndName(attrsAndName: String) =
+            if (attrsAndName.isEmpty()) this else "$this ${attrsAndName.trimStart()}"
+}
+
+internal sealed class ObjCReferenceType : ObjCType()
+
+internal sealed class ObjCNonNullReferenceType : ObjCReferenceType()
+
+internal data class ObjCNullableReferenceType(val nonNullType: ObjCNonNullReferenceType) : ObjCReferenceType() {
+    override fun render(attrsAndName: String) = nonNullType.render(" _Nullable".withAttrsAndName(attrsAndName))
+}
+
+internal class ObjCClassType(
+        val className: String,
+        val typeArguments: List<ObjCNonNullReferenceType> = emptyList()
+) : ObjCNonNullReferenceType() {
+
+    override fun render(attrsAndName: String) = buildString {
+        append(className)
+        if (typeArguments.isNotEmpty()) {
+            append("<")
+            typeArguments.joinTo(this) { it.render() }
+            append(">")
+        }
+        append(" *")
+        append(attrsAndName)
+    }
+}
+
+internal class ObjCProtocolType(val protocolName: String) : ObjCNonNullReferenceType() {
+
+    override fun render(attrsAndName: String) = "id<$protocolName>".withAttrsAndName(attrsAndName)
+}
+
+internal object ObjCIdType : ObjCNonNullReferenceType() {
+    override fun render(attrsAndName: String) = "id".withAttrsAndName(attrsAndName)
+}
+
+internal object ObjCInstanceType : ObjCNonNullReferenceType() {
+    override fun render(attrsAndName: String): String = "instancetype".withAttrsAndName(attrsAndName)
+}
+
+internal class ObjCBlockPointerType(
+        val returnType: ObjCReferenceType, val parameterTypes: List<ObjCReferenceType>
+) : ObjCNonNullReferenceType() {
+
+    override fun render(attrsAndName: String) = returnType.render(buildString {
+        append("(^")
+        append(attrsAndName)
+        append(")(")
+        if (parameterTypes.isEmpty()) append("void")
+        parameterTypes.joinTo(this) { it.render() }
+        append(')')
+    })
+}
+
+internal class ObjCPrimitiveType(val cName: String) : ObjCType() {
+    override fun render(attrsAndName: String) = cName.withAttrsAndName(attrsAndName)
+}
+
+internal class ObjCPointerType(val pointee: ObjCType, val nullable: Boolean = false) : ObjCType() {
+    override fun render(attrsAndName: String) =
+            pointee.render("*${if (nullable) {
+                " _Nullable".withAttrsAndName(attrsAndName)
+            } else {
+                attrsAndName
+            }}")
+}
+
+internal object ObjCVoidType : ObjCType() {
+    override fun render(attrsAndName: String) = "void".withAttrsAndName(attrsAndName)
+}
+

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
@@ -29,7 +29,7 @@ sealed class ObjCType {
             if (attrsAndName.isEmpty()) this else "$this ${attrsAndName.trimStart()}"
 }
 
-internal class ObjcRawType(private val rawText: String) : ObjCType() {
+internal class ObjCRawType(private val rawText: String) : ObjCType() {
     override fun render(attrsAndName: String): String = rawText.withAttrsAndName(attrsAndName)
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
@@ -29,6 +29,10 @@ sealed class ObjCType {
             if (attrsAndName.isEmpty()) this else "$this ${attrsAndName.trimStart()}"
 }
 
+internal class ObjcRawType(private val rawText: String) : ObjCType() {
+    override fun render(attrsAndName: String): String = rawText.withAttrsAndName(attrsAndName)
+}
+
 internal sealed class ObjCReferenceType : ObjCType()
 
 internal sealed class ObjCNonNullReferenceType : ObjCReferenceType()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
@@ -127,7 +127,3 @@ internal enum class ObjCValueType(
     val nsNumberValueSelector get() = "${nsNumberName}Value"
     val nsNumberFactorySelector get() = "numberWith${nsNumberName.capitalize()}:"
 }
-
-internal sealed class TypeBridge
-internal object ReferenceBridge : TypeBridge()
-internal data class ValueTypeBridge(val objCValueType: ObjCValueType) : TypeBridge()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
@@ -16,6 +16,8 @@
 
 package org.jetbrains.kotlin.backend.konan.objcexport
 
+import org.jetbrains.kotlin.backend.konan.ValueType
+
 internal sealed class ObjCType {
     final override fun toString(): String = this.render()
 
@@ -96,3 +98,32 @@ internal object ObjCVoidType : ObjCType() {
     override fun render(attrsAndName: String) = "void".withAttrsAndName(attrsAndName)
 }
 
+internal enum class ObjCValueType(
+        val kotlinValueType: ValueType, // It is here for simplicity.
+        val encoding: String
+) {
+
+    BOOL(ValueType.BOOLEAN, "c"),
+    CHAR(ValueType.BYTE, "c"),
+    UNSIGNED_SHORT(ValueType.CHAR, "S"),
+    SHORT(ValueType.SHORT, "s"),
+    INT(ValueType.INT, "i"),
+    LONG_LONG(ValueType.LONG, "q"),
+    FLOAT(ValueType.FLOAT, "f"),
+    DOUBLE(ValueType.DOUBLE, "d")
+
+    ;
+
+    // UNSIGNED_SHORT -> unsignedShort
+    val nsNumberName = this.name.split('_').mapIndexed { index, s ->
+        val lower = s.toLowerCase()
+        if (index > 0) lower.capitalize() else lower
+    }.joinToString("")
+
+    val nsNumberValueSelector get() = "${nsNumberName}Value"
+    val nsNumberFactorySelector get() = "numberWith${nsNumberName.capitalize()}:"
+}
+
+internal sealed class TypeBridge
+internal object ReferenceBridge : TypeBridge()
+internal data class ValueTypeBridge(val objCValueType: ObjCValueType) : TypeBridge()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -50,5 +50,5 @@ private fun buildMethodName(selectors: List<String>, parameters: List<ObjcParame
             selectors[0]
         } else {
             assert(selectors.size == parameters.size)
-            selectors.joinToString(separator = ":", postfix = ":")
+            selectors.joinToString(separator = "")
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlin.backend.konan.objcexport
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.ParameterDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 
 open class Stub<out D : DeclarationDescriptor>(val name: String, val descriptor: D?)
 
@@ -34,6 +35,11 @@ class ObjcMethod(descriptor: DeclarationDescriptor?,
 class ObjcParameter(name: String,
                     descriptor: ParameterDescriptor?,
                     val type: ObjCType) : Stub<ParameterDescriptor>(name, descriptor)
+
+class ObjcProperty(name: String,
+                   descriptor: PropertyDescriptor?,
+                   val type: ObjCType,
+                   val attributes: List<String>) : Stub<PropertyDescriptor>(name, descriptor)
 
 private fun buildMethodName(selectors: List<String>, parameters: List<ObjcParameter>): String =
         if (selectors.size == 1 && parameters.size == 0) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -15,11 +15,8 @@ class ObjcProtocol(name: String,
                    superProtocols: List<String>,
                    members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
 
-internal inline fun buildStub(block: StubBuilder.() -> Unit) = StubBuilder().let {
-    it.block()
-    it.build()
-}
-
-internal inline fun MutableCollection<Stub>.addBuiltBy(block: StubBuilder.() -> Unit) {
-    this.add(buildStub(block))
-}
+class ObjcInterface(name: String,
+                    descriptor: ClassDescriptor,
+                    val superClass: String,
+                    superProtocols: List<String>,
+                    members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.ParameterDescriptor
 
-open class Stub<out D : DeclarationDescriptor>(val name: String, val descriptor: D)
+open class Stub<out D : DeclarationDescriptor>(val name: String, val descriptor: D?)
 
 abstract class ClassStubBase<out D : DeclarationDescriptor>(name: String,
                                                             descriptor: D,
@@ -22,7 +22,7 @@ class ObjcInterface(name: String,
                     superProtocols: List<String>,
                     members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
 
-class ObjcMethod(descriptor: DeclarationDescriptor,
+class ObjcMethod(descriptor: DeclarationDescriptor?,
                  val isInstanceMethod: Boolean,
                  val returnType: ObjCType,
                  val selectors: List<String>,
@@ -32,7 +32,7 @@ class ObjcMethod(descriptor: DeclarationDescriptor,
                  val isDesignatedConstructor: Boolean) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor)
 
 class ObjcParameter(name: String,
-                    descriptor: ParameterDescriptor,
+                    descriptor: ParameterDescriptor?,
                     val type: ObjCType) : Stub<ParameterDescriptor>(name, descriptor)
 
 private fun buildMethodName(selectors: List<String>, parameters: List<ObjcParameter>): String =

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -31,9 +31,7 @@ class ObjcMethod(descriptor: DeclarationDescriptor?,
                  val returnType: ObjCType,
                  val selectors: List<String>,
                  val parameters: List<ObjcParameter>,
-                 val swiftName: String,
-                 val isConstructor: Boolean,
-                 val isDesignatedConstructor: Boolean) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor)
+                 val attributes: List<String>) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor)
 
 class ObjcParameter(name: String,
                     descriptor: ParameterDescriptor?,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -31,29 +31,7 @@ class ObjcMethod(descriptor: DeclarationDescriptor?,
                  val returnType: ObjCType,
                  val selectors: List<String>,
                  val parameters: List<ObjcParameter>,
-                 val attributes: List<String>) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor) {
-
-    //parameters and returnType are not included in equals as they are not included into signature
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ObjcMethod
-
-        if (isInstanceMethod != other.isInstanceMethod) return false
-        if (selectors != other.selectors) return false
-        if (attributes != other.attributes) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = isInstanceMethod.hashCode()
-        result = 31 * result + selectors.hashCode()
-        result = 31 * result + attributes.hashCode()
-        return result
-    }
-}
+                 val attributes: List<String>) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor)
 
 class ObjcParameter(name: String,
                     descriptor: ParameterDescriptor?,
@@ -64,31 +42,7 @@ class ObjcProperty(name: String,
                    val type: ObjCType,
                    val attributes: List<String>,
                    val setterName: String? = null,
-                   val getterName: String? = null) : Stub<PropertyDescriptor>(name, descriptor) {
-
-    //type is not included in equals as it's not included into signature
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ObjcProperty
-
-        if (name != other.name) return false
-        if (attributes != other.attributes) return false
-        if (setterName != other.setterName) return false
-        if (getterName != other.getterName) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = name.hashCode()
-        result = 31 * result + attributes.hashCode()
-        result = 31 * result + (setterName?.hashCode() ?: 0)
-        result = 31 * result + (getterName?.hashCode() ?: 0)
-        return result
-    }
-}
+                   val getterName: String? = null) : Stub<PropertyDescriptor>(name, descriptor)
 
 private fun buildMethodName(selectors: List<String>, parameters: List<ObjcParameter>): String =
         if (selectors.size == 1 && parameters.size == 0) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -40,7 +40,10 @@ class ObjcParameter(name: String,
 class ObjcProperty(name: String,
                    descriptor: PropertyDescriptor?,
                    val type: ObjCType,
-                   val attributes: List<String>) : Stub<PropertyDescriptor>(name, descriptor)
+                   val attributes: List<String>,
+                   val setterName: String? = null,
+                   val getterName: String? = null) : Stub<PropertyDescriptor>(name, descriptor)
+
 
 private fun buildMethodName(selectors: List<String>, parameters: List<ObjcParameter>): String =
         if (selectors.size == 1 && parameters.size == 0) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 open class Stub<out D : DeclarationDescriptor>(val name: String, val descriptor: D?)
 
 abstract class ClassStubBase<out D : DeclarationDescriptor>(name: String,
-                                                            descriptor: D,
+                                                            descriptor: D?,
                                                             val superProtocols: List<String>,
                                                             val members: List<Stub<*>>) : Stub<D>(name, descriptor)
 
@@ -18,9 +18,10 @@ class ObjcProtocol(name: String,
                    members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
 
 class ObjcInterface(name: String,
-                    descriptor: ClassDescriptor,
-                    val superClass: String,
+                    descriptor: ClassDescriptor?,
+                    val superClass: String?,
                     superProtocols: List<String>,
+                    val categoryName: String?,
                     members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
 
 class ObjcMethod(descriptor: DeclarationDescriptor?,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -31,7 +31,29 @@ class ObjcMethod(descriptor: DeclarationDescriptor?,
                  val returnType: ObjCType,
                  val selectors: List<String>,
                  val parameters: List<ObjcParameter>,
-                 val attributes: List<String>) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor)
+                 val attributes: List<String>) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor) {
+
+    //parameters and returnType are not included in equals as they are not included into signature
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ObjcMethod
+
+        if (isInstanceMethod != other.isInstanceMethod) return false
+        if (selectors != other.selectors) return false
+        if (attributes != other.attributes) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = isInstanceMethod.hashCode()
+        result = 31 * result + selectors.hashCode()
+        result = 31 * result + attributes.hashCode()
+        return result
+    }
+}
 
 class ObjcParameter(name: String,
                     descriptor: ParameterDescriptor?,
@@ -42,8 +64,31 @@ class ObjcProperty(name: String,
                    val type: ObjCType,
                    val attributes: List<String>,
                    val setterName: String? = null,
-                   val getterName: String? = null) : Stub<PropertyDescriptor>(name, descriptor)
+                   val getterName: String? = null) : Stub<PropertyDescriptor>(name, descriptor) {
 
+    //type is not included in equals as it's not included into signature
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ObjcProperty
+
+        if (name != other.name) return false
+        if (attributes != other.attributes) return false
+        if (setterName != other.setterName) return false
+        if (getterName != other.getterName) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + attributes.hashCode()
+        result = 31 * result + (setterName?.hashCode() ?: 0)
+        result = 31 * result + (getterName?.hashCode() ?: 0)
+        return result
+    }
+}
 
 private fun buildMethodName(selectors: List<String>, parameters: List<ObjcParameter>): String =
         if (selectors.size == 1 && parameters.size == 0) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -7,15 +7,15 @@ import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 
 open class Stub<out D : DeclarationDescriptor>(val name: String, val descriptor: D?)
 
-abstract class ClassStubBase<out D : DeclarationDescriptor>(name: String,
-                                                            descriptor: D?,
-                                                            val superProtocols: List<String>,
-                                                            val members: List<Stub<*>>) : Stub<D>(name, descriptor)
+abstract class ObjcClass<out D : DeclarationDescriptor>(name: String,
+                                                        descriptor: D?,
+                                                        val superProtocols: List<String>,
+                                                        val members: List<Stub<*>>) : Stub<D>(name, descriptor)
 
 class ObjcProtocol(name: String,
                    descriptor: ClassDescriptor,
                    superProtocols: List<String>,
-                   members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
+                   members: List<Stub<*>>) : ObjcClass<ClassDescriptor>(name, descriptor, superProtocols, members)
 
 class ObjcInterface(name: String,
                     val generics: List<String> = emptyList(),
@@ -24,7 +24,7 @@ class ObjcInterface(name: String,
                     superProtocols: List<String> = emptyList(),
                     val categoryName: String? = null,
                     members: List<Stub<*>> = emptyList(),
-                    val attributes: List<String> = emptyList()) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
+                    val attributes: List<String> = emptyList()) : ObjcClass<ClassDescriptor>(name, descriptor, superProtocols, members)
 
 class ObjcMethod(descriptor: DeclarationDescriptor?,
                  val isInstanceMethod: Boolean,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -18,11 +18,13 @@ class ObjcProtocol(name: String,
                    members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
 
 class ObjcInterface(name: String,
-                    descriptor: ClassDescriptor?,
-                    val superClass: String?,
-                    superProtocols: List<String>,
-                    val categoryName: String?,
-                    members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
+                    val generics: List<String> = emptyList(),
+                    descriptor: ClassDescriptor? = null,
+                    val superClass: String? = null,
+                    superProtocols: List<String> = emptyList(),
+                    val categoryName: String? = null,
+                    members: List<Stub<*>> = emptyList(),
+                    val attributes: List<String> = emptyList()) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
 
 class ObjcMethod(descriptor: DeclarationDescriptor?,
                  val isInstanceMethod: Boolean,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlin.backend.konan.objcexport
 
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.ParameterDescriptor
 
 open class Stub<out D : DeclarationDescriptor>(val name: String, val descriptor: D)
 
@@ -20,3 +21,24 @@ class ObjcInterface(name: String,
                     val superClass: String,
                     superProtocols: List<String>,
                     members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
+
+class ObjcMethod(descriptor: DeclarationDescriptor,
+                 val isInstanceMethod: Boolean,
+                 val returnType: ObjCType,
+                 val selectors: List<String>,
+                 val parameters: List<ObjcParameter>,
+                 val swiftName: String,
+                 val isConstructor: Boolean,
+                 val isDesignatedConstructor: Boolean) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor)
+
+class ObjcParameter(name: String,
+                    descriptor: ParameterDescriptor,
+                    val type: ObjCType) : Stub<ParameterDescriptor>(name, descriptor)
+
+private fun buildMethodName(selectors: List<String>, parameters: List<ObjcParameter>): String =
+        if (selectors.size == 1 && parameters.size == 0) {
+            selectors[0]
+        } else {
+            assert(selectors.size == parameters.size)
+            selectors.joinToString(separator = ":", postfix = ":")
+        }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -1,0 +1,26 @@
+package org.jetbrains.kotlin.backend.konan.objcexport
+
+internal data class Stub(val lines: List<String>)
+
+internal class StubBuilder {
+    private val lines = mutableListOf<String>()
+
+    operator fun String.unaryPlus() {
+        lines.add(this)
+    }
+
+    operator fun Stub.unaryPlus() {
+        this@StubBuilder.lines.addAll(this.lines)
+    }
+
+    fun build() = Stub(lines)
+}
+
+internal inline fun buildStub(block: StubBuilder.() -> Unit) = StubBuilder().let {
+    it.block()
+    it.build()
+}
+
+internal inline fun MutableCollection<Stub>.addBuiltBy(block: StubBuilder.() -> Unit) {
+    this.add(buildStub(block))
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -7,44 +7,44 @@ import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 
 open class Stub<out D : DeclarationDescriptor>(val name: String, val descriptor: D?)
 
-abstract class ObjcClass<out D : DeclarationDescriptor>(name: String,
+abstract class ObjCClass<out D : DeclarationDescriptor>(name: String,
                                                         descriptor: D?,
                                                         val superProtocols: List<String>,
                                                         val members: List<Stub<*>>) : Stub<D>(name, descriptor)
 
-class ObjcProtocol(name: String,
+class ObjCProtocol(name: String,
                    descriptor: ClassDescriptor,
                    superProtocols: List<String>,
-                   members: List<Stub<*>>) : ObjcClass<ClassDescriptor>(name, descriptor, superProtocols, members)
+                   members: List<Stub<*>>) : ObjCClass<ClassDescriptor>(name, descriptor, superProtocols, members)
 
-class ObjcInterface(name: String,
+class ObjCInterface(name: String,
                     val generics: List<String> = emptyList(),
                     descriptor: ClassDescriptor? = null,
                     val superClass: String? = null,
                     superProtocols: List<String> = emptyList(),
                     val categoryName: String? = null,
                     members: List<Stub<*>> = emptyList(),
-                    val attributes: List<String> = emptyList()) : ObjcClass<ClassDescriptor>(name, descriptor, superProtocols, members)
+                    val attributes: List<String> = emptyList()) : ObjCClass<ClassDescriptor>(name, descriptor, superProtocols, members)
 
-class ObjcMethod(descriptor: DeclarationDescriptor?,
+class ObjCMethod(descriptor: DeclarationDescriptor?,
                  val isInstanceMethod: Boolean,
                  val returnType: ObjCType,
                  val selectors: List<String>,
-                 val parameters: List<ObjcParameter>,
+                 val parameters: List<ObjCParameter>,
                  val attributes: List<String>) : Stub<DeclarationDescriptor>(buildMethodName(selectors, parameters), descriptor)
 
-class ObjcParameter(name: String,
+class ObjCParameter(name: String,
                     descriptor: ParameterDescriptor?,
                     val type: ObjCType) : Stub<ParameterDescriptor>(name, descriptor)
 
-class ObjcProperty(name: String,
+class ObjCProperty(name: String,
                    descriptor: PropertyDescriptor?,
                    val type: ObjCType,
                    val attributes: List<String>,
                    val setterName: String? = null,
                    val getterName: String? = null) : Stub<PropertyDescriptor>(name, descriptor)
 
-private fun buildMethodName(selectors: List<String>, parameters: List<ObjcParameter>): String =
+private fun buildMethodName(selectors: List<String>, parameters: List<ObjCParameter>): String =
         if (selectors.size == 1 && parameters.size == 0) {
             selectors[0]
         } else {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/stubs.kt
@@ -1,20 +1,19 @@
 package org.jetbrains.kotlin.backend.konan.objcexport
 
-internal data class Stub(val lines: List<String>)
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 
-internal class StubBuilder {
-    private val lines = mutableListOf<String>()
+open class Stub<out D : DeclarationDescriptor>(val name: String, val descriptor: D)
 
-    operator fun String.unaryPlus() {
-        lines.add(this)
-    }
+abstract class ClassStubBase<out D : DeclarationDescriptor>(name: String,
+                                                            descriptor: D,
+                                                            val superProtocols: List<String>,
+                                                            val members: List<Stub<*>>) : Stub<D>(name, descriptor)
 
-    operator fun Stub.unaryPlus() {
-        this@StubBuilder.lines.addAll(this.lines)
-    }
-
-    fun build() = Stub(lines)
-}
+class ObjcProtocol(name: String,
+                   descriptor: ClassDescriptor,
+                   superProtocols: List<String>,
+                   members: List<Stub<*>>) : ClassStubBase<ClassDescriptor>(name, descriptor, superProtocols, members)
 
 internal inline fun buildStub(block: StubBuilder.() -> Unit) = StubBuilder().let {
     it.block()


### PR DESCRIPTION
The main idea is to replace plain stubs (aka List<String>) with a tree of Objective-C declarations (see `stubs.kt`).  After the tree is built we can either render it with a StubRenderer or pass it to an IDE.