### PR TITLE
Add libiconv to mingw platform

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2793,7 +2793,7 @@ task jsinterop_math(type: RunStandaloneKonanTest) {
 }
 
 task interop_libiconv(type: RunStandaloneKonanTest) {
-    disabled = (isWindows() || (project.testTarget != null))
+    disabled = (project.testTarget != null)
     source = "interop/libiconv.kt"
     goldValue = "72 72\n101 101\n108 108\n108 108\n111 111\n33 33\n"
 }

--- a/platformLibs/src/platform/mingw/iconv.def
+++ b/platformLibs/src/platform/mingw/iconv.def
@@ -1,0 +1,24 @@
+depends = posix
+package = platform.iconv
+headers = iconv.h
+headerFilter = NOTHING
+linkerOpts = -Wl,-Bstatic -liconv -Wl,-Bdynamic
+
+---
+#undef iconv_t
+typedef void *iconv_t;
+
+#undef iconv_open
+static inline iconv_t iconv_open(const char* tocode, const char* fromcode) {
+	return libiconv_open(tocode, fromcode);
+}
+
+#undef iconv
+static inline size_t iconv(iconv_t cd, char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft) {
+	return libiconv(cd, inbuf, inbytesleft, outbuf, outbytesleft);
+}
+
+#undef iconv_close
+static inline int iconv_close(iconv_t cd) {
+	return libiconv_close(cd);
+}


### PR DESCRIPTION
```
> Task :backend.native:tests:interop_libiconv

execution: F:\src\kotlin-native-msink\test.output\local/interop_libiconv/libiconv.exe
72 72
101 101
108 108
108 108
111 111
33 33


Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.7/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 11s
```