### PR TITLE
Updates Zephyr STM32F4 Discovery sample for Zephyr 1.13.99.

### DIFF
--- a/samples/zephyr/CMakeLists.txt
+++ b/samples/zephyr/CMakeLists.txt
@@ -1,11 +1,13 @@
+cmake_minimum_required(VERSION 3.8.2)
+
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 
 add_library(libsupcpp STATIC IMPORTED)
 
-set_property(TARGET libsupcpp PROPERTY IMPORTED_LOCATION $ENV{GCCARMEMB_TOOLCHAIN_PATH}/arm-none-eabi/lib/thumb/libsupc++.a)
+set_property(TARGET libsupcpp PROPERTY IMPORTED_LOCATION $ENV{GNUARMEMB_TOOLCHAIN_PATH}/arm-none-eabi/lib/thumb/libsupc++.a)
 
-target_link_libraries(app libsupcpp)
+target_link_libraries(app PRIVATE libsupcpp)
 
 set_property(TARGET app PROPERTY LINKER_LANGUAGE C)
 

--- a/samples/zephyr/build.bat
+++ b/samples/zephyr/build.bat
@@ -8,9 +8,9 @@ set TOOLCHAIN=gcc-arm-none-eabi-7-2017-q4-major-win32
 set DIR=%~dp0
 if "%KONAN_DATA_DIR%"=="" (set KONAN_DATA_DIR=%userprofile%\.konan)
 set KONAN_DEPS=%KONAN_DATA_DIR%/dependencies
-set GCC_ARM=%KONAN_DEPS%/%TOOLCHAIN%
-set ZEPHYR_TOOLCHAIN_VARIANT=gccarmemb
-set GCCARMEMB_TOOLCHAIN_PATH=%GCC_ARM%
+set GNU_ARM=%KONAN_DEPS%/%TOOLCHAIN%
+set ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+set GNUARMEMB_TOOLCHAIN_PATH=%GNU_ARM%
 
 if defined KONAN_HOME (
     set "PATH=%KONAN_HOME%\bin;%PATH%"

--- a/samples/zephyr/build.sh
+++ b/samples/zephyr/build.sh
@@ -8,6 +8,9 @@ if [ "$ZEPHYR_BASE" == "PLEASE_SET_ZEPHYR_BASE" ] ; then
     exit 1
 fi
 
+export KONAN_DATA_DIR=$HOME/.konan
+export KONAN_DEPS=$KONAN_DATA_DIR/dependencies
+
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 if [ -z "$KONAN_HOME" ]; then
@@ -24,13 +27,13 @@ case "$OSTYPE" in
 esac
 fi
 
-GCC_ARM="$KONAN_DEPS/$TOOLCHAIN"
+GNU_ARM="$KONAN_DEPS/$TOOLCHAIN"
 
 rm -rf $DIR/build || exit 1
 mkdir -p $DIR/build && cd $DIR/build
 
-export ZEPHYR_GCC_VARIANT=gccarmemb
-export GCCARMEMB_TOOLCHAIN_PATH=$GCC_ARM
+export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+export GNUARMEMB_TOOLCHAIN_PATH=$GNU_ARM
 
 [ -f CMakeCache.txt ] || cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DBOARD=$BOARD .. || exit 1
 

--- a/samples/zephyr/c_interop/platforms/stm32f4_disco.bat
+++ b/samples/zephyr/c_interop/platforms/stm32f4_disco.bat
@@ -11,27 +11,26 @@ if "%BOARD%" == "" (
 )
 
 :: TODO: we need a robust automated way to ask Zephyr for
-:: all these $ZEPHYR_BASE based paths and the proper defines.
-:: TODO: The D flag in `-copt -Dxxx` sequence is interpreted to be a jvm property,
+:: all these %ZEPHYR_BASE% based paths and the proper defines.
+:: TODO: The D flag in `-compilerOpts -Dxxx` sequence is interpreted to be a jvm property,
 :: so we workaround the using -Xclang.
 
 call cinterop -def %DIR%/c_interop/platforms/%BOARD%.def ^
         -pkg platform.zephyr.%BOARD% ^
-        -copt "-Xclang -DSTM32F407xx" ^
-        -copt -I%ZEPHYR_BASE%/kernel/include ^
-        -copt -I%ZEPHYR_BASE%/arch/arm/include ^
-        -copt -I%ZEPHYR_BASE%/arch/arm/soc/st_stm32/stm32f4 ^
-        -copt -I%ZEPHYR_BASE%/arch/arm/soc/st_stm32/stm32f4/include ^
-        -copt -I%ZEPHYR_BASE%/arch/arm/soc/st_stm32/include ^
-        -copt -I%ZEPHYR_BASE%/boards/arm/%BOARD% ^
-        -copt -I%ZEPHYR_BASE%/include ^
-        -copt -I%ZEPHYR_BASE%/include/drivers ^
-        -copt -I%ZEPHYR_BASE%/ext/hal/cmsis/Include ^
-        -copt -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/soc ^
-        -copt -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/drivers/include ^
-        -copt -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/drivers/include/Legacy ^
-        -copt -I%ZEPHYR_BASE%/drivers ^
-        -copt -I%DIR%/build/zephyr/include/generated ^
-        -copt -I%DIR%/build/zephyr/include/generated/syscalls ^
+        -compilerOpts "-Xclang -DSTM32F407xx" ^
+        -compilerOpts -I%ZEPHYR_BASE%/kernel/include ^
+        -compilerOpts -I%ZEPHYR_BASE%/arch/arm/include ^
+        -compilerOpts -I%ZEPHYR_BASE%/soc/arm/st_stm32/stm32f4 ^
+        -compilerOpts -I%ZEPHYR_BASE%/soc/arm/st_stm32/common ^
+        -compilerOpts -I%ZEPHYR_BASE%/boards/arm/%BOARD% ^
+        -compilerOpts -I%ZEPHYR_BASE%/include ^
+        -compilerOpts -I%ZEPHYR_BASE%/include/drivers ^
+        -compilerOpts -I%ZEPHYR_BASE%/ext/hal/cmsis/Include ^
+        -compilerOpts -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/soc ^
+        -compilerOpts -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/drivers/include ^
+        -compilerOpts -I%ZEPHYR_BASE%/ext/hal/st/stm32cube/stm32f4xx/drivers/include/Legacy ^
+        -compilerOpts -I%ZEPHYR_BASE%/drivers ^
+        -compilerOpts -I%DIR%/build/zephyr/include/generated ^
+        -compilerOpts -I%DIR%/build/zephyr/include/generated/syscalls ^
         -o %DIR%/c_interop/platforms/build/%BOARD% ^
         -target zephyr_%BOARD% || exit /b

--- a/samples/zephyr/c_interop/platforms/stm32f4_disco.def
+++ b/samples/zephyr/c_interop/platforms/stm32f4_disco.def
@@ -5,6 +5,6 @@
 
 # Keep this one board independent.
 
-headers = autoconf.h zephyr.h board.h device.h gpio.h
+headers = autoconf.h zephyr.h generated_dts_board.h device.h gpio.h
 compilerOpts = -DKERNEL -DUSE_FULL_LL_DRIVER -DUSE_HAL_DRIVER -D_FORTIFY_SOURCE=2 -D__ZEPHYR__=1 -ffreestanding -std=c99 -nostdinc
 

--- a/samples/zephyr/c_interop/platforms/stm32f4_disco.sh
+++ b/samples/zephyr/c_interop/platforms/stm32f4_disco.sh
@@ -12,26 +12,25 @@ fi
 
 # TODO: we need a robust automated way to ask Zephyr for 
 # all these $ZEPHYR_BASE based paths and the proper defines.
-# TODO: The D flag in `-copt -Dxxx` sequence is interpreted to be a jvm property,
+# TODO: The D flag in `-compilerOpts -Dxxx` sequence is interpreted to be a jvm property,
 # so we workaround the using -Xclang.
 
 cinterop -def $DIR/c_interop/platforms/$BOARD.def \
         -pkg platform.zephyr.$BOARD \
-        -copt '-Xclang -DSTM32F407xx' \
-        -copt -I$ZEPHYR_BASE/kernel/include \
-        -copt -I$ZEPHYR_BASE/arch/arm/include \
-        -copt -I$ZEPHYR_BASE/arch/arm/soc/st_stm32/stm32f4 \
-        -copt -I$ZEPHYR_BASE/arch/arm/soc/st_stm32/stm32f4/include \
-        -copt -I$ZEPHYR_BASE/arch/arm/soc/st_stm32/include \
-        -copt -I$ZEPHYR_BASE/boards/arm/$BOARD \
-        -copt -I$ZEPHYR_BASE/include \
-        -copt -I$ZEPHYR_BASE/include/drivers \
-        -copt -I$ZEPHYR_BASE/ext/hal/cmsis/Include \
-        -copt -I$ZEPHYR_BASE/ext/hal/st/stm32cube/stm32f4xx/soc \
-        -copt -I$ZEPHYR_BASE/ext/hal/st/stm32cube/stm32f4xx/drivers/include \
-        -copt -I$ZEPHYR_BASE/ext/hal/st/stm32cube/stm32f4xx/drivers/include/Legacy \
-        -copt -I$ZEPHYR_BASE/drivers \
-        -copt -I$DIR/build/zephyr/include/generated \
-        -copt -I$DIR/build/zephyr/include/generated/syscalls \
+        -compilerOpts '-Xclang -DSTM32F407xx' \
+        -compilerOpts -I$ZEPHYR_BASE/kernel/include \
+        -compilerOpts -I$ZEPHYR_BASE/arch/arm/include \
+        -compilerOpts -I$ZEPHYR_BASE/soc/arm/st_stm32/stm32f4 \
+        -compilerOpts -I$ZEPHYR_BASE/soc/arm/st_stm32/common \
+        -compilerOpts -I$ZEPHYR_BASE/boards/arm/$BOARD \
+        -compilerOpts -I$ZEPHYR_BASE/include \
+        -compilerOpts -I$ZEPHYR_BASE/include/drivers \
+        -compilerOpts -I$ZEPHYR_BASE/ext/hal/cmsis/Include \
+        -compilerOpts -I$ZEPHYR_BASE/ext/hal/st/stm32cube/stm32f4xx/soc \
+        -compilerOpts -I$ZEPHYR_BASE/ext/hal/st/stm32cube/stm32f4xx/drivers/include \
+        -compilerOpts -I$ZEPHYR_BASE/ext/hal/st/stm32cube/stm32f4xx/drivers/include/Legacy \
+        -compilerOpts -I$ZEPHYR_BASE/drivers \
+        -compilerOpts -I$DIR/build/zephyr/include/generated \
+        -compilerOpts -I$DIR/build/zephyr/include/generated/syscalls \
         -o $DIR/c_interop/platforms/build/$BOARD \
         -target zephyr_$BOARD || exit 1

--- a/samples/zephyr/src/main.kt
+++ b/samples/zephyr/src/main.kt
@@ -8,16 +8,16 @@ import kotlinx.cinterop.*
 
 fun blinky(value: Int) {
 
-    val port = LED0_GPIO_PORT
+    val port = LED0_GPIO_CONTROLLER
     val led = LED0_GPIO_PIN
     var toggler = false
     val dev = device_get_binding(port)
 
-    gpio_pin_configure(dev, led, GPIO_DIR_OUT)
+    gpio_pin_configure(dev, led.convert(), GPIO_DIR_OUT)
 
     while (true) {
          /* Set pin to HIGH/LOW every 1 second */
-         gpio_pin_write(dev, led, if (toggler) 1 else 0);
+         gpio_pin_write(dev, led.convert(), if (toggler) 1U else 0U);
          toggler = !toggler
          k_sleep(1000 * value);
    }


### PR DESCRIPTION
As a first step towards #2449, I have updated the Zephyr STM32F4 Discovery sample so that it will compile with the latest tools: Kotlin Native 1.3.11 and Zephyr 1.13.99. This will still require setting the same environment variables as before. 