### PR TITLE
Filter tests with regard to file separator

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -211,7 +211,7 @@ static boolean isExcluded(String dir) {
 
     boolean result = false
     excluded.forEach {
-        if (dir.endsWith(it)) {
+        if (dir.endsWith(it.replace("/", File.separator))) {
             result = true
         }
     }

--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -897,7 +897,7 @@ fun runTest() {
     boolean isEnabledForNativeBackend(String fileName) {
         def text = project.file(fileName).text
 
-        if (excludeList.contains(fileName)) return false
+        if (excludeList.contains(fileName.replace(File.separator, "/"))) return false
 
         if (findLinesWithPrefixesRemoved(text, "// WITH_REFLECT").size() != 0) return false
 


### PR DESCRIPTION
Tests were not excluded on Windows due to incorrect paths comparing (with no regards to file separator)