### PR TITLE
Don't expose interface nested types as Swift nested types

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -167,7 +167,12 @@ internal class ObjCExportNamerImpl(
             val containingDeclaration = descriptor.containingDeclaration
             if (containingDeclaration is ClassDescriptor) {
                 append(getClassOrProtocolSwiftName(containingDeclaration))
-                        .append(".").append(descriptor.name.asString())
+
+                if (!descriptor.isInterface && !containingDeclaration.isInterface) {
+                    append(".").append(descriptor.name.asString())
+                } else {
+                    append(descriptor.name.asString().capitalize())
+                }
             } else {
                 appendTopLevelClassBaseName(descriptor)
             }


### PR DESCRIPTION
Since this turns out to be unsupported by Swift.

Also don't do this for nested interfaces as their status is unclear.