### PR TITLE
Pack stdlib sources into K/N bundle

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.CopyCommonSources
 import org.jetbrains.kotlin.konan.target.HostManager
 
 /*
@@ -112,10 +113,8 @@ configurations {
     kotlin_reflect_jar
     kotlin_script_runtime_jar
     kotlin_native_shared_jar
-    kotlin_common_stdlib_src
-    kotlin_test_common_src
-    kotlin_test_annotations_common_src
     trove4j_jar
+    kotlinCommonSources
 
     cli_bcRuntime {
         extendsFrom compilerRuntime
@@ -134,9 +133,10 @@ dependencies {
     kotlin_reflect_jar "$kotlinReflectModule@jar"
     kotlin_script_runtime_jar "$kotlinScriptRuntimeModule@jar"
     kotlin_native_shared_jar "$kotlinNativeSharedModule@jar"
-    kotlin_common_stdlib_src kotlinCommonStdlibModule
-    kotlin_test_common_src kotlinTestCommonModule
-    kotlin_test_annotations_common_src kotlinTestAnnotationsCommonModule
+
+    [kotlinCommonStdlibModule, kotlinTestCommonModule, kotlinTestAnnotationsCommonModule].each {
+        kotlinCommonSources(it) { transitive = false }
+    }
 
     compilerCompile "com.google.protobuf:protobuf-java:${protobufVersion}"
 
@@ -165,23 +165,9 @@ task stdlib(dependsOn: "${hostName}Stdlib")
 
 def commonSrc = file('build/stdlib')
 
-task unzipStdlibSources(type: Copy) {
-    dependsOn configurations.kotlin_common_stdlib_src
-    dependsOn configurations.kotlin_test_common_src
-    dependsOn configurations.kotlin_test_annotations_common_src
-
-    def jarFiles = configurations.kotlin_common_stdlib_src.files +
-            configurations.kotlin_test_common_src.files +
-            configurations.kotlin_test_annotations_common_src.files
-
-    jarFiles.forEach { jarFile ->
-        from(zipTree(jarFile)) {
-            include 'generated/**/*.kt'
-            include 'kotlin/**/*.kt'
-            include 'kotlin.test/*.kt'
-        }
-    }
-    destinationDir commonSrc
+task unzipStdlibSources(type: CopyCommonSources) {
+    outputDir commonSrc
+    sourcePaths configurations.kotlinCommonSources.files
 }
 
 final List<File> stdLibSrc = [
@@ -191,28 +177,6 @@ final List<File> stdLibSrc = [
         project(':runtime').file('src/main/kotlin'),
         project(':runtime').file('src/launcher/kotlin')
 ]
-
-task zipStdLibSources(type: Zip, dependsOn: unzipStdlibSources) {
-    from stdLibSrc, {
-        into "native"
-    }
-
-    from commonSrc, {
-        into "common"
-    }
-
-    archiveName 'kotlin-stdlib-native-sources.zip'
-    destinationDir buildDir
-}
-
-task teamcityPublishStdLibSources {
-    dependsOn zipStdLibSources
-    if (System.getenv("TEAMCITY_BUILD_PROPERTIES_FILE") != null) {
-        doLast {
-            println " ##teamcity[publishArtifacts '${tasks.zipStdLibSources.archivePath}'] "
-        }
-    }
-}
 
 // These files are built before the 'dist' is complete,
 // so we provide custom values for

--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import groovy.io.FileType
 import org.jetbrains.kotlin.konan.target.*
-import org.jetbrains.kotlin.konan.properties.*
 import org.jetbrains.kotlin.konan.util.*
 import org.jetbrains.kotlin.CopySamples
+import org.jetbrains.kotlin.CopyCommonSources
 import org.jetbrains.kotlin.konan.*
 
 buildscript {
@@ -191,6 +190,18 @@ class PlatformInfo {
     }
 }
 
+configurations {
+    ftpAntTask
+    kotlinCommonSources
+}
+
+dependencies {
+    ftpAntTask 'org.apache.ant:ant-commons-net:1.9.9'
+    [kotlinCommonStdlibModule, kotlinTestCommonModule, kotlinTestAnnotationsCommonModule].each {
+        kotlinCommonSources(it) { transitive = false }
+    }
+}
+
 task versionJar {
     dependsOn gradle.includedBuild('kotlin-native-version').task(':jar')
 }
@@ -217,6 +228,32 @@ task cross_dist(dependsOn: "crossDist")
 task list_dist(dependsOn: "listDist")
 task build {
     dependsOn ':dist', ':distPlatformLibs'
+}
+
+task distCommonSources(type: CopyCommonSources) {
+    outputDir "$distDir/sources"
+    sourcePaths configurations.kotlinCommonSources.files
+    zipSources true
+}
+
+task distNativeSources(type: Zip) {
+    destinationDirectory = file("$distDir/sources")
+    archiveFileName = "kotlin-stdlib-native-sources.zip"
+
+    includeEmptyDirs = false
+    include('**/*.kt')
+
+    from(project(':runtime').file('src/main/kotlin'))
+    from(project(':Interop:Runtime').file('src/main/kotlin'))
+    from(project(':Interop:Runtime').file('src/native/kotlin'))
+    from(project(':Interop:JsRuntime').file('src/main/kotlin')) {
+        into('kotlinx/wasm/jsinterop')
+    }
+}
+
+task distSources {
+    dependsOn(distCommonSources)
+    dependsOn(distNativeSources)
 }
 
 task distCompiler(type: Copy) {
@@ -319,7 +356,6 @@ task listDist(type: Exec) {
 task distRuntime(type: Copy) {
     dependsOn "${hostName}CrossDistRuntime"
     dependsOn('commonDistRuntime')
-    dependsOn(':backend.native:teamcityPublishStdLibSources')
 }
 
 def stdlib = 'klib/common/stdlib'
@@ -393,17 +429,10 @@ task crossDist {
     dependsOn 'crossDistRuntime', 'distCompiler'
 }
 
-configurations {
-    ftpAntTask
-}
-
-dependencies {
-    ftpAntTask 'org.apache.ant:ant-commons-net:1.9.9'
-}
-
 task bundle(type: (isWindows()) ? Zip : Tar) {
     dependsOn('crossDistPlatformLibs')
     dependsOn('crossDist')
+    dependsOn('distSources')
     def simpleOsName = HostManager.simpleOsName()
     baseName = "kotlin-native-$simpleOsName-$konanVersionFull"
     from("$project.rootDir/dist") {
@@ -441,6 +470,7 @@ task bundle(type: (isWindows()) ? Zip : Tar) {
 task 'tc-dist'(type: (isWindows()) ? Zip : Tar) {
     dependsOn('distPlatformLibs')
     dependsOn('dist')
+    dependsOn('distSources')
     def simpleOsName = HostManager.simpleOsName()
     baseName = "kotlin-native-dist-$simpleOsName-$konanVersionFull"
     from("$project.rootDir/dist") {

--- a/buildSrc/plugins/src/main/kotlin/org/jetbrains/kotlin/CopyCommonSources.kt
+++ b/buildSrc/plugins/src/main/kotlin/org/jetbrains/kotlin/CopyCommonSources.kt
@@ -1,0 +1,79 @@
+package org.jetbrains.kotlin
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class CopyCommonSources : DefaultTask() {
+    @Input
+    var zipSources: Boolean = false
+
+    @InputFiles
+    var sourcePaths: ConfigurableFileCollection = project.files()
+
+    @OutputDirectory
+    var outputDir: File = project.buildDir.resolve("sources")
+
+    fun zipSources(needToZip: Boolean) {
+        zipSources = needToZip
+    }
+
+    fun outputDir(path: Any) {
+        outputDir = project.file(path)
+    }
+
+    fun sourcePaths(paths: Any) {
+        sourcePaths = project.files(paths)
+    }
+
+    @TaskAction
+    fun copySources() {
+        if (zipSources) copyAndZip() else copyPlain()
+    }
+
+    private fun copyPlain() {
+        for (sourcePath in sourcePaths) {
+            sourcePath.copyFilteredTo(outputDir)
+        }
+    }
+
+    private fun copyAndZip() {
+        for (sourcePath in sourcePaths) {
+            val filePrefix = sourcePath.name.replace(Regex("-\\d+.*"), "")
+            val targetFileName = "$filePrefix-sources.zip"
+
+            val tempDir = project.buildDir.resolve(name).resolve(filePrefix).also {
+                it.deleteRecursively()
+                it.mkdirs()
+            }
+
+            sourcePath.copyFilteredTo(tempDir)
+
+            project.ant.invokeMethod(
+                    "zip",
+                    mapOf(
+                            "destfile" to outputDir.resolve(targetFileName).absolutePath,
+                            "basedir" to tempDir.absolutePath
+                    )
+            )
+        }
+    }
+
+    private fun File.copyFilteredTo(destinationDir: File) {
+        val fileTree = if (isFile) project.zipTree(this) else project.fileTree(this)
+
+        project.copy {
+            it.from(fileTree)
+            it.includeEmptyDirs = false
+            it.include("generated/**/*.kt")
+            it.include("kotlin/**/*.kt")
+            it.include("kotlin.test/*.kt")
+            it.into(destinationDir)
+        }
+    }
+}
+


### PR DESCRIPTION
A new directory inside K/N bundle named `sources` will contain the source code of stdlib in the form of few ZIP files:
```
$ ls -l dist/sources/
total 1000
-rw-r--r--  1 dmitriy.dolovov  staff  223434 Apr  1 18:18 kotlin-stdlib-common-sources.zip
-rw-r--r--  1 dmitriy.dolovov  staff  277248 Apr  1 18:18 kotlin-stdlib-native-sources.zip
-rw-r--r--  1 dmitriy.dolovov  staff     560 Apr  1 18:18 kotlin-test-annotations-common-sources.zip
-rw-r--r--  1 dmitriy.dolovov  staff    4041 Apr  1 18:18 kotlin-test-common-sources.zip
```

I did not merge this files into a single archive intentionally. Because it may be required to add source code selectively on IDE side, so I would like to have flexibility here.