### PR TITLE
Remove blank lines

### DIFF
--- a/samples/curl/src/main/kotlin/org/konan/libcurl/Program.kt
+++ b/samples/curl/src/main/kotlin/org/konan/libcurl/Program.kt
@@ -15,8 +15,6 @@ fun main(args: Array<String>) {
 
     curl.fetch()
     curl.close()
-
-
 }
 
 fun help() {


### PR DESCRIPTION
I'm not sure if you'd prefer to have one line before the closing `}`, or no lines. I figured the two may have been a mistake?