### PR TITLE
Fix path seperator problem on Windows of Gradle generateCMake task

### DIFF
--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/tasks/KonanGenerateCMakeTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/tasks/KonanGenerateCMakeTask.kt
@@ -123,7 +123,7 @@ open class KonanGenerateCMakeTask : DefaultTask() {
         }.joinToString(" ")
 
     private val KonanCompileTask.cMakeLinkerOpts: String
-        get() = linkerOpts.joinToString(" ")
+        get() = linkerOpts.joinToString(" ").replace('\\', '/')
 }
 
 private class Call(val name: String) {


### PR DESCRIPTION
This fix changes the path seperator in the CMakeLists.txt generated by generateCMake task of Gradle plugin from '\' to '/'.

Without this fix:
```
CMake Error at CMakeLists.txt:12 (konanc_executable):
  Syntax error in cmake code at

    C:/Users/cqjjj/source/repos/kotlin-libui/CMakeLists.txt:16

  when parsing string

    C:\Users\cqjjj\source\repos\kotlin-libui\build\konan\res\samples.res

  Invalid character escape '\U'.
```
