### PR TITLE
Fix composite build with stdlib

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -156,6 +156,10 @@ task start(dependsOn: "${hostName}Start")
 def commonSrc = file('build/stdlib')
 
 task unzipStdlibSources(type: Copy) {
+    if (project.hasProperty("kotlinProjectPath")) {
+        dependsOn gradle.includedBuild('kotlin').task(":kotlin-stdlib-common:sourcesJar")
+    }
+
     def jarFiles = configurations.kotlin_common_stdlib_src.files +
             configurations.kotlin_test_common_src.files +
             configurations.kotlin_test_annotations_common_src.files


### PR DESCRIPTION
Make unzip stdlib sources depend on stdlib-common's sources task