### PR TITLE
Add more features to JS <-> WASM logic

### DIFF
--- a/Interop/JsRuntime/src/main/js/jsinterop.js
+++ b/Interop/JsRuntime/src/main/js/jsinterop.js
@@ -79,6 +79,13 @@ konan.libraries.push ({
         var string = toUTF16String(stringPtr, stringLength);
         kotlinObject(arena, obj)[name] = string;
     },
+
+    Konan_js_getStringChar: function (arenaIndex, objIndex, charIndex) {
+        var arena = konan_dependencies.env.arenas.get(arenaIndex);
+        var value = arena[objIndex].charCodeAt(charIndex);
+	return value;
+    },
+
 });
 
 // TODO: This is just a shorthand notation.

--- a/Interop/JsRuntime/src/main/kotlin/jsinterop.kt
+++ b/Interop/JsRuntime/src/main/kotlin/jsinterop.kt
@@ -105,6 +105,18 @@ open class JsArray(arena: Arena, index: Object): JsValue(arena, index) {
         get() = this.getInt("length")
 }
 
+open class JsString(arena: Arena, index: Object): JsValue(arena, index) {
+    constructor(jsValue: JsValue): this(jsValue.arena, jsValue.index)
+    fun getString(): String {
+        val length = this.getInt("length")
+        var result = ""
+	for (i in 0..length-1) {
+            result += getStringChar(arena, index, i).toChar()
+        }
+        return result;
+    }
+}
+
 @Used
 @SymbolName("Konan_js_getInt")
 external public fun getInt(arena: Arena, obj: Object, propertyPtr: Pointer, propertyLen: Int): Int;
@@ -120,6 +132,10 @@ external public fun setFunction(arena: Arena, obj: Object, propertyName: Pointer
 @Used
 @SymbolName("Konan_js_setString")
 external public fun setString(arena: Arena, obj: Object, propertyName: Pointer, propertyLength: Int, stringPtr: Pointer, stringLength: Int )
+
+@Used
+@SymbolName("Konan_js_getStringChar")
+external public fun getStringChar(arena: Arena, obj: Object, index: Int ): Int
 
 fun setter(obj: JsValue, property: String, string: String) {
     setString(obj.arena, obj.index, stringPointer(property), stringLengthBytes(property), stringPointer(string), stringLengthBytes(string))

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/StubGenerator.kt
@@ -67,7 +67,7 @@ fun Type.wasmReturnMapping(value: String): String = when (this) {
     is idlInt -> value
     is idlFloat -> value
     is idlDouble -> value
-    is idlString -> "TODO(\"Implement me\")"
+    is idlString -> "JsString(ArenaManager.currentArena, $value).getString()"
     is idlObject -> "JsValue(ArenaManager.currentArena, $value)"
     is idlFunction -> "TODO(\"Implement me\")"
     is idlInterfaceRef -> "$name(ArenaManager.currentArena, $value)"

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/StubGenerator.kt
@@ -31,7 +31,7 @@ fun Arg.wasmMapping(): String = when (type) {
     is idlString -> "stringPointer($name), stringLengthBytes($name)"
     is idlObject -> TODO("implement me")
     is idlFunction -> "wrapFunction<R$name>($name), ArenaManager.currentArena"
-    is idlInterfaceRef -> TODO("Implement me")
+    is idlInterfaceRef -> "${name}.arena, ${name}.index"
     else -> error("Unexpected type")
 }
 
@@ -58,7 +58,7 @@ fun Arg.wasmArgNames(): List<String> = when (type) {
     is idlString -> listOf("${name}Ptr", "${name}Len")
     is idlObject -> TODO("implement me (idlObject)")
     is idlFunction -> listOf("${name}Index", "${name}ResultArena")
-    is idlInterfaceRef -> TODO("Implement me (idlInterfaceRef)")
+    is idlInterfaceRef -> listOf("${name}Arena", "${name}Index")
     else -> error("Unexpected type")
 }
 
@@ -291,7 +291,8 @@ fun Arg.composeWasmArgs(): String = when (type) {
     is idlFunction ->
         "    var $name = konan_dependencies.env.Konan_js_wrapLambda(lambdaResultArena, ${name}Index);\n"
 
-    is idlInterfaceRef -> TODO("Implement me")
+    is idlInterfaceRef -> 
+        "    var $name = kotlinObject(${name}Arena, ${name}Index);\n"
     else -> error("Unexpected type")
 }
 

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/idl/dom.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/idl/dom.kt
@@ -20,7 +20,7 @@ val idlDom = listOf(
         Operation("setTransform", idlVoid, Arg("a", idlInt), Arg("b", idlInt), Arg("c", idlInt), Arg("d", idlInt), Arg("e", idlInt), Arg("f", idlInt)),
         Operation("save", idlVoid),
         Operation("restore", idlVoid),
-        Operation("measureText", idlInterfaceRef("TextMetrics"), Arg("text", idlString)),
+        Operation("measureText", idlInterfaceRef("TextMetrics"), Arg("text", idlString))
    ),
     Interface("DOMRect",
         Attribute("left", idlInt),

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/idl/dom.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/idl/dom.kt
@@ -14,8 +14,14 @@ val idlDom = listOf(
         Operation("fillRect", idlVoid, Arg("x", idlInt), Arg("y", idlInt), Arg("width", idlInt), Arg("height", idlInt)),
         Operation("fillText", idlVoid, Arg("test", idlString), Arg("x", idlInt),  Arg("y", idlInt), Arg("maxWidth", idlInt)),
         Operation("fill", idlVoid),
-        Operation("closePath", idlVoid)
-    ),
+        Operation("closePath", idlVoid),
+        Operation("rect", idlVoid, Arg("x", idlInt), Arg("y", idlInt), Arg("width", idlInt), Arg("height", idlInt)),
+        Operation("translate", idlVoid, Arg("x", idlInt), Arg("y", idlInt)),
+        Operation("setTransform", idlVoid, Arg("a", idlInt), Arg("b", idlInt), Arg("c", idlInt), Arg("d", idlInt), Arg("e", idlInt), Arg("f", idlInt)),
+        Operation("save", idlVoid),
+        Operation("restore", idlVoid),
+        Operation("measureText", idlInterfaceRef("TextMetrics"), Arg("text", idlString)),
+   ),
     Interface("DOMRect",
         Attribute("left", idlInt),
         Attribute("right", idlInt),
@@ -27,11 +33,21 @@ val idlDom = listOf(
         Operation("getBoundingClientRect", idlInterfaceRef("DOMRect"))
     ),
     Interface("Document",
-        Operation("getElementById", idlObject, Arg("id", idlString))
+        Operation("getElementById", idlObject, Arg("id", idlString)),
+        Operation("createElement", idlObject, Arg("tagName", idlString))
+    ),
+    Interface("HTMLImage",
+        Attribute("src", idlString)
     ),
     Interface("MouseEvent",
         Attribute("clientX", idlInt, readOnly = true),
         Attribute("clientY", idlInt, readOnly = true)
+    ),
+    Interface("KeyboardEvent",
+        Attribute("key", idlString, readOnly = true)
+    ),
+    Interface("TextMetrics",
+        Attribute("width", idlDouble, readOnly = true)
     ),
     Interface("Response",
         Operation("json", idlObject)
@@ -43,7 +59,8 @@ val idlDom = listOf(
         Attribute("document", idlInterfaceRef("Document"), readOnly = true),
 
         Operation("fetch", idlInterfaceRef("Promise"), Arg("url", idlString)),
-        Operation("setInterval", idlVoid, Arg("lambda", idlFunction), Arg("interval", idlInt))
+        Operation("setInterval", idlInt, Arg("lambda", idlFunction), Arg("interval", idlInt)),
+        Operation("clearInterval", idlVoid, Arg("intervalID", idlInt))
     )
 )
 


### PR DESCRIPTION
Adds the missing logic to use an idlInterfaceRef type as an method-argument in the WebAssembly stub generator. For example needed to add the context.drawImage method in the dom-idl.