### PR TITLE
Update OBJC_INTEROP.md

### DIFF
--- a/OBJC_INTEROP.md
+++ b/OBJC_INTEROP.md
@@ -36,7 +36,7 @@ The table below shows how Kotlin concepts are mapped to Swift/Objective-C and vi
 | Primitive type | Primitive type / `NSNumber` | | [note](#nsnumber) |
 | `Unit` return type | `Void` | `void` | |
 | `String` | `String` | `NSString` | |
-| `String` | `NSMutableString` | `NSMutableString` | [note](#nsmutablestring) |
+| `String` | `String` | `NSMutableString` | [note](#nsmutablestring) |
 | `List` | `Array` | `NSArray` | |
 | `MutableList` | `NSMutableArray` | `NSMutableArray` | |
 | `Set` | `Set` | `NSSet` | |


### PR DESCRIPTION
`NSMutableString` is an Objective-C type, not a Swift type. Mutability is a core concept in Swift with `let` vs `var`.

Example: 

```swift
var test: String = "Hello!"
print(test)
test = "World!"
print(test)
```

Note that no `NSMutableString` type was used, and yet I could mutate the string. Magic!