### PR TITLE
Fix build for samples/tetris

### DIFF
--- a/samples/tetris/build.gradle
+++ b/samples/tetris/build.gradle
@@ -30,6 +30,7 @@ kotlin {
                             '-loleaut32',
                             '-lversion',
                             '-lwinmm',
+                            '-lsetupapi',
                             '-mwindows'
                     break
                 case presets.linuxArm32Hfp:


### PR DESCRIPTION
Updated version of msys2 SDL2 require additional flag for static linking