### PR TITLE
Bound check elimination using array.size

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/IrBuilderWithScopeExt.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/IrBuilderWithScopeExt.kt
@@ -1,0 +1,39 @@
+package org.jetbrains.kotlin.backend.konan.ir
+
+import org.jetbrains.kotlin.backend.common.lower.*
+import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.*
+import org.jetbrains.kotlin.ir.symbols.*
+import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.types.*
+
+fun IrBuilderWithScope.irNotEquals2(left: IrExpression, right: IrExpression): IrExpression {
+    return irNot(irEquals(left, right))
+}
+
+fun IrBuilderWithScope.irEquals(left: IrExpression, right: IrExpression): IrExpression {
+    return irCallWithArguments(context.irBuiltIns.eqeqSymbol, left, right)
+}
+
+fun IrBuilderWithScope.irLessThan(left: IrExpression, right: IrExpression): IrExpression {
+    return irCompare(context.irBuiltIns.lessFunByOperandType, left, right)
+}
+
+fun IrBuilderWithScope.irLessEqual(left: IrExpression, right: IrExpression): IrExpression {
+    return irCompare(context.irBuiltIns.lessOrEqualFunByOperandType, left, right)
+}
+
+fun IrBuilderWithScope.irGreaterThan(left: IrExpression, right: IrExpression): IrExpression {
+    return irCompare(context.irBuiltIns.greaterFunByOperandType, left, right)
+}
+
+fun IrBuilderWithScope.irCompare(map: Map<SimpleType, IrSimpleFunction>, left: IrExpression, right: IrExpression): IrExpression {
+    return irCallWithArguments(map[left.type.toKotlinType()]?.symbol!!, left, right)
+}
+
+fun IrBuilderWithScope.irCallWithArguments(callee: IrFunctionSymbol, vararg args: IrExpression): IrCall {
+    return irCall(callee).apply {
+        for ((index, arg) in args.withIndex()) putValueArgument(index, arg)
+    }
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/IrBuilderWithScopeExt.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/IrBuilderWithScopeExt.kt
@@ -20,13 +20,18 @@ fun IrBuilderWithScope.irLessThan(left: IrExpression, right: IrExpression): IrEx
     return irCompare(context.irBuiltIns.lessFunByOperandType, left, right)
 }
 
+fun IrBuilderWithScope.irGreaterThan(left: IrExpression, right: IrExpression): IrExpression {
+    return irCompare(context.irBuiltIns.greaterFunByOperandType, left, right)
+}
+
 fun IrBuilderWithScope.irLessEqual(left: IrExpression, right: IrExpression): IrExpression {
     return irCompare(context.irBuiltIns.lessOrEqualFunByOperandType, left, right)
 }
 
-fun IrBuilderWithScope.irGreaterThan(left: IrExpression, right: IrExpression): IrExpression {
-    return irCompare(context.irBuiltIns.greaterFunByOperandType, left, right)
+fun IrBuilderWithScope.irGreaterEqual(left: IrExpression, right: IrExpression): IrExpression {
+    return irCompare(context.irBuiltIns.greaterOrEqualFunByOperandType, left, right)
 }
+
 
 fun IrBuilderWithScope.irCompare(map: Map<SimpleType, IrSimpleFunction>, left: IrExpression, right: IrExpression): IrExpression {
     return irCallWithArguments(map[left.type.toKotlinType()]?.symbol!!, left, right)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/IrBuilderWithScopeExt.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/IrBuilderWithScopeExt.kt
@@ -2,42 +2,52 @@ package org.jetbrains.kotlin.backend.konan.ir
 
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.ir.builders.*
-import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.types.*
-import org.jetbrains.kotlin.types.*
 
-fun IrBuilderWithScope.irNotEquals2(left: IrExpression, right: IrExpression): IrExpression {
-    return irNot(irEquals(left, right))
+fun IrBuilderWithScope.irEquals(l: IrExpression, r: IrExpression): IrExpression = irCompare(CompType.EQ, l, r)
+fun IrBuilderWithScope.irNotEquals2(l: IrExpression, r: IrExpression): IrExpression = irCompare(CompType.NE, l, r)
+
+fun IrBuilderWithScope.irLessThan(l: IrExpression, r: IrExpression): IrExpression = irCompare(CompType.LT, l, r)
+fun IrBuilderWithScope.irGreaterThan(l: IrExpression, r: IrExpression): IrExpression = irCompare(CompType.GT, l, r)
+fun IrBuilderWithScope.irLessEqual(l: IrExpression, r: IrExpression): IrExpression = irCompare(CompType.LE, l, r)
+fun IrBuilderWithScope.irGreaterEqual(l: IrExpression, r: IrExpression): IrExpression = irCompare(CompType.GE, l, r)
+
+fun IrBuilderWithScope.irCompare(type: CompType, l: IrExpression, r: IrExpression): IrExpression {
+    return when (type) {
+        CompType.NE -> irNot(irCompare(CompType.EQ, l, r))
+        CompType.EQ -> irCallWithArguments(context.irBuiltIns.eqeqSymbol, l, r)
+        else -> irCallWithArguments(
+            when (type) {
+                CompType.LT -> context.irBuiltIns.lessFunByOperandType
+                CompType.LE -> context.irBuiltIns.lessOrEqualFunByOperandType
+                CompType.GT -> context.irBuiltIns.greaterFunByOperandType
+                CompType.GE -> context.irBuiltIns.greaterOrEqualFunByOperandType
+                else -> unreachable()
+            }[l.type.toKotlinType()]?.symbol!!,
+            l, r
+        )
+    }
 }
 
-fun IrBuilderWithScope.irEquals(left: IrExpression, right: IrExpression): IrExpression {
-    return irCallWithArguments(context.irBuiltIns.eqeqSymbol, left, right)
+private fun unreachable(): Nothing = throw RuntimeException("Unreachable")
+
+enum class CompType {
+    EQ, NE, LT, LE, GT, GE;
+
+    val inverted
+        get() = when (this) {
+            EQ -> NE
+            NE -> EQ
+            LT -> GE
+            LE -> GT
+            GT -> LE
+            GE -> LT
+        }
 }
 
-fun IrBuilderWithScope.irLessThan(left: IrExpression, right: IrExpression): IrExpression {
-    return irCompare(context.irBuiltIns.lessFunByOperandType, left, right)
-}
-
-fun IrBuilderWithScope.irGreaterThan(left: IrExpression, right: IrExpression): IrExpression {
-    return irCompare(context.irBuiltIns.greaterFunByOperandType, left, right)
-}
-
-fun IrBuilderWithScope.irLessEqual(left: IrExpression, right: IrExpression): IrExpression {
-    return irCompare(context.irBuiltIns.lessOrEqualFunByOperandType, left, right)
-}
-
-fun IrBuilderWithScope.irGreaterEqual(left: IrExpression, right: IrExpression): IrExpression {
-    return irCompare(context.irBuiltIns.greaterOrEqualFunByOperandType, left, right)
-}
-
-
-fun IrBuilderWithScope.irCompare(map: Map<SimpleType, IrSimpleFunction>, left: IrExpression, right: IrExpression): IrExpression {
-    return irCallWithArguments(map[left.type.toKotlinType()]?.symbol!!, left, right)
-}
-
-fun IrBuilderWithScope.irCallWithArguments(callee: IrFunctionSymbol, vararg args: IrExpression): IrCall {
+inline fun IrBuilderWithScope.irCallWithArguments(callee: IrFunctionSymbol, vararg args: IrExpression): IrCall {
     return irCall(callee).apply {
         for ((index, arg) in args.withIndex()) putValueArgument(index, arg)
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ForLoopsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ForLoopsLowering.kt
@@ -494,13 +494,12 @@ private class ForLoopsTransformer(val context: Context) : IrElementTransformerVo
         val forLoopInfo = iteratorToLoopInfo[irIteratorAccess.symbol] ?: return null
         assert(forLoopInfo.loopVariable != null)
 
+        val left = irGet(forLoopInfo.inductionVariable)
         val right = irGet(forLoopInfo.last)
         return if (forLoopInfo.until) {
-                val left = irGet(forLoopInfo.inductionVariable)
                 if (forLoopInfo.increasing) irLessThan(left, right) else irGreaterThan(left, right)
             } else {
-                val left = irGet(forLoopInfo.loopVariable!!)
-                irNotEquals2(left, right)
+                if (forLoopInfo.increasing) irLessEqual(left, right) else irGreaterEqual(left, right)
             } to forLoopInfo
     }
 

--- a/runtime/src/main/cpp/Arrays.cpp
+++ b/runtime/src/main/cpp/Arrays.cpp
@@ -57,20 +57,22 @@ extern const ObjHeader theEmptyArray;
 
 // TODO: those must be compiler intrinsics afterwards.
 
+inline void checkArrayBounds(const ArrayHeader* array, KInt index) {
+    if (static_cast<uint32_t>(index) >= array->count_) {
+        ThrowArrayIndexOutOfBoundsException();
+    }
+}
+
 // Array.kt
 OBJ_GETTER(Kotlin_Array_get, KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   RETURN_OBJ(*ArrayAddressOfElementAt(array, index));
 }
 
 void Kotlin_Array_set(KRef thiz, KInt index, KConstRef value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   UpdateRef(ArrayAddressOfElementAt(array, index), value);
 }
@@ -121,17 +123,13 @@ OBJ_GETTER0(Kotlin_emptyArray) {
 
 KByte Kotlin_ByteArray_get(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   return *ByteArrayAddressOfElementAt(array, index);
 }
 
 void Kotlin_ByteArray_set(KRef thiz, KInt index, KByte value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   *ByteArrayAddressOfElementAt(array, index) = value;
 }
@@ -143,119 +141,91 @@ KInt Kotlin_ByteArray_getArrayLength(KConstRef thiz) {
 
 KChar Kotlin_ByteArray_getCharAt(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 1) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 1);
   return *reinterpret_cast<const KChar*>(ByteArrayAddressOfElementAt(array, index));
 }
 
 KShort Kotlin_ByteArray_getShortAt(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 1) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 1);
   return *reinterpret_cast<const KShort*>(ByteArrayAddressOfElementAt(array, index));
 }
 
 KInt Kotlin_ByteArray_getIntAt(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 3) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 3);
   return *reinterpret_cast<const KInt*>(ByteArrayAddressOfElementAt(array, index));
 }
 
 KLong Kotlin_ByteArray_getLongAt(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 7) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 7);
   return *reinterpret_cast<const KLong*>(ByteArrayAddressOfElementAt(array, index));
 }
 
 KFloat Kotlin_ByteArray_getFloatAt(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 3) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 3);
   return *reinterpret_cast<const KFloat*>(ByteArrayAddressOfElementAt(array, index));
 }
 
 KDouble Kotlin_ByteArray_getDoubleAt(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 7) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 7);
   return *reinterpret_cast<const KDouble*>(ByteArrayAddressOfElementAt(array, index));
 }
 
 void Kotlin_ByteArray_setCharAt(KRef thiz, KInt index, KChar value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 1) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 1);
   mutabilityCheck(thiz);
   *reinterpret_cast<KChar*>(ByteArrayAddressOfElementAt(array, index)) = value;
 }
 
 void Kotlin_ByteArray_setShortAt(KRef thiz, KInt index, KShort value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 1) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 1);
   mutabilityCheck(thiz);
   *reinterpret_cast<KShort*>(ByteArrayAddressOfElementAt(array, index)) = value;
 }
 
 void Kotlin_ByteArray_setIntAt(KRef thiz, KInt index, KInt value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 3) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 3);
   mutabilityCheck(thiz);
   *reinterpret_cast<KInt*>(ByteArrayAddressOfElementAt(array, index)) = value;
 }
 
 void Kotlin_ByteArray_setLongAt(KRef thiz, KInt index, KLong value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 7) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 7);
   mutabilityCheck(thiz);
   *reinterpret_cast<KLong*>(ByteArrayAddressOfElementAt(array, index)) = value;
 }
 
 void Kotlin_ByteArray_setFloatAt(KRef thiz, KInt index, KFloat value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 3) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 3);
   mutabilityCheck(thiz);
   *reinterpret_cast<KFloat*>(ByteArrayAddressOfElementAt(array, index)) = value;
 }
 
 void Kotlin_ByteArray_setDoubleAt(KRef thiz, KInt index, KDouble value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index + 7) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index + 7);
   mutabilityCheck(thiz);
   *reinterpret_cast<KDouble*>(ByteArrayAddressOfElementAt(array, index)) = value;
 }
 
 KChar Kotlin_CharArray_get(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   return *PrimitiveArrayAddressOfElementAt<KChar>(array, index);
 }
 
 void Kotlin_CharArray_set(KRef thiz, KInt index, KChar value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   *PrimitiveArrayAddressOfElementAt<KChar>(array, index) = value;
 }
@@ -282,17 +252,13 @@ KInt Kotlin_CharArray_getArrayLength(KConstRef thiz) {
 
 KShort Kotlin_ShortArray_get(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   return *PrimitiveArrayAddressOfElementAt<KShort>(array, index);
 }
 
 void Kotlin_ShortArray_set(KRef thiz, KInt index, KShort value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   *PrimitiveArrayAddressOfElementAt<KShort>(array, index) = value;
 }
@@ -304,17 +270,13 @@ KInt Kotlin_ShortArray_getArrayLength(KConstRef thiz) {
 
 KInt Kotlin_IntArray_get(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   return *PrimitiveArrayAddressOfElementAt<KInt>(array, index);
 }
 
 void Kotlin_IntArray_set(KRef thiz, KInt index, KInt value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   *PrimitiveArrayAddressOfElementAt<KInt>(array, index) = value;
 }
@@ -377,18 +339,13 @@ void Kotlin_BooleanArray_copyImpl(KConstRef thiz, KInt fromIndex,
 
 KLong Kotlin_LongArray_get(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-
-        ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   return *PrimitiveArrayAddressOfElementAt<KLong>(array, index);
 }
 
 void Kotlin_LongArray_set(KRef thiz, KInt index, KLong value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   *PrimitiveArrayAddressOfElementAt<KLong>(array, index) = value;
 }
@@ -400,17 +357,13 @@ KInt Kotlin_LongArray_getArrayLength(KConstRef thiz) {
 
 KFloat Kotlin_FloatArray_get(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   return *PrimitiveArrayAddressOfElementAt<KFloat>(array, index);
 }
 
 void Kotlin_FloatArray_set(KRef thiz, KInt index, KFloat value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   *PrimitiveArrayAddressOfElementAt<KFloat>(array, index) = value;
 }
@@ -422,17 +375,13 @@ KInt Kotlin_FloatArray_getArrayLength(KConstRef thiz) {
 
 KDouble Kotlin_DoubleArray_get(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   return *PrimitiveArrayAddressOfElementAt<KDouble>(array, index);
 }
 
 void Kotlin_DoubleArray_set(KRef thiz, KInt index, KDouble value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   *PrimitiveArrayAddressOfElementAt<KDouble>(array, index) = value;
 }
@@ -444,17 +393,13 @@ KInt Kotlin_DoubleArray_getArrayLength(KConstRef thiz) {
 
 KBoolean Kotlin_BooleanArray_get(KConstRef thiz, KInt index) {
   const ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   return *PrimitiveArrayAddressOfElementAt<KBoolean>(array, index);
 }
 
 void Kotlin_BooleanArray_set(KRef thiz, KInt index, KBoolean value) {
   ArrayHeader* array = thiz->array();
-  if (static_cast<uint32_t>(index) >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, index);
   mutabilityCheck(thiz);
   *PrimitiveArrayAddressOfElementAt<KBoolean>(array, index) = value;
 }
@@ -479,18 +424,13 @@ OBJ_GETTER(Kotlin_ImmutableBinaryBlob_toByteArray, KConstRef thiz, KInt start, K
 
 KNativePtr Kotlin_ImmutableBinaryBlob_asCPointerImpl(KRef thiz, KInt offset) {
   ArrayHeader* array = thiz->array();
-  if (offset < 0 || offset > array->count_)  {
-        ThrowArrayIndexOutOfBoundsException();
-  }
+  checkArrayBounds(array, offset);
   return PrimitiveArrayAddressOfElementAt<KByte>(array, offset);
 }
 
 KNativePtr Kotlin_Arrays_getAddressOfElement(KRef thiz, KInt index) {
   ArrayHeader* array = thiz->array();
-  if (index < 0 || index >= array->count_) {
-    ThrowArrayIndexOutOfBoundsException();
-  }
-
+  checkArrayBounds(array, index);
   return AddressOfElementAt(array, index);
 }
 

--- a/runtime/src/main/cpp/Natives.h
+++ b/runtime/src/main/cpp/Natives.h
@@ -92,22 +92,22 @@ OBJ_GETTER(Kotlin_Any_toString, KConstRef thiz);
 OBJ_GETTER(Kotlin_Array_clone, KConstRef thiz);
 OBJ_GETTER(Kotlin_Array_get, KConstRef thiz, KInt index);
 void Kotlin_Array_set(KRef thiz, KInt index, KConstRef value);
-KInt Kotlin_Array_getArrayLength(KConstRef thiz);
+KInt Kotlin_Array_getArrayLength(KConstRef thiz) RUNTIME_CONST;
 
 OBJ_GETTER(Kotlin_ByteArray_clone, KConstRef thiz);
 KByte Kotlin_ByteArray_get(KConstRef thiz, KInt index);
 void Kotlin_ByteArray_set(KRef thiz, KInt index, KByte value);
-KInt Kotlin_ByteArray_getArrayLength(KConstRef thiz);
+KInt Kotlin_ByteArray_getArrayLength(KConstRef thiz) RUNTIME_CONST;
 
 OBJ_GETTER(Kotlin_CharArray_clone, KConstRef thiz);
 KChar Kotlin_CharArray_get(KConstRef thiz, KInt index);
 void Kotlin_CharArray_set(KRef thiz, KInt index, KChar value);
-KInt Kotlin_CharArray_getArrayLength(KConstRef thiz);
+KInt Kotlin_CharArray_getArrayLength(KConstRef thiz) RUNTIME_CONST;
 
 OBJ_GETTER(Kotlin_IntArray_clone, KConstRef thiz);
 KInt Kotlin_IntArray_get(KConstRef thiz, KInt index);
 void Kotlin_IntArray_set(KRef thiz, KInt index, KInt value);
-KInt Kotlin_IntArray_getArrayLength(KConstRef thiz);
+KInt Kotlin_IntArray_getArrayLength(KConstRef thiz) RUNTIME_CONST;
 
 // io/Console.kt
 void Kotlin_io_Console_print(KString message);

--- a/runtime/src/main/kotlin/kotlin/Arrays.kt
+++ b/runtime/src/main/kotlin/kotlin/Arrays.kt
@@ -43,12 +43,12 @@ public final class ByteArray {
     // TODO: What about inline constructors?
     @InlineConstructor
     public constructor(size: Int, init: (Int) -> Byte): this(size) {
-        for (i in 0..size - 1) {
+        for (i in 0 until this.size) {
             this[i] = init(i)
         }
     }
 
-    public val size: Int
+    inline public val size: Int
         get() = getArrayLength()
 
     @SymbolName("Kotlin_ByteArray_get")
@@ -58,7 +58,8 @@ public final class ByteArray {
     external public operator fun set(index: Int, value: Byte): Unit
 
     @SymbolName("Kotlin_ByteArray_getArrayLength")
-    external private fun getArrayLength(): Int
+    @PublishedApi
+    external internal fun getArrayLength(): Int
 
     /** Creates an iterator over the elements of the array. */
     public operator fun iterator(): ByteIterator {
@@ -95,12 +96,12 @@ public final class CharArray {
      */
     @InlineConstructor
     public constructor(size: Int, init: (Int) -> Char): this(size) {
-        for (i in 0..size - 1) {
+        for (i in 0 until this.size) {
             this[i] = init(i)
         }
     }
 
-    public val size: Int
+    inline public val size: Int
         get() = getArrayLength()
 
     @SymbolName("Kotlin_CharArray_get")
@@ -110,7 +111,8 @@ public final class CharArray {
     external public operator fun set(index: Int, value: Char): Unit
 
     @SymbolName("Kotlin_CharArray_getArrayLength")
-    external private fun getArrayLength(): Int
+    @PublishedApi
+    external internal fun getArrayLength(): Int
 
     /** Creates an iterator over the elements of the array. */
     public operator fun iterator(): kotlin.collections.CharIterator {
@@ -146,12 +148,12 @@ public final class ShortArray {
      */
     @InlineConstructor
     public constructor(size: Int, init: (Int) -> Short): this(size) {
-        for (i in 0..size - 1) {
+        for (i in 0 until this.size) {
             this[i] = init(i)
         }
     }
 
-    public val size: Int
+    inline public val size: Int
         get() = getArrayLength()
 
     @SymbolName("Kotlin_ShortArray_get")
@@ -161,7 +163,8 @@ public final class ShortArray {
     external public operator fun set(index: Int, value: Short): Unit
 
     @SymbolName("Kotlin_ShortArray_getArrayLength")
-    external private fun getArrayLength(): Int
+    @PublishedApi
+    external internal fun getArrayLength(): Int
 
     /** Creates an iterator over the elements of the array. */
     public operator fun iterator(): kotlin.collections.ShortIterator {
@@ -197,12 +200,12 @@ public final class IntArray {
      */
     @InlineConstructor
     public constructor(size: Int, init: (Int) -> Int): this(size) {
-        for (i in 0..size - 1) {
+        for (i in 0 until this.size) {
             this[i] = init(i)
         }
     }
 
-    public val size: Int
+    inline public val size: Int
         get() = getArrayLength()
 
     @SymbolName("Kotlin_IntArray_get")
@@ -212,7 +215,8 @@ public final class IntArray {
     external public operator fun set(index: Int, value: Int): Unit
 
     @SymbolName("Kotlin_IntArray_getArrayLength")
-    external private fun getArrayLength(): Int
+    @PublishedApi
+    external internal fun getArrayLength(): Int
 
     /** Creates an iterator over the elements of the array. */
     public operator fun iterator(): kotlin.collections.IntIterator {
@@ -248,12 +252,12 @@ public final class LongArray {
      */
     @InlineConstructor
     public constructor(size: Int, init: (Int) -> Long): this(size) {
-        for (i in 0..size - 1) {
+        for (i in 0 until this.size) {
             this[i] = init(i)
         }
     }
 
-    public val size: Int
+    inline public val size: Int
         get() = getArrayLength()
 
     @SymbolName("Kotlin_LongArray_get")
@@ -263,7 +267,8 @@ public final class LongArray {
     external public operator fun set(index: Int, value: Long): Unit
 
     @SymbolName("Kotlin_LongArray_getArrayLength")
-    external private fun getArrayLength(): Int
+    @PublishedApi
+    external internal fun getArrayLength(): Int
 
     /** Creates an iterator over the elements of the array. */
     public operator fun iterator(): kotlin.collections.LongIterator {
@@ -299,12 +304,12 @@ public final class FloatArray {
      */
     @InlineConstructor
     public constructor(size: Int, init: (Int) -> Float): this(size) {
-        for (i in 0..size - 1) {
+        for (i in 0 until this.size) {
             this[i] = init(i)
         }
     }
 
-    public val size: Int
+    inline public val size: Int
         get() = getArrayLength()
 
     @SymbolName("Kotlin_FloatArray_get")
@@ -314,7 +319,8 @@ public final class FloatArray {
     external public operator fun set(index: Int, value: Float): Unit
 
     @SymbolName("Kotlin_FloatArray_getArrayLength")
-    external private fun getArrayLength(): Int
+    @PublishedApi
+    external internal fun getArrayLength(): Int
 
     /** Creates an iterator over the elements of the array. */
     public operator fun iterator(): kotlin.collections.FloatIterator {
@@ -346,12 +352,12 @@ public final class DoubleArray {
      */
     @InlineConstructor
     public constructor(size: Int, init: (Int) -> Double): this(size) {
-        for (i in 0..size - 1) {
+        for (i in 0 until this.size) {
             this[i] = init(i)
         }
     }
 
-    public val size: Int
+    inline public val size: Int
         get() = getArrayLength()
 
     @SymbolName("Kotlin_DoubleArray_get")
@@ -361,7 +367,8 @@ public final class DoubleArray {
     external public operator fun set(index: Int, value: Double): Unit
 
     @SymbolName("Kotlin_DoubleArray_getArrayLength")
-    external private fun getArrayLength(): Int
+    @PublishedApi
+    external internal fun getArrayLength(): Int
 
     /** Creates an iterator over the elements of the array. */
     public operator fun iterator(): kotlin.collections.DoubleIterator {
@@ -393,12 +400,12 @@ public final class BooleanArray {
      */
     @InlineConstructor
     public constructor(size: Int, init: (Int) -> Boolean): this(size) {
-        for (i in 0..size - 1) {
+        for (i in 0 until this.size) {
             this[i] = init(i)
         }
     }
 
-    public val size: Int
+    inline public val size: Int
         get() = getArrayLength()
 
     @SymbolName("Kotlin_BooleanArray_get")
@@ -408,7 +415,8 @@ public final class BooleanArray {
     external public operator fun set(index: Int, value: Boolean): Unit
 
     @SymbolName("Kotlin_BooleanArray_getArrayLength")
-    external private fun getArrayLength(): Int
+    @PublishedApi
+    external internal fun getArrayLength(): Int
 
     /** Creates an iterator over the elements of the array. */
     public operator fun iterator(): kotlin.collections.BooleanIterator {


### PR DESCRIPTION
Proposal. Might have bugs. Let's wait for tests to run :)

Tested with this snippet:
```
fun loop(out: IntArray) {
        for (n in 0 until out.size) {
                out[n] = 10
        }
}

fun main(args: Array<String>) {
        val out = IntArray(1024)
        loop(out)
        println(out[10])
}
```

This should fix: https://github.com/JetBrains/kotlin-native/issues/1791

The idea is that K/N was generating for a:

```
for (n in 0 until array.size) X
```

a loop with (simplified):

```
val last = array.size - 1
var n = 0
do {
   X
} (n++ != last)
```

and LLVM doesn't like that.

Now I'm generating:

```
val last = array.size 
var n = 0
do {
   X
} (n++ < last)
```

And LLVM likes it and can detect that last matches the check in the bounds checking.
It still checks if the array size <= 0 before the loop starts. It should be fixed if the code is changed to:

```
val last = array.size 
var n = 0
while (n < last) {
   X
   n++
}
```

Also calling the `Kotlin_*_getArrayLength` directly + const was required for LLVM to like this.