### PR TITLE
Fix kotlin.system.getTimeMillis()

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -513,6 +513,11 @@ task runtime_worker_random(type: RunKonanTest) {
     source = "runtime/basic/worker_random.kt"
 }
 
+task runtime_time(type: RunKonanTest) {
+    goldValue = "since-epoch\ntime-advances\n"
+    source = "runtime/time/time0.kt"
+}
+
 task hello0(type: RunKonanTest) {
     goldValue = "Hello, world!\n"
     source = "runtime/basic/hello0.kt"

--- a/backend.native/tests/runtime/time/time0.kt
+++ b/backend.native/tests/runtime/time/time0.kt
@@ -1,0 +1,18 @@
+package runtime.time.time0
+
+import kotlin.system.*
+import kotlin.test.*
+
+@Test fun runTest() {
+    val time1 = getTimeMillis()
+    if (time1 >= 1508887000000) {
+        println("since-epoch")
+    }
+    while (true) {
+        val time2 = getTimeMillis()
+        if (time2 > time1) {
+            println("time-advances")
+            break
+        }
+    }
+}

--- a/runtime/src/main/cpp/Porting.cpp
+++ b/runtime/src/main/cpp/Porting.cpp
@@ -263,7 +263,7 @@ uint64_t getTimeNanos() {
 using namespace std::chrono;
 
 uint64_t getTimeMillis() {
-  return duration_cast<milliseconds>(high_resolution_clock::now().time_since_epoch()).count();
+  return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
 
 uint64_t getTimeNanos() {


### PR DESCRIPTION
- high_resolution_clock cannot be used with time_since_epoch