### PR TITLE
Make Threadlocal and SharedImmutable optional common annotations

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -462,11 +462,11 @@ internal class KonanSymbols(context: Context, val symbolTable: SymbolTable, val 
 
     val threadLocal =
             context.builtIns.builtInsModule.findClassAcrossModuleDependencies(
-                    ClassId.topLevel(FqName("kotlin.native.ThreadLocal")))!!
+                    ClassId.topLevel(FqName("kotlin.native.concurrent.ThreadLocal")))!!
 
     val sharedImmutable =
             context.builtIns.builtInsModule.findClassAcrossModuleDependencies(
-                    ClassId.topLevel(FqName("kotlin.native.SharedImmutable")))!!
+                    ClassId.topLevel(FqName("kotlin.native.concurrent.SharedImmutable")))!!
 
     private fun internalFunction(name: String): IrSimpleFunctionSymbol =
             symbolTable.referenceSimpleFunction(context.getInternalFunctions(name).single())

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -39,8 +39,8 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.descriptorUtil.classId
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
 
-private val threadLocalAnnotationFqName = FqName("kotlin.native.ThreadLocal")
-private val sharedAnnotationFqName = FqName("kotlin.native.SharedImmutable")
+private val threadLocalAnnotationFqName = FqName("kotlin.native.concurrent.ThreadLocal")
+private val sharedAnnotationFqName = FqName("kotlin.native.concurrent.SharedImmutable")
 private val frozenAnnotationFqName = FqName("kotlin.native.internal.Frozen")
 
 val IrField.propertyDescriptor: PropertyDescriptor

--- a/runtime/src/main/kotlin/kotlin/native/Annotations.kt
+++ b/runtime/src/main/kotlin/kotlin/native/Annotations.kt
@@ -44,19 +44,21 @@ public annotation class Throws(vararg val exceptionClasses: KClass<out Throwable
  * Top level variable or object is thread local, and so could be mutable.
  * One may use this annotation as the stopgap measure for singleton
  * object immutability.
+ *
  * PLEASE NOTE THAT THIS ANNOTATION MAY GO AWAY IN UPCOMING RELEASES.
  */
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
-public annotation class ThreadLocal
+public actual annotation class ThreadLocal
 
 /**
  * Top level variable is immutable and so could be shared.
+ *
  * PLEASE NOTE THAT THIS ANNOTATION MAY GO AWAY IN UPCOMING RELEASES.
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.BINARY)
-public annotation class SharedImmutable
+public actual annotation class SharedImmutable
 
 /**
  * Makes top level function available from C/C++ code with the given name.

--- a/runtime/src/main/kotlin/kotlin/native/Annotations.kt
+++ b/runtime/src/main/kotlin/kotlin/native/Annotations.kt
@@ -40,25 +40,15 @@ public annotation class Retain
 @Retention(AnnotationRetention.SOURCE)
 public annotation class Throws(vararg val exceptionClasses: KClass<out Throwable>)
 
-/**
- * Top level variable or object is thread local, and so could be mutable.
- * One may use this annotation as the stopgap measure for singleton
- * object immutability.
- *
- * PLEASE NOTE THAT THIS ANNOTATION MAY GO AWAY IN UPCOMING RELEASES.
- */
-@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.BINARY)
-public actual annotation class ThreadLocal
+@Deprecated("ThreadLocal was moved to kotlin.native.concurrent package " +
+        "and became available in Kotlin Common as optional annotation",
+        ReplaceWith("kotlin.native.concurrent.ThreadLocal"))
+public typealias ThreadLocal = kotlin.native.concurrent.ThreadLocal
 
-/**
- * Top level variable is immutable and so could be shared.
- *
- * PLEASE NOTE THAT THIS ANNOTATION MAY GO AWAY IN UPCOMING RELEASES.
- */
-@Target(AnnotationTarget.PROPERTY)
-@Retention(AnnotationRetention.BINARY)
-public actual annotation class SharedImmutable
+@Deprecated("SharedImmutable was moved to kotlin.native.concurrent package " +
+        "and became available in Kotlin Common as optional annotation",
+        ReplaceWith("kotlin.native.concurrent.SharedImmutable"))
+public typealias SharedImmutable = kotlin.native.concurrent.SharedImmutable
 
 /**
  * Makes top level function available from C/C++ code with the given name.

--- a/runtime/src/main/kotlin/kotlin/native/concurrent/Annotations.kt
+++ b/runtime/src/main/kotlin/kotlin/native/concurrent/Annotations.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package kotlin.native.concurrent
+
+/**
+ * Top level variable or object is thread local, and so could be mutable.
+ * One may use this annotation as the stopgap measure for singleton
+ * object immutability.
+ *
+ * PLEASE NOTE THAT THIS ANNOTATION MAY GO AWAY IN UPCOMING RELEASES.
+ */
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+public actual annotation class ThreadLocal
+
+/**
+ * Top level variable is immutable and so could be shared.
+ *
+ * PLEASE NOTE THAT THIS ANNOTATION MAY GO AWAY IN UPCOMING RELEASES.
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+public actual annotation class SharedImmutable


### PR DESCRIPTION
This change makes these annotations be available in common code as optional annotations.