### PR TITLE
 Refactor ObjCExportHeaderGenerator to allow per declaration translation

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -56,6 +56,7 @@ import java.lang.System.out
 import kotlin.LazyThreadSafetyMode.PUBLICATION
 import kotlin.reflect.KProperty
 import org.jetbrains.kotlin.backend.common.ir.copyTo
+import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExport
 import org.jetbrains.kotlin.ir.symbols.impl.IrTypeParameterSymbolImpl
 
 /**
@@ -206,6 +207,8 @@ internal class Context(config: KonanConfig) : KonanBackendContext(config) {
     }
 
     lateinit var moduleDescriptor: ModuleDescriptor
+
+    lateinit var objCExport: ObjCExport
 
     override val builtIns: KonanBuiltIns by lazy(PUBLICATION) {
         moduleDescriptor.builtIns as KonanBuiltIns

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.backend.konan.descriptors.konanLibrary
 import org.jetbrains.kotlin.backend.konan.ir.KonanSymbols
 import org.jetbrains.kotlin.backend.konan.llvm.*
 import org.jetbrains.kotlin.backend.konan.lower.ExpectToActualDefaultValueCopier
+import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExport
 import org.jetbrains.kotlin.backend.konan.serialization.*
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
@@ -45,6 +46,14 @@ internal val frontendPhase = konanUnitPhase(
         },
         name = "Frontend",
         description = "Frontend builds AST"
+)
+
+internal val objCExportPhase = konanUnitPhase(
+        op = {
+            objCExport = ObjCExport(this)
+        },
+        name = "ObjCExport",
+        description = "Objective-C header generation"
 )
 
 internal val psiToIrPhase = konanUnitPhase(
@@ -275,6 +284,7 @@ internal val toplevelPhase = namedUnitPhase(
         name = "Compiler",
         description = "The whole compilation process",
         lower = frontendPhase then
+                objCExportPhase then
                 psiToIrPhase then
                 irGeneratorPluginsPhase then
                 copyDefaultValuesToActualPhase then

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -314,7 +314,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         declaration.acceptChildrenVoid(this)
 
         // Note: it is here because it also generates some bitcode.
-        ObjCExport(codegen).produce()
+        context.objCExport.generate(codegen)
 
         codegen.objCDataGenerator?.finishModule()
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
@@ -5,58 +5,117 @@
 
 package org.jetbrains.kotlin.backend.konan.objcexport
 
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.getReceiverTypeFromFunctionType
 import org.jetbrains.kotlin.builtins.getReturnTypeFromFunctionType
 import org.jetbrains.kotlin.builtins.getValueParameterTypesFromFunctionType
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.resolve.descriptorUtil.classId
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
 
 internal interface CustomTypeMapper {
     val mappedClassId: ClassId
-    fun mapType(mappedSuperType: KotlinType): ObjCNonNullReferenceType
+    fun mapType(mappedSuperType: KotlinType, translator: ObjCExportTranslatorImpl): ObjCNonNullReferenceType
+}
 
-    class Simple(
-            override val mappedClassId: ClassId,
-            private val objCClassName: String
-    ) : CustomTypeMapper {
+internal object CustomTypeMappers {
+    /**
+     * Custom type mappers.
+     *
+     * Don't forget to update [hiddenTypes] after adding new one.
+     */
+    val byClassId: Map<ClassId, CustomTypeMapper> = with(KotlinBuiltIns.FQ_NAMES) {
+        val result = mutableListOf<CustomTypeMapper>()
 
-        override fun mapType(mappedSuperType: KotlinType): ObjCNonNullReferenceType =
-                ObjCClassType(objCClassName)
+        result += Collection(list, "NSArray")
+        result += Collection(mutableList, "NSMutableArray")
+        result += Collection(set, "NSSet")
+        result += Collection(mutableSet, { namer.mutableSetName.objCName })
+        result += Collection(map, "NSDictionary")
+        result += Collection(mutableMap, { namer.mutableMapName.objCName })
+
+        NSNumberKind.values().forEach {
+            // TODO: NSNumber seem to have different equality semantics.
+            val classId = it.mappedKotlinClassId
+            if (classId != null) {
+                result += Simple(classId, { namer.numberBoxName(classId).objCName })
+            }
+
+        }
+
+        result += Simple(ClassId.topLevel(string.toSafe()), "NSString")
+
+        (0..ObjCExportMapper.maxFunctionTypeParameterCount).forEach {
+            result += Function(it)
+        }
+
+        result.associateBy { it.mappedClassId }
     }
 
-    class Collection(
-            private val generator: ObjCExportHeaderGenerator,
-            mappedClassDescriptor: ClassDescriptor,
-            private val objCClassName: String
+    /**
+     * Types to be "hidden" during mapping, i.e. represented as `id`.
+     *
+     * Currently contains super types of classes handled by custom type mappers.
+     * Note: can be generated programmatically, but requires stdlib in this case.
+     */
+    val hiddenTypes: Set<ClassId> = listOf(
+            "kotlin.Any",
+            "kotlin.CharSequence",
+            "kotlin.Comparable",
+            "kotlin.Function",
+            "kotlin.Number",
+            "kotlin.collections.Collection",
+            "kotlin.collections.Iterable",
+            "kotlin.collections.MutableCollection",
+            "kotlin.collections.MutableIterable"
+    ).map { ClassId.topLevel(FqName(it)) }.toSet()
+
+    private class Simple(
+            override val mappedClassId: ClassId,
+            private val getObjCClassName: ObjCExportTranslatorImpl.() -> String
     ) : CustomTypeMapper {
 
-        override val mappedClassId = mappedClassDescriptor.classId!!
+        constructor(
+                mappedClassId: ClassId,
+                objCClassName: String
+        ) : this(mappedClassId, { objCClassName })
 
-        override fun mapType(mappedSuperType: KotlinType): ObjCNonNullReferenceType {
+        override fun mapType(mappedSuperType: KotlinType, translator: ObjCExportTranslatorImpl): ObjCNonNullReferenceType =
+                ObjCClassType(translator.getObjCClassName())
+    }
+
+    private class Collection(
+            mappedClassFqName: FqName,
+            private val getObjCClassName: ObjCExportTranslatorImpl.() -> String
+    ) : CustomTypeMapper {
+
+        constructor(
+                mappedClassFqName: FqName,
+                objCClassName: String
+        ) : this(mappedClassFqName, { objCClassName })
+
+        override val mappedClassId = ClassId.topLevel(mappedClassFqName)
+
+        override fun mapType(mappedSuperType: KotlinType, translator: ObjCExportTranslatorImpl): ObjCNonNullReferenceType {
             val typeArguments = mappedSuperType.arguments.map {
                 val argument = it.type
                 if (TypeUtils.isNullableType(argument)) {
                     // Kotlin `null` keys and values are represented as `NSNull` singleton.
                     ObjCIdType
                 } else {
-                    generator.mapReferenceTypeIgnoringNullability(argument)
+                    translator.mapReferenceTypeIgnoringNullability(argument)
                 }
             }
 
-            return ObjCClassType(objCClassName, typeArguments)
+            return ObjCClassType(translator.getObjCClassName(), typeArguments)
         }
     }
 
-    class Function(
-            private val generator: ObjCExportHeaderGenerator,
-            parameterCount: Int
-    ) : CustomTypeMapper {
-        override val mappedClassId: ClassId = generator.builtIns.getFunction(parameterCount).classId!!
+    private class Function(parameterCount: Int) : CustomTypeMapper {
+        override val mappedClassId: ClassId = KotlinBuiltIns.getFunctionClassId(parameterCount)
 
-        override fun mapType(mappedSuperType: KotlinType): ObjCNonNullReferenceType {
+        override fun mapType(mappedSuperType: KotlinType, translator: ObjCExportTranslatorImpl): ObjCNonNullReferenceType {
             val functionType = mappedSuperType
 
             val returnType = functionType.getReturnTypeFromFunctionType()
@@ -64,8 +123,8 @@ internal interface CustomTypeMapper {
                     functionType.getValueParameterTypesFromFunctionType().map { it.type }
 
             return ObjCBlockPointerType(
-                    generator.mapReferenceType(returnType),
-                    parameterTypes.map { generator.mapReferenceType(it) }
+                    translator.mapReferenceType(returnType),
+                    parameterTypes.map { translator.mapReferenceType(it) }
             )
         }
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.constants.ArrayValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue
@@ -19,332 +18,75 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.*
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
-import org.jetbrains.kotlin.types.isNullable
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 import org.jetbrains.kotlin.utils.addIfNotNull
 
-abstract class ObjCExportHeaderGenerator(
-        val moduleDescriptors: List<ModuleDescriptor>,
+interface ObjCExportTranslator {
+    fun translateFile(file: SourceFile, declarations: List<CallableMemberDescriptor>): ObjCInterface
+    fun translateClass(descriptor: ClassDescriptor): ObjCInterface
+    fun translateInterface(descriptor: ClassDescriptor): ObjCProtocol
+    fun translateExtensions(classDescriptor: ClassDescriptor, declarations: List<CallableMemberDescriptor>): ObjCInterface
+}
+
+interface ObjCExportWarningCollector {
+    fun reportWarning(text: String)
+    fun reportWarning(method: FunctionDescriptor, text: String)
+
+    object SILENT : ObjCExportWarningCollector {
+        override fun reportWarning(text: String) {}
+        override fun reportWarning(method: FunctionDescriptor, text: String) {}
+    }
+}
+
+internal class ObjCExportTranslatorImpl(
+        private val generator: ObjCExportHeaderGenerator?,
         val builtIns: KotlinBuiltIns,
-        topLevelNamePrefix: String
-) {
-
-    constructor(
-            moduleDescriptor: ModuleDescriptor,
-            builtIns: KotlinBuiltIns,
-            topLevelNamePrefix: String = moduleDescriptor.namePrefix
-    ) : this(moduleDescriptor, emptyList(), builtIns, topLevelNamePrefix)
-
-    constructor(
-            moduleDescriptor: ModuleDescriptor,
-            exportedDependencies: List<ModuleDescriptor>,
-            builtIns: KotlinBuiltIns,
-            topLevelNamePrefix: String = moduleDescriptor.namePrefix
-    ) : this(listOf(moduleDescriptor) + exportedDependencies, builtIns, topLevelNamePrefix)
-
-    internal val mapper: ObjCExportMapper = object : ObjCExportMapper() {
-        override fun getCategoryMembersFor(descriptor: ClassDescriptor) =
-                extensions[descriptor].orEmpty()
-
-        override fun isSpecialMapped(descriptor: ClassDescriptor): Boolean {
-            // TODO: this method duplicates some of the [mapReferenceType] logic.
-            return descriptor == builtIns.any ||
-                   descriptor.getAllSuperClassifiers().any { it.classId in customTypeMappers }
-        }
-    }
-
-    internal val namer = ObjCExportNamerImpl(moduleDescriptors.toSet(), builtIns, mapper, topLevelNamePrefix)
-
-    internal val generatedClasses = mutableSetOf<ClassDescriptor>()
-    internal val topLevel = mutableMapOf<SourceFile, MutableList<CallableMemberDescriptor>>()
-
-    /**
-     * Custom type mappers.
-     *
-     * Don't forget to update [hiddenTypes] after adding new one.
-     */
-    private val customTypeMappers: Map<ClassId, CustomTypeMapper> = with(builtIns) {
-        val result = mutableListOf<CustomTypeMapper>()
-
-        val generator = this@ObjCExportHeaderGenerator
-
-        result += CustomTypeMapper.Collection(generator, list, "NSArray")
-        result += CustomTypeMapper.Collection(generator, mutableList, "NSMutableArray")
-        result += CustomTypeMapper.Collection(generator, set, "NSSet")
-        result += CustomTypeMapper.Collection(generator, mutableSet, namer.mutableSetName.objCName)
-        result += CustomTypeMapper.Collection(generator, map, "NSDictionary")
-        result += CustomTypeMapper.Collection(generator, mutableMap, namer.mutableMapName.objCName)
-
-        NSNumberKind.values().forEach {
-            // TODO: NSNumber seem to have different equality semantics.
-            val classId = it.mappedKotlinClassId
-            if (classId != null) {
-                result += CustomTypeMapper.Simple(classId, namer.numberBoxName(classId).objCName)
-            }
-
-        }
-
-        result += CustomTypeMapper.Simple(string.classId!!, "NSString")
-
-        (0..mapper.maxFunctionTypeParameterCount).forEach {
-            result += CustomTypeMapper.Function(generator, it)
-        }
-
-        result.associateBy { it.mappedClassId }
-    }
-
-    /**
-     * Types to be "hidden" during mapping, i.e. represented as `id`.
-     *
-     * Currently contains super types of classes handled by [customTypeMappers].
-     * Note: can be generated programmatically, but requires stdlib in this case.
-     */
-    private val hiddenTypes: Set<ClassId> = listOf(
-            "kotlin.Any",
-            "kotlin.CharSequence",
-            "kotlin.Comparable",
-            "kotlin.Function",
-            "kotlin.Number",
-            "kotlin.collections.Collection",
-            "kotlin.collections.Iterable",
-            "kotlin.collections.MutableCollection",
-            "kotlin.collections.MutableIterable"
-    ).map { ClassId.topLevel(FqName(it)) }.toSet()
+        val mapper: ObjCExportMapper,
+        val namer: ObjCExportNamer,
+        val warningCollector: ObjCExportWarningCollector
+) : ObjCExportTranslator {
 
     private val kotlinAnyName = namer.kotlinAnyName
 
-    private val stubs = mutableListOf<Stub<*>>()
-    private val classOrInterfaceToName = mutableMapOf<ClassDescriptor, ObjCExportNamer.ClassOrProtocolName>()
-
-    private val classForwardDeclarations = mutableSetOf<String>()
-    private val protocolForwardDeclarations = mutableSetOf<String>()
-
-    private val extensions = mutableMapOf<ClassDescriptor, MutableList<CallableMemberDescriptor>>()
-    private val extraClassesToTranslate = mutableSetOf<ClassDescriptor>()
-
-    private fun objCInterface(
-            name: ObjCExportNamer.ClassOrProtocolName,
-            generics: List<String> = emptyList(),
-            descriptor: ClassDescriptor? = null,
-            superClass: String? = null,
-            superProtocols: List<String> = emptyList(),
-            members: List<Stub<*>> = emptyList(),
-            attributes: List<String> = emptyList()
-    ): ObjCInterface = ObjCInterface(
-            name.objCName,
-            generics,
-            descriptor,
-            superClass,
-            superProtocols,
-            null,
-            members,
-            attributes + name.toNameAttributes()
+    internal fun translateKotlinObjCClassAsUnavailableStub(descriptor: ClassDescriptor): ObjCInterface = objCInterface(
+            namer.getClassOrProtocolName(descriptor),
+            descriptor = descriptor,
+            superClass = "NSObject",
+            attributes = listOf("unavailable(\"Kotlin subclass of Objective-C class can't be imported\")")
     )
 
-    private fun objCProtocol(
-            name: ObjCExportNamer.ClassOrProtocolName,
-            descriptor: ClassDescriptor,
-            superProtocols: List<String>,
-            members: List<Stub<*>>,
-            attributes: List<String> = emptyList()
-    ): ObjCProtocol = ObjCProtocol(
-            name.objCName,
-            descriptor,
-            superProtocols,
-            members,
-            attributes + name.toNameAttributes()
-    )
-
-    private fun ObjCExportNamer.ClassOrProtocolName.toNameAttributes(): List<String> = listOfNotNull(
-            binaryName.takeIf { it != objCName }?.let { objcRuntimeNameAttribute(it) },
-            swiftName.takeIf { it != objCName }?.let { swiftNameAttribute(it) }
-    )
-
-    fun translateModule(): List<Stub<*>> {
-        // TODO: make the translation order stable
-        // to stabilize name mangling.
-
-        stubs.add(objCInterface(kotlinAnyName, superClass = "NSObject", members = buildMembers {
-            +ObjCMethod(null, true, ObjCInstanceType, listOf("init"), emptyList(), listOf("unavailable"))
-            +ObjCMethod(null, false, ObjCInstanceType, listOf("new"), emptyList(), listOf("unavailable"))
-            +ObjCMethod(null, false, ObjCVoidType, listOf("initialize"), emptyList(), listOf("objc_requires_super"))
-        }))
-
-        // TODO: add comment to the header.
-        stubs.add(ObjCInterface(
-                kotlinAnyName.objCName,
-                superProtocols = listOf("NSCopying"),
-                categoryName = "${kotlinAnyName.objCName}Copying"
-        ))
-
-        // TODO: only if appears
-        stubs.add(objCInterface(
-                namer.mutableSetName,
-                generics = listOf("ObjectType"),
-                superClass = "NSMutableSet<ObjectType>"
-        ))
-
-        // TODO: only if appears
-        stubs.add(objCInterface(
-                namer.mutableMapName,
-                generics = listOf("KeyType", "ObjectType"),
-                superClass = "NSMutableDictionary<KeyType, ObjectType>"
-        ))
-
-        stubs.add(ObjCInterface("NSError", categoryName = "NSErrorKotlinException", members = buildMembers {
-            +ObjCProperty("kotlinException", null, ObjCNullableReferenceType(ObjCIdType), listOf("readonly"))
-        }))
-
-        genKotlinNumbers()
-
-        val packageFragments = moduleDescriptors.flatMap { it.getPackageFragments() }
-
-        packageFragments.forEach { packageFragment ->
-            packageFragment.getMemberScope().getContributedDescriptors()
-                    .asSequence()
-                    .filterIsInstance<CallableMemberDescriptor>()
-                    .filter { mapper.shouldBeExposed(it) }
-                    .forEach {
-                        val classDescriptor = mapper.getClassIfCategory(it)
-                        if (classDescriptor != null) {
-                            extensions.getOrPut(classDescriptor, { mutableListOf() }) += it
-                        } else {
-                            topLevel.getOrPut(it.findSourceFile(), { mutableListOf() }) += it
-                        }
-                    }
-
-        }
-
-        fun MemberScope.translateClasses() {
-            getContributedDescriptors()
-                    .asSequence()
-                    .filterIsInstance<ClassDescriptor>()
-                    .forEach {
-                        if (mapper.shouldBeExposed(it)) {
-                            if (it.isInterface) {
-                                translateInterface(it)
-                            } else {
-                                translateClass(it)
-                            }
-
-                            it.unsubstitutedMemberScope.translateClasses()
-                        } else if (it.isKotlinObjCClass() && mapper.shouldBeVisible(it)) {
-                            assert(!it.isInterface)
-                            translateKotlinObjCClassAsUnavailableStub(it)
-                        }
-                    }
-        }
-
-        packageFragments.forEach { packageFragment ->
-            packageFragment.getMemberScope().translateClasses()
-        }
-
-        extensions.forEach { classDescriptor, declarations ->
-            translateExtensions(classDescriptor, declarations)
-        }
-
-        topLevel.forEach { sourceFile, declarations ->
-            translateTopLevel(sourceFile, declarations)
-        }
-
-        while (extraClassesToTranslate.isNotEmpty()) {
-            val descriptor = extraClassesToTranslate.first()
-            extraClassesToTranslate -= descriptor
-            if (descriptor.isInterface) {
-                translateInterface(descriptor)
-            } else {
-                translateClass(descriptor)
-            }
-        }
-
-        return stubs
-    }
-
-    private fun translateKotlinObjCClassAsUnavailableStub(descriptor: ClassDescriptor) {
-        stubs.add(objCInterface(
-                namer.getClassOrProtocolName(descriptor),
-                descriptor = descriptor,
-                superClass = "NSObject",
-                attributes = listOf("unavailable(\"Kotlin subclass of Objective-C class can't be imported\")")
-
-        ))
-    }
-
-    private fun genKotlinNumbers() {
-        val members = buildMembers {
-            NSNumberKind.values().forEach {
-                +nsNumberFactory(it, listOf("unavailable"))
-            }
-            NSNumberKind.values().forEach {
-                +nsNumberInit(it, listOf("unavailable"))
-            }
-        }
-        stubs.add(objCInterface(
-                namer.kotlinNumberName,
-                superClass = "NSNumber",
-                members = members
-        ))
-
-        NSNumberKind.values().forEach {
-            if (it.mappedKotlinClassId != null) {
-                stubs += genKotlinNumber(it.mappedKotlinClassId, it)
-            }
-        }
-    }
-
-    private fun genKotlinNumber(kotlinClassId: ClassId, kind: NSNumberKind): ObjCInterface {
-        val name = namer.numberBoxName(kotlinClassId)
-
-        val members = buildMembers {
-            +nsNumberFactory(kind)
-            +nsNumberInit(kind)
-        }
-        return objCInterface(
-                name,
-                superClass = namer.kotlinNumberName.objCName,
-                members = members
-        )
-    }
-
-    private fun nsNumberInit(kind: NSNumberKind, attributes: List<String> = emptyList()): ObjCMethod {
-        return ObjCMethod(
-                null,
-                false,
-                ObjCInstanceType,
-                listOf(kind.factorySelector),
-                listOf(ObjCParameter("value", null, kind.objCType)),
-                attributes
-        )
-    }
-
-    private fun nsNumberFactory(kind: NSNumberKind, attributes: List<String> = emptyList()): ObjCMethod {
-        return ObjCMethod(
-                null,
-                true,
-                ObjCInstanceType,
-                listOf(kind.initSelector),
-                listOf(ObjCParameter("value", null, kind.objCType)),
-                attributes
-        )
-    }
-
-    private fun translateClassName(descriptor: ClassDescriptor) = classOrInterfaceToName.getOrPut(descriptor) {
+    private fun referenceClass(descriptor: ClassDescriptor): ObjCExportNamer.ClassOrProtocolName {
         assert(mapper.shouldBeExposed(descriptor))
-        val forwardDeclarations = if (descriptor.isInterface) protocolForwardDeclarations else classForwardDeclarations
+        assert(!descriptor.isInterface)
+        generator?.requireClassOrInterface(descriptor)
 
-        namer.getClassOrProtocolName(descriptor).also { forwardDeclarations += it.objCName }
+        return translateClassOrInterfaceName(descriptor).also {
+            generator?.referenceClass(it.objCName, descriptor)
+        }
     }
 
-    private fun translateInterface(descriptor: ClassDescriptor) {
-        if (!generatedClasses.add(descriptor)) return
+    private fun referenceProtocol(descriptor: ClassDescriptor): ObjCExportNamer.ClassOrProtocolName {
+        assert(mapper.shouldBeExposed(descriptor))
+        assert(descriptor.isInterface)
+        generator?.requireClassOrInterface(descriptor)
 
-        val name = translateClassName(descriptor)
+        return translateClassOrInterfaceName(descriptor).also {
+            generator?.referenceProtocol(it.objCName, descriptor)
+        }
+    }
+
+    private fun translateClassOrInterfaceName(descriptor: ClassDescriptor): ObjCExportNamer.ClassOrProtocolName {
+        assert(mapper.shouldBeExposed(descriptor))
+
+        return namer.getClassOrProtocolName(descriptor)
+    }
+
+    override fun translateInterface(descriptor: ClassDescriptor): ObjCProtocol {
+        val name = translateClassOrInterfaceName(descriptor)
         val members: List<Stub<*>> = buildMembers { translateInterfaceMembers(descriptor) }
         val superProtocols: List<String> = descriptor.superProtocols
 
-        val protocolStub = objCProtocol(name, descriptor, superProtocols, members)
-
-        stubs.add(protocolStub)
+        return objCProtocol(name, descriptor, superProtocols, members)
     }
 
     private val ClassDescriptor.superProtocols: List<String>
@@ -353,47 +95,48 @@ abstract class ObjCExportHeaderGenerator(
                     .asSequence()
                     .filter { mapper.shouldBeExposed(it) }
                     .map {
-                        translateInterface(it)
-                        translateClassName(it).objCName
+                        generator?.generateInterface(it)
+                        referenceProtocol(it).objCName
                     }
                     .toList()
 
-    private fun translateExtensions(classDescriptor: ClassDescriptor, declarations: List<CallableMemberDescriptor>) {
-        translateClass(classDescriptor)
+    override fun translateExtensions(
+            classDescriptor: ClassDescriptor,
+            declarations: List<CallableMemberDescriptor>
+    ): ObjCInterface {
+        generator?.generateClass(classDescriptor)
 
-        val name = translateClassName(classDescriptor).objCName
+        val name = referenceClass(classDescriptor).objCName
         val members = buildMembers {
             translatePlainMembers(declarations)
         }
-        stubs.add(ObjCInterface(name, categoryName = "Extensions", members = members))
+        return ObjCInterface(name, categoryName = "Extensions", members = members)
     }
 
-    private fun translateTopLevel(sourceFile: SourceFile, declarations: List<CallableMemberDescriptor>) {
-        val name = namer.getFileClassName(sourceFile)
+    override fun translateFile(file: SourceFile, declarations: List<CallableMemberDescriptor>): ObjCInterface {
+        val name = namer.getFileClassName(file)
 
         // TODO: stop inheriting KotlinBase.
         val members = buildMembers {
             translatePlainMembers(declarations)
         }
-        stubs.add(objCInterface(
+        return objCInterface(
                 name,
                 superClass = namer.kotlinAnyName.objCName,
                 members = members,
                 attributes = listOf("objc_subclassing_restricted")
-        ))
+        )
     }
 
-    private fun translateClass(descriptor: ClassDescriptor) {
-        if (!generatedClasses.add(descriptor)) return
-
-        val name = translateClassName(descriptor)
+    override fun translateClass(descriptor: ClassDescriptor): ObjCInterface {
+        val name = translateClassOrInterfaceName(descriptor)
         val superClass = descriptor.getSuperClassNotAny()
 
         val superName = if (superClass == null) {
             kotlinAnyName
         } else {
-            translateClass(superClass)
-            translateClassName(superClass)
+            generator?.generateClass(superClass)
+            referenceClass(superClass)
         }
 
         val superProtocols: List<String> = descriptor.superProtocols
@@ -410,7 +153,7 @@ abstract class ObjCExportHeaderGenerator(
                         +buildMethod(it, it)
                         if (selector == "init") {
                             +ObjCMethod(it, false, ObjCInstanceType, listOf("new"), emptyList(),
-                                        listOf("availability(swift, unavailable, message=\"use object initializers instead\")"))
+                                    listOf("availability(swift, unavailable, message=\"use object initializers instead\")"))
                         }
                     }
 
@@ -467,7 +210,7 @@ abstract class ObjCExportHeaderGenerator(
 
         val attributes = if (descriptor.isFinalOrEnum) listOf("objc_subclassing_restricted") else emptyList()
 
-        val interfaceStub = objCInterface(
+        return objCInterface(
                 name,
                 descriptor = descriptor,
                 superClass = superName.objCName,
@@ -475,7 +218,6 @@ abstract class ObjCExportHeaderGenerator(
                 members = members,
                 attributes = attributes
         )
-        stubs.add(interfaceStub)
     }
 
     private fun ClassDescriptor.getExposedMembers(): List<CallableMemberDescriptor> =
@@ -744,9 +486,6 @@ abstract class ObjCExportHeaderGenerator(
         }
     }
 
-    private fun swiftNameAttribute(swiftName: String) = "swift_name(\"$swiftName\")"
-    private fun objcRuntimeNameAttribute(name: String) = "objc_runtime_name(\"$name\")"
-
     private val methodsWithThrowAnnotationConsidered = mutableSetOf<FunctionDescriptor>()
 
     private val uncheckedExceptionClasses = listOf("Error", "RuntimeException").map {
@@ -759,7 +498,8 @@ abstract class ObjCExportHeaderGenerator(
         val throwsAnnotation = method.annotations.findAnnotation(KonanFqNames.throws) ?: return
 
         if (!mapper.doesThrow(method)) {
-            reportWarning(method, "@${KonanFqNames.throws.shortName()} annotation should also be added to a base method")
+            warningCollector.reportWarning(method,
+                    "@${KonanFqNames.throws.shortName()} annotation should also be added to a base method")
         }
 
         if (method in methodsWithThrowAnnotationConsidered) return
@@ -770,13 +510,13 @@ abstract class ObjCExportHeaderGenerator(
             val classDescriptor = TypeUtils.getClassDescriptor((argument as KClassValue).getArgumentType(method.module)) ?: continue
 
             uncheckedExceptionClasses.firstOrNull { classDescriptor.isSubclassOf(it) }?.let {
-                reportWarning(method,
+                warningCollector.reportWarning(method,
                         "Method is declared to throw ${classDescriptor.fqNameSafe}, " +
                                 "but instances of ${it.fqNameSafe} and its subclasses aren't propagated " +
                                 "from Kotlin to Objective-C/Swift")
             }
 
-            scheduleClassToBeGenerated(classDescriptor)
+            generator?.requireClassOrInterface(classDescriptor)
         }
     }
 
@@ -799,6 +539,173 @@ abstract class ObjCExportHeaderGenerator(
         MethodBridge.ReturnValue.Instance.InitResult,
         MethodBridge.ReturnValue.Instance.FactoryResult -> ObjCInstanceType
     }
+
+    internal fun mapReferenceType(kotlinType: KotlinType): ObjCReferenceType =
+            mapReferenceTypeIgnoringNullability(kotlinType).let {
+                if (kotlinType.binaryRepresentationIsNullable()) {
+                    ObjCNullableReferenceType(it)
+                } else {
+                    it
+                }
+            }
+
+    internal fun mapReferenceTypeIgnoringNullability(kotlinType: KotlinType): ObjCNonNullReferenceType {
+        class TypeMappingMatch(val type: KotlinType, val descriptor: ClassDescriptor, val mapper: CustomTypeMapper)
+
+        val typeMappingMatches = (listOf(kotlinType) + kotlinType.supertypes()).mapNotNull { type ->
+            (type.constructor.declarationDescriptor as? ClassDescriptor)?.let { descriptor ->
+                mapper.customTypeMappers[descriptor.classId]?.let { mapper ->
+                    TypeMappingMatch(type, descriptor, mapper)
+                }
+            }
+        }
+
+        val mostSpecificMatches = typeMappingMatches.filter { match ->
+            typeMappingMatches.all { otherMatch ->
+                otherMatch.descriptor == match.descriptor ||
+                        !otherMatch.descriptor.isSubclassOf(match.descriptor)
+            }
+        }
+
+        if (mostSpecificMatches.size > 1) {
+            val types = mostSpecificMatches.map { it.type }
+            val firstType = types[0]
+            val secondType = types[1]
+
+            warningCollector.reportWarning(
+                    "Exposed type '$kotlinType' is '$firstType' and '$secondType' at the same time. " +
+                            "This most likely wouldn't work as expected.")
+
+            // TODO: the same warning for such classes.
+        }
+
+        mostSpecificMatches.firstOrNull()?.let {
+            return it.mapper.mapType(it.type, this)
+        }
+
+        val classDescriptor = kotlinType.getErasedTypeClass()
+
+        // TODO: translate `where T : BaseClass, T : SomeInterface` to `BaseClass* <SomeInterface>`
+
+        // TODO: expose custom inline class boxes properly.
+        if (classDescriptor == builtIns.any || classDescriptor.classId in mapper.hiddenTypes || classDescriptor.isInlined()) {
+            return ObjCIdType
+        }
+
+        if (classDescriptor.defaultType.isObjCObjectType()) {
+            return mapObjCObjectReferenceTypeIgnoringNullability(classDescriptor)
+        }
+
+        return if (classDescriptor.isInterface) {
+            ObjCProtocolType(referenceProtocol(classDescriptor).objCName)
+        } else {
+            ObjCClassType(referenceClass(classDescriptor).objCName)
+        }
+    }
+
+    private tailrec fun mapObjCObjectReferenceTypeIgnoringNullability(descriptor: ClassDescriptor): ObjCNonNullReferenceType {
+        // TODO: more precise types can be used.
+
+        if (descriptor.isObjCMetaClass()) return ObjCIdType
+
+        if (descriptor.isExternalObjCClass()) {
+            return if (descriptor.isInterface) {
+                val name = descriptor.name.asString().removeSuffix("Protocol")
+                generator?.referenceProtocol(name)
+                ObjCProtocolType(name)
+            } else {
+                val name = descriptor.name.asString()
+                generator?.referenceClass(name)
+                ObjCClassType(name)
+            }
+        }
+
+        if (descriptor.isKotlinObjCClass()) {
+            return mapObjCObjectReferenceTypeIgnoringNullability(descriptor.getSuperClassOrAny())
+        }
+
+        return ObjCIdType
+    }
+
+    private fun mapType(kotlinType: KotlinType, typeBridge: TypeBridge): ObjCType = when (typeBridge) {
+        ReferenceBridge -> mapReferenceType(kotlinType)
+        is ValueTypeBridge -> {
+            when (typeBridge.objCValueType) {
+                ObjCValueType.BOOL -> ObjCPrimitiveType("BOOL")
+                ObjCValueType.UNICHAR -> ObjCPrimitiveType("unichar")
+                ObjCValueType.CHAR -> ObjCPrimitiveType("int8_t")
+                ObjCValueType.SHORT -> ObjCPrimitiveType("int16_t")
+                ObjCValueType.INT -> ObjCPrimitiveType("int32_t")
+                ObjCValueType.LONG_LONG -> ObjCPrimitiveType("int64_t")
+                ObjCValueType.UNSIGNED_CHAR -> ObjCPrimitiveType("uint8_t")
+                ObjCValueType.UNSIGNED_SHORT -> ObjCPrimitiveType("uint16_t")
+                ObjCValueType.UNSIGNED_INT -> ObjCPrimitiveType("uint32_t")
+                ObjCValueType.UNSIGNED_LONG_LONG -> ObjCPrimitiveType("uint64_t")
+                ObjCValueType.FLOAT -> ObjCPrimitiveType("float")
+                ObjCValueType.DOUBLE -> ObjCPrimitiveType("double")
+                ObjCValueType.POINTER -> ObjCPointerType(ObjCVoidType)
+            }
+            // TODO: consider other namings.
+        }
+    }
+}
+
+abstract class ObjCExportHeaderGenerator internal constructor(
+        val moduleDescriptors: List<ModuleDescriptor>,
+        val builtIns: KotlinBuiltIns,
+        internal val mapper: ObjCExportMapper,
+        val namer: ObjCExportNamer
+) {
+
+    constructor(
+            moduleDescriptors: List<ModuleDescriptor>,
+            builtIns: KotlinBuiltIns,
+            topLevelNamePrefix: String
+    ) : this(moduleDescriptors, builtIns, topLevelNamePrefix, ObjCExportMapper())
+
+    private constructor(
+            moduleDescriptors: List<ModuleDescriptor>,
+            builtIns: KotlinBuiltIns,
+            topLevelNamePrefix: String,
+            mapper: ObjCExportMapper
+    ) : this(
+            moduleDescriptors,
+            builtIns,
+            mapper,
+            ObjCExportNamerImpl(moduleDescriptors.toSet(), builtIns, mapper, topLevelNamePrefix, local = false)
+    )
+
+    constructor(
+            moduleDescriptor: ModuleDescriptor,
+            builtIns: KotlinBuiltIns,
+            topLevelNamePrefix: String = moduleDescriptor.namePrefix
+    ) : this(moduleDescriptor, emptyList(), builtIns, topLevelNamePrefix)
+
+    constructor(
+            moduleDescriptor: ModuleDescriptor,
+            exportedDependencies: List<ModuleDescriptor>,
+            builtIns: KotlinBuiltIns,
+            topLevelNamePrefix: String = moduleDescriptor.namePrefix
+    ) : this(listOf(moduleDescriptor) + exportedDependencies, builtIns, topLevelNamePrefix)
+
+    private val stubs = mutableListOf<Stub<*>>()
+
+    private val classForwardDeclarations = linkedSetOf<String>()
+    private val protocolForwardDeclarations = linkedSetOf<String>()
+    private val extraClassesToTranslate = mutableSetOf<ClassDescriptor>()
+
+    private val translator = ObjCExportTranslatorImpl(this, builtIns, mapper, namer,
+            object : ObjCExportWarningCollector {
+                override fun reportWarning(text: String) =
+                        this@ObjCExportHeaderGenerator.reportWarning(text)
+
+                override fun reportWarning(method: FunctionDescriptor, text: String) =
+                        this@ObjCExportHeaderGenerator.reportWarning(method, text)
+            })
+
+    internal val generatedClasses = mutableSetOf<ClassDescriptor>()
+    internal val extensions = mutableMapOf<ClassDescriptor, MutableList<CallableMemberDescriptor>>()
+    internal val topLevel = mutableMapOf<SourceFile, MutableList<CallableMemberDescriptor>>()
 
     fun build(): List<String> = mutableListOf<String>().apply {
         add("#import <Foundation/Foundation.h>")
@@ -829,119 +736,235 @@ abstract class ObjCExportHeaderGenerator(
 
     protected abstract fun reportWarning(method: FunctionDescriptor, text: String)
 
-    internal fun mapReferenceType(kotlinType: KotlinType): ObjCReferenceType =
-            mapReferenceTypeIgnoringNullability(kotlinType).let {
-                if (kotlinType.binaryRepresentationIsNullable()) {
-                    ObjCNullableReferenceType(it)
-                } else {
-                    it
-                }
-            }
 
-    internal fun mapReferenceTypeIgnoringNullability(kotlinType: KotlinType): ObjCNonNullReferenceType {
-        class TypeMappingMatch(val type: KotlinType, val descriptor: ClassDescriptor, val mapper: CustomTypeMapper)
+    fun translateModule(): List<Stub<*>> {
+        // TODO: make the translation order stable
+        // to stabilize name mangling.
 
-        val typeMappingMatches = (listOf(kotlinType) + kotlinType.supertypes()).mapNotNull { type ->
-            (type.constructor.declarationDescriptor as? ClassDescriptor)?.let { descriptor ->
-                customTypeMappers[descriptor.classId]?.let { mapper ->
-                    TypeMappingMatch(type, descriptor, mapper)
-                }
-            }
+        stubs.add(objCInterface(namer.kotlinAnyName, superClass = "NSObject", members = buildMembers {
+            +ObjCMethod(null, true, ObjCInstanceType, listOf("init"), emptyList(), listOf("unavailable"))
+            +ObjCMethod(null, false, ObjCInstanceType, listOf("new"), emptyList(), listOf("unavailable"))
+            +ObjCMethod(null, false, ObjCVoidType, listOf("initialize"), emptyList(), listOf("objc_requires_super"))
+        }))
+
+        // TODO: add comment to the header.
+        stubs.add(ObjCInterface(
+                namer.kotlinAnyName.objCName,
+                superProtocols = listOf("NSCopying"),
+                categoryName = "${namer.kotlinAnyName.objCName}Copying"
+        ))
+
+        // TODO: only if appears
+        stubs.add(objCInterface(
+                namer.mutableSetName,
+                generics = listOf("ObjectType"),
+                superClass = "NSMutableSet<ObjectType>"
+        ))
+
+        // TODO: only if appears
+        stubs.add(objCInterface(
+                namer.mutableMapName,
+                generics = listOf("KeyType", "ObjectType"),
+                superClass = "NSMutableDictionary<KeyType, ObjectType>"
+        ))
+
+        stubs.add(ObjCInterface("NSError", categoryName = "NSErrorKotlinException", members = buildMembers {
+            +ObjCProperty("kotlinException", null, ObjCNullableReferenceType(ObjCIdType), listOf("readonly"))
+        }))
+
+        genKotlinNumbers()
+
+        val packageFragments = moduleDescriptors.flatMap { it.getPackageFragments() }
+
+        packageFragments.forEach { packageFragment ->
+            packageFragment.getMemberScope().getContributedDescriptors()
+                    .asSequence()
+                    .filterIsInstance<CallableMemberDescriptor>()
+                    .filter { mapper.shouldBeExposed(it) }
+                    .forEach {
+                        val classDescriptor = mapper.getClassIfCategory(it)
+                        if (classDescriptor != null) {
+                            extensions.getOrPut(classDescriptor, { mutableListOf() }) += it
+                        } else {
+                            topLevel.getOrPut(it.findSourceFile(), { mutableListOf() }) += it
+                        }
+                    }
+
         }
 
-        val mostSpecificMatches = typeMappingMatches.filter { match ->
-            typeMappingMatches.all { otherMatch ->
-                otherMatch.descriptor == match.descriptor ||
-                        !otherMatch.descriptor.isSubclassOf(match.descriptor)
-            }
+        fun MemberScope.translateClasses() {
+            getContributedDescriptors()
+                    .asSequence()
+                    .filterIsInstance<ClassDescriptor>()
+                    .forEach {
+                        if (mapper.shouldBeExposed(it)) {
+                            if (it.isInterface) {
+                                generateInterface(it)
+                            } else {
+                                generateClass(it)
+                            }
+
+                            it.unsubstitutedMemberScope.translateClasses()
+                        } else if (it.isKotlinObjCClass() && mapper.shouldBeVisible(it)) {
+                            assert(!it.isInterface)
+                            stubs += translator.translateKotlinObjCClassAsUnavailableStub(it)
+                        }
+                    }
         }
 
-        if (mostSpecificMatches.size > 1) {
-            val types = mostSpecificMatches.map { it.type }
-            val firstType = types[0]
-            val secondType = types[1]
-
-            reportWarning("Exposed type '$kotlinType' is '$firstType' and '$secondType' at the same time. " +
-                                     "This most likely wouldn't work as expected.")
-
-            // TODO: the same warning for such classes.
+        packageFragments.forEach { packageFragment ->
+            packageFragment.getMemberScope().translateClasses()
         }
 
-        mostSpecificMatches.firstOrNull()?.let {
-            return it.mapper.mapType(it.type)
+        extensions.forEach { classDescriptor, declarations ->
+            generateExtensions(classDescriptor, declarations)
         }
 
-        val classDescriptor = kotlinType.getErasedTypeClass()
-
-        // TODO: translate `where T : BaseClass, T : SomeInterface` to `BaseClass* <SomeInterface>`
-
-        // TODO: expose custom inline class boxes properly.
-        if (classDescriptor == builtIns.any || classDescriptor.classId in hiddenTypes || classDescriptor.isInlined()) {
-            return ObjCIdType
+        topLevel.forEach { sourceFile, declarations ->
+            generateFile(sourceFile, declarations)
         }
 
-        if (classDescriptor.defaultType.isObjCObjectType()) {
-            return mapObjCObjectReferenceTypeIgnoringNullability(classDescriptor)
-        }
-
-        scheduleClassToBeGenerated(classDescriptor)
-
-        return if (classDescriptor.isInterface) {
-            ObjCProtocolType(translateClassName(classDescriptor).objCName)
-        } else {
-            ObjCClassType(translateClassName(classDescriptor).objCName)
-        }
-    }
-
-    private tailrec fun mapObjCObjectReferenceTypeIgnoringNullability(descriptor: ClassDescriptor): ObjCNonNullReferenceType {
-        // TODO: more precise types can be used.
-
-        if (descriptor.isObjCMetaClass()) return ObjCIdType
-
-        if (descriptor.isExternalObjCClass()) {
-            return if (descriptor.isInterface) {
-                val name = descriptor.name.asString().removeSuffix("Protocol")
-                protocolForwardDeclarations += name
-                ObjCProtocolType(name)
+        while (extraClassesToTranslate.isNotEmpty()) {
+            val descriptor = extraClassesToTranslate.first()
+            extraClassesToTranslate -= descriptor
+            if (descriptor.isInterface) {
+                generateInterface(descriptor)
             } else {
-                val name = descriptor.name.asString()
-                classForwardDeclarations += name
-                ObjCClassType(name)
+                generateClass(descriptor)
             }
         }
 
-        if (descriptor.isKotlinObjCClass()) {
-            return mapObjCObjectReferenceTypeIgnoringNullability(descriptor.getSuperClassOrAny())
-        }
-
-        return ObjCIdType
+        return stubs
     }
 
-    private fun scheduleClassToBeGenerated(classDescriptor: ClassDescriptor) {
-        if (classDescriptor !in generatedClasses) {
-            extraClassesToTranslate += classDescriptor
-        }
-    }
-
-    private fun mapType(kotlinType: KotlinType, typeBridge: TypeBridge): ObjCType = when (typeBridge) {
-        ReferenceBridge -> mapReferenceType(kotlinType)
-        is ValueTypeBridge -> {
-            when (typeBridge.objCValueType) {
-                ObjCValueType.BOOL -> ObjCPrimitiveType("BOOL")
-                ObjCValueType.UNICHAR -> ObjCPrimitiveType("unichar")
-                ObjCValueType.CHAR -> ObjCPrimitiveType("int8_t")
-                ObjCValueType.SHORT -> ObjCPrimitiveType("int16_t")
-                ObjCValueType.INT -> ObjCPrimitiveType("int32_t")
-                ObjCValueType.LONG_LONG -> ObjCPrimitiveType("int64_t")
-                ObjCValueType.UNSIGNED_CHAR -> ObjCPrimitiveType("uint8_t")
-                ObjCValueType.UNSIGNED_SHORT -> ObjCPrimitiveType("uint16_t")
-                ObjCValueType.UNSIGNED_INT -> ObjCPrimitiveType("uint32_t")
-                ObjCValueType.UNSIGNED_LONG_LONG -> ObjCPrimitiveType("uint64_t")
-                ObjCValueType.FLOAT -> ObjCPrimitiveType("float")
-                ObjCValueType.DOUBLE -> ObjCPrimitiveType("double")
-                ObjCValueType.POINTER -> ObjCPointerType(ObjCVoidType)
+    private fun genKotlinNumbers() {
+        val members = buildMembers {
+            NSNumberKind.values().forEach {
+                +nsNumberFactory(it, listOf("unavailable"))
             }
-            // TODO: consider other namings.
+            NSNumberKind.values().forEach {
+                +nsNumberInit(it, listOf("unavailable"))
+            }
         }
+        stubs.add(objCInterface(
+                namer.kotlinNumberName,
+                superClass = "NSNumber",
+                members = members
+        ))
+
+        NSNumberKind.values().forEach {
+            if (it.mappedKotlinClassId != null) {
+                stubs += genKotlinNumber(it.mappedKotlinClassId, it)
+            }
+        }
+    }
+
+    private fun genKotlinNumber(kotlinClassId: ClassId, kind: NSNumberKind): ObjCInterface {
+        val name = namer.numberBoxName(kotlinClassId)
+
+        val members = buildMembers {
+            +nsNumberFactory(kind)
+            +nsNumberInit(kind)
+        }
+        return objCInterface(
+                name,
+                superClass = namer.kotlinNumberName.objCName,
+                members = members
+        )
+    }
+
+    private fun nsNumberInit(kind: NSNumberKind, attributes: List<String> = emptyList()): ObjCMethod {
+        return ObjCMethod(
+                null,
+                false,
+                ObjCInstanceType,
+                listOf(kind.factorySelector),
+                listOf(ObjCParameter("value", null, kind.objCType)),
+                attributes
+        )
+    }
+
+    private fun nsNumberFactory(kind: NSNumberKind, attributes: List<String> = emptyList()): ObjCMethod {
+        return ObjCMethod(
+                null,
+                true,
+                ObjCInstanceType,
+                listOf(kind.initSelector),
+                listOf(ObjCParameter("value", null, kind.objCType)),
+                attributes
+        )
+    }
+
+    private fun generateFile(sourceFile: SourceFile, declarations: List<CallableMemberDescriptor>) {
+        stubs.add(translator.translateFile(sourceFile, declarations))
+    }
+
+    private fun generateExtensions(classDescriptor: ClassDescriptor, declarations: List<CallableMemberDescriptor>) {
+        stubs.add(translator.translateExtensions(classDescriptor, declarations))
+    }
+
+    internal fun generateClass(descriptor: ClassDescriptor) {
+        if (!generatedClasses.add(descriptor)) return
+        stubs.add(translator.translateClass(descriptor))
+    }
+
+    internal fun generateInterface(descriptor: ClassDescriptor) {
+        if (!generatedClasses.add(descriptor)) return
+        stubs.add(translator.translateInterface(descriptor))
+    }
+
+    internal fun requireClassOrInterface(descriptor: ClassDescriptor) {
+        if (descriptor !in generatedClasses) {
+            extraClassesToTranslate += descriptor
+        }
+    }
+
+    internal fun referenceClass(objCName: String, descriptor: ClassDescriptor? = null) {
+        if (descriptor !in generatedClasses) classForwardDeclarations += objCName
+    }
+
+    internal fun referenceProtocol(objCName: String, descriptor: ClassDescriptor? = null) {
+        if (descriptor !in generatedClasses) protocolForwardDeclarations += objCName
     }
 }
+
+private fun objCInterface(
+        name: ObjCExportNamer.ClassOrProtocolName,
+        generics: List<String> = emptyList(),
+        descriptor: ClassDescriptor? = null,
+        superClass: String? = null,
+        superProtocols: List<String> = emptyList(),
+        members: List<Stub<*>> = emptyList(),
+        attributes: List<String> = emptyList()
+): ObjCInterface = ObjCInterface(
+        name.objCName,
+        generics,
+        descriptor,
+        superClass,
+        superProtocols,
+        null,
+        members,
+        attributes + name.toNameAttributes()
+)
+
+private fun objCProtocol(
+        name: ObjCExportNamer.ClassOrProtocolName,
+        descriptor: ClassDescriptor,
+        superProtocols: List<String>,
+        members: List<Stub<*>>,
+        attributes: List<String> = emptyList()
+): ObjCProtocol = ObjCProtocol(
+        name.objCName,
+        descriptor,
+        superProtocols,
+        members,
+        attributes + name.toNameAttributes()
+)
+
+private fun ObjCExportNamer.ClassOrProtocolName.toNameAttributes(): List<String> = listOfNotNull(
+        binaryName.takeIf { it != objCName }?.let { objcRuntimeNameAttribute(it) },
+        swiftName.takeIf { it != objCName }?.let { swiftNameAttribute(it) }
+)
+
+private fun swiftNameAttribute(swiftName: String) = "swift_name(\"$swiftName\")"
+private fun objcRuntimeNameAttribute(name: String) = "objc_runtime_name(\"$name\")"

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -703,9 +703,9 @@ abstract class ObjCExportHeaderGenerator internal constructor(
                         this@ObjCExportHeaderGenerator.reportWarning(method, text)
             })
 
-    internal val generatedClasses = mutableSetOf<ClassDescriptor>()
-    internal val extensions = mutableMapOf<ClassDescriptor, MutableList<CallableMemberDescriptor>>()
-    internal val topLevel = mutableMapOf<SourceFile, MutableList<CallableMemberDescriptor>>()
+    private val generatedClasses = mutableSetOf<ClassDescriptor>()
+    private val extensions = mutableMapOf<ClassDescriptor, MutableList<CallableMemberDescriptor>>()
+    private val topLevel = mutableMapOf<SourceFile, MutableList<CallableMemberDescriptor>>()
 
     fun build(): List<String> = mutableListOf<String>().apply {
         add("#import <Foundation/Foundation.h>")
@@ -730,6 +730,11 @@ abstract class ObjCExportHeaderGenerator internal constructor(
         }
 
         add("NS_ASSUME_NONNULL_END")
+    }
+
+    internal fun buildInterface(): ObjCExportedInterface {
+        val headerLines = build()
+        return ObjCExportedInterface(generatedClasses, extensions, topLevel, headerLines, namer, mapper)
     }
 
     protected abstract fun reportWarning(text: String)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGeneratorImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGeneratorImpl.kt
@@ -6,16 +6,17 @@
 package org.jetbrains.kotlin.backend.konan.objcexport
 
 import org.jetbrains.kotlin.backend.konan.Context
-import org.jetbrains.kotlin.backend.konan.getExportedDependencies
 import org.jetbrains.kotlin.backend.konan.reportCompilationWarning
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.util.report
 
-internal class ObjCExportHeaderGeneratorImpl(val context: Context) : ObjCExportHeaderGenerator(
-        context.moduleDescriptor,
-        context.getExportedDependencies(),
-        context.builtIns
-) {
+internal class ObjCExportHeaderGeneratorImpl(
+        val context: Context,
+        moduleDescriptors: List<ModuleDescriptor>,
+        mapper: ObjCExportMapper,
+        namer: ObjCExportNamer
+) : ObjCExportHeaderGenerator(moduleDescriptors, context.builtIns, mapper, namer) {
 
     override fun reportWarning(text: String) {
         context.reportCompilationWarning(text)


### PR DESCRIPTION
Also split ObjCExport header and code generation phases.