### PR TITLE
Stdlib array copying and sorting from templates

### DIFF
--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -1052,6 +1052,249 @@ public actual inline fun CharArray.copyOfRange(fromIndex: Int, toIndex: Int): Ch
 }
 
 /**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun <T> Array<T>.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): Array<T> {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = arrayOfUninitializedElements<T>(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun ByteArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): ByteArray {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = ByteArray(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun ShortArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): ShortArray {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = ShortArray(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun IntArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): IntArray {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = IntArray(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun LongArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): LongArray {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = LongArray(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun FloatArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): FloatArray {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = FloatArray(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun DoubleArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): DoubleArray {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = DoubleArray(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun BooleanArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): BooleanArray {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = BooleanArray(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
+ * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun CharArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): CharArray {
+    val newSize = toIndex - fromIndex
+    if (newSize < 0) {
+        throw IllegalArgumentException("$fromIndex > $toIndex")
+    }
+    val result = CharArray(newSize)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
+    return result
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun <T> Array<T>.copyOfUninitializedElements(newSize: Int): Array<T> {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun ByteArray.copyOfUninitializedElements(newSize: Int): ByteArray {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun ShortArray.copyOfUninitializedElements(newSize: Int): ShortArray {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun IntArray.copyOfUninitializedElements(newSize: Int): IntArray {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun LongArray.copyOfUninitializedElements(newSize: Int): LongArray {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun FloatArray.copyOfUninitializedElements(newSize: Int): FloatArray {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun DoubleArray.copyOfUninitializedElements(newSize: Int): DoubleArray {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun BooleanArray.copyOfUninitializedElements(newSize: Int): BooleanArray {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
+ * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
+ * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
+ * either throwing exception or returning some kind of implementation-specific default value.
+ */
+@PublishedApi
+internal fun CharArray.copyOfUninitializedElements(newSize: Int): CharArray {
+    return copyOfUninitializedElements(0, newSize)
+}
+
+/**
  * Returns an array containing all elements of the original array and then the given [element].
  */
 public actual operator fun <T> Array<T>.plus(element: T): Array<T> {

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -1341,49 +1341,49 @@ public actual inline fun <T> Array<T>.plusElement(element: T): Array<T> {
  * Sorts the array in-place.
  */
 public actual fun IntArray.sort(): Unit {
-    if (size > 1) kotlin.util.sortArray(this)
+    if (size > 1) sortArray(this)
 }
 
 /**
  * Sorts the array in-place.
  */
 public actual fun LongArray.sort(): Unit {
-    if (size > 1) kotlin.util.sortArray(this)
+    if (size > 1) sortArray(this)
 }
 
 /**
  * Sorts the array in-place.
  */
 public actual fun ByteArray.sort(): Unit {
-    if (size > 1) kotlin.util.sortArray(this)
+    if (size > 1) sortArray(this)
 }
 
 /**
  * Sorts the array in-place.
  */
 public actual fun ShortArray.sort(): Unit {
-    if (size > 1) kotlin.util.sortArray(this)
+    if (size > 1) sortArray(this)
 }
 
 /**
  * Sorts the array in-place.
  */
 public actual fun DoubleArray.sort(): Unit {
-    if (size > 1) kotlin.util.sortArray(this)
+    if (size > 1) sortArray(this)
 }
 
 /**
  * Sorts the array in-place.
  */
 public actual fun FloatArray.sort(): Unit {
-    if (size > 1) kotlin.util.sortArray(this)
+    if (size > 1) sortArray(this)
 }
 
 /**
  * Sorts the array in-place.
  */
 public actual fun CharArray.sort(): Unit {
-    if (size > 1) kotlin.util.sortArray(this)
+    if (size > 1) sortArray(this)
 }
 
 /**
@@ -1392,7 +1392,7 @@ public actual fun CharArray.sort(): Unit {
  * The sort is _stable_. It means that equal elements preserve their order relative to each other after sorting.
  */
 public actual fun <T : Comparable<T>> Array<out T>.sort(): Unit {
-    if (size > 1) kotlin.util.sortArrayComparable(this)
+    if (size > 1) sortArray(this)
 }
 
 /**
@@ -1401,7 +1401,7 @@ public actual fun <T : Comparable<T>> Array<out T>.sort(): Unit {
  * The sort is _stable_. It means that equal elements preserve their order relative to each other after sorting.
  */
 public actual fun <T> Array<out T>.sortWith(comparator: Comparator<in T>): Unit {
-    if (size > 1) kotlin.util.sortArrayWith(this, 0, size, comparator)
+    if (size > 1) sortArrayWith(this, 0, size, comparator)
 }
 
 /**

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -1405,6 +1405,15 @@ public actual fun <T> Array<out T>.sortWith(comparator: Comparator<in T>): Unit 
 }
 
 /**
+ * Sorts a range in the array in-place with the given [comparator].
+ * 
+ * The sort is _stable_. It means that equal elements preserve their order relative to each other after sorting.
+ */
+public fun <T> Array<out T>.sortWith(comparator: Comparator<in T>, fromIndex: Int = 0, toIndex: Int = size): Unit {
+    sortArrayWith(this, fromIndex, toIndex, comparator)
+}
+
+/**
  * Returns a *typed* object array containing all of the elements of this primitive array.
  */
 public actual fun ByteArray.toTypedArray(): Array<Byte> {

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -732,8 +732,7 @@ public actual fun CharArray.copyInto(destination: CharArray, destinationOffset: 
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun <T> Array<T>.copyOf(): Array<T> {
+public actual fun <T> Array<T>.copyOf(): Array<T> {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -742,8 +741,7 @@ public actual inline fun <T> Array<T>.copyOf(): Array<T> {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun ByteArray.copyOf(): ByteArray {
+public actual fun ByteArray.copyOf(): ByteArray {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -752,8 +750,7 @@ public actual inline fun ByteArray.copyOf(): ByteArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun ShortArray.copyOf(): ShortArray {
+public actual fun ShortArray.copyOf(): ShortArray {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -762,8 +759,7 @@ public actual inline fun ShortArray.copyOf(): ShortArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun IntArray.copyOf(): IntArray {
+public actual fun IntArray.copyOf(): IntArray {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -772,8 +768,7 @@ public actual inline fun IntArray.copyOf(): IntArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun LongArray.copyOf(): LongArray {
+public actual fun LongArray.copyOf(): LongArray {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -782,8 +777,7 @@ public actual inline fun LongArray.copyOf(): LongArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun FloatArray.copyOf(): FloatArray {
+public actual fun FloatArray.copyOf(): FloatArray {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -792,8 +786,7 @@ public actual inline fun FloatArray.copyOf(): FloatArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun DoubleArray.copyOf(): DoubleArray {
+public actual fun DoubleArray.copyOf(): DoubleArray {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -802,8 +795,7 @@ public actual inline fun DoubleArray.copyOf(): DoubleArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun BooleanArray.copyOf(): BooleanArray {
+public actual fun BooleanArray.copyOf(): BooleanArray {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -812,8 +804,7 @@ public actual inline fun BooleanArray.copyOf(): BooleanArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.copyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun CharArray.copyOf(): CharArray {
+public actual fun CharArray.copyOf(): CharArray {
     return this.copyOfUninitializedElements(size)
 }
 
@@ -826,8 +817,7 @@ public actual inline fun CharArray.copyOf(): CharArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizedPrimitiveCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun ByteArray.copyOf(newSize: Int): ByteArray {
+public actual fun ByteArray.copyOf(newSize: Int): ByteArray {
     return this.copyOfUninitializedElements(newSize)
 }
 
@@ -840,8 +830,7 @@ public actual inline fun ByteArray.copyOf(newSize: Int): ByteArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizedPrimitiveCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun ShortArray.copyOf(newSize: Int): ShortArray {
+public actual fun ShortArray.copyOf(newSize: Int): ShortArray {
     return this.copyOfUninitializedElements(newSize)
 }
 
@@ -854,8 +843,7 @@ public actual inline fun ShortArray.copyOf(newSize: Int): ShortArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizedPrimitiveCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun IntArray.copyOf(newSize: Int): IntArray {
+public actual fun IntArray.copyOf(newSize: Int): IntArray {
     return this.copyOfUninitializedElements(newSize)
 }
 
@@ -868,8 +856,7 @@ public actual inline fun IntArray.copyOf(newSize: Int): IntArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizedPrimitiveCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun LongArray.copyOf(newSize: Int): LongArray {
+public actual fun LongArray.copyOf(newSize: Int): LongArray {
     return this.copyOfUninitializedElements(newSize)
 }
 
@@ -882,8 +869,7 @@ public actual inline fun LongArray.copyOf(newSize: Int): LongArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizedPrimitiveCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun FloatArray.copyOf(newSize: Int): FloatArray {
+public actual fun FloatArray.copyOf(newSize: Int): FloatArray {
     return this.copyOfUninitializedElements(newSize)
 }
 
@@ -896,8 +882,7 @@ public actual inline fun FloatArray.copyOf(newSize: Int): FloatArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizedPrimitiveCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun DoubleArray.copyOf(newSize: Int): DoubleArray {
+public actual fun DoubleArray.copyOf(newSize: Int): DoubleArray {
     return this.copyOfUninitializedElements(newSize)
 }
 
@@ -910,8 +895,7 @@ public actual inline fun DoubleArray.copyOf(newSize: Int): DoubleArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizedPrimitiveCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun BooleanArray.copyOf(newSize: Int): BooleanArray {
+public actual fun BooleanArray.copyOf(newSize: Int): BooleanArray {
     return this.copyOfUninitializedElements(newSize)
 }
 
@@ -924,8 +908,7 @@ public actual inline fun BooleanArray.copyOf(newSize: Int): BooleanArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizedPrimitiveCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun CharArray.copyOf(newSize: Int): CharArray {
+public actual fun CharArray.copyOf(newSize: Int): CharArray {
     return this.copyOfUninitializedElements(newSize)
 }
 
@@ -938,8 +921,7 @@ public actual inline fun CharArray.copyOf(newSize: Int): CharArray {
  * 
  * @sample samples.collections.Arrays.CopyOfOperations.resizingCopyOf
  */
-@kotlin.internal.InlineOnly
-public actual inline fun <T> Array<T>.copyOf(newSize: Int): Array<T?> {
+public actual fun <T> Array<T>.copyOf(newSize: Int): Array<T?> {
     return this.copyOfNulls(newSize)
 }
 
@@ -949,8 +931,7 @@ public actual inline fun <T> Array<T>.copyOf(newSize: Int): Array<T?> {
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun <T> Array<T>.copyOfRange(fromIndex: Int, toIndex: Int): Array<T> {
+public actual fun <T> Array<T>.copyOfRange(fromIndex: Int, toIndex: Int): Array<T> {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -961,8 +942,7 @@ public actual inline fun <T> Array<T>.copyOfRange(fromIndex: Int, toIndex: Int):
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun ByteArray.copyOfRange(fromIndex: Int, toIndex: Int): ByteArray {
+public actual fun ByteArray.copyOfRange(fromIndex: Int, toIndex: Int): ByteArray {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -973,8 +953,7 @@ public actual inline fun ByteArray.copyOfRange(fromIndex: Int, toIndex: Int): By
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun ShortArray.copyOfRange(fromIndex: Int, toIndex: Int): ShortArray {
+public actual fun ShortArray.copyOfRange(fromIndex: Int, toIndex: Int): ShortArray {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -985,8 +964,7 @@ public actual inline fun ShortArray.copyOfRange(fromIndex: Int, toIndex: Int): S
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun IntArray.copyOfRange(fromIndex: Int, toIndex: Int): IntArray {
+public actual fun IntArray.copyOfRange(fromIndex: Int, toIndex: Int): IntArray {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -997,8 +975,7 @@ public actual inline fun IntArray.copyOfRange(fromIndex: Int, toIndex: Int): Int
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun LongArray.copyOfRange(fromIndex: Int, toIndex: Int): LongArray {
+public actual fun LongArray.copyOfRange(fromIndex: Int, toIndex: Int): LongArray {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -1009,8 +986,7 @@ public actual inline fun LongArray.copyOfRange(fromIndex: Int, toIndex: Int): Lo
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun FloatArray.copyOfRange(fromIndex: Int, toIndex: Int): FloatArray {
+public actual fun FloatArray.copyOfRange(fromIndex: Int, toIndex: Int): FloatArray {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -1021,8 +997,7 @@ public actual inline fun FloatArray.copyOfRange(fromIndex: Int, toIndex: Int): F
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun DoubleArray.copyOfRange(fromIndex: Int, toIndex: Int): DoubleArray {
+public actual fun DoubleArray.copyOfRange(fromIndex: Int, toIndex: Int): DoubleArray {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -1033,8 +1008,7 @@ public actual inline fun DoubleArray.copyOfRange(fromIndex: Int, toIndex: Int): 
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun BooleanArray.copyOfRange(fromIndex: Int, toIndex: Int): BooleanArray {
+public actual fun BooleanArray.copyOfRange(fromIndex: Int, toIndex: Int): BooleanArray {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -1045,8 +1019,7 @@ public actual inline fun BooleanArray.copyOfRange(fromIndex: Int, toIndex: Int):
  * @param fromIndex the start of the range (inclusive), must be in `0..array.size`
  * @param toIndex the end of the range (exclusive), must be in `fromIndex..array.size`
  */
-@kotlin.internal.InlineOnly
-public actual inline fun CharArray.copyOfRange(fromIndex: Int, toIndex: Int): CharArray {
+public actual fun CharArray.copyOfRange(fromIndex: Int, toIndex: Int): CharArray {
     checkCopyOfRangeArguments(fromIndex, toIndex, size)
     return copyOfUninitializedElements(fromIndex, toIndex)
 }
@@ -1057,7 +1030,6 @@ public actual inline fun CharArray.copyOfRange(fromIndex: Int, toIndex: Int): Ch
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun <T> Array<T>.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): Array<T> {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1074,7 +1046,6 @@ internal fun <T> Array<T>.copyOfUninitializedElements(fromIndex: Int, toIndex: I
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun ByteArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): ByteArray {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1091,7 +1062,6 @@ internal fun ByteArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int)
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun ShortArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): ShortArray {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1108,7 +1078,6 @@ internal fun ShortArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun IntArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): IntArray {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1125,7 +1094,6 @@ internal fun IntArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int):
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun LongArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): LongArray {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1142,7 +1110,6 @@ internal fun LongArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int)
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun FloatArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): FloatArray {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1159,7 +1126,6 @@ internal fun FloatArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun DoubleArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): DoubleArray {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1176,7 +1142,6 @@ internal fun DoubleArray.copyOfUninitializedElements(fromIndex: Int, toIndex: In
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun BooleanArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): BooleanArray {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1193,7 +1158,6 @@ internal fun BooleanArray.copyOfUninitializedElements(fromIndex: Int, toIndex: I
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun CharArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): CharArray {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {
@@ -1209,7 +1173,6 @@ internal fun CharArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int)
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun <T> Array<T>.copyOfUninitializedElements(newSize: Int): Array<T> {
     return copyOfUninitializedElements(0, newSize)
 }
@@ -1219,7 +1182,6 @@ internal fun <T> Array<T>.copyOfUninitializedElements(newSize: Int): Array<T> {
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun ByteArray.copyOfUninitializedElements(newSize: Int): ByteArray {
     return copyOfUninitializedElements(0, newSize)
 }
@@ -1229,7 +1191,6 @@ internal fun ByteArray.copyOfUninitializedElements(newSize: Int): ByteArray {
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun ShortArray.copyOfUninitializedElements(newSize: Int): ShortArray {
     return copyOfUninitializedElements(0, newSize)
 }
@@ -1239,7 +1200,6 @@ internal fun ShortArray.copyOfUninitializedElements(newSize: Int): ShortArray {
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun IntArray.copyOfUninitializedElements(newSize: Int): IntArray {
     return copyOfUninitializedElements(0, newSize)
 }
@@ -1249,7 +1209,6 @@ internal fun IntArray.copyOfUninitializedElements(newSize: Int): IntArray {
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun LongArray.copyOfUninitializedElements(newSize: Int): LongArray {
     return copyOfUninitializedElements(0, newSize)
 }
@@ -1259,7 +1218,6 @@ internal fun LongArray.copyOfUninitializedElements(newSize: Int): LongArray {
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun FloatArray.copyOfUninitializedElements(newSize: Int): FloatArray {
     return copyOfUninitializedElements(0, newSize)
 }
@@ -1269,7 +1227,6 @@ internal fun FloatArray.copyOfUninitializedElements(newSize: Int): FloatArray {
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun DoubleArray.copyOfUninitializedElements(newSize: Int): DoubleArray {
     return copyOfUninitializedElements(0, newSize)
 }
@@ -1279,7 +1236,6 @@ internal fun DoubleArray.copyOfUninitializedElements(newSize: Int): DoubleArray 
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun BooleanArray.copyOfUninitializedElements(newSize: Int): BooleanArray {
     return copyOfUninitializedElements(0, newSize)
 }
@@ -1289,7 +1245,6 @@ internal fun BooleanArray.copyOfUninitializedElements(newSize: Int): BooleanArra
  * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
  * either throwing exception or returning some kind of implementation-specific default value.
  */
-@PublishedApi
 internal fun CharArray.copyOfUninitializedElements(newSize: Int): CharArray {
     return copyOfUninitializedElements(0, newSize)
 }

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -538,7 +538,8 @@ public actual fun CharArray.contentToString(): String {
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun <T> Array<out T>.copyInto(destination: Array<T>, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): Array<T> {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    @Suppress("UNCHECKED_CAST")
+    arrayCopy(this as Array<Any?>, startIndex, destination as Array<Any?>, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -561,7 +562,7 @@ public actual fun <T> Array<out T>.copyInto(destination: Array<T>, destinationOf
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun ByteArray.copyInto(destination: ByteArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): ByteArray {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    arrayCopy(this, startIndex, destination, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -584,7 +585,7 @@ public actual fun ByteArray.copyInto(destination: ByteArray, destinationOffset: 
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun ShortArray.copyInto(destination: ShortArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): ShortArray {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    arrayCopy(this, startIndex, destination, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -607,7 +608,7 @@ public actual fun ShortArray.copyInto(destination: ShortArray, destinationOffset
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun IntArray.copyInto(destination: IntArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): IntArray {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    arrayCopy(this, startIndex, destination, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -630,7 +631,7 @@ public actual fun IntArray.copyInto(destination: IntArray, destinationOffset: In
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun LongArray.copyInto(destination: LongArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): LongArray {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    arrayCopy(this, startIndex, destination, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -653,7 +654,7 @@ public actual fun LongArray.copyInto(destination: LongArray, destinationOffset: 
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun FloatArray.copyInto(destination: FloatArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): FloatArray {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    arrayCopy(this, startIndex, destination, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -676,7 +677,7 @@ public actual fun FloatArray.copyInto(destination: FloatArray, destinationOffset
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun DoubleArray.copyInto(destination: DoubleArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): DoubleArray {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    arrayCopy(this, startIndex, destination, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -699,7 +700,7 @@ public actual fun DoubleArray.copyInto(destination: DoubleArray, destinationOffs
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun BooleanArray.copyInto(destination: BooleanArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): BooleanArray {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    arrayCopy(this, startIndex, destination, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -722,7 +723,7 @@ public actual fun BooleanArray.copyInto(destination: BooleanArray, destinationOf
 @SinceKotlin("1.3")
 @Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
 public actual fun CharArray.copyInto(destination: CharArray, destinationOffset: Int = 0, startIndex: Int = 0, endIndex: Int = size): CharArray {
-    this.copyRangeTo(destination, startIndex, endIndex, destinationOffset)
+    arrayCopy(this, startIndex, destination, destinationOffset, endIndex - startIndex)
     return destination
 }
 
@@ -1237,7 +1238,7 @@ public actual operator fun <T> Array<T>.plus(elements: Array<out T>): Array<T> {
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 
@@ -1248,7 +1249,7 @@ public actual operator fun ByteArray.plus(elements: ByteArray): ByteArray {
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 
@@ -1259,7 +1260,7 @@ public actual operator fun ShortArray.plus(elements: ShortArray): ShortArray {
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 
@@ -1270,7 +1271,7 @@ public actual operator fun IntArray.plus(elements: IntArray): IntArray {
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 
@@ -1281,7 +1282,7 @@ public actual operator fun LongArray.plus(elements: LongArray): LongArray {
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 
@@ -1292,7 +1293,7 @@ public actual operator fun FloatArray.plus(elements: FloatArray): FloatArray {
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 
@@ -1303,7 +1304,7 @@ public actual operator fun DoubleArray.plus(elements: DoubleArray): DoubleArray 
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 
@@ -1314,7 +1315,7 @@ public actual operator fun BooleanArray.plus(elements: BooleanArray): BooleanArr
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 
@@ -1325,7 +1326,7 @@ public actual operator fun CharArray.plus(elements: CharArray): CharArray {
     val thisSize = size
     val arraySize = elements.size
     val result = copyOfUninitializedElements(thisSize + arraySize)
-    elements.copyRangeTo(result, 0, arraySize, thisSize)
+    elements.copyInto(result, thisSize)
     return result
 }
 

--- a/runtime/src/main/kotlin/kotlin/Array.kt
+++ b/runtime/src/main/kotlin/kotlin/Array.kt
@@ -88,13 +88,3 @@ private class IteratorImpl<T>(val collection: Array<T>) : Iterator<T> {
         return index < collection.size
     }
 }
-
-/**
- * Returns an array containing all elements of the original array and then all elements of the given [elements] array.
- */
-@kotlin.internal.InlineOnly
-public inline operator fun <T> Array<T>.plus(elements: Array<T>): Array<T> {
-    val result = copyOfUninitializedElements(this.size + elements.size)
-    elements.copyRangeTo(result, 0, elements.size, this.size)
-    return result
-}

--- a/runtime/src/main/kotlin/kotlin/Arrays.kt
+++ b/runtime/src/main/kotlin/kotlin/Arrays.kt
@@ -8,13 +8,9 @@
 
 package kotlin
 
-import kotlin.collections.*
 import kotlin.internal.PureReifiable
 import kotlin.native.internal.ExportTypeInfo
 import kotlin.native.internal.InlineConstructor
-import kotlin.util.sortArray
-import kotlin.util.sortArrayComparable
-import kotlin.util.sortArrayWith
 
 /**
  * An array of bytes.

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayList.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayList.kt
@@ -200,7 +200,7 @@ actual class ArrayList<E> private constructor(
 
     private fun insertAtInternal(i: Int, n: Int) {
         ensureExtraCapacity(n)
-        array.copyRangeTo(array, fromIndex = i, toIndex = offset + length, destinationIndex = i + n)
+        array.copyInto(array, startIndex = i, endIndex = offset + length, destinationOffset = i + n)
         length += n
     }
 
@@ -238,7 +238,7 @@ actual class ArrayList<E> private constructor(
             return old
         } else {
             val old = array[i]
-            array.copyRangeTo(array, fromIndex = i + 1, toIndex = offset + length, destinationIndex = i)
+            array.copyInto(array, startIndex = i + 1, endIndex = offset + length, destinationOffset = i)
             array.resetAt(offset + length - 1)
             length--
             return old
@@ -249,7 +249,7 @@ actual class ArrayList<E> private constructor(
         if (backing != null) {
             backing.removeRangeInternal(rangeOffset, rangeLength)
         } else {
-            array.copyRangeTo(array, fromIndex = rangeOffset + rangeLength, toIndex = length, destinationIndex = rangeOffset)
+            array.copyInto(array, startIndex = rangeOffset + rangeLength, endIndex = length, destinationOffset = rangeOffset)
             array.resetRange(fromIndex = length - rangeLength, toIndex = length)
         }
         length -= rangeLength
@@ -272,7 +272,7 @@ actual class ArrayList<E> private constructor(
                 }
             }
             val removed = rangeLength - j
-            array.copyRangeTo(array, fromIndex = rangeOffset + rangeLength, toIndex = length, destinationIndex = rangeOffset + j)
+            array.copyInto(array, startIndex = rangeOffset + rangeLength, endIndex = length, destinationOffset = rangeOffset + j)
             array.resetRange(fromIndex = length - removed, toIndex = length)
             length -= removed
             return removed

--- a/runtime/src/main/kotlin/kotlin/collections/ArraySorting.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArraySorting.kt
@@ -3,9 +3,8 @@
  * that can be found in the LICENSE file.
  */
 
-package kotlin.util
+package kotlin.collections
 
-import kotlin.comparisons.*
 
 private fun <T: Comparable<T>> mergeSort(array: Array<T>, start: Int, endInclusive: Int) {
     @Suppress("UNCHECKED_CAST")
@@ -375,7 +374,7 @@ internal fun <T> sortArrayWith(
  * Sorts a subarray of [Comparable] elements specified by [fromIndex] (inclusive) and
  * [toIndex] (exclusive) parameters using the qsort algorithm.
  */
-internal fun <T: Comparable<T>> sortArrayComparable(array: Array<out T>) {
+internal fun <T: Comparable<T>> sortArray(array: Array<out T>) {
     @Suppress("UNCHECKED_CAST")
     mergeSort(array as Array<T>, 0, array.size - 1)
 }

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
@@ -235,61 +235,56 @@ internal fun IntArray.fill(fromIndex: Int, toIndex: Int, value: Int) {
 
 @SymbolName("Kotlin_Array_copyImpl")
 @PointsTo(0b000100, 0, 0b000001) // <array> points to <destination>, <destination> points to <array>.
-external private fun copyImpl(array: Array<Any?>, fromIndex: Int,
+internal external fun arrayCopy(array: Array<Any?>, fromIndex: Int,
                          destination: Array<Any?>, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_ByteArray_copyImpl")
-external private fun copyImpl(array: ByteArray, fromIndex: Int,
-                              destination: ByteArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: ByteArray, fromIndex: Int, destination: ByteArray, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_ShortArray_copyImpl")
-external private fun copyImpl(array: ShortArray, fromIndex: Int,
-                              destination: ShortArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: ShortArray, fromIndex: Int, destination: ShortArray, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_CharArray_copyImpl")
-external private fun copyImpl(array: CharArray, fromIndex: Int,
-                              destination: CharArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: CharArray, fromIndex: Int, destination: CharArray, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_IntArray_copyImpl")
-external private fun copyImpl(array: IntArray, fromIndex: Int,
-                              destination: IntArray, toIndex: Int, count: Int)
-@SymbolName("Kotlin_LongArray_copyImpl")
-external private fun copyImpl(array: LongArray, fromIndex: Int,
-                              destination: LongArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: IntArray, fromIndex: Int, destination: IntArray, toIndex: Int, count: Int)
 
-// Note: [copyImpl] for an unsigned array is bitwise identical to signed type, so
+@SymbolName("Kotlin_LongArray_copyImpl")
+internal external fun arrayCopy(array: LongArray, fromIndex: Int, destination: LongArray, toIndex: Int, count: Int)
+
+// Note: [arrayCopy] for an unsigned array is bitwise identical to signed type, so
 // signed array implementations from runtime are directly reused for unsigned ones.
 
 @ExperimentalUnsignedTypes
 @SymbolName("Kotlin_ByteArray_copyImpl")
-external private fun copyImpl(array: UByteArray, fromIndex: Int,
-                              destination: UByteArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: UByteArray, fromIndex: Int, destination: UByteArray, toIndex: Int, count: Int)
 
 @ExperimentalUnsignedTypes
 @SymbolName("Kotlin_ShortArray_copyImpl")
-external private fun copyImpl(array: UShortArray, fromIndex: Int,
-                              destination: UShortArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: UShortArray, fromIndex: Int, destination: UShortArray, toIndex: Int, count: Int)
 
 @ExperimentalUnsignedTypes
 @SymbolName("Kotlin_IntArray_copyImpl")
-external private fun copyImpl(array: UIntArray, fromIndex: Int,
+internal external fun arrayCopy(array: UIntArray, fromIndex: Int,
                               destination: UIntArray, toIndex: Int, count: Int)
 
 @ExperimentalUnsignedTypes
 @SymbolName("Kotlin_LongArray_copyImpl")
-external private fun copyImpl(array: ULongArray, fromIndex: Int,
+internal external fun arrayCopy(array: ULongArray, fromIndex: Int,
                               destination: ULongArray, toIndex: Int, count: Int)
 
+
 @SymbolName("Kotlin_FloatArray_copyImpl")
-external private fun copyImpl(array: FloatArray, fromIndex: Int,
+internal external fun arrayCopy(array: FloatArray, fromIndex: Int,
                               destination: FloatArray, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_DoubleArray_copyImpl")
-external private fun copyImpl(array: DoubleArray, fromIndex: Int,
+internal external fun arrayCopy(array: DoubleArray, fromIndex: Int,
                               destination: DoubleArray, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_BooleanArray_copyImpl")
-external private fun copyImpl(array: BooleanArray, fromIndex: Int,
+internal external fun arrayCopy(array: BooleanArray, fromIndex: Int,
                               destination: BooleanArray, toIndex: Int, count: Int)
 
 /**
@@ -299,65 +294,65 @@ external private fun copyImpl(array: BooleanArray, fromIndex: Int,
 @PublishedApi
 internal fun <E> Array<out E>.copyRangeTo(
         destination: Array<in E>, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(@Suppress("UNCHECKED_CAST") (this as Array<Any?>), fromIndex,
+    arrayCopy(@Suppress("UNCHECKED_CAST") (this as Array<Any?>), fromIndex,
              @Suppress("UNCHECKED_CAST") (destination as Array<Any?>),
              destinationIndex, toIndex - fromIndex)
 }
 
 internal fun ByteArray.copyRangeTo(destination: ByteArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 internal fun ShortArray.copyRangeTo(destination: ShortArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 internal fun CharArray.copyRangeTo(destination: CharArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 internal fun IntArray.copyRangeTo(destination: IntArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 internal fun LongArray.copyRangeTo(destination: LongArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
 internal fun UByteArray.copyRangeTo(destination: UByteArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
 internal fun UShortArray.copyRangeTo(destination: UShortArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
 internal fun UIntArray.copyRangeTo(destination: UIntArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 @SinceKotlin("1.3")
 @ExperimentalUnsignedTypes
 internal fun ULongArray.copyRangeTo(destination: ULongArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 internal fun FloatArray.copyRangeTo(destination: FloatArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 internal fun DoubleArray.copyRangeTo(destination: DoubleArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 internal fun BooleanArray.copyRangeTo(destination: BooleanArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
+    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
 }
 
 internal fun <E> Collection<E>.collectionToString(): String {

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
@@ -213,7 +213,7 @@ internal fun <E> Array<E>.resetAt(index: Int) {
 
 @SymbolName("Kotlin_Array_fillImpl")
 @PointsTo(0b01000, 0, 0, 0b00001) // <array> points to <value>, <value> points to <array>.
-external private fun fillImpl(array: Array<Any>, fromIndex: Int, toIndex: Int, value: Any?)
+external private fun fillImpl(array: Array<Any?>, fromIndex: Int, toIndex: Int, value: Any?)
 
 @SymbolName("Kotlin_IntArray_fillImpl")
 external private fun fillImpl(array: IntArray, fromIndex: Int, toIndex: Int, value: Int)
@@ -226,7 +226,7 @@ external private fun fillImpl(array: IntArray, fromIndex: Int, toIndex: Int, val
  * either throwing exception or returning some kind of implementation-specific default value.
  */
 internal fun <E> Array<E>.resetRange(fromIndex: Int, toIndex: Int) {
-    fillImpl(@Suppress("UNCHECKED_CAST") (this as Array<Any>), fromIndex, toIndex, null)
+    fillImpl(@Suppress("UNCHECKED_CAST") (this as Array<Any?>), fromIndex, toIndex, null)
 }
 
 internal fun IntArray.fill(fromIndex: Int, toIndex: Int, value: Int) {
@@ -235,8 +235,8 @@ internal fun IntArray.fill(fromIndex: Int, toIndex: Int, value: Int) {
 
 @SymbolName("Kotlin_Array_copyImpl")
 @PointsTo(0b000100, 0, 0b000001) // <array> points to <destination>, <destination> points to <array>.
-external private fun copyImpl(array: Array<Any>, fromIndex: Int,
-                         destination: Array<Any>, toIndex: Int, count: Int)
+external private fun copyImpl(array: Array<Any?>, fromIndex: Int,
+                         destination: Array<Any?>, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_ByteArray_copyImpl")
 external private fun copyImpl(array: ByteArray, fromIndex: Int,
@@ -299,8 +299,8 @@ external private fun copyImpl(array: BooleanArray, fromIndex: Int,
 @PublishedApi
 internal fun <E> Array<out E>.copyRangeTo(
         destination: Array<in E>, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    copyImpl(@Suppress("UNCHECKED_CAST") (this as Array<Any>), fromIndex,
-             @Suppress("UNCHECKED_CAST") (destination as Array<Any>),
+    copyImpl(@Suppress("UNCHECKED_CAST") (this as Array<Any?>), fromIndex,
+             @Suppress("UNCHECKED_CAST") (destination as Array<Any?>),
              destinationIndex, toIndex - fromIndex)
 }
 

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
@@ -19,37 +19,6 @@ internal fun <E> arrayOfUninitializedElements(size: Int): Array<E> {
     return Array<E>(size)
 }
 
-/**
- * Returns new array which is a copy of the original array with new elements filled with **lateinit** _uninitialized_ values.
- * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
- * either throwing exception or returning some kind of implementation-specific default value.
- */
-@PublishedApi
-internal fun <E> Array<E>.copyOfUninitializedElements(newSize: Int): Array<E> = copyOfUninitializedElements(0, newSize)
-
-@PublishedApi
-internal fun ByteArray.copyOfUninitializedElements(newSize: Int): ByteArray       = copyOfUninitializedElements(0, newSize)
-
-@PublishedApi
-internal fun ShortArray.copyOfUninitializedElements(newSize: Int): ShortArray     = copyOfUninitializedElements(0, newSize)
-
-@PublishedApi
-internal fun IntArray.copyOfUninitializedElements(newSize: Int): IntArray         = copyOfUninitializedElements(0, newSize)
-
-@PublishedApi
-internal fun LongArray.copyOfUninitializedElements(newSize: Int): LongArray       = copyOfUninitializedElements(0, newSize)
-
-@PublishedApi
-internal fun CharArray.copyOfUninitializedElements(newSize: Int): CharArray       = copyOfUninitializedElements(0, newSize)
-
-@PublishedApi
-internal fun FloatArray.copyOfUninitializedElements(newSize: Int): FloatArray     = copyOfUninitializedElements(0, newSize)
-
-@PublishedApi
-internal fun DoubleArray.copyOfUninitializedElements(newSize: Int): DoubleArray   = copyOfUninitializedElements(0, newSize)
-
-@PublishedApi
-internal fun BooleanArray.copyOfUninitializedElements(newSize: Int): BooleanArray = copyOfUninitializedElements(0, newSize)
 
 /**
  * Returns a new array which is a copy of the original array with new elements filled with null values.
@@ -64,7 +33,7 @@ internal fun <E> Array<E>.copyOfNulls(fromIndex: Int, toIndex: Int): Array<E?> {
         throw IllegalArgumentException("$fromIndex > $toIndex")
     }
     val result = @Suppress("TYPE_PARAMETER_AS_REIFIED") arrayOfNulls<E>(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
+    this.copyInto(result, 0, fromIndex, toIndex.coerceAtMost(size))
     return result
 }
 
@@ -94,111 +63,6 @@ internal fun <E, T> collectionToArray(collection: Collection<E>, array: Array<T>
  */
 internal fun <E> collectionToArray(collection: Collection<E>): Array<E>
         = collectionToArray(collection, arrayOfUninitializedElements(collection.size))
-
-/**
- * Returns new array which is a copy of the original array's range between [fromIndex] (inclusive)
- * and [toIndex] (exclusive) with new elements filled with **lateinit** _uninitialized_ values.
- * Attempts to read _uninitialized_ values from this array work in implementation-dependent manner,
- * either throwing exception or returning some kind of implementation-specific default value.
- */
-@PublishedApi
-internal fun <E> Array<E>.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): Array<E> {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = arrayOfUninitializedElements<E>(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
-
-@PublishedApi
-internal fun ByteArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): ByteArray {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = ByteArray(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
-
-@PublishedApi
-internal fun ShortArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): ShortArray {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = ShortArray(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
-
-@PublishedApi
-internal fun IntArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): IntArray {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = IntArray(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
-
-@PublishedApi
-internal fun LongArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): LongArray {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = LongArray(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
-
-@PublishedApi
-internal fun CharArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): CharArray {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = CharArray(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
-
-@PublishedApi
-internal fun FloatArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): FloatArray {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = FloatArray(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
-
-@PublishedApi
-internal fun DoubleArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): DoubleArray {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = DoubleArray(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
-
-@PublishedApi
-internal fun BooleanArray.copyOfUninitializedElements(fromIndex: Int, toIndex: Int): BooleanArray {
-    val newSize = toIndex - fromIndex
-    if (newSize < 0) {
-        throw IllegalArgumentException("$fromIndex > $toIndex")
-    }
-    val result = BooleanArray(newSize)
-    copyRangeTo(result, fromIndex, if (toIndex > size) size else toIndex, 0)
-    return result
-}
 
 
 /**

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
@@ -99,8 +99,7 @@ internal fun IntArray.fill(fromIndex: Int, toIndex: Int, value: Int) {
 
 @SymbolName("Kotlin_Array_copyImpl")
 @PointsTo(0b000100, 0, 0b000001) // <array> points to <destination>, <destination> points to <array>.
-internal external fun arrayCopy(array: Array<Any?>, fromIndex: Int,
-                         destination: Array<Any?>, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: Array<Any?>, fromIndex: Int, destination: Array<Any?>, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_ByteArray_copyImpl")
 internal external fun arrayCopy(array: ByteArray, fromIndex: Int, destination: ByteArray, toIndex: Int, count: Int)
@@ -117,107 +116,15 @@ internal external fun arrayCopy(array: IntArray, fromIndex: Int, destination: In
 @SymbolName("Kotlin_LongArray_copyImpl")
 internal external fun arrayCopy(array: LongArray, fromIndex: Int, destination: LongArray, toIndex: Int, count: Int)
 
-// Note: [arrayCopy] for an unsigned array is bitwise identical to signed type, so
-// signed array implementations from runtime are directly reused for unsigned ones.
-
-@ExperimentalUnsignedTypes
-@SymbolName("Kotlin_ByteArray_copyImpl")
-internal external fun arrayCopy(array: UByteArray, fromIndex: Int, destination: UByteArray, toIndex: Int, count: Int)
-
-@ExperimentalUnsignedTypes
-@SymbolName("Kotlin_ShortArray_copyImpl")
-internal external fun arrayCopy(array: UShortArray, fromIndex: Int, destination: UShortArray, toIndex: Int, count: Int)
-
-@ExperimentalUnsignedTypes
-@SymbolName("Kotlin_IntArray_copyImpl")
-internal external fun arrayCopy(array: UIntArray, fromIndex: Int,
-                              destination: UIntArray, toIndex: Int, count: Int)
-
-@ExperimentalUnsignedTypes
-@SymbolName("Kotlin_LongArray_copyImpl")
-internal external fun arrayCopy(array: ULongArray, fromIndex: Int,
-                              destination: ULongArray, toIndex: Int, count: Int)
-
-
 @SymbolName("Kotlin_FloatArray_copyImpl")
-internal external fun arrayCopy(array: FloatArray, fromIndex: Int,
-                              destination: FloatArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: FloatArray, fromIndex: Int, destination: FloatArray, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_DoubleArray_copyImpl")
-internal external fun arrayCopy(array: DoubleArray, fromIndex: Int,
-                              destination: DoubleArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: DoubleArray, fromIndex: Int, destination: DoubleArray, toIndex: Int, count: Int)
 
 @SymbolName("Kotlin_BooleanArray_copyImpl")
-internal external fun arrayCopy(array: BooleanArray, fromIndex: Int,
-                              destination: BooleanArray, toIndex: Int, count: Int)
+internal external fun arrayCopy(array: BooleanArray, fromIndex: Int, destination: BooleanArray, toIndex: Int, count: Int)
 
-/**
- * Copies a range of array elements at a specified [fromIndex] (inclusive) to [toIndex] (exclusive) range of indices
- * to another [destination] array starting at [destinationIndex].
- */
-@PublishedApi
-internal fun <E> Array<out E>.copyRangeTo(
-        destination: Array<in E>, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(@Suppress("UNCHECKED_CAST") (this as Array<Any?>), fromIndex,
-             @Suppress("UNCHECKED_CAST") (destination as Array<Any?>),
-             destinationIndex, toIndex - fromIndex)
-}
-
-internal fun ByteArray.copyRangeTo(destination: ByteArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-internal fun ShortArray.copyRangeTo(destination: ShortArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-internal fun CharArray.copyRangeTo(destination: CharArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-internal fun IntArray.copyRangeTo(destination: IntArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-internal fun LongArray.copyRangeTo(destination: LongArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-@SinceKotlin("1.3")
-@ExperimentalUnsignedTypes
-internal fun UByteArray.copyRangeTo(destination: UByteArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-@SinceKotlin("1.3")
-@ExperimentalUnsignedTypes
-internal fun UShortArray.copyRangeTo(destination: UShortArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-@SinceKotlin("1.3")
-@ExperimentalUnsignedTypes
-internal fun UIntArray.copyRangeTo(destination: UIntArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-@SinceKotlin("1.3")
-@ExperimentalUnsignedTypes
-internal fun ULongArray.copyRangeTo(destination: ULongArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-internal fun FloatArray.copyRangeTo(destination: FloatArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-internal fun DoubleArray.copyRangeTo(destination: DoubleArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
-
-internal fun BooleanArray.copyRangeTo(destination: BooleanArray, fromIndex: Int, toIndex: Int, destinationIndex: Int = 0) {
-    arrayCopy(this, fromIndex, destination, destinationIndex, toIndex - fromIndex)
-}
 
 internal fun <E> Collection<E>.collectionToString(): String {
     val sb = StringBuilder(2 + size * 3)

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
@@ -23,10 +23,8 @@ internal fun <E> arrayOfUninitializedElements(size: Int): Array<E> {
 /**
  * Returns a new array which is a copy of the original array with new elements filled with null values.
  */
-@PublishedApi
 internal fun <E> Array<E>.copyOfNulls(newSize: Int): Array<E?>  = copyOfNulls(0, newSize)
 
-@PublishedApi
 internal fun <E> Array<E>.copyOfNulls(fromIndex: Int, toIndex: Int): Array<E?> {
     val newSize = toIndex - fromIndex
     if (newSize < 0) {

--- a/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
@@ -6,11 +6,7 @@
 package kotlin.collections
 
 import kotlin.native.internal.InlineConstructor
-import kotlin.collections.*
 import kotlin.internal.PureReifiable
-import kotlin.util.sortArrayComparable
-import kotlin.util.sortArrayWith
-import kotlin.util.sortArray
 
 /** Returns the array if it's not `null`, or an empty array otherwise. */
 public actual inline fun <reified T> Array<out T>?.orEmpty(): Array<out T> = this ?: emptyArray<T>()

--- a/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
@@ -19,16 +19,6 @@ public actual inline fun <reified T> Array<out T>?.orEmpty(): Array<out T> = thi
         throw IllegalArgumentException("fromIndex ($fromIndex) is greater than toIndex ($toIndex).")
 }
 
-// TODO: Move to generated code
-/**
- * Sorts a range in the array in-place with the given [comparator].
- *
- * The sort is _stable_. It means that equal elements preserve their order relative to each other after sorting.
- */
-public fun <T> Array<out T>.sortWith(comparator: Comparator<in T>, fromIndex: Int = 0, toIndex: Int = size): Unit {
-    sortArrayWith(this, fromIndex, toIndex, comparator)
-}
-
 
 // TODO: internal
 /**

--- a/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
@@ -11,8 +11,7 @@ import kotlin.internal.PureReifiable
 /** Returns the array if it's not `null`, or an empty array otherwise. */
 public actual inline fun <reified T> Array<out T>?.orEmpty(): Array<out T> = this ?: emptyArray<T>()
 
-@Suppress("NOTHING_TO_INLINE")
-@PublishedApi internal inline fun checkCopyOfRangeArguments(fromIndex: Int, toIndex: Int, size: Int) {
+internal fun checkCopyOfRangeArguments(fromIndex: Int, toIndex: Int, size: Int) {
     if (toIndex > size)
         throw IndexOutOfBoundsException("toIndex ($toIndex) is greater than size ($size).")
     if (fromIndex > toIndex)

--- a/runtime/src/main/kotlin/kotlin/collections/MutableCollections.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/MutableCollections.kt
@@ -5,14 +5,12 @@
 
 package kotlin.collections
 
-import kotlin.comparisons.*
-
 /**
  * Sorts elements in the list in-place according to their natural sort order.
  *
  * The sort is _stable_. It means that equal elements preserve their order relative to each other after sorting.
  */
-public actual fun <T : Comparable<T>> MutableList<T>.sort(): Unit = sortWith(Comparator<T> { a: T, b: T -> a.compareTo(b) })
+public actual fun <T : Comparable<T>> MutableList<T>.sort(): Unit = sortWith(naturalOrder())
 
 /**
  * Sorts elements in the list in-place according to the order specified with [comparator].
@@ -22,7 +20,7 @@ public actual fun <T : Comparable<T>> MutableList<T>.sort(): Unit = sortWith(Com
 public actual fun <T> MutableList<T>.sortWith(comparator: Comparator<in T>): Unit {
     if (size > 1) {
         val it = listIterator()
-        val sortedArray = @Suppress("TYPE_PARAMETER_AS_REIFIED") toTypedArray().apply { sortWith(comparator) }
+        val sortedArray = @Suppress("UNCHECKED_CAST") (toTypedArray<Any?>() as Array<T>).apply { sortWith(comparator) }
         for (v in sortedArray) {
             it.next()
             it.set(v)

--- a/runtime/src/main/kotlin/kotlin/native/concurrent/MutableData.kt
+++ b/runtime/src/main/kotlin/kotlin/native/concurrent/MutableData.kt
@@ -34,7 +34,7 @@ public class MutableData constructor(capacity: Int = 16) {
         if (newSize > buffer.size) {
             val actualSize = maxOf(buffer.size * 3 / 2 + 1, newSize)
             val newBuffer = ByteArray(actualSize)
-            buffer.copyRangeTo(newBuffer, 0, size, 0)
+            buffer.copyInto(newBuffer, startIndex = 0, endIndex = size)
             newBuffer.share()
             buffer = newBuffer
         }
@@ -73,7 +73,7 @@ public class MutableData constructor(capacity: Int = 16) {
             throw IndexOutOfBoundsException("$fromIndex is bigger than $toIndex")
         if (toIndex == toIndex) return
         val where = resizeDataLocked(this.size + (toIndex - fromIndex))
-        data.copyRangeTo(buffer, fromIndex, toIndex, where)
+        data.copyInto(buffer, where, fromIndex, toIndex)
     }
 
     /**
@@ -91,7 +91,7 @@ public class MutableData constructor(capacity: Int = 16) {
      * Copies range of mutable data to the byte array.
      */
     public fun copyInto(output: ByteArray, destinationIndex: Int, startIndex: Int, endIndex: Int): Unit = locked(lock) {
-        buffer.copyRangeTo(output, startIndex, endIndex, destinationIndex)
+        buffer.copyInto(output, destinationIndex, startIndex, endIndex)
     }
 
     /**

--- a/runtime/src/main/kotlin/kotlin/text/StringBuilder.kt
+++ b/runtime/src/main/kotlin/kotlin/text/StringBuilder.kt
@@ -168,7 +168,7 @@ actual class StringBuilder private constructor (
         val extraLength = end - start
         ensureExtraCapacity(extraLength)
 
-        array.copyRangeTo(array, index, _length, index + extraLength)
+        array.copyInto(array, startIndex = index, endIndex = _length, destinationOffset = index + extraLength)
         var from = start
         var to = index
         while (from < end) {
@@ -183,8 +183,8 @@ actual class StringBuilder private constructor (
         checkInsertIndex(index)
         ensureExtraCapacity(chars.size)
 
-        array.copyRangeTo(array, index, _length, index + chars.size)
-        chars.copyRangeTo(array, 0, chars.size, index)
+        array.copyInto(array, startIndex = index, endIndex = _length, destinationOffset = index + chars.size)
+        chars.copyInto(array, destinationOffset = index)
 
         _length += chars.size
         return this
@@ -193,7 +193,7 @@ actual class StringBuilder private constructor (
     fun insert(index: Int, string: String): StringBuilder {
         checkInsertIndex(index)
         ensureExtraCapacity(string.length)
-        array.copyRangeTo(array, index, _length, index + string.length)
+        array.copyInto(array, startIndex = index, endIndex = _length, destinationOffset = index + string.length)
         _length += insertString(array, index, string)
         return this
     }
@@ -235,7 +235,7 @@ actual class StringBuilder private constructor (
 
     fun append(it: CharArray): StringBuilder {
         ensureExtraCapacity(it.size)
-        it.copyRangeTo(array, 0, it.size, _length)
+        it.copyInto(array, _length)
         _length += it.size
         return this
     }
@@ -262,7 +262,7 @@ actual class StringBuilder private constructor (
 
     fun deleteCharAt(index: Int) {
         checkIndex(index)
-        array.copyRangeTo(array, index + 1, _length, index)
+        array.copyInto(array, startIndex = index + 1, endIndex = _length, destinationOffset = index)
         --_length
     }
 


### PR DESCRIPTION
I've rebased two branches on master: `stdlib-sorting` and `stdlib-array-copying`. There was one merge conflict in `collections/Arrays.kt`.