### PR TITLE
Forbid calling Objective-C initializers

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/CodeUtils.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/CodeUtils.kt
@@ -68,7 +68,7 @@ private val charactersAllowedInKotlinStringLiterals: Set<Char> = mutableSetOf<Ch
     addAll('a' .. 'z')
     addAll('A' .. 'Z')
     addAll('0' .. '9')
-    addAll(listOf('_', '@', ':', ';', '.', ',', '{', '}', '=', '[', ']', '^', '#', '*', ' '))
+    addAll(listOf('_', '@', ':', ';', '.', ',', '{', '}', '=', '[', ']', '^', '#', '*', ' ', '(', ')'))
 }
 
 fun block(header: String, lines: Iterable<String>) = block(header, lines.asSequence())

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
@@ -925,6 +925,7 @@ class StubGenerator(
                 add("EXTENSION_SHADOWED_BY_MEMBER") // For Objective-C categories represented as extensions.
                 add("REDUNDANT_NULLABLE") // This warning appears due to Obj-C typedef nullability incomplete support.
                 add("DEPRECATION") // For uncheckedCast.
+                add("DEPRECATION_ERROR") // For initializers.
             }
         }
 


### PR DESCRIPTION
These methods must not be used directly, construstors and factory methods are provided instead