### PR TITLE
more fixed for documentation files

### DIFF
--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -60,8 +60,8 @@ title: "Concurrency in Kotlin/Native"
   For more complete example please refer to the [workers example](https://github.com/JetBrains/kotlin-native/tree/master/samples/workers)
  in the Kotlin/Native repository.
 
-
-## <a name="transfer"></a>Object transfer and freezing
+<a name="transfer"></a>
+## Object transfer and freezing
 
    Important invariant that Kotlin/Native runtime maintains is that object is either owned by a single
   thread/worker, or is immutable (_shared XOR mutable_). This ensures that the same data has a single mutator, and so no need for
@@ -82,7 +82,8 @@ title: "Concurrency in Kotlin/Native"
  is allowed. Currently, Kotlin/Native runtime only freezes enum objects after creation, although additional
  autofreezing of certain provably immutable objects could be implemented in the future.
 
-## <a name="detach"></a>Object subgraph detachment
+<a name="detach"></a>
+## Object subgraph detachment
 
    Object subgraph without external references could be disconnected using `detachObjectGraph` to
   a `COpaquePointer` value, which could be stored in `void*` data, so disconnected object subgraphs
@@ -90,7 +91,8 @@ title: "Concurrency in Kotlin/Native"
   or worker. Combined with [raw memory sharing](#shared) it allows side channel object transfer between
   concurrent threads, if worker mechanisms are insufficient for the particular task.
 
-## <a name="shared"></a>Raw shared memory
+<a name="shared"></a>
+## Raw shared memory
 
   Considering strong ties of Kotlin/Native with C via interoperability, in conjunction with other mechanisms
  mentioned above one could build popular data structures, like concurrent hashmap or shared cache with
@@ -118,7 +120,8 @@ class SharedData(rawPtr: NativePtr) : CStructVar(rawPtr) {
 So combined with the top level variable declared above, it allows seeing the same memory from different
 threads and building traditional concurrent structures with platform-specific synchronization primitives.
 
-## <a name="top_level"></a>Global variables and singletons
+<a name="top_level"></a>
+## Global variables and singletons
 
   Frequently, global variables are a source of unintended concurrency issues, so _Kotlin/Native_ implements
 following mechanisms to prevent unintended sharing of state via global objects:

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Concurrency in Kotlin/Native"
----
-
 ### Concurrency in Kotlin/Native
 
   Kotlin/Native runtime doesn't encourage a classical thread-oriented concurrency

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Debugging"
----
-
 ## Debugging
 
 Currently Kotlin native compiler produces debug info compatible with DWARF 2 specification, so modern debugger tools could

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,8 +1,3 @@
----
-type: doc
-layout: reference
-title: "FAQ"
----
 ### Q: How do I run my program?
 
 A: Define top level function `fun main(args: Array<String>)`, please ensure it's not

--- a/GRADLE_PLUGIN.md
+++ b/GRADLE_PLUGIN.md
@@ -63,7 +63,7 @@ The Kotlin/Native Gradle plugin allows one to build artifacts of the following t
 
 * Executable
 * KLibrary - a library used by Kotlin/Native compiler (`*.klib`)
-* Interoperability library - a special type of library providing an interoperability with some native API. See [INTEROP.md](c_interop.html) for details
+* Interoperability library - a special type of library providing an interoperability with some native API. See [INTEROP.md](INTEROP.md) for details
 * Dynamic library (`*.so`/`*.dylib`/`*.dll`)
 * Objective-C framework
 * LLVM bitcode

--- a/GRADLE_PLUGIN.md
+++ b/GRADLE_PLUGIN.md
@@ -69,7 +69,7 @@ The Kotlin/Native Gradle plugin allows one to build artifacts of the following t
 
 * Executable
 * KLibrary - a library used by Kotlin/Native compiler (`*.klib`)
-* Interoperability library - a special type of library providing an interoperability with some native API. See [`INTEROP.md`](INTEROP.md) for details
+* Interoperability library - a special type of library providing an interoperability with some native API. See [INTEROP.md](c_interop.html) for details
 * Dynamic library (`*.so`/`*.dylib`/`*.dll`)
 * Objective-C framework
 * LLVM bitcode
@@ -381,7 +381,7 @@ Using a dynamic library is shown in the [python extension sample](samples/python
 
 An Objective-C framework can be built using the `framework` artifact block. This block contains the
 same options as other ones. One may access the framework built using `artifact` property of the building task
-(see the [**Tasks**](#Tasks) section). Unlike other artifacts this property points to a directory instead of a regular file.
+(see the [**Tasks**](#tasks) section). Unlike other artifacts this property points to a directory instead of a regular file.
     
     ```
     konanArtifacts {

--- a/GRADLE_PLUGIN.md
+++ b/GRADLE_PLUGIN.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Kotlin/Native Gradle plugin"
----
-
 # Kotlin/Native Gradle plugin
 
 _Note: For the experimental DSL see the [corresponding section](#experimental-plugin)_.

--- a/IMMUTABILITY.md
+++ b/IMMUTABILITY.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Immutability in Kotlin/Native"
----
-
 # Immutability in Kotlin/Native
 
  Kotlin/Native implements strict mutability checks, ensuring

--- a/INTEROP.md
+++ b/INTEROP.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Kotlin/Native interoperability"
----
-
 # _Kotlin/Native_ interoperability #
 
 ## Introduction ##

--- a/INTEROP.md
+++ b/INTEROP.md
@@ -18,7 +18,7 @@ types, function and constants into the Kotlin world. Generated stubs can be
 imported into an IDE for purposes of code completion and navigation.
 
  Interoperability with Swift/Objective-C is provided too and covered by the
-separate document [OBJC_INTEROP.md](objc_interop.html).
+separate document [OBJC_INTEROP.md](OBJC_INTEROP.md).
 
 ## Simple example ##
 

--- a/INTEROP.md
+++ b/INTEROP.md
@@ -24,7 +24,7 @@ types, function and constants into the Kotlin world. Generated stubs can be
 imported into an IDE for purposes of code completion and navigation.
 
  Interoperability with Swift/Objective-C is provided too and covered by the
-separate document [OBJC_INTEROP.md](OBJC_INTEROP.md).
+separate document [OBJC_INTEROP.md](objc_interop.html).
 
 ## Simple example ##
 

--- a/LIBRARIES.md
+++ b/LIBRARIES.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Kotlin/Native libraries"
----
-
 # Kotlin/Native libraries
 
 ## Kotlin compiler specifics

--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Kotlin/Native in multiplatform projects"
----
-
 # Kotlin/Native in multiplatform projects
 
 While Kotlin/Native could be used as the only Kotlin compiler in the project, it is pretty common to combine

--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -374,5 +374,5 @@ framework in order to get code completion). Let's print our greeting:
 ### Sample
 
 A sample implementation which follows these documenation can be found [here](https://github.com/JetBrains/kotlin-mpp-example).
-You may also look at the [calculator sample](samples/calculator). It has a simpler structure (particularly both Android app
+You may also look at the [calculator sample](https://github.com/JetBrains/kotlin-native/tree/master/samples/calculator). It has a simpler structure (particularly both Android app
 and Kotlin/Native library are combined in a single Gradle build) but also uses the multiplatform support provided by Kotlin. 

--- a/OBJC_INTEROP.md
+++ b/OBJC_INTEROP.md
@@ -9,7 +9,7 @@ Kotlin/Native provides bidirectional interoperability with Objective-C.
 Objective-C frameworks and libraries can be used in Kotlin code if
 properly imported to the build (system frameworks are imported by default).
 See e.g. "Interop libraries" in
-[Gradle plugin documentation](gradle_plugin.html#building-artifacts).
+[Gradle plugin documentation](GRADLE_PLUGIN.md#building-artifacts).
 Swift library can be used in Kotlin code if its API is exported to Objective-C
 with `@objc`. Pure Swift modules are not yet supported.
 
@@ -231,5 +231,5 @@ this library would disable these compiler checks.
 
 ## C features
 
-See [INTEROP.md](c_interop.html) for the case when library uses some plain C features
+See [INTEROP.md](INTEROP.md) for the case when library uses some plain C features
 (e.g. unsafe pointers, structs etc.).

--- a/OBJC_INTEROP.md
+++ b/OBJC_INTEROP.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Kotlin/Native interoperability with Swift/Objective-C"
----
-
 # _Kotlin/Native_ interoperability with Swift/Objective-C
 
 This documents covers some details of Kotlin/Native interoperability with
@@ -20,7 +14,7 @@ Swift library can be used in Kotlin code if its API is exported to Objective-C
 with `@objc`. Pure Swift modules are not yet supported.
 
 Kotlin module can be used in Swift/Objective-C code if compiled into a
-[framework](gradle_plugin.html#framework). See [calculator sample](https://github.com/JetBrains/kotlin-native/tree/master/samples/calculator)
+[framework](GRADLE_PLUGIN.md#framework). See [calculator sample](https://github.com/JetBrains/kotlin-native/tree/master/samples/calculator)
 as an example.
 
 ## Mappings

--- a/OBJC_INTEROP.md
+++ b/OBJC_INTEROP.md
@@ -15,12 +15,12 @@ Kotlin/Native provides bidirectional interoperability with Objective-C.
 Objective-C frameworks and libraries can be used in Kotlin code if
 properly imported to the build (system frameworks are imported by default).
 See e.g. "Interop libraries" in
-[Gradle plugin documentation](GRADLE_PLUGIN.md#building-artifacts).
+[Gradle plugin documentation](gradle_plugin.html#building-artifacts).
 Swift library can be used in Kotlin code if its API is exported to Objective-C
 with `@objc`. Pure Swift modules are not yet supported.
 
 Kotlin module can be used in Swift/Objective-C code if compiled into a
-[framework](GRADLE_PLUGIN.md#framework). See [calculator sample](samples/calculator)
+[framework](gradle_plugin.html#framework). See [calculator sample](https://github.com/JetBrains/kotlin-native/tree/master/samples/calculator)
 as an example.
 
 ## Mappings
@@ -48,7 +48,7 @@ The table below shows how Kotlin concepts are mapped to Swift/Objective-C and vi
 | `Set` | `Set` | `NSSet` | |
 | `MutableSet` | `NSMutableSet` | `NSMutableSet` | [note](#collections) |
 | `Map` | `Dictionary` | `NSDictionary` | |
-| `MutableMap` | `NSMutableDictionary` | `NSMutableDictionary` | [note](#mutable-collections) |
+| `MutableMap` | `NSMutableDictionary` | `NSMutableDictionary` | [note](#collections) |
 | Function type | Function type | Block pointer type | [note](#function-types) |
 
 ### Name translation
@@ -237,5 +237,5 @@ this library would disable these compiler checks.
 
 ## C features
 
-See [INTEROP.md](INTEROP.md) for the case when library uses some plain C features
+See [INTEROP.md](c_interop.html) for the case when library uses some plain C features
 (e.g. unsafe pointers, structs etc.).

--- a/PLATFORM_LIBS.md
+++ b/PLATFORM_LIBS.md
@@ -1,9 +1,3 @@
----
-type: doc
-layout: reference
-title: "Platform libraries"
----
-
 # Platform libraries
 
 ## Overview


### PR DESCRIPTION
More fixes to make kotlin-web-site compile
those changes breaks links between `.md` files on GitHub