### PR TITLE
Don't look for target specific linkerOpts.

### DIFF
--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
@@ -36,7 +36,7 @@ class KonanLibraryImpl(
         get() = manifestProperties.readKonanLibraryVersioning()
 
     override val linkerOpts: List<String>
-        get() = manifestProperties.propertyList(KLIB_PROPERTY_LINKED_OPTS, target!!.visibleName)
+        get() = manifestProperties.propertyList(KLIB_PROPERTY_LINKED_OPTS)
 
     override val bitcodePaths: List<String>
         get() = layout.realFiles { (it.kotlinDir.listFilesOrEmpty + it.nativeDir.listFilesOrEmpty).map { it.absolutePath } }


### PR DESCRIPTION
The default substitutions in manifest should have taken care of that.