### PR TITLE
 Update Kotlin to 1.3-M2-release-211

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -181,6 +181,7 @@ targetList.each { target ->
                 '-output', project(':runtime').file("build/${target}Stdlib"),
                 '-produce', 'library', '-module_name', 'stdlib', '-XXLanguage:+AllowContractsForCustomFunctions',
                 '-Xmulti-platform', '-Xuse-experimental=kotlin.Experimental',
+                '-Xuse-experimental=kotlin.contracts.ExperimentalContracts',
                 commonSrc.absolutePath,
                 project(':Interop:Runtime').file('src/main/kotlin'),
                 project(':Interop:Runtime').file('src/native/kotlin'),

--- a/backend.native/tests/stdlib_external/utils.kt
+++ b/backend.native/tests/stdlib_external/utils.kt
@@ -15,6 +15,4 @@ public actual fun assertTypeEquals(expected: Any?, actual: Any?) {
     }
 }
 
-public actual fun randomInt(limit: Int): Int = kotlin.random.Random.nextInt(limit)
-
 internal actual fun String.removeLeadingPlusOnJava6(): String = this

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/builtins/konan/KonanBuiltIns.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/builtins/konan/KonanBuiltIns.kt
@@ -1,11 +1,19 @@
 package org.jetbrains.kotlin.builtins.konan
 
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
+import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.resolve.DescriptorUtils.COROUTINES_PACKAGE_FQ_NAME_RELEASE
 import org.jetbrains.kotlin.storage.StorageManager
 
 class KonanBuiltIns(storageManager: StorageManager) : KotlinBuiltIns(storageManager) {
 
     override fun getSuspendFunction(parameterCount: Int) =
-            getBuiltInClassByName(Name.identifier("SuspendFunction$parameterCount"))
+            builtInsModule.findClassAcrossModuleDependencies(
+                    ClassId(
+                            COROUTINES_PACKAGE_FQ_NAME_RELEASE,
+                            Name.identifier("SuspendFunction$parameterCount")
+                    )
+            )!!
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@
 #
 
 # A version of the Kotlin "toolchain" (compiler, runtime, stdlib etc) used by the build script.
-buildKotlinVersion=1.3-M1-eap-77
-buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_13M1_Compiler),number:1.3-M1-eap-77,branch:default:any/artifacts/content/maven
+buildKotlinVersion=1.3-M1
+buildKotlinCompilerRepo=http://dl.bintray.com/kotlin/kotlin-eap
 remoteRoot=konan_tests
 testDataVersion=1226829:id
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_13M2_CompilerAllPlugins),number:1.3-M2-release-200,tag:kotlin-native,pinned:true,branch:(default:any)/artifacts/content/maven

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@ buildKotlinVersion=1.3-M1
 buildKotlinCompilerRepo=http://dl.bintray.com/kotlin/kotlin-eap
 remoteRoot=konan_tests
 testDataVersion=1226829:id
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_13M2_CompilerAllPlugins),number:1.3-M2-release-200,tag:kotlin-native,pinned:true,branch:(default:any)/artifacts/content/maven
-kotlinVersion=1.3-M2-release-200
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_13M2_CompilerAllPlugins),number:1.3-M2-release-211,tag:kotlin-native,pinned:true,branch:(default:any)/artifacts/content/maven
+kotlinVersion=1.3-M2-release-211
 testKotlinVersion=1.3-M2-release-203
 konanVersion=0.9
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'

--- a/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
@@ -607,6 +607,213 @@ public inline fun <T> Array<out T>.subarrayContentToString(offset: Int, length: 
 }
 
 /**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun <T> Array<out T>.copyInto(destination: Array<T>, destinationOffset: Int, startIndex: Int, endIndex: Int): Array<T> {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun ByteArray.copyInto(destination: ByteArray, destinationOffset: Int, startIndex: Int, endIndex: Int): ByteArray {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun ShortArray.copyInto(destination: ShortArray, destinationOffset: Int, startIndex: Int, endIndex: Int): ShortArray {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun IntArray.copyInto(destination: IntArray, destinationOffset: Int, startIndex: Int, endIndex: Int): IntArray {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun LongArray.copyInto(destination: LongArray, destinationOffset: Int, startIndex: Int, endIndex: Int): LongArray {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun FloatArray.copyInto(destination: FloatArray, destinationOffset: Int, startIndex: Int, endIndex: Int): FloatArray {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun DoubleArray.copyInto(destination: DoubleArray, destinationOffset: Int, startIndex: Int, endIndex: Int): DoubleArray {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun BooleanArray.copyInto(destination: BooleanArray, destinationOffset: Int, startIndex: Int, endIndex: Int): BooleanArray {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
+ * Copies this array or its subrange into the [destination] array and returns that array.
+ *
+ * It's allowed to pass the same array in the [destination] and even specify the subrange so that it overlaps with the destination range.
+ *
+ * @param destination the array to copy to.
+ * @param destinationOffset the position in the [destination] array to copy to, 0 by default.
+ * @param startIndex the beginning (inclusive) of the subrange to copy, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to copy, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of this array indices or when `startIndex > endIndex`.
+ * @throws IndexOutOfBoundsException when the subrange doesn't fit into the [destination] array starting at the specified [destinationIndex],
+ * or when that index is out of the [destination] array indices range.
+ *
+ * @return the [destination] array.
+ */
+@SinceKotlin("1.3")
+public actual fun CharArray.copyInto(destination: CharArray, destinationOffset: Int, startIndex: Int, endIndex: Int): CharArray {
+    val realEndIndex = if (endIndex == -1) this.size else endIndex // TODO: Remove when default value from expect is fixed
+    this.copyRangeTo(destination, startIndex, realEndIndex, destinationOffset)
+    return destination
+}
+
+/**
  * Returns `true` if the two specified arrays are *deeply* equal to one another,
  * i.e. contain the same number of the same elements in the same order.
  *

--- a/runtime/src/main/kotlin/kotlin/coroutines/SuspendFunction.kt
+++ b/runtime/src/main/kotlin/kotlin/coroutines/SuspendFunction.kt
@@ -3,7 +3,7 @@
  * that can be found in the LICENSE file.
  */
 
-package kotlin
+package kotlin.coroutines
 
 import kotlin.native.internal.FixmeReflection
 

--- a/runtime/src/main/kotlin/kotlin/coroutines/SuspendFunctions.kt
+++ b/runtime/src/main/kotlin/kotlin/coroutines/SuspendFunctions.kt
@@ -3,7 +3,7 @@
  * that can be found in the LICENSE file.
  */
 
-package kotlin
+package kotlin.coroutines
 
 public interface SuspendFunction0<out R> : SuspendFunction<R> {
     operator suspend fun invoke(): R

--- a/runtime/src/main/kotlin/kotlin/text/StringNumberConversions.kt
+++ b/runtime/src/main/kotlin/kotlin/text/StringNumberConversions.kt
@@ -149,5 +149,3 @@ public actual fun String.toDoubleOrNull(): Double? {
         return null
     }
 }
-
-internal fun numberFormatError(input: String): Nothing = throw NumberFormatException("Invalid number format: '$input'")


### PR DESCRIPTION
Built from rrr/1.3-M2/kotlin-native-upstream (921831e7)
based on 1.3-M2 release.

Fix #1968

Also update buildKotlinVersion to 1.3-M1 to prevent Gradle plugin from depending on unreleased Kotlin artifacts
