### PR TITLE
Fix warning when staticLibraries used in .def file

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/LibraryUtils.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/LibraryUtils.kt
@@ -38,7 +38,7 @@ internal fun argsToCompiler(staticLibraries: Array<String>, libraryPaths: Array<
 
 internal fun argsToCompiler(staticLibraries: List<String>, libraryPaths: List<String>) = 
     resolveLibraries(staticLibraries, libraryPaths)
-        .map { it -> listOf("-includeBinary", it) } 
+        .map { it -> listOf("-include-binary", it) }
         .flatten()
         .toTypedArray()
 


### PR DESCRIPTION
`warning: argument -includeBinary is deprecated. Please use -include-binary instead`