### PR TITLE
Ignore synthetic constructor from kotlinx.serialization plugin 

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/SerializeDescriptorReference.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/SerializeDescriptorReference.kt
@@ -28,6 +28,8 @@ class DescriptorReferenceSerializer(val declarationTable: DeclarationTable, val 
 
         if (descriptor is ParameterDescriptor || (descriptor is VariableDescriptor && descriptor !is PropertyDescriptor) || descriptor is TypeParameterDescriptor) return null
 
+        if (declaration is IrConstructor && (declaration.origin as? IrDeclarationOriginImpl)?.name == "SERIALIZER") return null
+
         val containingDeclaration = descriptor.containingDeclaration!!
 
         val (packageFqName, classFqName) = when (containingDeclaration) {


### PR DESCRIPTION
during IR serialization, since it does not have corresponding descriptor in
descriptor tree