### PR TITLE
Use HTTPS when downloading dependencies

### DIFF
--- a/GRADLE_PLUGIN.md
+++ b/GRADLE_PLUGIN.md
@@ -28,7 +28,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven {
-            url = 'http://dl.bintray.com/kotlin/kotlin-eap'
+            url = 'https://dl.bintray.com/kotlin/kotlin-eap'
         }
     }
 }
@@ -50,7 +50,7 @@ buildscript {
            url "https://dl.bintray.com/jetbrains/kotlin-native-dependencies"
        }
        maven {
-           url "http://dl.bintray.com/kotlin/kotlin-eap"
+           url "https://dl.bintray.com/kotlin/kotlin-eap"
        }
    }
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -36,8 +36,8 @@ configurations {
 
 repositories {
     ivy {
-        ivyPattern      'http://teamcity.jetbrains.com/guestAuth/repository/download/[module]/[revision]/teamcity-ivy.xml'
-        artifactPattern 'http://teamcity.jetbrains.com/guestAuth/repository/download/[module]/[revision]/[artifact](.[ext])'
+        ivyPattern      'https://teamcity.jetbrains.com/guestAuth/repository/download/[module]/[revision]/teamcity-ivy.xml'
+        artifactPattern 'https://teamcity.jetbrains.com/guestAuth/repository/download/[module]/[revision]/[artifact](.[ext])'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 
 # A version of the Kotlin "toolchain" (compiler, runtime, stdlib etc) used by the build script.
 buildKotlinVersion=1.3.0-rc-6
-buildKotlinCompilerRepo=http://dl.bintray.com/kotlin/kotlin-dev
+buildKotlinCompilerRepo=https://dl.bintray.com/kotlin/kotlin-dev
 remoteRoot=konan_tests
 testDataVersion=1226829:id
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_130_CompilerAllPlugins),number:1.3.0-rc-57,tag:kotlin-native,pinned:true/artifacts/content/maven

--- a/samples/calculator/build.gradle
+++ b/samples/calculator/build.gradle
@@ -1,12 +1,12 @@
 allprojects {
     buildscript {
         repositories {
-            maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
+            maven { url "https://dl.bintray.com/kotlin/kotlin-dev" }
         }
     }
 
     repositories {
-        maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
+        maven { url "https://dl.bintray.com/kotlin/kotlin-dev" }
     }
 }
 


### PR DESCRIPTION
Downloading executable code over unencrypted/unauthenticated connections exposes developers to potential remote code execution through man-in-the-middle attacks:
https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/

There is apparently some support for PGP signing in Maven and Gradle which could also be used to prevent this, but it doesn't appear to be enabled by default (i.e., the signatures are not verified).