### PR TITLE
Make launcher.js work in Web Workers / Worklets

### DIFF
--- a/runtime/src/launcher/js/launcher.js
+++ b/runtime/src/launcher/js/launcher.js
@@ -19,7 +19,7 @@ let heap;
 let global_arguments;
 
 function isBrowser() {
-    return typeof window !== 'undefined';
+    return typeof self !== 'undefined';
 }
 
 let runtime;


### PR DESCRIPTION
Since WebAssembly object should be exposed to Window/Worker/Worklet according to [it's WebIDL](https://webassembly.github.io/spec/js-api/index.html#webassembly-namespace)