### PR TITLE
Zephyr ARM sysroot

### DIFF
--- a/tools/scripts/update_zephyr.sh
+++ b/tools/scripts/update_zephyr.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+KONAN_TOOLCHAIN_VERSION=1
+TARBALL_zephyr_arm=target-sysroot-$KONAN_TOOLCHAIN_VERSION-zephyr-arm
+OUT=`pwd`
+
+if [ -z "ZEPHYR_SDK_INSTALL_DIR" ]; then
+    echo "Using default Zephyr SDK install location"
+    export ZEPHYR_SDK_INSTALL_DIR="/opt/zephyr-sdk"
+fi
+
+sdk=armv5-zephyr-eabi
+p=$ZEPHYR_SDK_INSTALL_DIR/sysroots/$sdk/usr
+echo "Packing SDK $sdk as $OUT/$TARBALL_zephyr_arm.tar.gz..."
+tar -czvf $OUT/$TARBALL_zephyr_arm.tar.gz -C $p .


### PR DESCRIPTION
Adds script for generating sysroot tarball from zephyr sdk. I have successfully built using this sysroot by modifying my platform konan properties and manually adding the sysroot to `.konan/dependencies` and adding it to the extracted file. I will submit a separate PR for updating the konan properties. This PR assumes you have the Zephyr SDK directory installed at either the default location (`/opt/zephyr-sdk`) or an environment variable (`ZEPHYR_SDK_INSTALL_DIR`) set to the correct location.

As part of reviewing this I would like to point out some of the broader issues with this sysroot. First, zephyr provides an sdk (what this sysroot is generated from) that provides more than simply arm support and their CMake scripts already determine the correct sysroot (it is available in their cmake). Kotlin native LLVM could access these and then support would be very universally broadened to all of Zephyr. 

I have successfully configured the zephyr code with a kotlin native project to build using the Zephyr SDK with the existing arm toolchain/wasm sysroot for kotlin. At present zephyr's C++ support is most notably missing `new` which I believe is a problem for kotlin native's runtime code at present.

Alternatively, zephyr has full support for being built with GNU ARM tools (assuming an ARM target) and in this situation if I understand correctly will use the GNU ARM provided sysroot. Kotlin native already distributes this and with a small modification, the separate sysroot could be distributed in a way that fits with existing model. If additional architectures were desired, they could be added like any other assuming LLVM compatible toolchains (i.e. GNU MIPS). 

In my opinion, it would be best to use the Zephyr SDK with Zephyr sysroot or GNU ARM toolchain with GNU ARM sysroot, either of which would mean this PR is invalid. Since both are GNU licensed, I don't see that it makes much of a difference in that regard, the issue would be more the desired path by those in charge/the community.