### PR TITLE
Update Xcode version to 10 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ without the need to ship an additional execution runtime.
 
 Prerequisites:
 *   install JDK for your platform, instead of JRE. The build requires ```tools.jar```, which is not included in JRE;
-*   on macOS install Xcode 9.4.1
+*   on macOS install Xcode 10.0
 *   on Fedora 26+ ```yum install ncurses-compat-libs``` may be needed
 
 To compile from sources use following steps:


### PR DESCRIPTION
When I run `./gradlew dependencies:update`, I got error below. Would be nice to update Xcode version from 9 to 10 since it's major update.

```
* What went wrong:
A problem occurred evaluating root project 'kotlin-native'.
> expected Xcode version 10.0, got 9.4.1, consider updating Xcode or use "ignoreXcodeVersionCheck" variable in konan.properties
```