### PR TITLE
Add libiconv to mingw platform

### DIFF
--- a/platformLibs/src/platform/mingw/iconv.def
+++ b/platformLibs/src/platform/mingw/iconv.def
@@ -1,0 +1,5 @@
+depends = posix
+package = platform.iconv
+headers = iconv.h
+headerFilter = **
+linkerOpts = -liconv


### PR DESCRIPTION
There is libiconv in mingw 

```
# unzip -l msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64.zip \
    | grep -E '.*\.(so|h|a)$' | grep ......
     9292  2017-11-14 10:37   /include/iconv.h
  1085382  2017-11-14 10:37   /lib/libiconv.a
     8964  2017-11-14 10:37   /lib/libiconv.dll.a
```