### PR TITLE
Remove Array.copyRange and replace its internal usages with copyRangeTo

### DIFF
--- a/runtime/src/main/kotlin/kotlin/collections/ArrayList.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayList.kt
@@ -200,7 +200,7 @@ actual class ArrayList<E> private constructor(
 
     private fun insertAtInternal(i: Int, n: Int) {
         ensureExtraCapacity(n)
-        array.copyRange(fromIndex = i, toIndex = offset + length, destinationIndex = i + n)
+        array.copyRangeTo(array, fromIndex = i, toIndex = offset + length, destinationIndex = i + n)
         length += n
     }
 
@@ -238,7 +238,7 @@ actual class ArrayList<E> private constructor(
             return old
         } else {
             val old = array[i]
-            array.copyRange(fromIndex = i + 1, toIndex = offset + length, destinationIndex = i)
+            array.copyRangeTo(array, fromIndex = i + 1, toIndex = offset + length, destinationIndex = i)
             array.resetAt(offset + length - 1)
             length--
             return old
@@ -249,7 +249,7 @@ actual class ArrayList<E> private constructor(
         if (backing != null) {
             backing.removeRangeInternal(rangeOffset, rangeLength)
         } else {
-            array.copyRange(fromIndex = rangeOffset + rangeLength, toIndex = length, destinationIndex = rangeOffset)
+            array.copyRangeTo(array, fromIndex = rangeOffset + rangeLength, toIndex = length, destinationIndex = rangeOffset)
             array.resetRange(fromIndex = length - rangeLength, toIndex = length)
         }
         length -= rangeLength
@@ -272,7 +272,7 @@ actual class ArrayList<E> private constructor(
                 }
             }
             val removed = rangeLength - j
-            array.copyRange(fromIndex = rangeOffset + rangeLength, toIndex = length, destinationIndex = rangeOffset + j)
+            array.copyRangeTo(array, fromIndex = rangeOffset + rangeLength, toIndex = length, destinationIndex = rangeOffset + j)
             array.resetRange(fromIndex = length - removed, toIndex = length)
             length -= removed
             return removed

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
@@ -359,13 +359,6 @@ internal fun DoubleArray.copyRangeTo(destination: DoubleArray, fromIndex: Int, t
 internal fun BooleanArray.copyRangeTo(destination: BooleanArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
     copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
-/**
- * Copies a range of array elements at a specified [fromIndex] (inclusive) to [toIndex] (exclusive) range of indices
- * to another part of this array starting at [destinationIndex].
- */
-public fun <E> Array<E>.copyRange(fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyRangeTo(this, fromIndex, toIndex, destinationIndex)
-}
 
 internal fun <E> Collection<E>.collectionToString(): String {
     val sb = StringBuilder(2 + size * 3)


### PR DESCRIPTION
Fix #2145 by removing the `Array.copyRange`. All usages should use common `copyInto` methods