### PR TITLE
Fix Objective-C header for deeply nested classes

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -184,7 +184,22 @@ internal class ObjCExportNamerImpl(
             if (containingDeclaration is ClassDescriptor) {
                 append(getClassOrProtocolSwiftName(containingDeclaration))
 
-                if (!descriptor.isInterface && !containingDeclaration.isInterface) {
+                val importAsMember = when {
+                    descriptor.isInterface || containingDeclaration.isInterface -> {
+                        // Swift doesn't support neither nested nor outer protocols.
+                        false
+                    }
+
+                    this.contains('.') -> {
+                        // Swift doesn't support swift_name with deeply nested names.
+                        // It seems to support "OriginalObjCName.SwiftName" though,
+                        // but this doesn't seem neither documented nor reliable.
+                        false
+                    }
+
+                    else -> true
+                }
+                if (importAsMember) {
                     append(".").append(descriptor.name.asString())
                 } else {
                     append(descriptor.name.asString().capitalize())

--- a/backend.native/tests/framework/values/values.kt
+++ b/backend.native/tests/framework/values/values.kt
@@ -269,3 +269,12 @@ fun Any.same() = this
 
 // https://github.com/JetBrains/kotlin-native/issues/2571
 val PROPERTY_NAME_MUST_NOT_BE_ALTERED_BY_SWIFT = 111
+
+// https://github.com/JetBrains/kotlin-native/issues/2667
+class Deeply {
+    class Nested {
+        class Type {
+            val thirtyTwo = 32
+        }
+    }
+}

--- a/backend.native/tests/framework/values/values.swift
+++ b/backend.native/tests/framework/values/values.swift
@@ -492,6 +492,7 @@ func testPureSwiftClasses() throws {
 
 func testNames() throws {
     try assertEquals(actual: ValuesKt.PROPERTY_NAME_MUST_NOT_BE_ALTERED_BY_SWIFT, expected: 111)
+    try assertEquals(actual: Deeply.NestedType().thirtyTwo, expected: 32)
 }
 
 // -------- Execution of the test --------


### PR DESCRIPTION
Fix #2667