### PR TITLE
[gradle-plugin] Make dependency export non-transitive by default

### DIFF
--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/experimental/internal/KotlinNativeDependenciesImpl.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/experimental/internal/KotlinNativeDependenciesImpl.kt
@@ -43,11 +43,7 @@ open class KotlinNativeDependenciesImpl @Inject constructor(
         implementationDependencies.extendsFrom(this)
     }
 
-    override var transitiveExport: Boolean
-        get() = exportDependencies.isTransitive
-        set(value) {
-            exportDependencies.isTransitive = value
-        }
+    override var transitiveExport: Boolean = false
 
     override fun export(notation: Any) {
         exportDependencies.dependencies.add(dependencyHandler.create(notation))

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/experimental/internal/KotlinNativeFrameworkImpl.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/experimental/internal/KotlinNativeFrameworkImpl.kt
@@ -60,6 +60,7 @@ open class KotlinNativeFrameworkImpl @Inject constructor(
     // A configuration containing exported klibs.
     override val export = configurations.create(names.withPrefix("export")).apply {
         isCanBeConsumed = false
+        isTransitive = component.dependencies.transitiveExport
         attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, KotlinUsages.KOTLIN_API))
         attributes.attribute(CppBinary.DEBUGGABLE_ATTRIBUTE, debuggable)
         attributes.attribute(CppBinary.OPTIMIZED_ATTRIBUTE, optimized)


### PR DESCRIPTION
Fix for KT-28936.