### PR TITLE
KT-29970: correctly handle commandline arguments with whitespace

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
@@ -18,7 +18,7 @@ package org.jetbrains.kotlin.native.interop.tool
 
 import org.jetbrains.kotlin.cli.common.arguments.*
 import org.jetbrains.kotlin.konan.util.ARGUMENT_NO_DELIMITER
-import org.jetbrains.kotlin.konan.util.parseCommandLineString
+import org.jetbrains.kotlin.konan.util.CommandLineOpts
 
 // TODO: unify camel and snake cases.
 // Possible solution is to accept both cases
@@ -69,10 +69,12 @@ class CInteropArguments : CommonInteropArguments() {
     @Argument(value = "-compilerOpts", shortName = "-copt", valueDescription = "<arg>", description = "additional compiler options", delimiter = " ")
     var compilerOpts: Array<String> = arrayOf()
 
-    @Argument(value = "-linkerOpts", shortName = "-lopt", valueDescription = "<arg>", description = "additional linker options", delimiter = ARGUMENT_NO_DELIMITER)
-    var linkerOptsInternal: Array<String> = arrayOf()
-
-    val linkerOpts: Array<String> by parseCommandLineString { linkerOptsInternal }
+    private val linkerOptsHolder = CommandLineOpts()
+    val linkerOpts: List<String> by linkerOptsHolder
+    @Argument(value = "-linkerOpt", valueDescription = "<arg>", description = "single additional linker option", delimiter = ARGUMENT_NO_DELIMITER)
+    var linkerOptInternal by linkerOptsHolder.singletonOpt
+    @Argument(value = "-linkerOpts", shortName = "-lopt", valueDescription = "<args>", description = "additional linker options", delimiter = ARGUMENT_NO_DELIMITER)
+    var linkerOptsInternal by linkerOptsHolder.multipleOpts
 
     @Argument(value = "-shims", description = "wrap bindings by a tracing layer") 
     var shims: Boolean = false

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/CommandLine.kt
@@ -17,6 +17,8 @@
 package org.jetbrains.kotlin.native.interop.tool
 
 import org.jetbrains.kotlin.cli.common.arguments.*
+import org.jetbrains.kotlin.konan.util.ARGUMENT_NO_DELIMITER
+import org.jetbrains.kotlin.konan.util.parseCommandLineString
 
 // TODO: unify camel and snake cases.
 // Possible solution is to accept both cases
@@ -67,8 +69,10 @@ class CInteropArguments : CommonInteropArguments() {
     @Argument(value = "-compilerOpts", shortName = "-copt", valueDescription = "<arg>", description = "additional compiler options", delimiter = " ")
     var compilerOpts: Array<String> = arrayOf()
 
-    @Argument(value = "-linkerOpts", shortName = "-lopt", valueDescription = "<arg>", description = "additional linker options", delimiter = " ")
-    var linkerOpts: Array<String> = arrayOf()
+    @Argument(value = "-linkerOpts", shortName = "-lopt", valueDescription = "<arg>", description = "additional linker options", delimiter = ARGUMENT_NO_DELIMITER)
+    var linkerOptsInternal: Array<String> = arrayOf()
+
+    val linkerOpts: Array<String> by parseCommandLineString { linkerOptsInternal }
 
     @Argument(value = "-shims", description = "wrap bindings by a tracing layer") 
     var shims: Boolean = false

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/main.kt
@@ -88,6 +88,7 @@ Run interop tool with -def <def_file_for_lib>.def
 Following flags are supported:
   -def <file>.def specifies library definition file
   -compilerOpts <c compiler flags> specifies flags passed to clang
+  -linkerOpt  <linker flag> specifies single flag passed to linker as-is
   -linkerOpts <linker flags> specifies flags passed to linker
   -verbose <boolean> increases verbosity
   -shims <boolean> adds generation of shims tracing native library calls

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -121,7 +121,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                 put(LIBRARY_FILES,
                         arguments.libraries.toNonNullList())
 
-                put(LINKER_ARGS, arguments.linkerArguments.toNonNullList())
+                put(LINKER_ARGS, arguments.linkerArguments)
                 arguments.moduleName ?. let{ put(MODULE_NAME, it) }
                 arguments.target ?.let{ put(TARGET, it) }
 

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -11,6 +11,8 @@ import org.jetbrains.kotlin.cli.common.arguments.Argument
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.AnalysisFlag
 import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.konan.util.ARGUMENT_NO_DELIMITER
+import org.jetbrains.kotlin.konan.util.parseCommandLineString
 
 class K2NativeCompilerArguments : CommonCompilerArguments() {
     // First go the options interesting to the general public.
@@ -60,8 +62,10 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     @Argument(value = "-nopack", description = "Don't pack the library into a klib file")
     var nopack: Boolean = false
 
-    @Argument(value="-linker-options", deprecatedName = "-linkerOpts", valueDescription = "<arg>", description = "Pass arguments to linker", delimiter = " ")
-    var linkerArguments: Array<String>? = null
+    @Argument(value="-linker-options", deprecatedName = "-linkerOpts", valueDescription = "<arg>", description = "Pass arguments to linker", delimiter = ARGUMENT_NO_DELIMITER)
+    var linkerArgumentsInternal: Array<String> = arrayOf()
+
+    val linkerArguments: Array<String> by parseCommandLineString { linkerArgumentsInternal }
 
     @Argument(value = "-nostdlib", description = "Don't link with stdlib")
     var nostdlib: Boolean = false

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.AnalysisFlag
 import org.jetbrains.kotlin.config.AnalysisFlags
 import org.jetbrains.kotlin.konan.util.ARGUMENT_NO_DELIMITER
-import org.jetbrains.kotlin.konan.util.parseCommandLineString
+import org.jetbrains.kotlin.konan.util.CommandLineOpts
 
 class K2NativeCompilerArguments : CommonCompilerArguments() {
     // First go the options interesting to the general public.
@@ -62,10 +62,14 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     @Argument(value = "-nopack", description = "Don't pack the library into a klib file")
     var nopack: Boolean = false
 
-    @Argument(value="-linker-options", deprecatedName = "-linkerOpts", valueDescription = "<arg>", description = "Pass arguments to linker", delimiter = ARGUMENT_NO_DELIMITER)
-    var linkerArgumentsInternal: Array<String> = arrayOf()
+    private val linkerOpts = CommandLineOpts()
+    val linkerArguments by linkerOpts
 
-    val linkerArguments: Array<String> by parseCommandLineString { linkerArgumentsInternal }
+    @Argument(value="-linker-option", valueDescription = "<arg>", description = "Pass single argument to linker", delimiter = ARGUMENT_NO_DELIMITER)
+    var linkerArgumentInternal by linkerOpts.singletonOpt
+
+    @Argument(value="-linker-options", deprecatedName = "-linkerOpts", valueDescription = "<args>", description = "Pass arguments to linker", delimiter = ARGUMENT_NO_DELIMITER)
+    var linkerArgumentsInternal by linkerOpts.multipleOpts
 
     @Argument(value = "-nostdlib", description = "Don't link with stdlib")
     var nostdlib: Boolean = false

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.konan.properties.loadProperties
 import org.jetbrains.kotlin.konan.properties.propertyList
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.util.defaultTargetSubstitutions
+import org.jetbrains.kotlin.konan.util.getParsedCommandLineString
 import org.jetbrains.kotlin.konan.util.substitute
 
 class KonanLibraryImpl(
@@ -51,7 +52,7 @@ class KonanLibraryImpl(
         get() = manifestProperties.readKonanLibraryVersioning()
 
     override val linkerOpts: List<String>
-        get() = manifestProperties.propertyList(KLIB_PROPERTY_LINKED_OPTS)
+        get() = manifestProperties.getParsedCommandLineString(KLIB_PROPERTY_LINKED_OPTS)
 
     override val bitcodePaths: List<String>
         get() = layout.realFiles { (it.kotlinDir.listFilesOrEmpty + it.nativeDir.listFilesOrEmpty).map { it.absolutePath } }

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
@@ -19,6 +19,7 @@ package org.jetbrains.kotlin.konan.exec
 import java.lang.ProcessBuilder
 import java.lang.ProcessBuilder.Redirect
 import org.jetbrains.kotlin.konan.KonanExternalToolFailure
+import org.jetbrains.kotlin.konan.util.escapeToCommandLineString
 
 
 open class Command(initialCommand: List<String>) {
@@ -106,6 +107,6 @@ open class Command(initialCommand: List<String>) {
     }
 
     private fun log() {
-        if (logger != null) logger!! { command.toList<String>().joinToString(" ") }
+        if (logger != null) logger!! { escapeToCommandLineString(command.toList()) }
     }
 }

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/CommandLineOpts.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/CommandLineOpts.kt
@@ -1,0 +1,166 @@
+package org.jetbrains.kotlin.konan.util
+
+import java.util.*
+import kotlin.properties.ReadOnlyProperty
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+
+/// we use the fake delimiter to support the feature
+/// of the [@Argument] parser to merge several arguments
+/// into the same argument (it works only for [Array<String>]
+/// type, but we do not need the separator
+///
+/// the right fix is to update the [@Argument] to support paths separation
+const val ARGUMENT_NO_DELIMITER = "\\n\\t\\t\\n\\t\\t\\n\\ue000\\ue001\\ue002\\n\\t\\t\\t\\t\\n"
+
+private fun parseCommandLineString(it: String) : List<String> {
+  val arguments = mutableListOf<String>()
+  val buf = StringBuilder()
+
+  var isEscape = false
+  for (ch in it) {
+      when {
+        ch != ' ' && ch != '\\' -> {
+          if(isEscape) {
+            buf.append('\\')
+            isEscape = false
+          }
+          buf.append(ch)
+        }
+
+        ch == '\\' -> when {
+          isEscape -> {
+            buf.append('\\')
+            isEscape = false
+          }
+
+          else -> {
+            isEscape = true
+          }
+        }
+
+        ch == ' ' -> when {
+          isEscape -> {
+            buf.append(' ')
+            isEscape = false
+          }
+
+          else -> {
+            if (buf.isNotEmpty()) {
+              arguments += buf.toString()
+              buf.setLength(0)
+            }
+          }
+        }
+      }
+  }
+  if (isEscape) buf.append('\\')
+
+  if (buf.isNotEmpty()) {
+    arguments += buf.toString()
+  }
+
+  return arguments
+}
+
+fun escapeToCommandLineString(args: Iterable<String>) : String {
+  return args.joinToString(separator = " ", transform = {
+    it.replace("\\", "\\\\").replace(" ", "\\ ")
+  })
+}
+
+fun Properties.getParsedCommandLineString(name: String): List<String> {
+  val s = getProperty(name) ?: return listOf()
+  return parseCommandLineString(s)
+}
+
+
+class CommandLineOpts : ReadOnlyProperty<Any, List<String>> {
+  private val arguments = mutableListOf<String>()
+
+  override fun getValue(thisRef: Any, property: KProperty<*>) = arguments.toList()
+
+  private inline fun setterProperty(crossinline setter: (String) -> Unit) = object : ReadWriteProperty<Any, Array<String>> {
+    override fun getValue(thisRef: Any, property: KProperty<*>): Array<String> {
+      //we return an empty array to avoid concatenation of values from
+      //org.jetbrains.kotlin.cli.common.arguments.ParseCommandLineArgumentsKt.updateField
+      return emptyArray()
+    }
+
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: Array<String>) {
+      if (value.size != 1) throw IllegalArgumentException("One argument was expected")
+      setter(value[0])
+    }
+  }
+
+  val singletonOpt = setterProperty { arguments += it }
+  val multipleOpts = setterProperty { arguments += parseCommandLineString(it) }
+}
+
+
+fun main() {
+  //A substitute for unit tests. There is no infrastructure for unit tests right now
+
+  fun testEscape(input: String, vararg args: String) {
+    val actual = parseCommandLineString(input)
+    if (actual != listOf(*args)) error("invalid value, but was: $actual")
+
+    val str = escapeToCommandLineString(listOf(*args))
+    val strActual = parseCommandLineString(str)
+    if (strActual != listOf(*args)) error("invalid value, but was: $strActual")
+  }
+
+  testEscape("")
+  testEscape("a", "a")
+  testEscape("a\\", "a\\")
+  testEscape("a\\\\", "a\\")
+  testEscape("a\\\\ ", "a\\")
+
+  testEscape("\\a", "\\a")
+  testEscape("\\\\a", "\\a")
+  testEscape("\\\\ a", "\\", "a")
+
+  testEscape("a b", "a", "b")
+  testEscape(" a b ", "a", "b")
+  testEscape(" a\\ b ", "a b")
+  testEscape(" a\\\\ b ", "a\\", "b")
+  testEscape(" a\\\\\\ b ", "a\\ b")
+
+
+  class TestArguments {
+    private val linkerOptsHolder = CommandLineOpts()
+    val linkerOpts: List<String> by linkerOptsHolder
+    var linkerOptInternal by linkerOptsHolder.singletonOpt
+    var linkerOptsInternal by linkerOptsHolder.multipleOpts
+  }
+
+  lateinit var x : TestArguments
+  fun reset() { x = TestArguments() }
+  fun assertArgs(vararg args: String) {
+    if (x.linkerOpts != listOf(*args)) error("invalid value, but was: ${x.linkerOpts}")
+  }
+
+  reset()
+  assertArgs()
+
+  reset()
+  x.linkerOptsInternal = arrayOf("a b\\ c \\d\\")
+  assertArgs("a", "b c", "\\d\\")
+
+  reset()
+  x.linkerOptInternal = arrayOf("a b c")
+  assertArgs("a b c")
+
+  reset()
+  x.linkerOptInternal = arrayOf("a b c")
+  x.linkerOptsInternal = arrayOf("d   e")
+  x.linkerOptInternal = arrayOf("g")
+  x.linkerOptInternal = arrayOf(" h ")
+  x.linkerOptsInternal = arrayOf(" i j\\ k ")
+  assertArgs("a b c", "d", "e", "g", " h ", "i", "j k")
+
+  reset()
+  x.linkerOptsInternal = arrayOf("d\\\\ e")
+  assertArgs("d\\", "e")
+}

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DefFile.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DefFile.kt
@@ -57,7 +57,7 @@ class DefFile(val file:File?, val config:DefFileConfig, val manifestAddendProper
         }
 
         val linkerOpts by lazy {
-            properties.getSpaceSeparated("linkerOpts")
+            properties.getParsedCommandLineString("linkerOpts")
         }
 
         val linker by lazy {

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/Util.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/Util.kt
@@ -79,6 +79,19 @@ fun parseCommandLineString(value: () -> Array<String>) = object: ReadOnlyPropert
     }
 }
 
+fun escapeToCommandLineString(args: Iterable<String>) : String {
+    return args.joinToString(separator = " ", transform = {
+        when {
+            it.startsWith("\'") && it.endsWith("\'") -> it
+            it.startsWith("\"") && it.endsWith("\"") -> it
+            it.contains(" ") -> "\"$it\""
+            it.isEmpty() -> "\"\""
+            //TODO: possible incorrect case for "a b c\" (slash escapes ")
+            else -> it
+        }
+    })
+}
+
 fun parseCommandLineString(cmdString: String): List<String> {
     //inspired by IntelliJ IDEA source code (Apache 2.0 by JetBrains)
     //com.intellij.openapi.util.text.StringUtilRt#splitHonorQuotes

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/Util.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/Util.kt
@@ -18,9 +18,6 @@ package org.jetbrains.kotlin.konan.util
 
 import kotlin.system.measureTimeMillis
 import org.jetbrains.kotlin.konan.file.*
-import java.util.*
-import kotlin.properties.ReadOnlyProperty
-import kotlin.reflect.KProperty
 
 // FIXME(ddol): KLIB-REFACTORING-CLEANUP: remove this function:
 fun <T> printMillisec(message: String, body: () -> T): T {
@@ -62,69 +59,3 @@ fun String.removeSuffixIfPresent(suffix: String) =
     if (this.endsWith(suffix)) this.dropLast(suffix.length) else this
 
 fun <T> Lazy<T>.getValueOrNull(): T? = if (isInitialized()) value else null
-
-
-
-/// we use the fake delimiter to support the feature
-/// of the [@Argument] parser to merge several arguments
-/// into the same argument (it works only for [Array<String>]
-/// type, but we do not need the separator
-///
-/// the right fix is to update the [@Argument] to support paths separation
-const val ARGUMENT_NO_DELIMITER = "\\n\\t\\t\\n\\t\\t\\n\\ue000\\ue001\\ue002\\n\\t\\t\\t\\t\\n"
-
-fun parseCommandLineString(value: () -> Array<String>) = object: ReadOnlyProperty<Any, Array<String>> {
-    override fun getValue(thisRef: Any, property: KProperty<*>): Array<String> {
-        return value().flatMap { parseCommandLineString(it) }.toTypedArray()
-    }
-}
-
-fun escapeToCommandLineString(args: Iterable<String>) : String {
-    return args.joinToString(separator = " ", transform = {
-        when {
-            it.startsWith("\'") && it.endsWith("\'") -> it
-            it.startsWith("\"") && it.endsWith("\"") -> it
-            it.contains(" ") -> "\"$it\""
-            it.isEmpty() -> "\"\""
-            //TODO: possible incorrect case for "a b c\" (slash escapes ")
-            else -> it
-        }
-    })
-}
-
-fun parseCommandLineString(cmdString: String): List<String> {
-    //inspired by IntelliJ IDEA source code (Apache 2.0 by JetBrains)
-    //com.intellij.openapi.util.text.StringUtilRt#splitHonorQuotes
-
-    val result = mutableListOf<String>()
-    val builder = StringBuilder(cmdString.length)
-
-    var inQuotes = false
-    for (i in 0 until cmdString.length) {
-        val c = cmdString[i]
-        if (c == ' ' && !inQuotes) {
-            if (builder.isNotEmpty()) {
-                result.add(builder.toString())
-                builder.setLength(0)
-            }
-            continue
-        }
-        if ((c == '"' || c == '\'') && !(i > 0 && cmdString[i - 1] == '\\')) {
-            inQuotes = !inQuotes
-            continue
-        }
-
-        builder.append(c)
-    }
-
-    if (builder.isNotEmpty()) {
-        result.add(builder.toString())
-    }
-
-    return result
-}
-
-fun Properties.getParsedCommandLineString(name: String): List<String> {
-    val s = getProperty(name) ?: return listOf()
-    return parseCommandLineString(s)
-}

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/Util.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/Util.kt
@@ -18,6 +18,9 @@ package org.jetbrains.kotlin.konan.util
 
 import kotlin.system.measureTimeMillis
 import org.jetbrains.kotlin.konan.file.*
+import java.util.*
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
 
 // FIXME(ddol): KLIB-REFACTORING-CLEANUP: remove this function:
 fun <T> printMillisec(message: String, body: () -> T): T {
@@ -59,3 +62,56 @@ fun String.removeSuffixIfPresent(suffix: String) =
     if (this.endsWith(suffix)) this.dropLast(suffix.length) else this
 
 fun <T> Lazy<T>.getValueOrNull(): T? = if (isInitialized()) value else null
+
+
+
+/// we use the fake delimiter to support the feature
+/// of the [@Argument] parser to merge several arguments
+/// into the same argument (it works only for [Array<String>]
+/// type, but we do not need the separator
+///
+/// the right fix is to update the [@Argument] to support paths separation
+const val ARGUMENT_NO_DELIMITER = "\\n\\t\\t\\n\\t\\t\\n\\ue000\\ue001\\ue002\\n\\t\\t\\t\\t\\n"
+
+fun parseCommandLineString(value: () -> Array<String>) = object: ReadOnlyProperty<Any, Array<String>> {
+    override fun getValue(thisRef: Any, property: KProperty<*>): Array<String> {
+        return value().flatMap { parseCommandLineString(it) }.toTypedArray()
+    }
+}
+
+fun parseCommandLineString(cmdString: String): List<String> {
+    //inspired by IntelliJ IDEA source code (Apache 2.0 by JetBrains)
+    //com.intellij.openapi.util.text.StringUtilRt#splitHonorQuotes
+
+    val result = mutableListOf<String>()
+    val builder = StringBuilder(cmdString.length)
+
+    var inQuotes = false
+    for (i in 0 until cmdString.length) {
+        val c = cmdString[i]
+        if (c == ' ' && !inQuotes) {
+            if (builder.isNotEmpty()) {
+                result.add(builder.toString())
+                builder.setLength(0)
+            }
+            continue
+        }
+        if ((c == '"' || c == '\'') && !(i > 0 && cmdString[i - 1] == '\\')) {
+            inQuotes = !inQuotes
+            continue
+        }
+
+        builder.append(c)
+    }
+
+    if (builder.isNotEmpty()) {
+        result.add(builder.toString())
+    }
+
+    return result
+}
+
+fun Properties.getParsedCommandLineString(name: String): List<String> {
+    val s = getProperty(name) ?: return listOf()
+    return parseCommandLineString(s)
+}

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/experimental/tasks/CInteropTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/experimental/tasks/CInteropTask.kt
@@ -102,7 +102,7 @@ open class CInteropTask @Inject constructor(val settings: CInteropSettingsImpl):
             }
 
             linkerOpts.forEach {
-                addArg("-lopt", it)
+                addArg("-linkerOpt", it)
             }
 
             addArgs("-copt", allHeadersDirs.map { "-I${it.absolutePath}" })

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/tasks/KonanInteropTask.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/tasks/KonanInteropTask.kt
@@ -91,7 +91,7 @@ open class KonanInteropTask @Inject constructor(val workerExecutor: WorkerExecut
             linkerOpts.addAll(it.files.map { it.canonicalPath })
         }
         linkerOpts.forEach {
-            addArg("-lopt", it)
+            addArg("-linkerOpt", it)
         }
 
         addArgs("-copt", includeDirs.allHeadersDirs.map { "-I${it.absolutePath}" })


### PR DESCRIPTION
compilerOpts, linkerOpts, and other files may have arguments with spaces: paths, framework names, etc. The PR fixes the way we deal with such paths to make sure we do not split them blindly by whitespace. 

There are few more fixes required for the MPP plugin code in Kotlin main repository, see the issue for more details
https://youtrack.jetbrains.com/issue/KT-29970