### PR TITLE
Make binaries' rpath comply conventions on iOS and macOS

### DIFF
--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -152,8 +152,18 @@ open class MacOSBasedLinker(targetProperties: AppleConfigurables)
             +"-lSystem"
             +libraries
             +linkerArgs
+            +rpath(dynamic)
         }) + if (debug) listOf(dsymUtilCommand(executable, outputDsymBundle)) else emptyList()
     }
+
+    private fun rpath(dynamic: Boolean): List<String> = listOfNotNull(
+            when (target.family) {
+                Family.OSX -> "@executable_path/../Frameworks"
+                Family.IOS -> "@executable_path/Frameworks"
+                else -> error(target)
+            },
+            "@loader_path/Frameworks".takeIf { dynamic }
+    ).flatMap { listOf("-rpath", it) }
 
     fun dsymUtilCommand(executable: ExecutableFile, outputDsymBundle: String) =
             object : Command(dsymutilCommand(executable, outputDsymBundle)) {


### PR DESCRIPTION
This simplifies linking embedded frameworks.
See #2555