### PR TITLE
Refine LLVM bitcode imports detection

### DIFF
--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
@@ -100,7 +100,7 @@ external fun getReceiverOrSuper(receiver: NativePtr, superClass: NativePtr): COp
 @Retention(AnnotationRetention.BINARY)
 annotation class ExternalObjCClass(val protocolGetter: String = "", val binaryName: String = "")
 
-@Target(AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
 @Retention(AnnotationRetention.BINARY)
 annotation class ObjCMethod(val selector: String, val bridge: String)
 

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
@@ -125,6 +125,10 @@ annotation class InteropStubs()
 @Retention(AnnotationRetention.SOURCE)
 internal annotation class ObjCMethodImp(val selector: String, val encoding: String)
 
+@PublishedApi
+@TypedIntrinsic(IntrinsicType.OBJC_GET_SELECTOR)
+internal external fun objCGetSelector(selector: String): COpaquePointer
+
 @kotlin.native.internal.ExportForCppRuntime("Kotlin_Interop_getObjCClass")
 private fun getObjCClassByName(name: NativePtr): NativePtr {
     val result = objc_lookUpClass(name)

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/GlobalVariableStub.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/GlobalVariableStub.kt
@@ -27,7 +27,8 @@ class GlobalVariableStub(global: GlobalDecl, stubGenerator: StubGenerator) : Kot
         stubGenerator.simpleBridgeGenerator.kotlinToNative(
                 nativeBacked = this,
                 returnType = BridgedType.NATIVE_PTR,
-                kotlinValues = emptyList()
+                kotlinValues = emptyList(),
+                independent = false
         ) {
             "&${global.name}"
         }
@@ -58,7 +59,8 @@ class GlobalVariableStub(global: GlobalDecl, stubGenerator: StubGenerator) : Kot
                 getter = mirror.info.argFromBridged(stubGenerator.simpleBridgeGenerator.kotlinToNative(
                         nativeBacked = this,
                         returnType = mirror.info.bridgedType,
-                        kotlinValues = emptyList()
+                        kotlinValues = emptyList(),
+                        independent = false
                 ) {
                     mirror.info.cToBridged(expr = global.name)
                 }, kotlinScope, nativeBacked = this)
@@ -71,7 +73,8 @@ class GlobalVariableStub(global: GlobalDecl, stubGenerator: StubGenerator) : Kot
                     stubGenerator.simpleBridgeGenerator.kotlinToNative(
                             nativeBacked = setterStub,
                             returnType = BridgedType.VOID,
-                            kotlinValues = listOf(bridgedValue)
+                            kotlinValues = listOf(bridgedValue),
+                            independent = false
                     ) { nativeValues ->
                         out("${global.name} = ${mirror.info.cFromBridged(
                                 nativeValues.single(),

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
@@ -157,6 +157,8 @@ data class KotlinFunctionType(
 internal val cnamesStructsPackageName = "cnames.structs"
 
 object KotlinTypes {
+    val independent = Classifier.topLevel("kotlin.native.internal", "Independent")
+
     val boolean by BuiltInType
     val byte by BuiltInType
     val short by BuiltInType

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/MappingBridgeGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/MappingBridgeGenerator.kt
@@ -32,6 +32,7 @@ interface MappingBridgeGenerator {
             nativeBacked: NativeBacked,
             returnType: Type,
             kotlinValues: List<TypedKotlinValue>,
+            independent: Boolean,
             block: NativeCodeBuilder.(nativeValues: List<NativeExpression>) -> NativeExpression
     ): KotlinExpression
 

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/MappingBridgeGeneratorImpl.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/MappingBridgeGeneratorImpl.kt
@@ -35,6 +35,7 @@ class MappingBridgeGeneratorImpl(
             nativeBacked: NativeBacked,
             returnType: Type,
             kotlinValues: List<TypedKotlinValue>,
+            independent: Boolean,
             block: NativeCodeBuilder.(nativeValues: List<NativeExpression>) -> NativeExpression
     ): KotlinExpression {
         val bridgeArguments = mutableListOf<BridgeTypedKotlinValue>()
@@ -70,7 +71,7 @@ class MappingBridgeGeneratorImpl(
         }
 
         val callExpr = simpleBridgeGenerator.kotlinToNative(
-                nativeBacked, bridgeReturnType, bridgeArguments
+                nativeBacked, bridgeReturnType, bridgeArguments, independent
         ) { bridgeNativeValues ->
 
             val nativeValues = mutableListOf<String>()

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/Mappings.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/Mappings.kt
@@ -307,7 +307,8 @@ sealed class TypeInfo {
                         type.returnType,
                         type.parameterTypes.mapIndexed { index, it ->
                             TypedKotlinValue(it, "p$index")
-                        } + TypedKotlinValue(PointerType(VoidType), "interpretCPointer<COpaque>($kniBlockPtr)")
+                        } + TypedKotlinValue(PointerType(VoidType), "interpretCPointer<COpaque>($kniBlockPtr)"),
+                        independent = true
 
                 ) { nativeValues ->
                     val type = type

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -226,7 +226,11 @@ class ObjCMethodStub(private val stubGenerator: StubGenerator,
                 bodyGenerator,
                 this@ObjCMethodStub,
                 returnType,
-                nativeBridgeArguments
+                nativeBridgeArguments,
+                independent = when (container) {
+                    is ObjCClassOrProtocol -> true // Every proper instance has this method in its method table.
+                    is ObjCCategory -> false // Method is contributed by native dependency.
+                }
         ) { nativeValues ->
             val messengerParameterTypes = mutableListOf<String>()
             messengerParameterTypes.add("void*")

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -178,6 +178,7 @@ class ObjCMethodStub(private val stubGenerator: StubGenerator,
 
         val kniReceiverParameter = "kniR"
         val kniSuperClassParameter = "kniSC"
+        val kniSelectorParameter = "kniSEL"
 
         val voidPtr = PointerType(VoidType)
 
@@ -198,6 +199,9 @@ class ObjCMethodStub(private val stubGenerator: StubGenerator,
         nativeBridgeArguments.add(
                 TypedKotlinValue(voidPtr,
                         "getReceiverOrSuper($kniReceiverParameter, $kniSuperClassParameter)"))
+
+        kotlinObjCBridgeParameters.add(KotlinParameter(kniSelectorParameter, KotlinTypes.cOpaquePointer))
+        nativeBridgeArguments.add(TypedKotlinValue(voidPtr, kniSelectorParameter))
 
         val kotlinParameterNames = method.getKotlinParameterNames()
 
@@ -224,7 +228,6 @@ class ObjCMethodStub(private val stubGenerator: StubGenerator,
                 returnType,
                 nativeBridgeArguments
         ) { nativeValues ->
-            val selector = "@selector(${method.selector})"
             val messengerParameterTypes = mutableListOf<String>()
             messengerParameterTypes.add("void*")
             messengerParameterTypes.add("SEL")
@@ -239,7 +242,7 @@ class ObjCMethodStub(private val stubGenerator: StubGenerator,
 
             val messenger = "(($messengerType) ${nativeValues.first()})"
 
-            val messengerArguments = listOf(nativeValues[1]) + selector + nativeValues.drop(2)
+            val messengerArguments = nativeValues.drop(1)
 
             "$messenger(${messengerArguments.joinToString()})"
         }

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGenerator.kt
@@ -60,6 +60,7 @@ interface SimpleBridgeGenerator {
             nativeBacked: NativeBacked,
             returnType: BridgedType,
             kotlinValues: List<BridgeTypedKotlinValue>,
+            independent: Boolean,
             block: NativeCodeBuilder.(nativeValues: List<NativeExpression>) -> NativeExpression
     ): KotlinExpression
 

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGeneratorImpl.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGeneratorImpl.kt
@@ -71,7 +71,8 @@ class SimpleBridgeGeneratorImpl(
             nativeBacked: NativeBacked,
             returnType: BridgedType,
             kotlinValues: List<BridgeTypedKotlinValue>,
-            block: NativeCodeBuilder.(arguments: List<NativeExpression>) -> NativeExpression
+            independent: Boolean,
+            block: NativeCodeBuilder.(nativeValues: List<NativeExpression>) -> NativeExpression
     ): KotlinExpression {
 
         val kotlinLines = mutableListOf<String>()
@@ -116,6 +117,7 @@ class SimpleBridgeGeneratorImpl(
             }
             KotlinPlatform.NATIVE -> {
                 val functionName = pkgName.replace(INVALID_CLANG_IDENTIFIER_REGEX, "_") + "_$kotlinFunctionName"
+                if (independent) kotlinLines.add("@" + topLevelKotlinScope.reference(KotlinTypes.independent))
                 kotlinLines.add("@SymbolName(${functionName.quoteAsKotlinLiteral()})")
                 "$cReturnType $functionName ($joinedCParameters)"
             }

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/StubGenerator.kt
@@ -660,7 +660,8 @@ class StubGenerator(
                         bodyGenerator,
                         this,
                         func.returnType,
-                        bridgeArguments
+                        bridgeArguments,
+                        independent = false
                 ) { nativeValues ->
                     "${func.name}(${nativeValues.joinToString()})"
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LinkStage.kt
@@ -40,7 +40,10 @@ internal class LinkStage(val context: Context) {
 
     private val nomain = config.get(KonanConfigKeys.NOMAIN) ?: false
     private val emitted = context.bitcodeFileName
-    private val libraries = context.llvm.librariesToLink
+
+    private val bitcodeLibraries = context.llvm.bitcodeToLink
+    private val nativeDependencies = context.llvm.nativeDependenciesToLink
+
     private fun MutableList<String>.addNonEmpty(elements: List<String>) {
         addAll(elements.filter { !it.isEmpty() })
     }
@@ -221,7 +224,7 @@ internal class LinkStage(val context: Context) {
     fun makeObjectFiles() {
 
         val bitcodeFiles = listOf(emitted) +
-                libraries.map { it.bitcodePaths }.flatten().filter { it.isBitcode }
+                bitcodeLibraries.map { it.bitcodePaths }.flatten().filter { it.isBitcode }
 
         objectFiles.add(when (platform.configurables) {
             is WasmConfigurables
@@ -235,10 +238,10 @@ internal class LinkStage(val context: Context) {
 
     fun linkStage() {
         val includedBinaries =
-                libraries.map { it.includedPaths }.flatten()
+                nativeDependencies.map { it.includedPaths }.flatten()
 
         val libraryProvidedLinkerFlags =
-                libraries.map { it.linkerOpts }.flatten()
+                nativeDependencies.map { it.linkerOpts }.flatten()
 
         link(objectFiles, includedBinaries, libraryProvidedLinkerFlags)
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/RuntimeNames.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/RuntimeNames.kt
@@ -8,4 +8,5 @@ object RuntimeNames {
     val exportForCompilerAnnotation = FqName("kotlin.native.internal.ExportForCompiler")
     val exportTypeInfoAnnotation = FqName("kotlin.native.internal.ExportTypeInfo")
     val cCall = FqName("kotlinx.cinterop.internal.CCall")
+    val independent = FqName("kotlin.native.internal.Independent")
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -233,6 +233,8 @@ internal class KonanSymbols(context: Context, val symbolTable: SymbolTable, val 
     val interopCreateNSStringFromKString =
             symbolTable.referenceSimpleFunction(context.interopBuiltIns.CreateNSStringFromKString)
 
+    val interopObjCGetSelector = interopFunction("objCGetSelector")
+
     val objCExportTrapOnUndeclaredException =
             symbolTable.referenceSimpleFunction(context.builtIns.kotlinNativeInternal.getContributedFunctions(
                     Name.identifier("trapOnUndeclaredException"),

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BinaryInterface.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BinaryInterface.kt
@@ -102,6 +102,10 @@ object KonanMangler : KotlinManglerImpl() {
                         append(it.selector)
                         if (this@platformSpecificFunctionName is IrConstructor && this@platformSpecificFunctionName.isObjCConstructor) append("#Constructor")
 
+                        if ((this@platformSpecificFunctionName as? IrSimpleFunction)?.correspondingProperty != null) {
+                            append("#Accessor")
+                        }
+
                         // We happen to have the clashing combinations such as
                         //@ObjCMethod("issueChallengeToPlayers:message:", "objcKniBridge1165")
                         //external fun GKScore.issueChallengeToPlayers(playerIDs: List<*>?, message: String?): Unit

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/Imports.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/Imports.kt
@@ -15,8 +15,9 @@ import org.jetbrains.kotlin.konan.library.KonanLibrary
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
 internal interface LlvmImports {
-    fun add(origin: CompiledKonanModuleOrigin)
-    fun isImported(library: KonanLibrary): Boolean
+    fun add(origin: CompiledKonanModuleOrigin, onlyBitcode: Boolean = false)
+    fun bitcodeIsUsed(library: KonanLibrary): Boolean
+    fun nativeDependenciesAreUsed(library: KonanLibrary): Boolean
 }
 
 internal val DeclarationDescriptor.llvmSymbolOrigin: CompiledKonanModuleOrigin

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
@@ -4,6 +4,7 @@ import kotlinx.cinterop.cValuesOf
 import llvm.*
 import org.jetbrains.kotlin.backend.konan.descriptors.TypedIntrinsic
 import org.jetbrains.kotlin.backend.konan.descriptors.isTypedIntrinsic
+import org.jetbrains.kotlin.backend.konan.llvm.objc.genObjCSelector
 import org.jetbrains.kotlin.backend.konan.reportCompilationError
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
@@ -51,6 +52,7 @@ internal enum class IntrinsicType {
     OBJC_GET_OBJC_CLASS,
     OBJC_GET_RECEIVER_OR_SUPER,
     OBJC_INIT_BY,
+    OBJC_GET_SELECTOR,
     // Other
     GET_CLASS_TYPE_INFO,
     CREATE_UNINITIALIZED_INSTANCE,
@@ -148,6 +150,10 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
                 environment.evaluateCall(constructorDescriptor, args, Lifetime.IRRELEVANT)
                 receiver
             }
+            IntrinsicType.OBJC_GET_SELECTOR -> {
+                val selector = (callSite.getValueArgument(0) as IrConst<*>).value as String
+                environment.functionGenerationContext.genObjCSelector(selector)
+            }
             IntrinsicType.INIT_INSTANCE -> {
                 val callee = callSite as IrCall
                 val initializer = callee.getValueArgument(1) as IrCall
@@ -232,6 +238,7 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
                     reportNonLoweredIntrinsic(intrinsicType)
                 IntrinsicType.INIT_INSTANCE,
                 IntrinsicType.OBJC_INIT_BY,
+                IntrinsicType.OBJC_GET_SELECTOR,
                 IntrinsicType.IMMUTABLE_BLOB ->
                     reportSpecialIntrinsic(intrinsicType)
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -2123,7 +2123,8 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         val protocolGetter = context.llvm.externalFunction(
                 protocolGetterName,
                 functionType(int8TypePtr, false),
-                irClass.llvmSymbolOrigin
+                irClass.llvmSymbolOrigin,
+                independent = true // Protocol is header-only declaration.
         )
 
         return call(protocolGetter, emptyList())

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/KotlinObjCClassInfoGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/KotlinObjCClassInfoGenerator.kt
@@ -120,7 +120,8 @@ internal class KotlinObjCClassInfoGenerator(override val context: Context) : Con
                 context.llvm.externalFunction(
                         imp,
                         functionType(voidType),
-                        origin = info.bridge.llvmSymbolOrigin
+                        origin = info.bridge.llvmSymbolOrigin,
+                        independent = true
                 )
         )
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmDeclarations.kt
@@ -397,7 +397,8 @@ private class DeclarationsGeneratorVisitor(override val context: Context) :
 
             context.llvm.externalFunction(declaration.symbolName, llvmFunctionType,
                     // Assume that `external fun` is defined in native libs attached to this module:
-                    origin = declaration.llvmSymbolOrigin
+                    origin = declaration.llvmSymbolOrigin,
+                    independent = declaration.hasAnnotation(RuntimeNames.independent)
             )
         } else {
             val symbolName = if (declaration.isExported()) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/ObjCCodeGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objc/ObjCCodeGenerator.kt
@@ -14,11 +14,7 @@ internal open class ObjCCodeGenerator(val codegen: CodeGenerator) {
 
     val dataGenerator = codegen.objCDataGenerator!!
 
-    fun FunctionGenerationContext.genSelector(selector: String): LLVMValueRef {
-        val selectorRef = dataGenerator.genSelectorRef(selector)
-        // TODO: clang emits it with `invariant.load` metadata.
-        return load(selectorRef.llvm)
-    }
+    fun FunctionGenerationContext.genSelector(selector: String): LLVMValueRef = genObjCSelector(selector)
 
     fun FunctionGenerationContext.genGetLinkedClass(name: String): LLVMValueRef {
         val classRef = dataGenerator.genClassRef(name)
@@ -42,4 +38,10 @@ internal open class ObjCCodeGenerator(val codegen: CodeGenerator) {
     // TODO: this doesn't support stret.
     fun msgSender(functionType: LLVMTypeRef): LLVMValueRef =
             objcMsgSend.bitcast(pointerType(functionType)).llvm
+}
+
+internal fun FunctionGenerationContext.genObjCSelector(selector: String): LLVMValueRef {
+    val selectorRef = codegen.objCDataGenerator!!.genSelectorRef(selector)
+    // TODO: clang emits it with `invariant.load` metadata.
+    return load(selectorRef.llvm)
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -587,10 +587,13 @@ internal class InteropLoweringPart1(val context: Context) : IrBuildingTransforme
         return irCall(bridge, symbolTable.translateErased(info.bridge.returnType!!)).apply {
             putValueArgument(0, superClass)
             putValueArgument(1, receiver)
+            putValueArgument(2, irCall(symbols.interopObjCGetSelector.owner).apply {
+                putValueArgument(0, irString(info.selector))
+            })
 
-            assert(arguments.size + 2 == info.bridge.valueParameters.size)
+            assert(arguments.size + 3 == info.bridge.valueParameters.size)
             arguments.forEachIndexed { index, argument ->
-                putValueArgument(index + 2, argument)
+                putValueArgument(index + 3, argument)
             }
         }
     }

--- a/runtime/src/main/kotlin/kotlin/native/internal/Annotations.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/Annotations.kt
@@ -105,3 +105,11 @@ internal annotation class PointsTo(vararg val onWhom: Int)
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
 internal annotation class TypedIntrinsic(val kind: String)
+
+/**
+ * Indicates that `@SymbolName external` function is implemented in library-stored bitcode
+ * and doesn't have native dependencies.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class Independent

--- a/runtime/src/main/kotlin/kotlin/native/internal/IntrinsicType.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/IntrinsicType.kt
@@ -42,6 +42,7 @@ class IntrinsicType {
         const val OBJC_GET_OBJC_CLASS           = "OBJC_GET_OBJC_CLASS"
         const val OBJC_GET_RECEIVER_OR_SUPER    = "OBJC_GET_RECEIVER_OR_SUPER"
         const val OBJC_INIT_BY                  = "OBJC_INIT_BY"
+        const val OBJC_GET_SELECTOR             = "OBJC_GET_SELECTOR"
 
         // Other
         const val GET_CLASS_TYPE_INFO           = "GET_CLASS_TYPE_INFO"


### PR DESCRIPTION
Don't link native libraries if external function requires only library-stored bitcode.
Also make Objective-C interop stubs bitcode less harmful by excluding selectors.