### PR TITLE
Allow absent abiVersion and compilerVersion in library manifest, just…

### DIFF
--- a/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
+++ b/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
@@ -97,12 +97,16 @@ class Library(val name: String, val requestedRepository: String?, val target: St
     fun info() {
         val library = libraryInRepoOrCurrentDir(repository, name)
         val headerAbiVersion = library.versions.abiVersion
+        val headerCompilerVersion = library.versions.compilerVersion
+        val headerLibraryVersion = library.versions.libraryVersion
         val moduleName = ModuleDeserializer(library.moduleHeaderData).moduleName
 
         println("")
         println("Resolved to: ${library.libraryName.File().absolutePath}")
         println("Module name: $moduleName")
         println("ABI version: $headerAbiVersion")
+        println("Compiler version: $headerCompilerVersion")
+        println("Library version: $headerLibraryVersion")
         val targets = library.targetList.joinToString(", ")
         print("Available targets: $targets\n")
     }

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/KonanLibraryVersioning.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/KonanLibraryVersioning.kt
@@ -9,20 +9,20 @@ import org.jetbrains.kotlin.konan.parseKonanAbiVersion
 
 data class KonanLibraryVersioning(
     val libraryVersion: String?,
-    val compilerVersion: KonanVersion,
-    val abiVersion: KonanAbiVersion
+    val compilerVersion: KonanVersion?,
+    val abiVersion: KonanAbiVersion?
 )
 
 fun Properties.writeKonanLibraryVersioning(versions: KonanLibraryVersioning) {
-    this.setProperty(KLIB_PROPERTY_ABI_VERSION, versions.abiVersion.toString())
+    versions.abiVersion ?. let { this.setProperty(KLIB_PROPERTY_ABI_VERSION, it.toString()) }
     versions.libraryVersion ?. let { this.setProperty(KLIB_PROPERTY_LIBRARY_VERSION, it) }
-    this.setProperty(KLIB_PROPERTY_COMPILER_VERSION, "${versions.compilerVersion}")
+    versions.compilerVersion ?. let { this.setProperty(KLIB_PROPERTY_COMPILER_VERSION, "${versions.compilerVersion}") }
 }
 
 fun Properties.readKonanLibraryVersioning(): KonanLibraryVersioning {
-    val abiVersion = this.getProperty(KLIB_PROPERTY_ABI_VERSION)!!.parseKonanAbiVersion()
+    val abiVersion = this.getProperty(KLIB_PROPERTY_ABI_VERSION)?.parseKonanAbiVersion()
     val libraryVersion = this.getProperty(KLIB_PROPERTY_LIBRARY_VERSION)
-    val compilerVersion = this.getProperty(KLIB_PROPERTY_COMPILER_VERSION)!!.parseKonanVersion()
+    val compilerVersion = this.getProperty(KLIB_PROPERTY_COMPILER_VERSION)?.parseKonanVersion()
 
     return KonanLibraryVersioning(abiVersion = abiVersion, libraryVersion = libraryVersion, compilerVersion = compilerVersion)
 }

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/SearchPathResolver.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/SearchPathResolver.kt
@@ -172,27 +172,33 @@ internal fun SearchPathResolverWithTarget.libraryMatch(candidate: KonanLibraryIm
     val resolverTarget = this.target
     val candidatePath = candidate.libraryFile.absolutePath
 
+    val candidateCompilerVersion = candidate.versions.compilerVersion
+    val candidateAbiVersion = candidate.versions.abiVersion
+    val candidateLibraryVersion = candidate.versions.libraryVersion
+
     if (resolverTarget != null && !candidate.targetList.contains(resolverTarget.visibleName)) {
         logger("skipping $candidatePath. The target doesn't match. Expected '$resolverTarget', found ${candidate.targetList}")
         return false
     }
 
-    if (knownCompilerVersions != null &&
-            !knownCompilerVersions!!.contains(candidate.versions.compilerVersion)) {
-        logger("skipping $candidatePath. The compiler versions don't match. Expected '${knownCompilerVersions}', found '${candidate.versions.compilerVersion}'")
+     if (candidateCompilerVersion == null ||
+        knownCompilerVersions != null &&
+            !knownCompilerVersions!!.contains(candidateCompilerVersion)) {
+        logger("skipping $candidatePath. The compiler versions don't match. Expected '${knownCompilerVersions}', found '${candidateCompilerVersion}'")
         return false
     }
 
-    if (knownAbiVersions != null &&
-            !knownAbiVersions!!.contains(candidate.versions.abiVersion)) {
-        logger("skipping $candidatePath. The abi versions don't match. Expected '${knownAbiVersions}', found '${candidate.versions.abiVersion}'")
+    if (candidateAbiVersion == null ||
+        knownAbiVersions != null &&
+            !knownAbiVersions!!.contains(candidateAbiVersion)) {
+        logger("skipping $candidatePath. The abi versions don't match. Expected '${knownAbiVersions}', found '${candidateAbiVersion}'")
         return false
     }
 
-    if (candidate.versions.libraryVersion != unresolved.libraryVersion &&
-            candidate.versions.libraryVersion != null &&
+    if (candidateLibraryVersion != unresolved.libraryVersion &&
+            candidateLibraryVersion != null &&
             unresolved.libraryVersion != null) {
-        logger("skipping $candidatePath. The library versions don't match. Expected '${unresolved.libraryVersion}', found '${candidate.versions.libraryVersion}'")
+        logger("skipping $candidatePath. The library versions don't match. Expected '${unresolved.libraryVersion}', found '${candidateLibraryVersion}'")
         return false
     }
 


### PR DESCRIPTION
… treat them as mismatching.