### PR TITLE
[experiment] windows 32-bit target

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -98,7 +98,7 @@ internal class LinkStage(val context: Context) {
             else -> configurables.optNooptFlags
         } + llvmProfilingFlags()).toTypedArray()
         val optimizedBc = temporary("optimized", ".bc")
-        targetTool("opt", combinedBc, "-o", optimizedBc, *optFlags)
+        hostLlvmTool("opt", combinedBc, "-o", optimizedBc, *optFlags)
 
         val llcFlags = (configurables.llcFlags + when {
             optimize -> configurables.llcOptFlags
@@ -106,9 +106,9 @@ internal class LinkStage(val context: Context) {
             else -> configurables.llcNooptFlags
         } + llvmProfilingFlags()).toTypedArray()
         val combinedO = temporary("combined", ".o")
-        targetTool("llc", optimizedBc, "-o", combinedO, *llcFlags, "-filetype=obj")
+        hostLlvmTool("llc", optimizedBc, "-o", combinedO, *llcFlags, "-filetype=obj")
         val linkedWasm = temporary("linked", ".wasm")
-        targetTool("wasm-ld", combinedO, "-o", linkedWasm, *configurables.lldFlags.toTypedArray())
+        hostLlvmTool("wasm-ld", combinedO, "-o", linkedWasm, *configurables.lldFlags.toTypedArray())
         return linkedWasm
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -108,8 +108,7 @@ internal class LinkStage(val context: Context) {
         val combinedO = temporary("combined", ".o")
         hostLlvmTool("llc", optimizedBc, "-o", combinedO, *llcFlags, "-filetype=obj")
         val linkedWasm = temporary("linked", ".wasm")
-        val output = hostLlvmTool("wasm-ld", combinedO, "-o", linkedWasm, *configurables.lldFlags.toTypedArray())
-        output.forEach { println("##teamcity [message text='$it']") }
+        hostLlvmTool("wasm-ld", combinedO, "-o", linkedWasm, *configurables.lldFlags.toTypedArray())
         return linkedWasm
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -107,7 +107,9 @@ internal class LinkStage(val context: Context) {
         } + llvmProfilingFlags()).toTypedArray()
         val combinedO = temporary("combined", ".o")
         hostLlvmTool("llc", optimizedBc, "-o", combinedO, *llcFlags, "-filetype=obj")
+        println("llc complete")
         hostLlvmTool("wasm-ld", "-v")
+        println("version is shown")
         val linkedWasm = temporary("linked", ".wasm")
         hostLlvmTool("wasm-ld", combinedO, "-o", linkedWasm, *configurables.lldFlags.toTypedArray())
         return linkedWasm

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -107,6 +107,7 @@ internal class LinkStage(val context: Context) {
         } + llvmProfilingFlags()).toTypedArray()
         val combinedO = temporary("combined", ".o")
         hostLlvmTool("llc", optimizedBc, "-o", combinedO, *llcFlags, "-filetype=obj")
+        hostLlvmTool("wasm-ld", "-v")
         val linkedWasm = temporary("linked", ".wasm")
         hostLlvmTool("wasm-ld", combinedO, "-o", linkedWasm, *configurables.lldFlags.toTypedArray())
         return linkedWasm

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -91,7 +91,7 @@ internal class LinkStage(val context: Context) {
         val combinedBc = temporary("combined", ".bc")
         // TODO: use -only-needed for the stdlib
         hostLlvmTool("llvm-link", *bitcodeFiles.toTypedArray(), "-o", combinedBc)
-
+        println("llvm-link complete")
         val optFlags = (configurables.optFlags + when {
             optimize -> configurables.optOptFlags
             debug -> configurables.optDebugFlags
@@ -99,7 +99,7 @@ internal class LinkStage(val context: Context) {
         } + llvmProfilingFlags()).toTypedArray()
         val optimizedBc = temporary("optimized", ".bc")
         hostLlvmTool("opt", combinedBc, "-o", optimizedBc, *optFlags)
-
+        println("opt complete")
         val llcFlags = (configurables.llcFlags + when {
             optimize -> configurables.llcOptFlags
             debug -> configurables.llcDebugFlags

--- a/backend.native/llvm.def
+++ b/backend.native/llvm.def
@@ -32,6 +32,7 @@ linkerOpts.linux= -fPIC \
      -lrt -ldl -lpthread -lz -lm
 
 linkerOpts.mingw = -lole32 -luuid -static-libgcc -static-libstdc++ \
+    -Wl,-Bstatic -lz \
     -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic
 
 # It looks like mingw port compiled without LLVM_ENABLE_DUMP

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2877,6 +2877,7 @@ task runStdlibTests(type: RunStdlibTest) {
 }
 
 task buildKonanTests(type: BuildKonanTest) {
+    dependsOn hello1
     compileList = [ "codegen",  "datagen", "lower", "runtime", "serialization"]
 
     // These tests should not be built into the TestRunner's test executable

--- a/cmd/run_konan.bat
+++ b/cmd/run_konan.bat
@@ -95,7 +95,7 @@ goto :eof
   rem libclang.dll is dynamically linked and thus requires correct PATH to be loaded.
   rem TODO: remove this hack.
   if "%KONAN_DATA_DIR%"=="" (set KONAN_DATA_DIR=%USERPROFILE%\.konan)
-  set "PATH=%KONAN_DATA_DIR%\dependencies\msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64\bin;%PATH%"
+  set "PATH=%KONAN_DATA_DIR%\dependencies\msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1\bin;%PATH%"
 goto :eof
 
 :end

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -334,11 +334,11 @@ dependencies.macos_x64-wasm32 = \
     target-sysroot-2-wasm \
     target-toolchain-3-macos-wasm
 
-targetToolchain.linux_x64-wasm32 = target-toolchain-1-linux-wasm
+targetToolchain.linux_x64-wasm32 = target-toolchain-2-linux-wasm
 dependencies.linux_x64-wasm32 = \
     clang-llvm-6.0.1-linux-x86-64 \
     target-sysroot-2-wasm \
-    target-toolchain-1-linux-wasm
+    target-toolchain-2-linux-wasm
 
 targetToolchain.mingw_x64-wasm32 = target-toolchain-1-mingw-wasm
 dependencies.mingw_x64-wasm32 = \

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -328,11 +328,11 @@ dependencies.mingw_x64 = \
     libffi-3.2.1-mingw-w64-x86-64
 
 # WebAssembly 32-bit.
-targetToolchain.macos_x64-wasm32 = target-toolchain-2-osx-wasm
+targetToolchain.macos_x64-wasm32 = target-toolchain-3-macos-wasm
 dependencies.macos_x64-wasm32 = \
     clang-llvm-6.0.0-darwin-macos \
     target-sysroot-2-wasm \
-    target-toolchain-2-osx-wasm
+    target-toolchain-3-macos-wasm
 
 targetToolchain.linux_x64-wasm32 = target-toolchain-1-linux-wasm
 dependencies.linux_x64-wasm32 = \
@@ -346,16 +346,17 @@ dependencies.mingw_x64-wasm32 = \
     target-sysroot-2-wasm \
     target-toolchain-1-mingw-wasm
 
-quadruple.wasm32 = wasm32
+quadruple.wasm32 = wasm32-unknown-unknown
 llvmLtoFlags.wasm32 =
 targetSysRoot.wasm32 = target-sysroot-2-wasm
-optFlags.wasm32 = -internalize -globaldce
+optFlags.wasm32 = -internalize -globaldce -mtriple=wasm32-unknown-unknown-wasm
 optNooptFlags.wasm32 = -O1
 optOptFlags.wasm32 = -O3
 optDebugFlags.wasm32 = -O0
-llcFlags.wasm32 =
+llcFlags.wasm32 = -mtriple=wasm32-unknown-unknown-wasm
 llcNooptFlags.wasm32 = -O1
 llcOptFlags.wasm32 = -O3
 llcDebugFlags.wasm32 = -O0
-# The stack size is in bytes.
-s2wasmFlags.wasm32 = --allocate-stack 1048576 --import-memory
+# TODO: make explicit list of external symbols
+lld.wasm32 = --allow-undefined --no-entry --global-base=0
+

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -139,7 +139,7 @@ osVersionMinFlagClang.ios_x64 = -mios-simulator-version-min
 osVersionMin.ios_x64 = 8.0
 
 # Linux x86-64.
-llvmHome.linux_x64 = clang-llvm-6.0.0-linux-x86-64
+llvmHome.linux_x64 = clang-llvm-6.0.1-linux-x86-64
 gccToolchain.linux_x64 = target-gcc-toolchain-3-linux-x86-64
 targetToolchain.linux_x64 = target-gcc-toolchain-3-linux-x86-64/x86_64-unknown-linux-gnu
 
@@ -164,14 +164,14 @@ entrySelector.linux_x64 = --defsym main=Konan_main
 # targetSysRoot relative
 abiSpecificLibraries.linux_x64 = ../lib64 lib64 usr/lib64
 dependencies.linux_x64 = \
-    clang-llvm-6.0.0-linux-x86-64 \
+    clang-llvm-6.0.1-linux-x86-64 \
     target-gcc-toolchain-3-linux-x86-64 \
     libffi-3.2.1-2-linux-x86-64
 
 # Raspberry Pi
 targetToolchain.linux_x64-linux_arm32_hfp = target-gcc-toolchain-3-linux-x86-64/x86_64-unknown-linux-gnu
 dependencies.linux_x64-linux_arm32_hfp = \
-    clang-llvm-6.0.0-linux-x86-64 \
+    clang-llvm-6.0.1-linux-x86-64 \
     target-gcc-toolchain-3-linux-x86-64 \
     target-sysroot-1-raspberrypi \
     libffi-3.2.1-2-linux-x86-64 \
@@ -203,7 +203,7 @@ abiSpecificLibraries.linux_arm32_hfp = \
 # MIPS
 targetToolchain.linux_x64-linux_mips32 = target-gcc-toolchain-2-linux-mips/x86_64-unknown-linux-gnu
 dependencies.linux_x64-linux_mips32 = \
-    clang-llvm-6.0.0-linux-x86-64 \
+    clang-llvm-6.0.1-linux-x86-64 \
     target-gcc-toolchain-2-linux-mips \
     target-gcc-toolchain-3-linux-x86-64 \
     target-sysroot-2-mips \
@@ -232,7 +232,7 @@ abiSpecificLibraries.linux_mips32 =
 # MIPSel
 targetToolchain.linux_x64-linux_mipsel32 = target-gcc-toolchain-2-linux-mips/x86_64-unknown-linux-gnu
 dependencies.linux_x64-linux_mipsel32 = \
-    clang-llvm-6.0.0-linux-x86-64 \
+    clang-llvm-6.0.1-linux-x86-64 \
     target-gcc-toolchain-2-linux-mips \
     target-gcc-toolchain-3-linux-x86-64 \
     target-sysroot-2-mipsel \
@@ -267,7 +267,7 @@ dependencies.macos_x64-android_arm32 = \
     libffi-3.2.1-2-android_arm32
 targetToolchain.linux_x64-android_arm32 = target-toolchain-21-linux-android_arm32
 dependencies.linux_x64-android_arm32 = \
-    clang-llvm-6.0.0-linux-x86-64 \
+    clang-llvm-6.0.1-linux-x86-64 \
     target-sysroot-21-android_arm32 \
     target-toolchain-21-linux-android_arm32 \
     libffi-3.2.1-2-android_arm32
@@ -292,7 +292,7 @@ dependencies.macos_x64-android_arm64 = \
     libffi-3.2.1-2-android_arm64
 targetToolchain.linux_x64-android_arm64 = target-toolchain-21-linux-android_arm64
 dependencies.linux_x64-android_arm64 = \
-    clang-llvm-6.0.0-linux-x86-64 \
+    clang-llvm-6.0.1-linux-x86-64 \
     target-sysroot-21-android_arm64 \
     target-toolchain-21-linux-android_arm64 \
     libffi-3.2.1-2-android_arm64
@@ -336,7 +336,7 @@ dependencies.macos_x64-wasm32 = \
 
 targetToolchain.linux_x64-wasm32 = target-toolchain-1-linux-wasm
 dependencies.linux_x64-wasm32 = \
-    clang-llvm-6.0.0-linux-x86-64 \
+    clang-llvm-6.0.1-linux-x86-64 \
     target-sysroot-2-wasm \
     target-toolchain-1-linux-wasm
 

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -31,10 +31,10 @@ downloadingAttemptIntervalMs = 3000
 homeDependencyCache = .konan/cache
 
 llvmDebugOptFlags = -O1
-llvmVersion = 5.0.0
+llvmVersion = 6.0.0
 
 # Mac OS X.
-llvmHome.macos_x64 = clang-llvm-5.0.0-darwin-macos
+llvmHome.macos_x64 = clang-llvm-6.0.0-darwin-macos
 targetToolchain.macos_x64 = target-toolchain-6-macos_x64
 
 arch.macos_x64 = x86_64
@@ -54,7 +54,7 @@ osVersionMin.macos_x64 = 10.11
 entrySelector.macos_x64 = -alias _Konan_main _main
 dependencies.macos_x64 = \
     libffi-3.2.1-2-darwin-macos \
-    clang-llvm-5.0.0-darwin-macos
+    clang-llvm-6.0.0-darwin-macos
 
 target-sysroot-6-macos_x64.default = \
   remote:internal
@@ -66,7 +66,7 @@ target-toolchain-6-macos_x64.default = \
 targetToolchain.macos_x64-ios_arm32 = target-toolchain-6-macos_x64
 dependencies.macos_x64-ios_arm32 = \
   libffi-3.2.1-2-darwin-ios \
-  clang-llvm-5.0.0-darwin-macos
+  clang-llvm-6.0.0-darwin-macos
 
 target-sysroot-6-ios_arm32.default = \
   remote:internal
@@ -92,7 +92,7 @@ osVersionMin.ios_arm32 = 9.0
 targetToolchain.macos_x64-ios_arm64 = target-toolchain-6-macos_x64
 dependencies.macos_x64-ios_arm64 = \
   libffi-3.2.1-2-darwin-ios \
-  clang-llvm-5.0.0-darwin-macos
+  clang-llvm-6.0.0-darwin-macos
 
 target-sysroot-6-ios_arm64.default = \
   remote:internal
@@ -117,7 +117,7 @@ osVersionMin.ios_arm64 = 8.0
 targetToolchain.macos_x64-ios_x64 = target-toolchain-6-macos_x64
 dependencies.macos_x64-ios_x64 = \
   libffi-3.2.1-1-darwin-ios_sim \
-  clang-llvm-5.0.0-darwin-macos
+  clang-llvm-6.0.0-darwin-macos
 
 target-sysroot-6-ios_x64.default = \
   remote:internal
@@ -139,7 +139,7 @@ osVersionMinFlagClang.ios_x64 = -mios-simulator-version-min
 osVersionMin.ios_x64 = 8.0
 
 # Linux x86-64.
-llvmHome.linux_x64 = clang-llvm-5.0.0-linux-x86-64
+llvmHome.linux_x64 = clang-llvm-6.0.0-linux-x86-64
 gccToolchain.linux_x64 = target-gcc-toolchain-3-linux-x86-64
 targetToolchain.linux_x64 = target-gcc-toolchain-3-linux-x86-64/x86_64-unknown-linux-gnu
 
@@ -164,14 +164,14 @@ entrySelector.linux_x64 = --defsym main=Konan_main
 # targetSysRoot relative
 abiSpecificLibraries.linux_x64 = ../lib64 lib64 usr/lib64
 dependencies.linux_x64 = \
-    clang-llvm-5.0.0-linux-x86-64 \
+    clang-llvm-6.0.0-linux-x86-64 \
     target-gcc-toolchain-3-linux-x86-64 \
     libffi-3.2.1-2-linux-x86-64
 
 # Raspberry Pi
 targetToolchain.linux_x64-linux_arm32_hfp = target-gcc-toolchain-3-linux-x86-64/x86_64-unknown-linux-gnu
 dependencies.linux_x64-linux_arm32_hfp = \
-    clang-llvm-5.0.0-linux-x86-64 \
+    clang-llvm-6.0.0-linux-x86-64 \
     target-gcc-toolchain-3-linux-x86-64 \
     target-sysroot-1-raspberrypi \
     libffi-3.2.1-2-linux-x86-64 \
@@ -203,7 +203,7 @@ abiSpecificLibraries.linux_arm32_hfp = \
 # MIPS
 targetToolchain.linux_x64-linux_mips32 = target-gcc-toolchain-2-linux-mips/x86_64-unknown-linux-gnu
 dependencies.linux_x64-linux_mips32 = \
-    clang-llvm-5.0.0-linux-x86-64 \
+    clang-llvm-6.0.0-linux-x86-64 \
     target-gcc-toolchain-2-linux-mips \
     target-gcc-toolchain-3-linux-x86-64 \
     target-sysroot-2-mips \
@@ -232,7 +232,7 @@ abiSpecificLibraries.linux_mips32 =
 # MIPSel
 targetToolchain.linux_x64-linux_mipsel32 = target-gcc-toolchain-2-linux-mips/x86_64-unknown-linux-gnu
 dependencies.linux_x64-linux_mipsel32 = \
-    clang-llvm-5.0.0-linux-x86-64 \
+    clang-llvm-6.0.0-linux-x86-64 \
     target-gcc-toolchain-2-linux-mips \
     target-gcc-toolchain-3-linux-x86-64 \
     target-sysroot-2-mipsel \
@@ -261,13 +261,13 @@ abiSpecificLibraries.linux_mipsel32 =
 targetToolchain.macos_x64-android_arm32 = target-toolchain-21-osx-android_arm32
 # TODO: split dependencies to host-dependent and host-independent parts.
 dependencies.macos_x64-android_arm32 = \
-    clang-llvm-5.0.0-darwin-macos \
+    clang-llvm-6.0.0-darwin-macos \
     target-sysroot-21-android_arm32 \
     target-toolchain-21-osx-android_arm32 \
     libffi-3.2.1-2-android_arm32
 targetToolchain.linux_x64-android_arm32 = target-toolchain-21-linux-android_arm32
 dependencies.linux_x64-android_arm32 = \
-    clang-llvm-5.0.0-linux-x86-64 \
+    clang-llvm-6.0.0-linux-x86-64 \
     target-sysroot-21-android_arm32 \
     target-toolchain-21-linux-android_arm32 \
     libffi-3.2.1-2-android_arm32
@@ -286,13 +286,13 @@ linkerKonanFlags.android_arm32 = -lm -latomic -lstdc++ -landroid
 targetToolchain.macos_x64-android_arm64 = target-toolchain-21-osx-android_arm64
 # TODO: split dependencies to host-dependent and host-independent parts.
 dependencies.macos_x64-android_arm64 = \
-    clang-llvm-5.0.0-darwin-macos \
+    clang-llvm-6.0.0-darwin-macos \
     target-sysroot-21-android_arm64 \
     target-toolchain-21-osx-android_arm64 \
     libffi-3.2.1-2-android_arm64
 targetToolchain.linux_x64-android_arm64 = target-toolchain-21-linux-android_arm64
 dependencies.linux_x64-android_arm64 = \
-    clang-llvm-5.0.0-linux-x86-64 \
+    clang-llvm-6.0.0-linux-x86-64 \
     target-sysroot-21-android_arm64 \
     target-toolchain-21-linux-android_arm64 \
     libffi-3.2.1-2-android_arm64
@@ -306,11 +306,11 @@ linkerKonanFlags.android_arm64 = -lm -latomic -lstdc++ -landroid
 linkerNoDebugFlags.android_arm64 = -Wl,-S
 
 # Windows x86-64, based on mingw-w64.
-llvmHome.mingw_x64 = msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64
-targetToolchain.mingw_x64 = msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64
+llvmHome.mingw_x64 = mingw64
+targetToolchain.mingw_x64 = mingw64
 
 quadruple.mingw_x64 = x86_64-w64-mingw32
-targetSysRoot.mingw_x64 = msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64
+targetSysRoot.mingw_x64 = mingw64
 libffiDir.mingw_x64 = libffi-3.2.1-mingw-w64-x86-64
 llvmLtoFlags.mingw_x64 =
 llvmLtoOptFlags.mingw_x64 = -O3 -function-sections
@@ -324,25 +324,25 @@ linkerKonanFlags.mingw_x64 =-static-libgcc -static-libstdc++ \
 linkerOptimizationFlags.mingw_x64 = -Wl,--gc-sections
 entrySelector.mingw_x64 = -Wl,--defsym,main=Konan_main
 dependencies.mingw_x64 = \
-    msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64 \
+    mingw64 \
     libffi-3.2.1-mingw-w64-x86-64
 
 # WebAssembly 32-bit.
 targetToolchain.macos_x64-wasm32 = target-toolchain-2-osx-wasm
 dependencies.macos_x64-wasm32 = \
-    clang-llvm-5.0.0-darwin-macos \
+    clang-llvm-6.0.0-darwin-macos \
     target-sysroot-2-wasm \
     target-toolchain-2-osx-wasm
 
 targetToolchain.linux_x64-wasm32 = target-toolchain-1-linux-wasm
 dependencies.linux_x64-wasm32 = \
-    clang-llvm-5.0.0-linux-x86-64 \
+    clang-llvm-6.0.0-linux-x86-64 \
     target-sysroot-2-wasm \
     target-toolchain-1-linux-wasm
 
 targetToolchain.mingw_x64-wasm32 = target-toolchain-1-mingw-wasm
 dependencies.mingw_x64-wasm32 = \
-    msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64 \
+    mingw64 \
     target-sysroot-2-wasm \
     target-toolchain-1-mingw-wasm
 

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -31,7 +31,7 @@ downloadingAttemptIntervalMs = 3000
 homeDependencyCache = .konan/cache
 
 llvmDebugOptFlags = -O1
-llvmVersion = 6.0.0
+llvmVersion = 6.0.1
 
 # Mac OS X.
 llvmHome.macos_x64 = clang-llvm-6.0.1-darwin-macos

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -306,11 +306,11 @@ linkerKonanFlags.android_arm64 = -lm -latomic -lstdc++ -landroid
 linkerNoDebugFlags.android_arm64 = -Wl,-S
 
 # Windows x86-64, based on mingw-w64.
-llvmHome.mingw_x64 = mingw64
-targetToolchain.mingw_x64 = mingw64
+llvmHome.mingw_x64 = msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1
+targetToolchain.mingw_x64 = msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1
 
 quadruple.mingw_x64 = x86_64-w64-mingw32
-targetSysRoot.mingw_x64 = mingw64
+targetSysRoot.mingw_x64 = msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1
 libffiDir.mingw_x64 = libffi-3.2.1-mingw-w64-x86-64
 llvmLtoFlags.mingw_x64 =
 llvmLtoOptFlags.mingw_x64 = -O3 -function-sections
@@ -324,7 +324,7 @@ linkerKonanFlags.mingw_x64 =-static-libgcc -static-libstdc++ \
 linkerOptimizationFlags.mingw_x64 = -Wl,--gc-sections
 entrySelector.mingw_x64 = -Wl,--defsym,main=Konan_main
 dependencies.mingw_x64 = \
-    mingw64 \
+    msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1 \
     libffi-3.2.1-mingw-w64-x86-64
 
 # WebAssembly 32-bit.
@@ -342,7 +342,7 @@ dependencies.linux_x64-wasm32 = \
 
 targetToolchain.mingw_x64-wasm32 = target-toolchain-1-mingw-wasm
 dependencies.mingw_x64-wasm32 = \
-    mingw64 \
+    msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1 \
     target-sysroot-2-wasm \
     target-toolchain-1-mingw-wasm
 

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -34,7 +34,7 @@ llvmDebugOptFlags = -O1
 llvmVersion = 6.0.0
 
 # Mac OS X.
-llvmHome.macos_x64 = clang-llvm-6.0.0-darwin-macos
+llvmHome.macos_x64 = clang-llvm-6.0.1-darwin-macos
 targetToolchain.macos_x64 = target-toolchain-6-macos_x64
 
 arch.macos_x64 = x86_64
@@ -54,7 +54,7 @@ osVersionMin.macos_x64 = 10.11
 entrySelector.macos_x64 = -alias _Konan_main _main
 dependencies.macos_x64 = \
     libffi-3.2.1-2-darwin-macos \
-    clang-llvm-6.0.0-darwin-macos
+    clang-llvm-6.0.1-darwin-macos
 
 target-sysroot-6-macos_x64.default = \
   remote:internal
@@ -66,7 +66,7 @@ target-toolchain-6-macos_x64.default = \
 targetToolchain.macos_x64-ios_arm32 = target-toolchain-6-macos_x64
 dependencies.macos_x64-ios_arm32 = \
   libffi-3.2.1-2-darwin-ios \
-  clang-llvm-6.0.0-darwin-macos
+  clang-llvm-6.0.1-darwin-macos
 
 target-sysroot-6-ios_arm32.default = \
   remote:internal
@@ -92,7 +92,7 @@ osVersionMin.ios_arm32 = 9.0
 targetToolchain.macos_x64-ios_arm64 = target-toolchain-6-macos_x64
 dependencies.macos_x64-ios_arm64 = \
   libffi-3.2.1-2-darwin-ios \
-  clang-llvm-6.0.0-darwin-macos
+  clang-llvm-6.0.1-darwin-macos
 
 target-sysroot-6-ios_arm64.default = \
   remote:internal
@@ -117,7 +117,7 @@ osVersionMin.ios_arm64 = 8.0
 targetToolchain.macos_x64-ios_x64 = target-toolchain-6-macos_x64
 dependencies.macos_x64-ios_x64 = \
   libffi-3.2.1-1-darwin-ios_sim \
-  clang-llvm-6.0.0-darwin-macos
+  clang-llvm-6.0.1-darwin-macos
 
 target-sysroot-6-ios_x64.default = \
   remote:internal
@@ -261,7 +261,7 @@ abiSpecificLibraries.linux_mipsel32 =
 targetToolchain.macos_x64-android_arm32 = target-toolchain-21-osx-android_arm32
 # TODO: split dependencies to host-dependent and host-independent parts.
 dependencies.macos_x64-android_arm32 = \
-    clang-llvm-6.0.0-darwin-macos \
+    clang-llvm-6.0.1-darwin-macos \
     target-sysroot-21-android_arm32 \
     target-toolchain-21-osx-android_arm32 \
     libffi-3.2.1-2-android_arm32
@@ -286,7 +286,7 @@ linkerKonanFlags.android_arm32 = -lm -latomic -lstdc++ -landroid
 targetToolchain.macos_x64-android_arm64 = target-toolchain-21-osx-android_arm64
 # TODO: split dependencies to host-dependent and host-independent parts.
 dependencies.macos_x64-android_arm64 = \
-    clang-llvm-6.0.0-darwin-macos \
+    clang-llvm-6.0.1-darwin-macos \
     target-sysroot-21-android_arm64 \
     target-toolchain-21-osx-android_arm64 \
     libffi-3.2.1-2-android_arm64
@@ -330,7 +330,7 @@ dependencies.mingw_x64 = \
 # WebAssembly 32-bit.
 targetToolchain.macos_x64-wasm32 = target-toolchain-3-macos-wasm
 dependencies.macos_x64-wasm32 = \
-    clang-llvm-6.0.0-darwin-macos \
+    clang-llvm-6.0.1-darwin-macos \
     target-sysroot-2-wasm \
     target-toolchain-3-macos-wasm
 

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -340,11 +340,11 @@ dependencies.linux_x64-wasm32 = \
     target-sysroot-2-wasm \
     target-toolchain-2-linux-wasm
 
-targetToolchain.mingw_x64-wasm32 = target-toolchain-1-mingw-wasm
+targetToolchain.mingw_x64-wasm32 = target-toolchain-2-mingw-wasm
 dependencies.mingw_x64-wasm32 = \
     msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1 \
     target-sysroot-2-wasm \
-    target-toolchain-1-mingw-wasm
+    target-toolchain-2-mingw-wasm
 
 quadruple.wasm32 = wasm32-unknown-unknown
 llvmLtoFlags.wasm32 =

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -358,5 +358,5 @@ llcNooptFlags.wasm32 = -O1
 llcOptFlags.wasm32 = -O3
 llcDebugFlags.wasm32 = -O0
 # TODO: make explicit list of external symbols
-lld.wasm32 = --allow-undefined --no-entry --global-base=0
+lld.wasm32 = --allow-undefined --no-entry --global-base=0 --verbose
 

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -358,5 +358,5 @@ llcNooptFlags.wasm32 = -O1
 llcOptFlags.wasm32 = -O3
 llcDebugFlags.wasm32 = -O0
 # TODO: make explicit list of external symbols
-lld.wasm32 = --allow-undefined --no-entry --global-base=0 --verbose
+lld.wasm32 = --allow-undefined --no-entry --global-base=0
 

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -318,7 +318,6 @@ llvmLtoNooptFlags.mingw_x64 = -O1
 linkerNoDebugFlags.mingw_x64 = -Wl,-S
 linkerDynamicFlags.mingw_x64 = -shared
 linkerKonanFlags.mingw_x64 =-static-libgcc -static-libstdc++ \
-  -Xclang -flto-visibility-public-std \
   -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic \
   -Wl,--defsym,__cxa_demangle=Konan_cxa_demangle
 linkerOptimizationFlags.mingw_x64 = -Wl,--gc-sections

--- a/konan/platforms/zephyr/stm32f4_disco
+++ b/konan/platforms/zephyr/stm32f4_disco
@@ -25,18 +25,18 @@ boardSpecificClangFlags.zephyr_stm32f4_disco = -mabi=aapcs -mthumb -mcpu=cortex-
 
 targetToolchain.linux_x64-zephyr_stm32f4_disco = gcc-arm-none-eabi-7-2017-q4-major-linux/arm-none-eabi
 dependencies.linux_x64-zephyr_stm32f4_disco = \
-    clang-llvm-5.0.0-linux-x86-64 \
+    clang-llvm-6.0.0-linux-x86-64 \
     gcc-arm-none-eabi-7-2017-q4-major-linux \
     target-sysroot-2-wasm
 
 targetToolchain.macos_x64-zephyr_stm32f4_disco = gcc-arm-none-eabi-7-2017-q4-major-mac/arm-none-eabi
 dependencies.macos_x64-zephyr_stm32f4_disco = \
     gcc-arm-none-eabi-7-2017-q4-major-mac \
-    clang-llvm-5.0.0-darwin-macos \
+    clang-llvm-6.0.0-darwin-macos \
     target-sysroot-2-wasm
 
 targetToolchain.mingw_x64-zephyr_stm32f4_disco = gcc-arm-none-eabi-7-2017-q4-major-win32/arm-none-eabi
 dependencies.mingw_x64-zephyr_stm32f4_disco = \
-    msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64 \
+    mingw64 \
     gcc-arm-none-eabi-7-2017-q4-major-win32 \
     target-sysroot-2-wasm

--- a/konan/platforms/zephyr/stm32f4_disco
+++ b/konan/platforms/zephyr/stm32f4_disco
@@ -25,7 +25,7 @@ boardSpecificClangFlags.zephyr_stm32f4_disco = -mabi=aapcs -mthumb -mcpu=cortex-
 
 targetToolchain.linux_x64-zephyr_stm32f4_disco = gcc-arm-none-eabi-7-2017-q4-major-linux/arm-none-eabi
 dependencies.linux_x64-zephyr_stm32f4_disco = \
-    clang-llvm-6.0.0-linux-x86-64 \
+    clang-llvm-6.0.1-linux-x86-64 \
     gcc-arm-none-eabi-7-2017-q4-major-linux \
     target-sysroot-2-wasm
 

--- a/konan/platforms/zephyr/stm32f4_disco
+++ b/konan/platforms/zephyr/stm32f4_disco
@@ -32,7 +32,7 @@ dependencies.linux_x64-zephyr_stm32f4_disco = \
 targetToolchain.macos_x64-zephyr_stm32f4_disco = gcc-arm-none-eabi-7-2017-q4-major-mac/arm-none-eabi
 dependencies.macos_x64-zephyr_stm32f4_disco = \
     gcc-arm-none-eabi-7-2017-q4-major-mac \
-    clang-llvm-6.0.0-darwin-macos \
+    clang-llvm-6.0.1-darwin-macos \
     target-sysroot-2-wasm
 
 targetToolchain.mingw_x64-zephyr_stm32f4_disco = gcc-arm-none-eabi-7-2017-q4-major-win32/arm-none-eabi

--- a/konan/platforms/zephyr/stm32f4_disco
+++ b/konan/platforms/zephyr/stm32f4_disco
@@ -37,6 +37,6 @@ dependencies.macos_x64-zephyr_stm32f4_disco = \
 
 targetToolchain.mingw_x64-zephyr_stm32f4_disco = gcc-arm-none-eabi-7-2017-q4-major-win32/arm-none-eabi
 dependencies.mingw_x64-zephyr_stm32f4_disco = \
-    mingw64 \
+    msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1 \
     gcc-arm-none-eabi-7-2017-q4-major-win32 \
     target-sysroot-2-wasm

--- a/runtime/src/main/cpp/Memory.cpp
+++ b/runtime/src/main/cpp/Memory.cpp
@@ -912,7 +912,7 @@ void ObjectContainer::Init(const TypeInfo* typeInfo) {
      // header->refCount_ is zero initialized by AllocContainer().
     SetHeader(GetPlace(), typeInfo);
     MEMORY_LOG("object at %p\n", GetPlace())
-    OBJECT_ALLOC_EVENT(memoryState, type_info->instanceSize_, GetPlace())
+    OBJECT_ALLOC_EVENT(memoryState, typeInfo->instanceSize_, GetPlace())
   }
 }
 

--- a/runtime/src/main/cpp/math/fmod.cpp
+++ b/runtime/src/main/cpp/math/fmod.cpp
@@ -1,6 +1,10 @@
 #include <math.h>
 #include <stdint.h>
 
+#ifdef KONAN_WASM
+#include "../Common.h"
+RUNTIME_USED
+#endif
 double fmod(double x, double y)
 {
 	union {double f; uint64_t i;} ux = {x}, uy = {y};

--- a/runtime/src/main/cpp/math/fmodf.cpp
+++ b/runtime/src/main/cpp/math/fmodf.cpp
@@ -1,6 +1,10 @@
 #include <math.h>
 #include <stdint.h>
 
+#ifdef KONAN_WASM
+#include "../Common.h"
+RUNTIME_USED
+#endif
 float fmodf(float x, float y)
 {
 	union {float f; uint32_t i;} ux = {x}, uy = {y};

--- a/samples/tetris/build.bat
+++ b/samples/tetris/build.bat
@@ -2,7 +2,7 @@
 setlocal
 set DIR=.
 if "%KONAN_DATA_DIR%"=="" (set "KONAN_DATA_DIR=%userprofile%\.konan")
-set "PATH=..\..\dist\bin;..\..\bin;%KONAN_DATA_DIR%\dependencies\msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64\bin;%PATH%"
+set "PATH=..\..\dist\bin;..\..\bin;%KONAN_DATA_DIR%\dependencies\msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1\bin;%PATH%"
 if "%TARGET%" == "" set TARGET=mingw
 rem Requires default mingw64 install path yet.
 set MINGW=\msys64\mingw64

--- a/samples/tetris/build.gradle
+++ b/samples/tetris/build.gradle
@@ -62,7 +62,7 @@ task windowsResources (type: Exec) {
     def rcFile = file('Tetris.rc')
     def path = System.getenv("PATH")
 
-    def windresDir = "$konanUserDir/dependencies/msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64/bin"
+    def windresDir = "$konanUserDir/dependencies/msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1/bin"
 
     commandLine "$windresDir/windres", rcFile, '-O', 'coff', '-o', resFile
     environment 'PATH', "$windresDir;$path"

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
@@ -77,10 +77,9 @@ open class Command(initialCommand: List<String>) {
 
         try {
             val builder = ProcessBuilder(command)
-
             builder.redirectInput(Redirect.INHERIT)
             builder.redirectError(Redirect.INHERIT)
-            builder.redirectOutput(ProcessBuilder.Redirect.to(outputFile))
+            builder.redirectOutput(Redirect.INHERIT)
                     .redirectErrorStream(withErrors)
             // Note: getting process output could be done without redirecting to temporary file,
             // however this would require managing a thread to read `process.inputStream` because

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
@@ -78,12 +78,22 @@ class ClangArgs(private val configurables: Configurables) : Configurables by con
                             "-I$absoluteTargetSysRoot/usr/include/c++/4.9.x",
                             "-I$absoluteTargetSysRoot/usr/include/c++/4.9.x/aarch64-linux-android")
 
+                // By default wasm target forces `hidden` visibility which causes
+                // linkage problems.
                 KonanTarget.WASM32 ->
-                    listOf("-target", targetArg!!, "-fno-rtti", "-fno-exceptions",
-                            "-D_LIBCPP_ABI_VERSION=2", "-D_LIBCPP_NO_EXCEPTIONS=1",
-                            "-nostdinc", "-Xclang", "-nobuiltininc", "-Xclang", "-nostdsysteminc",
-                            "-Xclang", "-isystem$absoluteTargetSysRoot/include/libcxx", "-Xclang", "-isystem$absoluteTargetSysRoot/lib/libcxxabi/include",
-                            "-Xclang", "-isystem$absoluteTargetSysRoot/include/compat", "-Xclang", "-isystem$absoluteTargetSysRoot/include/libc")
+                    listOf("-target", targetArg!!,
+                            "-fno-rtti",
+                            "-fno-exceptions",
+                            "-fvisibility=default",
+                            "-D_LIBCPP_ABI_VERSION=2",
+                            "-D_LIBCPP_NO_EXCEPTIONS=1",
+                            "-nostdinc",
+                            "-Xclang", "-nobuiltininc",
+                            "-Xclang", "-nostdsysteminc",
+                            "-Xclang", "-isystem$absoluteTargetSysRoot/include/libcxx",
+                            "-Xclang", "-isystem$absoluteTargetSysRoot/lib/libcxxabi/include",
+                            "-Xclang", "-isystem$absoluteTargetSysRoot/include/compat",
+                            "-Xclang", "-isystem$absoluteTargetSysRoot/include/libc")
 
                 is KonanTarget.ZEPHYR ->
                     listOf("-target", targetArg!!,
@@ -142,7 +152,7 @@ class ClangArgs(private val configurables: Configurables) : Configurables by con
             KonanTarget.WASM32 ->
                 listOf("-DKONAN_WASM=1", "-DKONAN_NO_FFI=1", "-DKONAN_NO_THREADS=1", "-DKONAN_NO_EXCEPTIONS=1",
                         "-DKONAN_INTERNAL_DLMALLOC=1", "-DKONAN_INTERNAL_SNPRINTF=1",
-                        "-DKONAN_INTERNAL_NOW=1", "-DKONAN_NO_MEMMEM", "-DKONAN_NO_CTORS_SECTION")
+                        "-DKONAN_INTERNAL_NOW=1", "-DKONAN_NO_MEMMEM", "-DKONAN_NO_CTORS_SECTION=1")
 
             is KonanTarget.ZEPHYR ->
                 listOf( "-DKONAN_ZEPHYR=1", "-DKONAN_NO_FFI=1", "-DKONAN_NO_THREADS=1", "-DKONAN_NO_EXCEPTIONS=1",

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Configurables.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Configurables.kt
@@ -76,7 +76,6 @@ interface RaspberryPiConfigurables : LinuxBasedConfigurables
 interface AndroidConfigurables : NonAppleConfigurables
 
 interface WasmConfigurables : NonAppleConfigurables {
-    val s2wasmFlags get()   = targetList("s2wasmFlags")
 
     val llcFlags get()      = targetList("llcFlags")
     val llcNooptFlags get() = targetList("llcNooptFlags")
@@ -87,6 +86,8 @@ interface WasmConfigurables : NonAppleConfigurables {
     val optNooptFlags get() = targetList("optNooptFlags")
     val optOptFlags get()   = targetList("optOptFlags")
     val optDebugFlags get() = targetList("optDebugFlags")
+
+    val lldFlags get()      = targetList("lld")
 }
 
 interface ZephyrConfigurables : NonAppleConfigurables {

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -44,8 +44,6 @@ abstract class LinkerFlags(val configurables: Configurables)
         else -> error("Don't know libLTO location for this platform.")
     }
 
-    val libLTO = "$libLTODir/${System.mapLibraryName("LTO")}"
-
     val targetLibffi = configurables.libffiDir?.let { listOf("${configurables.absoluteLibffiDir}/lib/libffi.a") }
             ?: emptyList()
 
@@ -145,7 +143,6 @@ open class MacOSBasedLinker(targetProperties: AppleConfigurables)
         val dynamic = kind == LinkerOutputKind.DYNAMIC_LIBRARY
         return listOf(Command(linker).apply {
             +"-demangle"
-            +listOf("-object_path_lto", "temporary.o", "-lto_library", libLTO)
             +listOf("-dynamic", "-arch", arch)
             +osVersionMinFlags
             +listOf("-syslibroot", absoluteTargetSysRoot, "-o", executable)
@@ -250,11 +247,6 @@ open class LinuxBasedLinker(targetProperties: LinuxBasedConfigurables)
             if (!isMips) +"--hash-style=gnu" // MIPS doesn't support hash-style=gnu
             +specificLibs
             +listOf("-L$absoluteTargetSysRoot/../lib", "-L$absoluteTargetSysRoot/lib", "-L$absoluteTargetSysRoot/usr/lib")
-            if (optimize) {
-                +"-plugin"
-                +"$llvmLib/LLVMgold.so"
-                +pluginOptimizationFlags
-            }
             if (optimize) +linkerOptimizationFlags
             if (!debug) +linkerNoDebugFlags
             if (dynamic) +linkerDynamicFlags

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -266,7 +266,7 @@ open class MingwLinker(targetProperties: MingwConfigurables)
     : LinkerFlags(targetProperties), MingwConfigurables by targetProperties {
 
     private val ar = "$absoluteTargetToolchain\\bin\\ar"
-    private val linker = "$absoluteTargetToolchain/bin/clang++"
+    private val linker = "$absoluteTargetToolchain\\bin\\g++"
 
     override val useCompilerDriverAsLinker: Boolean get() = true
 

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanToolRunner.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KonanToolRunner.kt
@@ -99,7 +99,7 @@ internal class KonanInteropRunner(project: Project, additionalJvmArgs: List<Stri
         if (HostManager.host == KonanTarget.MINGW_X64) {
 	    //TODO: Oh-ho-ho fix it in more convinient way.
             environment.put("PATH", DependencyProcessor.defaultDependenciesRoot.absolutePath +
-                    "\\msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64" +
+                    "\\msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1" +
                     "\\bin;${environment.get("PATH")}")
         }
     }


### PR DESCRIPTION
Started exploring possibilites to add 32-bit windows target.

First, currently we have on windows one big toolchain, combining clang/llvm and gcc.
On other hosts `clang` is separated from toolchain - it's host tool, used for all targets.
So on windows it should be separated too?

Ok, but then another issue - if `gcc` toolchain separated from `clang` - we cannot use `clang++` as linker.
And how to replace it? I see possibilites:
- replace to `g++`
- replace to `ld`, as on all other platforms
- replace to `lld` from llvm.

I tried first option, but get error when compiling `tetrts`:

```
error: f:\Work\.konan\dependencies\msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1\bin\g++ invocation reported errors
```

And no other info. How to debug what it want?
Or maybe I'm on wrong way?