### PR TITLE
delete dependency archive after extraction

### DIFF
--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
@@ -93,7 +93,7 @@ class DependencyProcessor(dependenciesRoot: File,
                           attemptIntervalMs: Long = DependencyDownloader.DEFAULT_ATTEMPT_INTERVAL_MS,
                           customProgressCallback: ProgressCallback? = null,
                           val keepUnstable: Boolean = true,
-                          val deleteArchives :Boolean = true) {
+                          val deleteArchives: Boolean = true) {
 
     val dependenciesDirectory = dependenciesRoot.apply { mkdirs() }
     val cacheDirectory = homeDependencyCache.apply { mkdirs() }

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
@@ -92,7 +92,8 @@ class DependencyProcessor(dependenciesRoot: File,
                           maxAttempts: Int = DependencyDownloader.DEFAULT_MAX_ATTEMPTS,
                           attemptIntervalMs: Long = DependencyDownloader.DEFAULT_ATTEMPT_INTERVAL_MS,
                           customProgressCallback: ProgressCallback? = null,
-                          val keepUnstable: Boolean = true) {
+                          val keepUnstable: Boolean = true,
+                          val deleteArchives :Boolean = true) {
 
     val dependenciesDirectory = dependenciesRoot.apply { mkdirs() }
     val cacheDirectory = homeDependencyCache.apply { mkdirs() }
@@ -200,7 +201,9 @@ class DependencyProcessor(dependenciesRoot: File,
         }
         println("Extracting dependency: $archive into $dependenciesDirectory")
         extractor.extract(archive, dependenciesDirectory)
-        archive.delete()
+        if (deleteArchives) {
+            archive.delete()
+        }
         extractedDependencies.addAndSave(depName)
     }
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
@@ -200,6 +200,7 @@ class DependencyProcessor(dependenciesRoot: File,
         }
         println("Extracting dependency: $archive into $dependenciesDirectory")
         extractor.extract(archive, dependenciesDirectory)
+        archive.delete()
         extractedDependencies.addAndSave(depName)
     }
 


### PR DESCRIPTION
On my macOS machine, ~/.konan/cache takes up to 858M of disk space, while they are all extracted archives.

Delete those archive files when extraction is completed.

```bash
 ~ $ du -sh ~/.konan/cache
858M	/Users/young/.konan/cache
 ~ $ ls -lh ~/.konan/cache
total 1757488
-rw-r--r--  1 young  staff   374M Feb 28  2018 clang-llvm-5.0.0-darwin-macos.tar.gz
-rw-r--r--  1 young  staff   423M Oct 23 16:44 clang-llvm-6.0.1-darwin-macos.tar.gz
-rw-r--r--  1 young  staff    24K Oct 23 16:42 libffi-3.2.1-1-darwin-ios_sim.tar.gz
-rw-r--r--  1 young  staff    57K Feb 28  2018 libffi-3.2.1-2-darwin-ios.tar.gz
-rw-r--r--  1 young  staff    59K Nov  8 17:18 libffi-3.2.1-2-darwin-ios_sim.tar.gz
-rw-r--r--  1 young  staff    28K Feb 28  2018 libffi-3.2.1-2-darwin-macos.tar.gz
-rw-r--r--  1 young  staff   152K Nov 16 10:31 libffi-3.2.1-3-darwin-ios.tar.gz
-rw-r--r--  1 young  staff    73K Nov 14 10:56 libffi-3.2.1-3-darwin-macos.tar.gz
-rw-r--r--  1 young  staff   2.7M Feb 28  2018 target-sysroot-2-wasm.tar.gz
-rw-r--r--  1 young  staff    48M Feb 28  2018 target-toolchain-2-osx-wasm.tar.gz
```