### PR TITLE
Support Android targets on Mingw host

### DIFF
--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -289,6 +289,12 @@ dependencies.linux_x64-android_arm32 = \
     target-sysroot-21-android_arm32 \
     target-toolchain-21-linux-android_arm32 \
     libffi-3.2.1-2-linux-x86-64
+targetToolchain.mingw_x64-android_arm32 = target-toolchain-21-windows-android_arm32
+dependencies.mingw_x64-android_arm32 = \
+    msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1 \
+    target-sysroot-21-android_arm32 \
+    target-toolchain-21-windows-android_arm32 \
+    libffi-3.2.1-mingw-w64-x86-64
 
 quadruple.android_arm32 = arm-linux-androideabi
 entrySelector.android_arm32 =  -Wl,--defsym -Wl,main=Konan_main
@@ -313,6 +319,12 @@ dependencies.linux_x64-android_arm64 = \
     target-sysroot-21-android_arm64 \
     target-toolchain-21-linux-android_arm64 \
     libffi-3.2.1-2-linux-x86-64
+targetToolchain.mingw_x64-android_arm64 = target-toolchain-21-windows-android_arm64
+dependencies.mingw_x64-android_arm64 = \
+    msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1 \
+    target-sysroot-21-android_arm64 \
+    target-toolchain-21-windows-android_arm64 \
+    libffi-3.2.1-mingw-w64-x86-64
 
 quadruple.android_arm64 = aarch64-linux-android
 entrySelector.android_arm64 =  -Wl,--defsym -Wl,main=Konan_main

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/KonanTarget.kt
@@ -184,6 +184,8 @@ open class HostManager(protected val distribution: Distribution = Distribution()
                     KonanTarget.MINGW_X64,
                     KonanTarget.LINUX_X64,
                     KonanTarget.LINUX_ARM32_HFP,
+                    KonanTarget.ANDROID_ARM32,
+                    //KonanTarget.ANDROID_ARM64,
                     KonanTarget.WASM32
                 ) + zephyrSubtargets
                 KonanTarget.MACOS_X64 -> listOf(

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -93,7 +93,7 @@ open class AndroidLinker(targetProperties: AndroidConfigurables)
     : LinkerFlags(targetProperties), AndroidConfigurables by targetProperties {
 
     private val prefix = "$absoluteTargetToolchain/bin/"
-    private val clang = "$prefix/clang"
+    private val clang = if (HostManager.hostIsMingw) "$prefix/clang.cmd" else "$prefix/clang"
     private val ar = "$absoluteTargetToolchain/${targetProperties.targetArg}/bin/ar"
 
     override val useCompilerDriverAsLinker: Boolean get() = true


### PR DESCRIPTION
Toolchains: [arm32](https://yadi.sk/d/jcZt8V0XjpIfJg), [arm64](https://yadi.sk/d/YMlGS7UR8PvUIg)

arm32 works, arm64 (if uncommented) fails with weird error I do not understand:
```
> Task :common:android_arm64Hash FAILED
clang: Unknown command line argument '-aarch64-fix-cortex-a53-835769=1'.  Try: 'clang -help'
clang: Did you mean '-arm-force-fast-isel=1'?
clang: Unknown command line argument '-aarch64-fix-cortex-a53-835769=1'.  Try: 'clang -help'
clang: Did you mean '-arm-force-fast-isel=1'?
clang: Unknown command line argument '-aarch64-fix-cortex-a53-835769=1'.  Try: 'clang -help'
clang: Did you mean '-arm-force-fast-isel=1'?
clang: Unknown command line argument '-aarch64-fix-cortex-a53-835769=1'.  Try: 'clang -help'
clang: Did you mean '-arm-force-fast-isel=1'?

FAILURE: Build failed with an exception.
```