### PR TITLE
Improve framework translation

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -112,7 +112,6 @@ abstract class ObjCExportHeaderGenerator(
             descriptor: ClassDescriptor? = null,
             superClass: String? = null,
             superProtocols: List<String> = emptyList(),
-            categoryName: String? = null,
             members: List<Stub<*>> = emptyList(),
             attributes: List<String> = emptyList()
     ): ObjCInterface = ObjCInterface(
@@ -121,7 +120,7 @@ abstract class ObjCExportHeaderGenerator(
             descriptor,
             superClass,
             superProtocols,
-            categoryName,
+            null,
             members,
             attributes + name.toNameAttributes()
     )
@@ -156,8 +155,8 @@ abstract class ObjCExportHeaderGenerator(
         }))
 
         // TODO: add comment to the header.
-        stubs.add(objCInterface(
-                kotlinAnyName,
+        stubs.add(ObjCInterface(
+                kotlinAnyName.objCName,
                 superProtocols = listOf("NSCopying"),
                 categoryName = "${kotlinAnyName.objCName}Copying"
         ))
@@ -333,11 +332,11 @@ abstract class ObjCExportHeaderGenerator(
     private fun translateExtensions(classDescriptor: ClassDescriptor, declarations: List<CallableMemberDescriptor>) {
         translateClass(classDescriptor)
 
-        val name = translateClassName(classDescriptor)
+        val name = translateClassName(classDescriptor).objCName
         val members = buildMembers {
             translateMembers(declarations)
         }
-        stubs.add(objCInterface(name, categoryName = "Extensions", members = members))
+        stubs.add(ObjCInterface(name, categoryName = "Extensions", members = members))
     }
 
     private fun translateTopLevel(sourceFile: SourceFile, declarations: List<CallableMemberDescriptor>) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -444,11 +444,14 @@ private fun ObjCExportMapper.canHaveSameSelector(first: FunctionDescriptor, seco
     if (first.extensionReceiverParameter?.type != second.extensionReceiverParameter?.type) {
         return false
     }
-    if (first.valueParameters.map { it.type } != second.valueParameters.map { it.type }) {
+
+    if (first is PropertySetterDescriptor && second is PropertySetterDescriptor) {
+        // Methods should merge in any common subclass as it can't have two properties with same name.
+    } else if (first.valueParameters.map { it.type } == second.valueParameters.map { it.type }) {
+        // Methods should merge in any common subclasses since they have the same signature.
+    } else {
         return false
     }
-
-    // Otherwise both are Kotlin member methods should merge in any common subclass.
 
     // Check if methods have the same bridge (and thus the same ABI):
     return bridgeMethod(first) == bridgeMethod(second)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -407,7 +407,8 @@ private fun ObjCExportMapper.canBeInheritedBySameClass(
         second: CallableMemberDescriptor
 ): Boolean {
     if (this.isTopLevel(first) || this.isTopLevel(second)) {
-        return (first.containingDeclaration.fqNameSafe == second.containingDeclaration.fqNameSafe)
+        return this.isTopLevel(first) && this.isTopLevel(second) &&
+                first.source.containingFile == second.source.containingFile
     }
 
     val firstClass = this.getClassIfCategory(first) ?: first.containingDeclaration as ClassDescriptor

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -46,9 +46,6 @@ internal class ObjCExportNamerImpl(
         private val topLevelNamePrefix: String = moduleDescriptor.namePrefix
 ) : ObjCExportNamer {
 
-    private fun String.mangleClassOrProtocolName(): ObjCExportNamer.ClassOrProtocolName =
-            ObjCExportNamer.ClassOrProtocolName(swiftName = this, objCName = "$topLevelNamePrefix${this}")
-
     private fun String.toUnmangledClassOrProtocolName(): ObjCExportNamer.ClassOrProtocolName =
             ObjCExportNamer.ClassOrProtocolName(swiftName = this, objCName = this)
 
@@ -95,13 +92,15 @@ internal class ObjCExportNamerImpl(
                 !mapper.canHaveSameName(first, second)
     }
 
-    private val classNames = object : Mapping<Any, String>() {
-        override fun conflict(first: Any, second: Any): Boolean = true
+    private inner open class GlobalNameMapping<in T : Any, N> : Mapping<T, N>() {
+        final override fun conflict(first: T, second: T): Boolean = true
     }
 
-    private val protocolNames = object : Mapping<Any, String>() {
-        override fun conflict(first: Any, second: Any): Boolean = true
-    }
+    private val objCClassNames = GlobalNameMapping<Any, String>()
+    private val objCProtocolNames = GlobalNameMapping<ClassDescriptor, String>()
+
+    // Classes and protocols share the same namespace in Swift.
+    private val swiftClassAndProtocolNames = GlobalNameMapping<Any, String>()
 
     private abstract inner class ClassPropertyNameMapping<T : Any> : Mapping<T, String>() {
 
@@ -127,12 +126,26 @@ internal class ObjCExportNamerImpl(
                 first.containingDeclaration == second.containingDeclaration
     }
 
-    override fun getFileClassName(file: SourceFile): ObjCExportNamer.ClassOrProtocolName = classNames.getOrPut(file) {
-        val psiSourceFile = file as? PsiSourceFile ?: error("SourceFile '$file' is not PsiSourceFile")
-        val psiFile = psiSourceFile.psiFile
-        val ktFile = psiFile as? KtFile ?: error("PsiFile '$psiFile' is not KtFile")
-        StringBuilder(PackagePartClassUtils.getFilePartShortName(ktFile.name)).mangledSequence { append("_") }
-    }.mangleClassOrProtocolName()
+    override fun getFileClassName(file: SourceFile): ObjCExportNamer.ClassOrProtocolName {
+        val baseName by lazy {
+            val psiSourceFile = file as? PsiSourceFile ?: error("SourceFile '$file' is not PsiSourceFile")
+            val psiFile = psiSourceFile.psiFile
+            val ktFile = psiFile as? KtFile ?: error("PsiFile '$psiFile' is not KtFile")
+            PackagePartClassUtils.getFilePartShortName(ktFile.name)
+        }
+
+        val objCName = objCClassNames.getOrPut(file) {
+            StringBuilder(topLevelNamePrefix).append(baseName)
+                    .mangledBySuffixUnderscores()
+        }
+
+        val swiftName = swiftClassAndProtocolNames.getOrPut(file) {
+            StringBuilder(baseName)
+                    .mangledBySuffixUnderscores()
+        }
+
+        return ObjCExportNamer.ClassOrProtocolName(swiftName = swiftName, objCName = objCName)
+    }
 
     private val predefinedClassNames = mapOf(
             builtIns.any to kotlinAnyName,
@@ -140,22 +153,48 @@ internal class ObjCExportNamerImpl(
             builtIns.mutableMap to mutableMapName
     )
 
-    override fun getClassOrProtocolName(descriptor: ClassDescriptor): ObjCExportNamer.ClassOrProtocolName {
-        predefinedClassNames[descriptor]?.let { return it }
+    override fun getClassOrProtocolName(descriptor: ClassDescriptor): ObjCExportNamer.ClassOrProtocolName =
+            predefinedClassNames[descriptor]
+                    ?: ObjCExportNamer.ClassOrProtocolName(
+                            swiftName = getClassOrProtocolSwiftName(descriptor),
+                            objCName = getClassOrProtocolObjCName(descriptor)
+                    )
 
-        val mapping = if (descriptor.isInterface) protocolNames else classNames
+    private fun getClassOrProtocolSwiftName(
+            descriptor: ClassDescriptor
+    ): String = swiftClassAndProtocolNames.getOrPut(descriptor) {
+        StringBuilder().apply {
+            val containingDeclaration = descriptor.containingDeclaration
+            if (containingDeclaration is ClassDescriptor) {
+                append(getClassOrProtocolSwiftName(containingDeclaration))
+                        .append(".").append(descriptor.name.asString())
+            } else {
+                appendTopLevelClassBaseName(descriptor)
+            }
+        }.mangledBySuffixUnderscores()
+    }
 
-        return mapping.getOrPut(descriptor) {
+    private fun getClassOrProtocolObjCName(descriptor: ClassDescriptor): String {
+        val objCMapping = if (descriptor.isInterface) objCProtocolNames else objCClassNames
+        return objCMapping.getOrPut(descriptor) {
             StringBuilder().apply {
-                if (descriptor.module != moduleDescriptor) {
-                    append(descriptor.module.namePrefix)
-                }
+                val containingDeclaration = descriptor.containingDeclaration
+                if (containingDeclaration is ClassDescriptor) {
+                    append(getClassOrProtocolObjCName(containingDeclaration))
+                            .append(descriptor.name.asString().capitalize())
 
-                descriptor.parentsWithSelf.takeWhile { it is ClassDescriptor }
-                        .toList().reversed()
-                        .joinTo(this, "") { it.name.asString().capitalize() }
-            }.mangledSequence { append("_") }
-        }.mangleClassOrProtocolName()
+                } else {
+                    append(topLevelNamePrefix).appendTopLevelClassBaseName(descriptor)
+                }
+            }.mangledBySuffixUnderscores()
+        }
+    }
+
+    private fun StringBuilder.appendTopLevelClassBaseName(descriptor: ClassDescriptor) = apply {
+        if (descriptor.module != moduleDescriptor) {
+            append(descriptor.module.namePrefix)
+        }
+        append(descriptor.name.asString())
     }
 
     override fun getSelector(method: FunctionDescriptor): String = methodSelectors.getOrPut(method) {
@@ -258,7 +297,7 @@ internal class ObjCExportNamerImpl(
         return objectInstanceSelectors.getOrPut(descriptor) {
             val name = descriptor.name.asString().decapitalize().mangleIfSpecialFamily("get")
 
-            StringBuilder(name).mangledSequence { append("_") }
+            StringBuilder(name).mangledBySuffixUnderscores()
         }
     }
 
@@ -272,7 +311,7 @@ internal class ObjCExportNamerImpl(
                 if (index == 0) lower else lower.capitalize()
             }.joinToString("").mangleIfSpecialFamily("the")
 
-            StringBuilder(name).mangledSequence { append("_") }
+            StringBuilder(name).mangledBySuffixUnderscores()
         }
     }
 
@@ -280,8 +319,8 @@ internal class ObjCExportNamerImpl(
         val any = builtIns.any
 
         predefinedClassNames.forEach { descriptor, name ->
-            // Note: it is a hack.
-            classNames.forceAssign(descriptor, name.swiftName)
+            objCClassNames.forceAssign(descriptor, name.objCName)
+            swiftClassAndProtocolNames.forceAssign(descriptor, name.swiftName)
         }
 
         fun ClassDescriptor.method(name: String) =
@@ -336,7 +375,7 @@ internal class ObjCExportNamerImpl(
     private fun String.startsWithWords(words: String) = this.startsWith(words) &&
             (this.length == words.length || !this[words.length].isLowerCase())
 
-    private abstract inner class Mapping<T : Any, N>() {
+    private abstract inner class Mapping<in T : Any, N>() {
         private val elementToName = mutableMapOf<T, N>()
         private val nameToElements = mutableMapOf<N, MutableList<T>>()
 
@@ -389,6 +428,8 @@ private inline fun StringBuilder.mangledSequence(crossinline mangle: StringBuild
             this@mangledSequence.mangle()
             this@mangledSequence.toString()
         }
+
+private fun StringBuilder.mangledBySuffixUnderscores() = this.mangledSequence { append("_") }
 
 private fun ObjCExportMapper.canHaveCommonSubtype(first: ClassDescriptor, second: ClassDescriptor): Boolean {
     if (first.isSubclassOf(second) || second.isSubclassOf(first)) {

--- a/backend.native/tests/framework/values/values.swift
+++ b/backend.native/tests/framework/values/values.swift
@@ -377,7 +377,7 @@ func testDataClass() throws {
 }
 
 func testCompanionObj() throws {
-    try assertEquals(actual: WithCompanionAndObjectCompanion().str, expected: "String")
+    try assertEquals(actual: WithCompanionAndObject.Companion().str, expected: "String")
     try assertEquals(actual: ValuesKt.getCompanionObject().str, expected: "String")
 
     let namedFromCompanion = ValuesKt.getCompanionObject().named


### PR DESCRIPTION
* Don't add swift_name attribute to categories
* Improve name clash detection for top-level declarations
* Improve name clash detection for property setters (#1843)
* Don't add overriding and refining interface methods to protocols (#1884)
* Improve inner/nested class names in framework