### PR TITLE
Fixed external tests

### DIFF
--- a/backend.native/tests/external/codegen/box/callableReference/bound/multiCase.kt
+++ b/backend.native/tests/external/codegen/box/callableReference/bound/multiCase.kt
@@ -10,6 +10,7 @@ var A.w: Int
         v = c + 10
     }
 
+@konan.ThreadLocal
 object F {
     var u = 0
 }

--- a/backend.native/tests/external/codegen/box/callableReference/property/delegatedMutable.kt
+++ b/backend.native/tests/external/codegen/box/callableReference/property/delegatedMutable.kt
@@ -2,6 +2,7 @@ import kotlin.reflect.KProperty
 
 var result: String by Delegate
 
+@konan.ThreadLocal
 object Delegate {
     var value = "lol"
 

--- a/backend.native/tests/external/codegen/box/classes/kt9642.kt
+++ b/backend.native/tests/external/codegen/box/classes/kt9642.kt
@@ -6,6 +6,7 @@ class Outer {
         }
     }
 
+    @konan.ThreadLocal
     companion object {
         public var s = "fail"
             private set

--- a/backend.native/tests/external/codegen/box/delegatedProperty/kt4138.kt
+++ b/backend.native/tests/external/codegen/box/delegatedProperty/kt4138.kt
@@ -7,6 +7,7 @@ class Delegate<T>(var inner: T) {
 
 
 class Foo (val f: Int) {
+    @konan.ThreadLocal
     companion object {
         val A: Foo by Delegate(Foo(11))
         var B: Foo by Delegate(Foo(11))
@@ -14,6 +15,7 @@ class Foo (val f: Int) {
 }
 
 interface FooTrait {
+    @konan.ThreadLocal
     companion object {
         val A: Foo by Delegate(Foo(11))
         var B: Foo by Delegate(Foo(11))

--- a/backend.native/tests/external/codegen/box/extensionProperties/kt9897.kt
+++ b/backend.native/tests/external/codegen/box/extensionProperties/kt9897.kt
@@ -1,3 +1,4 @@
+@konan.ThreadLocal
 object Test {
     var z = "0"
     var l = 0L

--- a/backend.native/tests/external/codegen/box/ieee754/equalsNaN.kt
+++ b/backend.native/tests/external/codegen/box/ieee754/equalsNaN.kt
@@ -2,6 +2,7 @@
 
 import kotlin.test.*
 
+@konan.ThreadLocal
 object O {
     var equalsCalled: Boolean = false
         get(): Boolean {

--- a/backend.native/tests/external/codegen/box/increment/classNaryGetSet.kt
+++ b/backend.native/tests/external/codegen/box/increment/classNaryGetSet.kt
@@ -1,3 +1,4 @@
+@konan.ThreadLocal
 object A {
     var x = 0
 

--- a/backend.native/tests/external/codegen/box/objects/useImportedMember.kt
+++ b/backend.native/tests/external/codegen/box/objects/useImportedMember.kt
@@ -18,6 +18,7 @@ open class BaseClass {
         get() = this
 }
 
+@konan.ThreadLocal
 object C: BaseClass(), I<String> {
     fun f(s: Int) = 1
     fun f(s: String) = 2

--- a/backend.native/tests/external/codegen/box/objects/useImportedMemberFromCompanion.kt
+++ b/backend.native/tests/external/codegen/box/objects/useImportedMemberFromCompanion.kt
@@ -19,6 +19,7 @@ open class BaseClass {
 }
 
 class Class {
+    @konan.ThreadLocal
     companion object C: BaseClass(), I<String> {
         fun f(s: Int) = 1
         fun f(s: String) = 2

--- a/backend.native/tests/external/codegen/box/operatorConventions/operatorSetLambda.kt
+++ b/backend.native/tests/external/codegen/box/operatorConventions/operatorSetLambda.kt
@@ -1,5 +1,6 @@
 // See KT-14999
 
+@konan.ThreadLocal
 object Obj {
     var key = ""
     var value = ""

--- a/backend.native/tests/external/codegen/box/properties/classObjectProperties.kt
+++ b/backend.native/tests/external/codegen/box/properties/classObjectProperties.kt
@@ -1,5 +1,6 @@
 class Test {
 
+    @konan.ThreadLocal
     companion object {
 
         public val prop1 : Int = 10

--- a/backend.native/tests/external/codegen/box/properties/kt4140.kt
+++ b/backend.native/tests/external/codegen/box/properties/kt4140.kt
@@ -1,5 +1,6 @@
 class TestObject()
 {
+    @konan.ThreadLocal
     companion object {
         var prop: Int = 1
             get() = field++

--- a/backend.native/tests/external/codegen/box/properties/kt4252.kt
+++ b/backend.native/tests/external/codegen/box/properties/kt4252.kt
@@ -2,6 +2,7 @@ class CallbackBlock {}
 
 public class Foo
 {
+    @konan.ThreadLocal
     companion object {
         private var bar = 0
     }

--- a/backend.native/tests/external/codegen/box/properties/kt4252_2.kt
+++ b/backend.native/tests/external/codegen/box/properties/kt4252_2.kt
@@ -1,4 +1,5 @@
 class Foo() {
+    @konan.ThreadLocal
     companion object {
         val bar = "OK";
         var boo = "FAIL";

--- a/backend.native/tests/external/codegen/box/properties/kt4383.kt
+++ b/backend.native/tests/external/codegen/box/properties/kt4383.kt
@@ -4,6 +4,7 @@ class D {
     operator fun getValue(a: Any, p: KProperty<*>) { }
 }
 
+@konan.ThreadLocal
 object P {
     val u = Unit
     val v by D()

--- a/backend.native/tests/external/codegen/box/properties/kt8928.kt
+++ b/backend.native/tests/external/codegen/box/properties/kt8928.kt
@@ -2,6 +2,7 @@ class App {
     fun init() {
         s = "OK"
     }
+    @konan.ThreadLocal
     companion object {
         var s: String = "Fail"
             private set

--- a/backend.native/tests/external/codegen/box/properties/lateinit/accessor.kt
+++ b/backend.native/tests/external/codegen/box/properties/lateinit/accessor.kt
@@ -8,6 +8,7 @@ public class A {
         return str
     }
 
+    @konan.ThreadLocal
     private companion object {
         private lateinit var str: String
     }

--- a/backend.native/tests/external/codegen/box/properties/lateinit/isInitializedAndDeinitialize/emptyLhs.kt
+++ b/backend.native/tests/external/codegen/box/properties/lateinit/isInitializedAndDeinitialize/emptyLhs.kt
@@ -14,6 +14,7 @@ class Foo {
     }
 }
 
+@konan.ThreadLocal
 object Bar {
     lateinit var p: String
 

--- a/backend.native/tests/external/codegen/box/reflection/noReflectAtRuntime/methodsFromAny/delegatedProperty.kt
+++ b/backend.native/tests/external/codegen/box/reflection/noReflectAtRuntime/methodsFromAny/delegatedProperty.kt
@@ -4,6 +4,7 @@
 import kotlin.reflect.KProperty
 import kotlin.test.assertEquals
 
+@konan.ThreadLocal
 object Delegate {
     lateinit var prop: KProperty<*>
 

--- a/backend.native/tests/external/codegen/box/statics/incInClassObject.kt
+++ b/backend.native/tests/external/codegen/box/statics/incInClassObject.kt
@@ -1,4 +1,5 @@
 class A {
+    @konan.ThreadLocal
     companion object {
         private var r: Int = 1;
 

--- a/backend.native/tests/external/codegen/box/statics/incInObject.kt
+++ b/backend.native/tests/external/codegen/box/statics/incInObject.kt
@@ -1,3 +1,4 @@
+@konan.ThreadLocal
 object A {
     private var r: Int = 1;
 

--- a/backend.native/tests/external/codegen/box/statics/kt8089.kt
+++ b/backend.native/tests/external/codegen/box/statics/kt8089.kt
@@ -1,4 +1,5 @@
 class C {
+    @konan.ThreadLocal
     companion object {
         private val s: String
         private var s2: String


### PR DESCRIPTION
Marked all mutable objects with konan.ThreadLocal annotation