### PR TITLE
Fix minor bug in memory management

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2201,6 +2201,10 @@ task memory_weak1(type: RunKonanTest) {
     source = "runtime/memory/weak1.kt"
 }
 
+task memory_only_gc(type: RunStandaloneKonanTest) {
+    source = "runtime/memory/only_gc.kt"
+}
+
 task mpp1(type: RunStandaloneKonanTest) {
     source = "codegen/mpp/mpp1.kt"
     flags = ['-tr', '-Xmulti-platform']

--- a/backend.native/tests/runtime/memory/only_gc.kt
+++ b/backend.native/tests/runtime/memory/only_gc.kt
@@ -1,0 +1,4 @@
+fun main(args: Array<String>) {
+    konan.internal.GC.collect()
+}
+

--- a/runtime/src/main/cpp/Memory.cpp
+++ b/runtime/src/main/cpp/Memory.cpp
@@ -1358,6 +1358,8 @@ void GarbageCollect() {
 
   state->gcInProgress = true;
 
+  processFinalizerQueue(state);
+
   while (state->toFree->size() > 0) {
     CollectCycles(state);
     processFinalizerQueue(state);


### PR DESCRIPTION
Properly handle the case when the program finishes with empty 'toFree' buffer
but non-empty deallocation queue.