### PR TITLE
Fix for https://github.com/JetBrains/kotlin-native/issues/2179.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DFGBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DFGBuilder.kt
@@ -573,7 +573,7 @@ internal class ModuleDFGBuilder(val context: Context, val irModule: IrModuleFrag
                                         DataFlowIR.Node.NewObject(
                                                 symbolTable.mapFunction(callee),
                                                 arguments,
-                                                symbolTable.mapClassReferenceType(callee.constructedClass),
+                                                symbolTable.mapClassReferenceType(callee.constructedClass, false),
                                                 value
                                         )
                                     } else {

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2571,6 +2571,11 @@ task inline_twiceInlinedObject(type: RunKonanTest) {
     source = "codegen/inline/twiceInlinedObject.kt"
 }
 
+task inline_localObjectReturnedFromWhen(type: RunKonanTest) {
+    goldValue = "Ok\n"
+    source = "codegen/inline/localObjectReturnedFromWhen.kt"
+}
+
 task classDeclarationInsideInline(type: RunKonanTest) {
     source = "codegen/inline/classDeclarationInsideInline.kt"
     goldValue = "test1: 1.0\n1\ntest2\n"

--- a/backend.native/tests/codegen/inline/localObjectReturnedFromWhen.kt
+++ b/backend.native/tests/codegen/inline/localObjectReturnedFromWhen.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package codegen.inline.localObjectReturnedFromWhen
+
+import kotlin.test.*
+
+fun foo() {
+    123?.let {
+        object : () -> Unit {
+            override fun invoke() = Unit
+        }
+    }
+}
+
+@Test fun runTest() {
+    foo()
+    println("Ok")
+}


### PR DESCRIPTION
Erased local objects types, as otherwise we would have to copy them correctly,
and this is hard because they could leak out of the inline function quite high (see the test).