### PR TITLE
docs: fixed link to Grouping.eachCount sample

### DIFF
--- a/runtime/src/main/kotlin/kotlin/collections/Collections.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Collections.kt
@@ -57,7 +57,7 @@ public fun <T> MutableList<T>.replaceAll(transformation: (T) -> T) {
  *
  * @return a [Map] associating the key of each group with the count of elements in the group.
  *
- * @sample samples.collections.Collections.Transformations.groupingByEachCount
+ * @sample samples.collections.Grouping.groupingByEachCount
  */
 @SinceKotlin("1.1")
 public actual fun <T, K> Grouping<T, K>.eachCount(): Map<K, Int> = eachCountTo(mutableMapOf<K, Int>())


### PR DESCRIPTION
The sample for Grouping.eachCount() was moved. Fixed the link accordingly.