### PR TITLE
Don't use IR annotations to check for 'ThreadLocal'

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -38,7 +38,6 @@ import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.getArguments
-import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
@@ -50,7 +49,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
 private val threadLocalAnnotationFqName = FqName("konan.ThreadLocal")
 
 val IrClassSymbol.objectIsShared get() =
-    !owner.hasAnnotation(threadLocalAnnotationFqName)
+    !descriptor.annotations.hasAnnotation(threadLocalAnnotationFqName)
 
 internal fun emitLLVM(context: Context) {
     val irModule = context.irModule!!


### PR DESCRIPTION
Fix #1768