### PR TITLE
Split serialized package fragments metadata

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.backend.konan
 
 import org.jetbrains.kotlin.backend.konan.descriptors.findPackage
+import org.jetbrains.kotlin.backend.konan.descriptors.findPackageView
 import org.jetbrains.kotlin.backend.konan.descriptors.getStringValue
 import org.jetbrains.kotlin.backend.konan.irasdescriptors.constructedClass
 import org.jetbrains.kotlin.backend.konan.irasdescriptors.getExternalObjCMethodInfo
@@ -21,6 +22,7 @@ import org.jetbrains.kotlin.resolve.ExternalOverridabilityCondition
 import org.jetbrains.kotlin.resolve.constants.BooleanValue
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperClassifiers
+import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
@@ -75,15 +77,15 @@ private fun FunctionDescriptor.decodeObjCMethodAnnotation(): ObjCMethodInfo? {
     assert (this.kind.isReal)
 
     val methodAnnotation = this.annotations.findAnnotation(objCMethodFqName) ?: return null
-    val packageFragment = this.findPackage()
+    val packageView = this.findPackageView()
 
     val bridgeName = methodAnnotation.getStringValue("bridge")
 
-    return objCMethodInfoByBridge(packageFragment, bridgeName)
+    return objCMethodInfoByBridge(packageView, bridgeName)
 }
 
-private fun objCMethodInfoByBridge(packageFragment: PackageFragmentDescriptor, bridgeName: String): ObjCMethodInfo {
-    val bridge = packageFragment.getMemberScope()
+private fun objCMethodInfoByBridge(packageView: PackageViewDescriptor, bridgeName: String): ObjCMethodInfo {
+    val bridge = packageView.memberScope
             .getContributedFunctions(Name.identifier(bridgeName), NoLookupLocation.FROM_BACKEND)
             .single()
 
@@ -213,7 +215,7 @@ fun FunctionDescriptor.getObjCFactoryInitMethodInfo(): ObjCMethodInfo? {
     val factoryAnnotation = this.annotations.findAnnotation(objCFactoryFqName) ?: return null
     val bridgeName = factoryAnnotation.getStringValue("bridge")
 
-    return objCMethodInfoByBridge(this.findPackage(), bridgeName)
+    return objCMethodInfoByBridge(this.findPackageView(), bridgeName)
 }
 
 fun inferObjCSelector(descriptor: FunctionDescriptor): String = if (descriptor.valueParameters.isEmpty()) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/LegacyDescriptorUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/LegacyDescriptorUtils.kt
@@ -114,6 +114,11 @@ tailrec internal fun DeclarationDescriptor.findPackage(): PackageFragmentDescrip
     else this.containingDeclaration!!.findPackage()
 }
 
+internal fun DeclarationDescriptor.findPackageView(): PackageViewDescriptor {
+    val packageFragment = this.findPackage()
+    return packageFragment.module.getPackage(packageFragment.fqName)
+}
+
 internal fun DeclarationDescriptor.allContainingDeclarations(): List<DeclarationDescriptor> {
     var list = mutableListOf<DeclarationDescriptor>()
     var current = this.containingDeclaration

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibraryWriter.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/KonanLibraryWriter.kt
@@ -25,7 +25,7 @@ interface KonanLibraryWriter {
 
 class LinkData(
     val module: ByteArray,
-    val fragments: List<ByteArray>,
+    val fragments: List<List<ByteArray>>,
     val fragmentNames: List<String> 
 )
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/MetadataWriterImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/MetadataWriterImpl.kt
@@ -13,8 +13,11 @@ internal class MetadataWriterImpl(libraryLayout: KonanLibraryLayout): KonanLibra
     fun addLinkData(linkData: LinkData) {
         moduleHeaderFile.writeBytes(linkData.module)
         linkData.fragments.forEachIndexed { index, it ->
-            val name = linkData.fragmentNames[index] 
-            packageFile(name).writeBytes(it)
+            val name = linkData.fragmentNames[index]
+            packageFragmentsDir(name).mkdirs()
+            for ((i, fragment) in it.withIndex()) {
+                packageFragmentFile(name, i).writeBytes(fragment)
+            }
         }
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/MetadataWriterImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/library/impl/MetadataWriterImpl.kt
@@ -13,10 +13,15 @@ internal class MetadataWriterImpl(libraryLayout: KonanLibraryLayout): KonanLibra
     fun addLinkData(linkData: LinkData) {
         moduleHeaderFile.writeBytes(linkData.module)
         linkData.fragments.forEachIndexed { index, it ->
-            val name = linkData.fragmentNames[index]
-            packageFragmentsDir(name).mkdirs()
+            val packageFqName = linkData.fragmentNames[index]
+            val shortName = packageFqName.substringAfterLast(".")
+            val dir = packageFragmentsDir(packageFqName)
+            dir.deleteRecursively()
+            dir.mkdirs()
+            val numCount = it.size.toString().length
+            fun withLeadingZeros(i: Int) = String.format("%0${numCount}d", i)
             for ((i, fragment) in it.withIndex()) {
-                packageFragmentFile(name, i).writeBytes(fragment)
+                packageFragmentFile(packageFqName, "${withLeadingZeros(i)}_$shortName").writeBytes(fragment)
             }
         }
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanDescriptorSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanDescriptorSerializer.kt
@@ -615,7 +615,7 @@ class KonanDescriptorSerializer private constructor(
     fun packagePartProto(packageFqName: FqName, members: Collection<DeclarationDescriptor>): ProtoBuf.Package.Builder {
         val builder = ProtoBuf.Package.newBuilder()
 
-        for (declaration in sort(members)) {
+        for (declaration in members) {
             when (declaration) {
                 is PropertyDescriptor -> builder.addProperty(propertyProto(declaration))
                 is FunctionDescriptor -> builder.addFunction(functionProto(declaration))

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibrary.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibrary.kt
@@ -38,7 +38,8 @@ interface KonanLibrary {
 
     val dataFlowGraph: ByteArray?
     val moduleHeaderData: ByteArray
-    fun packageMetadata(fqName: String): ByteArray
+    fun packageMetadataPartCount(fqName: String): Int
+    fun packageMetadata(fqName: String, partIndex: Int): ByteArray
 }
 
 val KonanLibrary.uniqueName

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibrary.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibrary.kt
@@ -38,8 +38,8 @@ interface KonanLibrary {
 
     val dataFlowGraph: ByteArray?
     val moduleHeaderData: ByteArray
-    fun packageMetadataPartCount(fqName: String): Int
-    fun packageMetadata(fqName: String, partIndex: Int): ByteArray
+    fun packageMetadataParts(fqName: String): Set<String>
+    fun packageMetadata(fqName: String, partName: String): ByteArray
 }
 
 val KonanLibrary.uniqueName

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibraryConstants.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibraryConstants.kt
@@ -1,0 +1,4 @@
+package org.jetbrains.kotlin.konan.library
+
+const val KLIB_METADATA_FILE_EXTENSION = "knm"
+const val KLIB_METADATA_FILE_EXTENSION_WITH_DOT = ".$KLIB_METADATA_FILE_EXTENSION"

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibraryLayout.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibraryLayout.kt
@@ -39,6 +39,9 @@ interface KonanLibraryLayout {
     val dataFlowGraphFile
         get() = File(linkdataDir, "module_data_flow_graph")
 
-    fun packageFile(packageName: String)
-            = File(linkdataDir, if (packageName == "") "root_package.knm" else "package_$packageName.knm")
+    fun packageFragmentsDir(packageName: String)
+            = File(linkdataDir, if (packageName == "") "root_package" else "package_$packageName")
+
+    fun packageFragmentFile(packageFqName: String, partIndex: Int) =
+            File(packageFragmentsDir(packageFqName), "$partIndex.knm")
 }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibraryLayout.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanLibraryLayout.kt
@@ -42,6 +42,6 @@ interface KonanLibraryLayout {
     fun packageFragmentsDir(packageName: String)
             = File(linkdataDir, if (packageName == "") "root_package" else "package_$packageName")
 
-    fun packageFragmentFile(packageFqName: String, partIndex: Int) =
-            File(packageFragmentsDir(packageFqName), "$partIndex.knm")
+    fun packageFragmentFile(packageFqName: String, partName: String) =
+            File(packageFragmentsDir(packageFqName), "$partName$KLIB_METADATA_FILE_EXTENSION_WITH_DOT")
 }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanMetadataReader.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanMetadataReader.kt
@@ -2,5 +2,5 @@ package org.jetbrains.kotlin.konan.library
 
 interface MetadataReader {
     fun loadSerializedModule(libraryLayout: KonanLibraryLayout): ByteArray
-    fun loadSerializedPackageFragment(libraryLayout: KonanLibraryLayout, fqName: String): ByteArray
+    fun loadSerializedPackageFragment(libraryLayout: KonanLibraryLayout, fqName: String, partIndex: Int): ByteArray
 }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanMetadataReader.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/KonanMetadataReader.kt
@@ -2,5 +2,5 @@ package org.jetbrains.kotlin.konan.library
 
 interface MetadataReader {
     fun loadSerializedModule(libraryLayout: KonanLibraryLayout): ByteArray
-    fun loadSerializedPackageFragment(libraryLayout: KonanLibraryLayout, fqName: String, partIndex: Int): ByteArray
+    fun loadSerializedPackageFragment(libraryLayout: KonanLibraryLayout, fqName: String, partName: String): ByteArray
 }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/impl/DefaultMetadataReaderImpl.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/impl/DefaultMetadataReaderImpl.kt
@@ -8,6 +8,6 @@ internal object DefaultMetadataReaderImpl : MetadataReader {
     override fun loadSerializedModule(libraryLayout: KonanLibraryLayout): ByteArray =
             libraryLayout.moduleHeaderFile.readBytes()
 
-    override fun loadSerializedPackageFragment(libraryLayout: KonanLibraryLayout, fqName: String): ByteArray =
-            libraryLayout.packageFile(fqName).readBytes()
+    override fun loadSerializedPackageFragment(libraryLayout: KonanLibraryLayout, fqName: String, partIndex: Int): ByteArray =
+            libraryLayout.packageFragmentFile(fqName, partIndex).readBytes()
 }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/impl/DefaultMetadataReaderImpl.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/impl/DefaultMetadataReaderImpl.kt
@@ -8,6 +8,6 @@ internal object DefaultMetadataReaderImpl : MetadataReader {
     override fun loadSerializedModule(libraryLayout: KonanLibraryLayout): ByteArray =
             libraryLayout.moduleHeaderFile.readBytes()
 
-    override fun loadSerializedPackageFragment(libraryLayout: KonanLibraryLayout, fqName: String, partIndex: Int): ByteArray =
-            libraryLayout.packageFragmentFile(fqName, partIndex).readBytes()
+    override fun loadSerializedPackageFragment(libraryLayout: KonanLibraryLayout, fqName: String, partName: String): ByteArray =
+            libraryLayout.packageFragmentFile(fqName, partName).readBytes()
 }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
@@ -56,7 +56,10 @@ internal class KonanLibraryImpl(
 
     override val moduleHeaderData: ByteArray by lazy { layout.inPlace { metadataReader.loadSerializedModule(it) } }
 
-    override fun packageMetadata(fqName: String) = layout.inPlace { metadataReader.loadSerializedPackageFragment(it, fqName) }
+    override fun packageMetadataPartCount(fqName: String): Int =
+            layout.inPlace { it.packageFragmentsDir(fqName).listFiles.count { file -> file.extension == "knm" } }
+
+    override fun packageMetadata(fqName: String, partIndex: Int) = layout.inPlace { metadataReader.loadSerializedPackageFragment(it, fqName, partIndex) }
 
     override fun toString() = "$libraryName[default=$isDefault]"
 }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
@@ -56,10 +56,24 @@ internal class KonanLibraryImpl(
 
     override val moduleHeaderData: ByteArray by lazy { layout.inPlace { metadataReader.loadSerializedModule(it) } }
 
-    override fun packageMetadataPartCount(fqName: String): Int =
-            layout.inPlace { it.packageFragmentsDir(fqName).listFiles.count { file -> file.extension == "knm" } }
+    override fun packageMetadata(packageFqName: String, partName: String) =
+            layout.inPlace { metadataReader.loadSerializedPackageFragment(it, packageFqName, partName) }
 
-    override fun packageMetadata(fqName: String, partIndex: Int) = layout.inPlace { metadataReader.loadSerializedPackageFragment(it, fqName, partIndex) }
+    override fun packageMetadataParts(fqName: String): Set<String> =
+            layout.inPlace { inPlaceLayout ->
+                val fileList =
+                        inPlaceLayout.packageFragmentsDir(fqName)
+                                .listFiles
+                                .mapNotNull {
+                                    it.name
+                                            .substringBeforeLast(KLIB_METADATA_FILE_EXTENSION_WITH_DOT, missingDelimiterValue = "")
+                                            .takeIf { it.isNotEmpty() }
+                                }
+
+                fileList.toSortedSet().also {
+                    require(it.size == fileList.size) { "Duplicated names: ${fileList.groupingBy { it }.eachCount().filter { (_, count) -> count > 1 }}" }
+                }
+            }
 
     override fun toString() = "$libraryName[default=$isDefault]"
 }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/KonanClassDataFinder.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/KonanClassDataFinder.kt
@@ -18,8 +18,9 @@ class KonanClassDataFinder(
         val nameList = proto.classNameList
 
         val index = nameList.indexOfFirst { nameResolver.getClassId(it) == classId }
-        if (index == -1)
-            error("Could not find serialized class $classId")
+        if (index == -1) {
+            return null
+        }
 
         val foundClass = proto.getClasses(index) ?: error("Could not find data for serialized class $classId")
 

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/KonanPackageFragment.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/KonanPackageFragment.kt
@@ -19,7 +19,8 @@ class KonanPackageFragment(
         private val library: KonanLibrary,
         private val packageAccessedHandler: PackageAccessedHandler?,
         storageManager: StorageManager,
-        module: ModuleDescriptor
+        module: ModuleDescriptor,
+        partIndex: Int
 ) : DeserializedPackageFragment(fqName, storageManager, module) {
 
     lateinit var components: DeserializationComponents
@@ -31,7 +32,7 @@ class KonanPackageFragment(
     // The proto field is lazy so that we can load only needed
     // packages from the library.
     private val protoForNames: KonanProtoBuf.LinkDataPackageFragment by lazy {
-        parsePackageFragment(library.packageMetadata(fqName.asString()))
+        parsePackageFragment(library.packageMetadata(fqName.asString(), partIndex))
     }
 
     val proto: KonanProtoBuf.LinkDataPackageFragment

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/KonanPackageFragment.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/KonanPackageFragment.kt
@@ -20,7 +20,7 @@ class KonanPackageFragment(
         private val packageAccessedHandler: PackageAccessedHandler?,
         storageManager: StorageManager,
         module: ModuleDescriptor,
-        partIndex: Int
+        partName: String
 ) : DeserializedPackageFragment(fqName, storageManager, module) {
 
     lateinit var components: DeserializationComponents
@@ -32,7 +32,7 @@ class KonanPackageFragment(
     // The proto field is lazy so that we can load only needed
     // packages from the library.
     private val protoForNames: KonanProtoBuf.LinkDataPackageFragment by lazy {
-        parsePackageFragment(library.packageMetadata(fqName.asString(), partIndex))
+        parsePackageFragment(library.packageMetadata(fqName.asString(), partName))
     }
 
     val proto: KonanProtoBuf.LinkDataPackageFragment

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/impl/KonanDeserializedPackageFragmentsFactoryImpl.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/impl/KonanDeserializedPackageFragmentsFactoryImpl.kt
@@ -29,8 +29,12 @@ internal object KonanDeserializedPackageFragmentsFactoryImpl: KonanDeserializedP
             moduleDescriptor: ModuleDescriptor,
             packageAccessedHandler: PackageAccessedHandler?,
             storageManager: StorageManager
-    ) = packageFragmentNames.map {
-        KonanPackageFragment(FqName(it), library, packageAccessedHandler, storageManager, moduleDescriptor)
+    ) = packageFragmentNames.flatMap {
+        val fqName = FqName(it)
+        val count = library.packageMetadataPartCount(fqName.asString())
+        List(count) { partIndex ->
+            KonanPackageFragment(fqName, library, packageAccessedHandler, storageManager, moduleDescriptor, partIndex)
+        }
     }
 
     override fun createSyntheticPackageFragments(

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/impl/KonanDeserializedPackageFragmentsFactoryImpl.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/serialization/konan/impl/KonanDeserializedPackageFragmentsFactoryImpl.kt
@@ -31,9 +31,9 @@ internal object KonanDeserializedPackageFragmentsFactoryImpl: KonanDeserializedP
             storageManager: StorageManager
     ) = packageFragmentNames.flatMap {
         val fqName = FqName(it)
-        val count = library.packageMetadataPartCount(fqName.asString())
-        List(count) { partIndex ->
-            KonanPackageFragment(fqName, library, packageAccessedHandler, storageManager, moduleDescriptor, partIndex)
+        val parts = library.packageMetadataParts(fqName.asString())
+        parts.map { partName ->
+            KonanPackageFragment(fqName, library, packageAccessedHandler, storageManager, moduleDescriptor, partName)
         }
     }
 


### PR DESCRIPTION
This mainly required to reduce IDE footprint
Also, this change improves size of Kotlin Native Dist
as it recreates string & names table per each package part