### PR TITLE
[build] settings globally lose GRADLE_METADATA

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-enableFeaturePreview('GRADLE_METADATA')
 include ':dependencies'
 include ':Interop:Indexer'
 include ':Interop:JsRuntime'


### PR DESCRIPTION
After upgrade to Gradle 4.10 enabling this feature breaks composite build with kotlin, because of libraries in kotlin built with gradle metadata version 0.3.   
(cherry picked from commit a6a4a0a5438b4dc7e84d491b319a95229bc51fac)