### PR TITLE
Several urgent fixes for IR serialization

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InlineClasses.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InlineClasses.kt
@@ -202,7 +202,10 @@ private val implicitInlineClasses =
                 KonanFqNames.nativePtr +
                 InteropFqNames.cPointer).toSet()
 
-private fun IrClass.getAllSuperClassifiers(): List<IrClass> = listOf(this) + this.superTypes.flatMap { (it.classifierOrFail.owner as IrClass).getAllSuperClassifiers() }
+private val superQualifierTable = mutableMapOf<IrClass, List<IrClass>>()
+private fun IrClass.getAllSuperClassifiers(): List<IrClass> = superQualifierTable.getOrPut(this) {
+    listOf(this) + this.superTypes.flatMap { (it.classifierOrFail.owner as IrClass).getAllSuperClassifiers() }
+}
 
 internal object KotlinTypeInlineClassesSupport : InlineClassesSupport<ClassDescriptor, KotlinType>() {
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/DeclarationTable.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/DeclarationTable.kt
@@ -6,17 +6,10 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrAnonymousInitializerImpl
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 
-fun <K, V> MutableMap<K, V>.putOnce(k:K, v: V): Unit {
-    assert(!this.containsKey(k) || this[k] == v) {
-        "adding $v for $k, but it is already ${this[k]} for $k"
-    }
-    this.put(k, v)
-}
-
 class DescriptorTable {
     private val descriptors = mutableMapOf<DeclarationDescriptor, Long>()
     fun put(descriptor: DeclarationDescriptor, uniqId: UniqId) {
-        descriptors.putOnce(descriptor, uniqId.index)
+        descriptors.getOrPut(descriptor) { uniqId.index }
     }
     fun get(descriptor: DeclarationDescriptor) = descriptors[descriptor]
 }
@@ -35,26 +28,26 @@ class DeclarationTable(val builtIns: IrBuiltIns, val descriptorTable: Descriptor
         }
     }
 
-    fun uniqIdByDeclaration(value: IrDeclaration): UniqId {
-        val index = table.getOrPut(value) {
+    fun uniqIdByDeclaration(value: IrDeclaration): UniqId = table.getOrPut(value) {
+        val index = if (value.origin == IrDeclarationOrigin.FAKE_OVERRIDE ||
+            !value.isExported()
+            || value is IrVariable
+            || value is IrTypeParameter
+            || value is IrValueParameter
+            || value is IrAnonymousInitializerImpl
+        ) {
 
-            if (value.origin == IrDeclarationOrigin.FAKE_OVERRIDE ||
-                !value.isExported()
-                    || value is IrVariable
-                    || value is IrTypeParameter
-                    || value is IrValueParameter
-                    || value is IrAnonymousInitializerImpl
-            ) {
-
-                UniqId(currentIndex++, true)
-            } else {
-                UniqId(value.uniqIdIndex, false)
-            }
+            UniqId(currentIndex++, true)
+        } else {
+            UniqId(value.uniqIdIndex, false)
         }
 
-        debugIndex.put(index, "${if (index.isLocal) "" else value.uniqSymbolName()} descriptor = ${value.descriptor}")
+        // It can grow as large as 1/3 of ir/* size.
+        // debugIndex.put(index) {
+        //     "${if (index.isLocal) "" else value.uniqSymbolName()} descriptor = ${value.descriptor}"
+        //}.also {it == null}
 
-        return index
+        index
     }
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/DeserializeDescriptorReference.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/DeserializeDescriptorReference.kt
@@ -2,31 +2,46 @@ package org.jetbrains.kotlin.backend.konan.serialization
 
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
-import org.jetbrains.kotlin.metadata.KonanIr
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedClassDescriptor
 
+// This is all information needed to find a descriptor in the
+// tree of deserialized descriptors. Think of it as base + offset.
+// packageFqName + classFqName + index allow to localize some deserialized descriptor.
+// Then the rest of the fields allow to find the needed descriptor relative to the one with index.
 class DescriptorReferenceDeserializer(val currentModule: ModuleDescriptor, val resolvedForwardDeclarations: MutableMap<UniqIdKey, UniqIdKey>) {
+    fun deserializeDescriptorReference(
+        packageFqNameString: String,
+        classFqNameString: String,
+        name: String,
+        index: Long?,
+        isEnumEntry: Boolean = false,
+        isEnumSpecial: Boolean = false,
+        isDefaultConstructor: Boolean = false,
+        isFakeOverride: Boolean = false,
+        isGetter: Boolean = false,
+        isSetter: Boolean = false
+    ): DeclarationDescriptor {
+        val packageFqName = packageFqNameString.let {
+            if (it == "<root>") FqName.ROOT else FqName(it)
+        }// TODO: whould we store an empty string in the protobuf?
 
-    fun deserializeDescriptorReference(proto: KonanIr.DescriptorReference): DeclarationDescriptor {
-        val packageFqName =
-            if (proto.packageFqName == "<root>") FqName.ROOT else FqName(proto.packageFqName) // TODO: whould we store an empty string in the protobuf?
-        val classFqName = FqName(proto.classFqName)
-        val protoIndex = if (proto.hasUniqId()) proto.uniqId.index else null
+        val classFqName = FqName(classFqNameString)
+        val protoIndex = index
 
-        val (clazz, members) = if (proto.classFqName == "") {
+        val (clazz, members) = if (classFqNameString == "") {
             Pair(null, currentModule.getPackage(packageFqName).memberScope.getContributedDescriptors())
         } else {
             val clazz = currentModule.findClassAcrossModuleDependencies(ClassId(packageFqName, classFqName, false))!!
             Pair(clazz, clazz.unsubstitutedMemberScope.getContributedDescriptors() + clazz.getConstructors())
         }
 
-        if (proto.packageFqName.startsWith("cnames.") || proto.packageFqName.startsWith("objcnames.")) {
+        if (packageFqNameString.startsWith("cnames.") || packageFqNameString.startsWith("objcnames.")) {
             val descriptor =
-                currentModule.findClassAcrossModuleDependencies(ClassId(packageFqName, FqName(proto.name), false))!!
+                currentModule.findClassAcrossModuleDependencies(ClassId(packageFqName, FqName(name), false))!!
             if (!descriptor.fqNameUnsafe.asString().startsWith("cnames") && !descriptor.fqNameUnsafe.asString().startsWith(
                     "objcnames"
                 )
@@ -44,23 +59,21 @@ class DescriptorReferenceDeserializer(val currentModule: ModuleDescriptor, val r
             return descriptor
         }
 
-        if (proto.isEnumEntry) {
-            val name = proto.name
+        if (isEnumEntry) {
             val memberScope = (clazz as DeserializedClassDescriptor).getUnsubstitutedMemberScope()
             return memberScope.getContributedClassifier(Name.identifier(name), NoLookupLocation.FROM_BACKEND)!!
         }
 
-        if (proto.isEnumSpecial) {
-            val name = proto.name
+        if (isEnumSpecial) {
             return clazz!!.getStaticScope()
                 .getContributedFunctions(Name.identifier(name), NoLookupLocation.FROM_BACKEND).single()
         }
 
         members.forEach { member ->
-            if (proto.isDefaultConstructor && member is ClassConstructorDescriptor) return member
+            if (isDefaultConstructor && member is ClassConstructorDescriptor) return member
 
             val realMembers =
-                if (proto.isFakeOverride && member is CallableMemberDescriptor && member.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE)
+                if (isFakeOverride && member is CallableMemberDescriptor && member.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE)
                     member.resolveFakeOverrideMaybeAbstract()
                 else
                     setOf(member)
@@ -69,12 +82,12 @@ class DescriptorReferenceDeserializer(val currentModule: ModuleDescriptor, val r
 
             if (memberIndices.contains(protoIndex)) {
                 return when {
-                    member is PropertyDescriptor && proto.isSetter -> member.setter!!
-                    member is PropertyDescriptor && proto.isGetter -> member.getter!!
+                    member is PropertyDescriptor && isSetter -> member.setter!!
+                    member is PropertyDescriptor && isGetter -> member.getter!!
                     else -> member
                 }
             }
         }
-        error("Could not find serialized descriptor for index: ${proto.uniqId.index} ${proto.packageFqName},${proto.classFqName},${proto.name}")
+        error("Could not find serialized descriptor for index: ${index} ${packageFqName},${classFqName},${name}")
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIr.proto
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIr.proto
@@ -5,9 +5,9 @@ option java_outer_classname = "KonanIr";
 option optimize_for = LITE_RUNTIME;
 
 message DescriptorReference {
-    required string package_fq_name = 1;
-    required string class_fq_name = 2;
-    required string name = 3;
+    required String package_fq_name = 1;
+    required String class_fq_name = 2;
+    required String name = 3;
     optional UniqId uniq_id = 4;
     optional bool is_getter = 5 [default = false];
     optional bool is_setter = 6 [default = false];
@@ -28,7 +28,7 @@ message Coordinates {
     required int32 end_offset = 2;
 }
 
-/* ------ Top Level---------------------------------------------- */
+/* ------ Top Level---------------------------------------KonanIrModuleDeserializer.kt------- */
 
 message IrDeclarationContainer {
     repeated IrDeclaration declaration = 1;
@@ -50,6 +50,16 @@ message IrModule {
     repeated IrFile file = 2;
     required IrSymbolTable symbol_table = 3;
     required IrTypeTable type_table = 4;
+}
+
+/* ------ String Table ------------------------------------------ */
+
+message String {
+    required int32 index = 1;
+}
+
+message StringTable {
+    repeated string value = 1;
 }
 
 /* ------ IrSymbols --------------------------------------------- */
@@ -74,7 +84,7 @@ message IrSymbolData {
     required IrSymbolKind kind = 1;
     required UniqId uniq_id = 2;
     required UniqId top_level_uniq_id = 3;
-    optional string fqname = 4;
+    optional String fqname = 4;
     optional DescriptorReference descriptor_reference = 5;
 }
 
@@ -153,7 +163,7 @@ message IrTypeIndex {
 
 message IrBreak {
     required int32 loop_id = 1;
-    optional string label = 2;
+    optional String label = 2;
 }
 
 message IrBlock {
@@ -183,7 +193,7 @@ message IrCall {
 
 message IrFunctionReference {
     required IrSymbol symbol = 1;
-    optional string origin = 2;
+    optional Origin origin = 2;
     required MemberAccessCommon member_access = 3;
 }
 
@@ -192,7 +202,7 @@ message IrPropertyReference {
     optional IrSymbol field = 1;
     optional IrSymbol getter = 2;
     optional IrSymbol setter = 3;
-    optional string origin = 4;
+    optional Origin origin = 4;
     required MemberAccessCommon member_access = 5;
 }
 
@@ -216,13 +226,13 @@ message IrConst {
         int64 long = 7;
         float float = 8;
         double double = 9;
-        string string = 10;
+        String string = 10;
     }
 }
 
 message IrContinue {
     required int32 loop_id = 1;
-    optional string label = 2;
+    optional String label = 2;
 }
 
 message IrDelegatingConstructorCall {
@@ -272,7 +282,7 @@ message IrInstanceInitializerCall {
 message Loop {
     required int32 loop_id = 1;
     required IrExpression condition = 2;
-    optional string label = 3;
+    optional String label = 3;
     optional IrExpression body = 4;
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIr.proto
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIr.proto
@@ -28,6 +28,52 @@ message Coordinates {
     required int32 end_offset = 2;
 }
 
+message Visibility {
+    required String name = 1;
+}
+
+message IrStatementOrigin {
+    required String name = 1;
+}
+
+enum KnownOrigin {
+    CUSTOM = 1;
+    DEFINED = 2;
+    FAKE_OVERRIDE = 3;
+    FOR_LOOP_ITERATOR = 4;
+    FOR_LOOP_VARIABLE = 5;
+    FOR_LOOP_IMPLICIT_VARIABLE = 6;
+    PROPERTY_BACKING_FIELD = 7;
+    DEFAULT_PROPERTY_ACCESSOR = 8;
+    DELEGATE = 9;
+    DELEGATED_PROPERTY_ACCESSOR = 10;
+    DELEGATED_MEMBER = 11;
+    ENUM_CLASS_SPECIAL_MEMBER = 12;
+    FUNCTION_FOR_DEFAULT_PARAMETER = 13;
+    FILE_CLASS = 14;
+    GENERATED_DATA_CLASS_MEMBER = 15;
+    GENERATED_INLINE_CLASS_MEMBER = 16;
+    LOCAL_FUNCTION_FOR_LAMBDA = 17;
+    CATCH_PARAMETER = 19;
+    INSTANCE_RECEIVER = 20;
+    PRIMARY_CONSTRUCTOR_PARAMETER = 21;
+    IR_TEMPORARY_VARIABLE = 22;
+    IR_EXTERNAL_DECLARATION_STUB = 23;
+    IR_EXTERNAL_JAVA_DECLARATION_STUB = 24;
+    IR_BUILTINS_STUB = 25;
+    BRIDGE = 26;
+    FIELD_FOR_ENUM_ENTRY = 27;
+    FIELD_FOR_ENUM_VALUES = 28;
+    FIELD_FOR_OBJECT_INSTANCE = 29;
+}
+
+message IrDeclarationOrigin {
+    oneof either {
+        KnownOrigin origin = 1;
+        String custom = 2;
+    }
+}
+
 /* ------ Top Level---------------------------------------KonanIrModuleDeserializer.kt------- */
 
 message IrDeclarationContainer {
@@ -35,7 +81,7 @@ message IrDeclarationContainer {
 }
 
 message FileEntry { // TODO: extend me.
-    required string name = 1;
+    required String name = 1;
 }
 
 message IrFile {
@@ -46,10 +92,11 @@ message IrFile {
 }
 
 message IrModule {
-    required string name = 1;
+    required String name = 1;
     repeated IrFile file = 2;
     required IrSymbolTable symbol_table = 3;
     required IrTypeTable type_table = 4;
+    required StringTable string_table = 5;
 }
 
 /* ------ String Table ------------------------------------------ */
@@ -59,7 +106,7 @@ message String {
 }
 
 message StringTable {
-    repeated string value = 1;
+    repeated string strings = 1;
 }
 
 /* ------ IrSymbols --------------------------------------------- */
@@ -193,7 +240,7 @@ message IrCall {
 
 message IrFunctionReference {
     required IrSymbol symbol = 1;
-    optional Origin origin = 2;
+    optional IrStatementOrigin origin = 2;
     required MemberAccessCommon member_access = 3;
 }
 
@@ -202,7 +249,7 @@ message IrPropertyReference {
     optional IrSymbol field = 1;
     optional IrSymbol getter = 2;
     optional IrSymbol setter = 3;
-    optional Origin origin = 4;
+    optional IrStatementOrigin origin = 4;
     required MemberAccessCommon member_access = 5;
 }
 
@@ -421,8 +468,8 @@ message IrFunction {
 }
 
 message IrFunctionBase {
-    required string name = 1;
-    required string visibility = 2;
+    required String name = 1;
+    required Visibility visibility = 2;
     required bool is_inline = 3;
     required bool is_external = 4;
     required IrTypeParameterContainer type_parameters = 5;
@@ -443,8 +490,8 @@ message IrConstructor {
 message IrField {
     required IrSymbol symbol = 1;
     optional IrExpression initializer = 2;
-    required string name = 3;
-    required string visibility = 4;
+    required String name = 3;
+    required Visibility visibility = 4;
     required bool is_final = 5;
     required bool is_external = 6;
     required bool is_static = 7;
@@ -453,8 +500,8 @@ message IrField {
 
 message IrProperty {
     optional DescriptorReference descriptor = 1; // IrProperty doesn't have a symbol at all. Preserve this rudiment for now.
-    required string name = 2;
-    required string visibility = 3;
+    required String name = 2;
+    required Visibility visibility = 3;
     required ModalityKind modality = 4;
     required bool is_var = 5;
     required bool is_const = 6;
@@ -467,7 +514,7 @@ message IrProperty {
 }
 
 message IrVariable {
-    required string name = 1;
+    required String name = 1;
     required IrSymbol symbol = 2;
     required IrTypeIndex type = 3;
     required bool is_var = 4;
@@ -494,7 +541,7 @@ enum ModalityKind { // It is ModalityKind to not clash with Modality in descript
 
 message IrValueParameter {
     required IrSymbol symbol = 1;
-    required string name = 2;
+    required String name = 2;
     required int32 index = 3;
     required IrTypeIndex type = 4;
     optional IrTypeIndex vararg_element_type = 5;
@@ -505,7 +552,7 @@ message IrValueParameter {
 
 message IrTypeParameter {
     required IrSymbol symbol = 1;
-    required string name = 2;
+    required String name = 2;
     required int32 index = 3;
     required IrTypeVariance variance = 4;
     repeated IrTypeIndex super_type = 5;
@@ -518,9 +565,9 @@ message IrTypeParameterContainer {
 
 message IrClass {
     required IrSymbol symbol = 1;
-    required string name = 2;
+    required String name = 2;
     required ClassKind kind = 3;
-    required string visibility = 4;
+    required Visibility visibility = 4;
     required ModalityKind modality = 5;
     // TODO: consider using flags for the booleans.
     required bool is_companion = 6;
@@ -538,7 +585,7 @@ message IrEnumEntry {
     required IrSymbol symbol = 1;
     optional IrExpression initializer = 2;
     optional IrDeclaration corresponding_class = 3;
-    required string name = 4;
+    required String name = 4;
 }
 
 message IrAnonymousInit {
@@ -564,17 +611,12 @@ message IrDeclarator {
     }
 }
 
-message IrDeclarationOrigin {
-    required string name = 1;
-}
-
 message IrDeclaration {
     required IrDeclarationOrigin origin = 1;
     required Coordinates coordinates = 2;
     required Annotations annotations = 3;
     required IrDeclarator declarator = 4;
-    //repeated IrDeclaration nested = 5;
-    required string file_name = 5; // TODO: files should be communicated some other way, I suppose.
+    required String file_name = 5; // TODO: files should be communicated some other way, I suppose.
 }
 
 /* ------- IrStatements --------------------------------------------- */

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleDeserializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleDeserializer.kt
@@ -284,11 +284,13 @@ class KonanIrModuleDeserializer(
                         classDescriptor,
                         classDescriptor.modality
                 ) { symbol: IrClassSymbol -> IrClassImpl(UNDEFINED_OFFSET, UNDEFINED_OFFSET, irrelevantOrigin, symbol) }
+                .also {
+                    it.parent = file
+                }
                 declaration
 
             }
             file.declarations.addAll(declarations)
-            file
         }
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/SerializeDescriptorReference.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/SerializeDescriptorReference.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.metadata.KonanIr
 import org.jetbrains.kotlin.resolve.descriptorUtil.classId
 
 
-class DescriptorReferenceSerializer(val declarationTable: DeclarationTable) {
+class DescriptorReferenceSerializer(val declarationTable: DeclarationTable, val serializeString: (String) -> KonanIr.String) {
 
     // Not all exported descriptors are deserialized, some a synthesized anew during metadata deserialization.
     // Those created descriptors can't carry the uniqIdIndex, since it is available only for deserialized descriptors.
@@ -73,9 +73,9 @@ class DescriptorReferenceSerializer(val declarationTable: DeclarationTable) {
         uniqId?.let { declarationTable.descriptors.put(discoverableDescriptorsDeclaration.descriptor, it) }
 
         val proto = KonanIr.DescriptorReference.newBuilder()
-            .setPackageFqName(packageFqName)
-            .setClassFqName(classFqName)
-            .setName(descriptor.name.toString())
+            .setPackageFqName(serializeString(packageFqName))
+            .setClassFqName(serializeString(classFqName))
+            .setName(serializeString(descriptor.name.toString()))
 
         if (uniqId != null) proto.setUniqId(protoUniqId(uniqId))
 

--- a/platformLibs/build.gradle
+++ b/platformLibs/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     }
 
     ext.konanHome = distDir.absolutePath
-    ext.jvmArgs = project.findProperty("platformLibsJvmArgs") ?: "-Xmx4G"
+    ext.jvmArgs = project.findProperty("platformLibsJvmArgs") ?: "-Xmx6G"
     ext.setProperty("konan.home", konanHome)
     ext.setProperty("konan.jvmArgs", jvmArgs)
 }

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/KonanAbiVersion.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/KonanAbiVersion.kt
@@ -6,7 +6,7 @@ fun String.parseKonanAbiVersion(): KonanAbiVersion {
 
 data class KonanAbiVersion(val version: Int) {
     companion object {
-        val CURRENT = KonanAbiVersion(5)
+        val CURRENT = KonanAbiVersion(6)
     }
     override fun toString() = "$version"
 }


### PR DESCRIPTION
Several performance tunings for IR (de)serialization.
Make sure forward declarations have the parent field set.
Bump klib ABI version.