### PR TITLE
Fix html5Canvas example

### DIFF
--- a/samples/html5Canvas/index.html
+++ b/samples/html5Canvas/index.html
@@ -2,7 +2,7 @@
 <head>
 <meta charset="utf-8">
 
-<script src="build/bin/html5Canvas/main/release/executable/html5Canvas.wasm.js" wasm="build/bin/html5Canvas/main/release/executable/html5Canvas.wasm"> </script>
+<script src="build/bin/html5Canvas/mainReleaseExecutable/main.wasm.js" wasm="build/bin/html5Canvas/mainReleaseExecutable/main.wasm"> </script>
 
 </head>
 <body>


### PR DESCRIPTION
The out of the box setup of the html5Canvas example does not work anymore, apparently some output paths have changed. This fixes the issue.