### PR TITLE
IR: Fixed bug with dispatch receiver parameter

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -211,21 +211,18 @@ fun IrClass.createParameterDeclarations() {
 fun IrFunction.createDispatchReceiverParameter(origin: IrDeclarationOrigin? = null) {
     assert(dispatchReceiverParameter == null)
 
-    dispatchReceiverParameter = WrappedReceiverParameterDescriptor().let {
-        IrValueParameterImpl(
-                startOffset, endOffset,
-                origin ?: parentAsClass.origin,
-                IrValueParameterSymbolImpl(it),
-                Name.special("<this>"),
-                0,
-                parentAsClass.defaultType,
-                null,
-                false,
-                false
-        ).apply {
-            it.bind(this)
-            parent = this@createDispatchReceiverParameter
-        }
+    dispatchReceiverParameter = IrValueParameterImpl(
+            startOffset, endOffset,
+            origin ?: parentAsClass.origin,
+            IrValueParameterSymbolImpl(parentAsClass.thisReceiver!!.descriptor),
+            Name.special("<this>"),
+            0,
+            parentAsClass.defaultType,
+            null,
+            false,
+            false
+    ).apply {
+        parent = this@createDispatchReceiverParameter
     }
 }
 


### PR DESCRIPTION
When building dispatch receiver for newly created functions
take ReceiverParameter from the parent class rather than create new