### PR TITLE
Devirtualization bug fix with main

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
@@ -253,6 +253,9 @@ internal object Devirtualization {
                             .filterIsInstance<DataFlowIR.Type.Public>()
                             .filter { !it.isAbstract }
                             .forEach { addInstantiatingClass(it) }
+                } else {
+                    // String is implicitly created as argument of <main>.
+                    addInstantiatingClass(symbolTable.mapType(context.irBuiltIns.stringType))
                 }
                 // Traverse call graph from the roots.
                 rootSet.forEach { dfs(it) }
@@ -701,6 +704,12 @@ internal object Devirtualization {
             private var stack = mutableListOf<DataFlowIR.FunctionSymbol>()
 
             fun build() {
+                if (entryPoint != null) {
+                    // String arguments are implicitly put into the <args> array parameter of <main>.
+                    concreteClass(symbolTable.mapType(context.irBuiltIns.stringType).resolved()).addEdge(
+                            fieldNode(constraintGraph.arrayItemField)
+                    )
+                }
                 rootSet.forEach { createFunctionConstraintGraph(it, true)!! }
                 while (stack.isNotEmpty()) {
                     val symbol = stack.pop()


### PR DESCRIPTION
Added explicit handling of arguments of `main`.

The main function has one argument: `Array<String>`. It is implicitly created by the runtime and is not visible to devirtualization analysis. Thus we need to take this into account explicitly with two steps:
1. Say that `String` is instantiated.
2. Add edge from `String` to `Array.Item`.