### PR TITLE
 platform.zlib: fix + mingw + test

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2841,6 +2841,12 @@ task interop_libiconv(type: RunStandaloneKonanTest) {
     goldValue = "72 72\n101 101\n108 108\n108 108\n111 111\n33 33\n"
 }
 
+task interop_zlib(type: RunStandaloneKonanTest) {
+    disabled = (project.testTarget != null)
+    source = "interop/platform_zlib.kt"
+    goldValue = "Hello!\nHello!\n"
+}
+
 task produce_dynamic(type: DynamicKonanTest) {
     disabled = (project.testTarget != null && project.testTarget != project.hostName)
     source = "produce_dynamic/simple/hello.kt"

--- a/backend.native/tests/interop/platform_zlib.kt
+++ b/backend.native/tests/interop/platform_zlib.kt
@@ -1,0 +1,21 @@
+import kotlinx.cinterop.*
+import platform.zlib.*
+
+val source = immutableBinaryBlobOf(0xF3, 0x48, 0xCD, 0xC9, 0xC9, 0x57, 0x04, 0x00).asCPointer(0)!!
+val golden = immutableBinaryBlobOf(0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x21, 0x00).asCPointer(0)!!
+
+fun main(args: Array<String>) = memScoped {
+    val buffer = allocArray<ByteVar>(32)
+
+    val z = alloc<z_stream>().apply {
+        next_in   = source
+        avail_in  = 8
+        next_out  = buffer
+        avail_out = 32
+    }.ptr
+
+    if (inflateInit2(z, -15) == Z_OK && inflate(z, Z_FINISH) == Z_STREAM_END && inflateEnd(z) == Z_OK) 
+        println(buffer.toKString())
+
+    println(golden.toKString())
+}

--- a/platformLibs/src/platform/android/zlib.def
+++ b/platformLibs/src/platform/android/zlib.def
@@ -1,5 +1,34 @@
 depends = posix
 package = platform.zlib
 headers = zconf.h zlib.h
-headerFilter = **
+headerFilter = zlib.h
+compilerOpts = -DByte=uByte -DBytef=uBytef
 linkerOpts = -lz
+
+---
+#undef deflateInit
+static inline int deflateInit(z_streamp strm, int level) {
+	return deflateInit_(strm, level, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef deflateInit2
+static inline int deflateInit2(z_streamp strm, int level, int method,
+                               int windowBits, int memLevel, int strategy) {
+	return deflateInit2_(strm, level, method, windowBits, memLevel,
+                         strategy, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateInit
+static inline int inflateInit(z_streamp strm) {
+	return inflateInit_(strm, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateInit2
+static inline int inflateInit2(z_streamp strm, int windowBits) {
+    return inflateInit2_(strm, windowBits, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateBackInit
+static inline int inflateBackInit(z_streamp strm, int windowBits, unsigned char *window) {
+    return inflateBackInit_(strm, windowBits, window, ZLIB_VERSION, (int)sizeof(z_stream));
+}

--- a/platformLibs/src/platform/ios/zlib.def
+++ b/platformLibs/src/platform/ios/zlib.def
@@ -1,4 +1,34 @@
 depends = posix
 package = platform.zlib
 headers = zconf.h zlib.h
+headerFilter = zlib.h
+compilerOpts = -DByte=uByte -DBytef=uBytef
 linkerOpts = -lz
+
+---
+#undef deflateInit
+static inline int deflateInit(z_streamp strm, int level) {
+	return deflateInit_(strm, level, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef deflateInit2
+static inline int deflateInit2(z_streamp strm, int level, int method,
+                               int windowBits, int memLevel, int strategy) {
+	return deflateInit2_(strm, level, method, windowBits, memLevel,
+                         strategy, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateInit
+static inline int inflateInit(z_streamp strm) {
+	return inflateInit_(strm, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateInit2
+static inline int inflateInit2(z_streamp strm, int windowBits) {
+    return inflateInit2_(strm, windowBits, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateBackInit
+static inline int inflateBackInit(z_streamp strm, int windowBits, unsigned char *window) {
+    return inflateBackInit_(strm, windowBits, window, ZLIB_VERSION, (int)sizeof(z_stream));
+}

--- a/platformLibs/src/platform/mingw/zlib.def
+++ b/platformLibs/src/platform/mingw/zlib.def
@@ -2,8 +2,8 @@ depends = posix
 package = platform.zlib
 headers = zconf.h zlib.h
 headerFilter = zlib.h
-compilerOpts = -DByte=uByte -DBytef=uBytef -D_ANSI_SOURCE -D_POSIX_C_SOURCE=199309 -D_BSD_SOURCE -D_XOPEN_SOURCE=700
-linkerOpts = -lz
+compilerOpts = -DByte=uByte -DBytef=uBytef
+linkerOpts = -Wl,-Bstatic -lz -Wl,-Bdynamic
 
 ---
 #undef deflateInit

--- a/platformLibs/src/platform/osx/zlib.def
+++ b/platformLibs/src/platform/osx/zlib.def
@@ -1,4 +1,34 @@
 depends = posix
 package = platform.zlib
 headers = zconf.h zlib.h
+headerFilter = zlib.h
+compilerOpts = -DByte=uByte -DBytef=uBytef
 linkerOpts = -lz
+
+---
+#undef deflateInit
+static inline int deflateInit(z_streamp strm, int level) {
+	return deflateInit_(strm, level, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef deflateInit2
+static inline int deflateInit2(z_streamp strm, int level, int method,
+                               int windowBits, int memLevel, int strategy) {
+	return deflateInit2_(strm, level, method, windowBits, memLevel,
+                         strategy, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateInit
+static inline int inflateInit(z_streamp strm) {
+	return inflateInit_(strm, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateInit2
+static inline int inflateInit2(z_streamp strm, int windowBits) {
+    return inflateInit2_(strm, windowBits, ZLIB_VERSION, (int)sizeof(z_stream));
+}
+
+#undef inflateBackInit
+static inline int inflateBackInit(z_streamp strm, int windowBits, unsigned char *window) {
+    return inflateBackInit_(strm, windowBits, window, ZLIB_VERSION, (int)sizeof(z_stream));
+}


### PR DESCRIPTION
```
> Task :backend.native:tests:interop_zlib FAILED
llvm-lto: error: Linking globals named '_Konan_init_zlib': symbol multiply defined!
error: compilation failed: The F:\Work\.konan\dependencies\msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64/bin/llvm-lto command returned non-zero exit code: 1.

 * Source files: zlib.kt
 * Compiler version info: Konan: 0.9-dev / Kotlin: 1.2.70
 * Output kind: PROGRAM

exception: org.jetbrains.kotlin.konan.KonanExternalToolFailure: The F:\Work\.konan\dependencies\msys2-mingw-w64-x86_64-gcc-7.2.0-clang-llvm-5.0.0-windows-x86-64/bin/llvm-lto command returned non-zero exit code: 1.
	at org.jetbrains.kotlin.konan.exec.Command.handleExitCode(ExecuteCommand.kt:100)
	at org.jetbrains.kotlin.konan.exec.Command.execute(ExecuteCommand.kt:66)
	at org.jetbrains.kotlin.backend.konan.LinkStage.runTool(LinkStage.kt:55)
	at org.jetbrains.kotlin.backend.konan.LinkStage.runTool(LinkStage.kt:51)
	at org.jetbrains.kotlin.backend.konan.LinkStage.llvmLto(LinkStage.kt:71)
	at org.jetbrains.kotlin.backend.konan.LinkStage.access$llvmLto(LinkStage.kt:29)
	at org.jetbrains.kotlin.backend.konan.LinkStage$linkStage$1.invoke(LinkStage.kt:239)
	at org.jetbrains.kotlin.backend.konan.LinkStage$linkStage$1.invoke(LinkStage.kt:29)
	at org.jetbrains.kotlin.backend.konan.PhaseManager$phase$$inlined$with$lambda$1.invoke(KonanPhases.kt:146)
	at org.jetbrains.kotlin.backend.konan.PhaseManager$phase$$inlined$with$lambda$1.invoke(KonanPhases.kt:120)
	at org.jetbrains.kotlin.konan.util.UtilKt.profileIf(Util.kt:34)
	at org.jetbrains.kotlin.backend.konan.PhaseManager.phase(KonanPhases.kt:145)
	at org.jetbrains.kotlin.backend.konan.LinkStage.linkStage(LinkStage.kt:231)
	at org.jetbrains.kotlin.backend.konan.KonanDriverKt$runTopLevelPhases$7.invoke(KonanDriver.kt:118)
	at org.jetbrains.kotlin.backend.konan.KonanDriverKt$runTopLevelPhases$7.invoke(KonanDriver.kt)
	at org.jetbrains.kotlin.backend.konan.PhaseManager$phase$$inlined$with$lambda$1.invoke(KonanPhases.kt:146)
	at org.jetbrains.kotlin.backend.konan.PhaseManager$phase$$inlined$with$lambda$1.invoke(KonanPhases.kt:120)
	at org.jetbrains.kotlin.konan.util.UtilKt.profileIf(Util.kt:34)
	at org.jetbrains.kotlin.backend.konan.PhaseManager.phase(KonanPhases.kt:145)
	at org.jetbrains.kotlin.backend.konan.KonanDriverKt.runTopLevelPhases(KonanDriver.kt:117)
	at org.jetbrains.kotlin.cli.bc.K2Native.doExecute(K2Native.kt:89)
	at org.jetbrains.kotlin.cli.bc.K2Native.doExecute(K2Native.kt:45)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.java:96)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.java:52)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:93)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:71)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:39)
	at org.jetbrains.kotlin.cli.common.CLITool$Companion.doMainNoExit(CLITool.kt:202)
	at org.jetbrains.kotlin.cli.common.CLITool$Companion.doMain(CLITool.kt:194)
	at org.jetbrains.kotlin.cli.bc.K2Native$Companion$main$1.invoke(K2Native.kt:213)
	at org.jetbrains.kotlin.cli.bc.K2Native$Companion$main$1.invoke(K2Native.kt:204)
	at org.jetbrains.kotlin.konan.util.UtilKt.profileIf(Util.kt:34)
	at org.jetbrains.kotlin.konan.util.UtilKt.profile(Util.kt:29)
	at org.jetbrains.kotlin.cli.bc.K2Native$Companion.main(K2Native.kt:206)
	at org.jetbrains.kotlin.cli.bc.K2NativeKt.main(K2Native.kt:218)



FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':backend.native:tests:interop_zlib'.
> Process 'command 'C:\Program Files\Java\jdk1.8.0_111\bin\java.exe'' finished with non-zero exit value 2

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.7/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 8s
65 actionable tasks: 1 executed, 64 up-to-date
```
