### PR TITLE
Publish kotlin-stdlib-native sources

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -156,6 +156,26 @@ task unzipStdlibSources(type: Copy) {
     destinationDir commonSrc
 }
 
+final List<File> stdLibSrc = [
+        project(':Interop:Runtime').file('src/main/kotlin'),
+        project(':Interop:Runtime').file('src/native/kotlin'),
+        project(':Interop:JsRuntime').file('src/main/kotlin'),
+        project(':runtime').file('src/main/kotlin')
+]
+
+task zipStdLibSources(type: Zip, dependsOn: unzipStdlibSources) {
+    from stdLibSrc, {
+        into "native"
+    }
+
+    from commonSrc, { 
+        into "common"
+    }
+
+    archiveName 'kotlin-stdlib-native-sources.zip'
+    destinationDir buildDir
+}
+
 // These files are built before the 'dist' is complete,
 // so we provide custom values for
 // konan.home, --runtime, -Djava.library.path etc
@@ -186,14 +206,8 @@ targetList.each { target ->
                 '-Xallow-result-return-type',
                 commonSrc.absolutePath,
                 "-Xcommon-sources=${commonSrc.absolutePath}",
-                project(':Interop:Runtime').file('src/main/kotlin'),
-                project(':Interop:Runtime').file('src/native/kotlin'),
-                project(':Interop:JsRuntime').file('src/main/kotlin'),
-                project(':runtime').file('src/main/kotlin')]
-        inputs.dir(project(':runtime').file('src/main/kotlin'))
-        inputs.dir(project(':Interop:Runtime').file('src/main/kotlin'))
-        inputs.dir(project(':Interop:Runtime').file('src/native/kotlin'))
-        inputs.dir(project(':Interop:JsRuntime').file('src/main/kotlin'))
+                *stdLibSrc]
+        stdLibSrc.forEach { inputs.dir(it) }
         inputs.dir(commonSrc)
         outputs.dir(project(':runtime').file("build/${target}Stdlib"))
 

--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -176,6 +176,13 @@ task zipStdLibSources(type: Zip, dependsOn: unzipStdlibSources) {
     destinationDir buildDir
 }
 
+task teamcityPublishStdLibSources {
+  dependsOn zipStdLibSources
+  doLast {
+    println " ##teamcity[publishArtifacts '${tasks.zipStdLibSources.archivePath}'] "
+  }
+}
+
 // These files are built before the 'dist' is complete,
 // so we provide custom values for
 // konan.home, --runtime, -Djava.library.path etc

--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -178,8 +178,10 @@ task zipStdLibSources(type: Zip, dependsOn: unzipStdlibSources) {
 
 task teamcityPublishStdLibSources {
   dependsOn zipStdLibSources
-  doLast {
-    println " ##teamcity[publishArtifacts '${tasks.zipStdLibSources.archivePath}'] "
+  if (System.getenv("TEAMCITY_BUILD_PROPERTIES_FILE") != null) {
+    doLast {
+      println " ##teamcity[publishArtifacts '${tasks.zipStdLibSources.archivePath}'] "
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -278,6 +278,7 @@ task listDist(type: Exec) {
 task distRuntime(type: Copy) {
     dependsOn "${hostName}CrossDistRuntime"
     dependsOn('commonDistRuntime')
+    dependsOn(':backend.native:teamcityPublishStdLibSources')
 }
 
 def stdlib = 'klib/common/stdlib'


### PR DESCRIPTION
Added several tasks to zip and publish stdlib sources
I use TeamCity service message to publish library from the build
It is not clear if it makes sense to include same sources into the compiler or kotlin-stdlib packages