### PR TITLE
Allow IR Lazy functions in IR serialization

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/IrModuleSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/IrModuleSerializer.kt
@@ -825,7 +825,7 @@ internal class IrModuleSerializer(
         return proto.build()
     }
 
-    private fun serializeIrFunctionBase(function: IrFunctionBase): KonanIr.IrFunctionBase {
+    private fun serializeIrFunctionBase(function: IrFunction): KonanIr.IrFunctionBase {
         val proto = KonanIr.IrFunctionBase.newBuilder()
             .setName(serializeString(function.name.toString()))
             .setVisibility(serializeVisibility(function.visibility))
@@ -856,7 +856,7 @@ internal class IrModuleSerializer(
     private fun serializeIrConstructor(declaration: IrConstructor): KonanIr.IrConstructor =
         KonanIr.IrConstructor.newBuilder()
             .setSymbol(serializeIrSymbol(declaration.symbol))
-            .setBase(serializeIrFunctionBase(declaration as IrFunctionBase))
+            .setBase(serializeIrFunctionBase(declaration))
             .setIsPrimary(declaration.isPrimary)
             .build()
 
@@ -877,7 +877,7 @@ internal class IrModuleSerializer(
         //    proto.setCorrespondingProperty(protoUniqId(uniqId))
         //}
 
-        val base = serializeIrFunctionBase(function as IrFunctionBase)
+        val base = serializeIrFunctionBase(function)
         proto.setBase(base)
 
         return proto.build()


### PR DESCRIPTION
Such function types are sometimes produced by serialization plugin and
are sublcasses of 'IrLazyFuncitonBase' and 'IrFunction'.
Interfaces for IrFunction and IrFunctionBase are identical anyway

https://youtrack.jetbrains.com/issue/KT-29771