### PR TITLE
Use compiler-generated C stubs to call Objective-C methods

### DIFF
--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
@@ -42,7 +42,7 @@ fun optional(): Nothing = throw RuntimeException("Do not call me!!!")
 
 @Deprecated(
         "Add @OverrideInit to constructor to make it override Objective-C initializer",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
 )
 @TypedIntrinsic(IntrinsicType.OBJC_INIT_BY)
 external fun <T : ObjCObjectBase> T.initBy(constructorCall: T): T
@@ -56,8 +56,7 @@ private fun ObjCObjectBase.superInitCheck(superInitCallResult: ObjCObject?) {
         throw UnsupportedOperationException("Super initializer has replaced object")
 }
 
-@Deprecated("Use plain Kotlin cast", ReplaceWith("this as T"), DeprecationLevel.WARNING)
-fun <T : Any?> Any?.uncheckedCast(): T = @Suppress("UNCHECKED_CAST") (this as T) // TODO: make private
+internal fun <T : Any?> Any?.uncheckedCast(): T = @Suppress("UNCHECKED_CAST") (this as T)
 
 @SymbolName("Kotlin_Interop_refFromObjC")
 external fun <T> interpretObjCPointerOrNull(objcPtr: NativePtr): T?
@@ -93,8 +92,9 @@ var <T : Any?> ObjCNotImplementedVar<T>.value: T
 typealias ObjCStringVarOf<T> = ObjCNotImplementedVar<T>
 typealias ObjCBlockVar<T> = ObjCNotImplementedVar<T>
 
-@TypedIntrinsic(IntrinsicType.OBJC_GET_RECEIVER_OR_SUPER)
-external fun getReceiverOrSuper(receiver: NativePtr, superClass: NativePtr): COpaquePointer?
+@TypedIntrinsic(IntrinsicType.OBJC_CREATE_SUPER_STRUCT)
+@PublishedApi
+internal external fun createObjCSuperStruct(receiver: NativePtr, superClass: NativePtr): NativePtr
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)
@@ -102,11 +102,7 @@ annotation class ExternalObjCClass(val protocolGetter: String = "", val binaryNa
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
 @Retention(AnnotationRetention.BINARY)
-annotation class ObjCMethod(val selector: String, val bridge: String)
-
-@Target(AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.BINARY)
-annotation class ObjCBridge(val selector: String, val encoding: String, val imp: String = "")
+annotation class ObjCMethod(val selector: String, val encoding: String, val isStret: Boolean = false)
 
 @Target(AnnotationTarget.CONSTRUCTOR)
 @Retention(AnnotationRetention.BINARY)
@@ -114,7 +110,7 @@ annotation class ObjCConstructor(val initSelector: String, val designated: Boole
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
-annotation class ObjCFactory(val bridge: String)
+annotation class ObjCFactory(val selector: String, val encoding: String, val isStret: Boolean = false)
 
 @Target(AnnotationTarget.FILE)
 @Retention(AnnotationRetention.BINARY)
@@ -158,10 +154,13 @@ private fun allocObjCObject(clazz: NativePtr): NativePtr {
 @kotlin.native.internal.ExportForCompiler
 private external fun <T : ObjCObject> getObjCClass(): NativePtr
 
+@PublishedApi
 @TypedIntrinsic(IntrinsicType.OBJC_GET_MESSENGER)
-external fun getMessenger(superClass: NativePtr): COpaquePointer?
+internal external fun getMessenger(superClass: NativePtr): COpaquePointer?
+
+@PublishedApi
 @TypedIntrinsic(IntrinsicType.OBJC_GET_MESSENGER_STRET)
-external fun getMessengerStret(superClass: NativePtr): COpaquePointer?
+internal external fun getMessengerStret(superClass: NativePtr): COpaquePointer?
 
 
 internal class ObjCWeakReferenceImpl : kotlin.native.ref.WeakReferenceImpl() {
@@ -180,13 +179,17 @@ private external fun ObjCWeakReferenceImpl.init(objcPtr: NativePtr)
 
 // Konan runtme:
 
-@Deprecated("Use plain Kotlin cast of String to NSString", level = DeprecationLevel.WARNING)
+@Deprecated("Use plain Kotlin cast of String to NSString", level = DeprecationLevel.ERROR)
 @SymbolName("Kotlin_Interop_CreateNSStringFromKString")
 external fun CreateNSStringFromKString(str: String?): NativePtr
 
-@Deprecated("Use plain Kotlin cast of NSString to String", level = DeprecationLevel.WARNING)
+@Deprecated("Use plain Kotlin cast of NSString to String", level = DeprecationLevel.ERROR)
 @SymbolName("Kotlin_Interop_CreateKStringFromNSString")
 external fun CreateKStringFromNSString(ptr: NativePtr): String?
+
+@PublishedApi
+@SymbolName("Kotlin_Interop_CreateObjCObjectHolder")
+internal external fun createObjCObjectHolder(ptr: NativePtr): Any?
 
 // Objective-C runtime:
 

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCUtils.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCUtils.kt
@@ -25,7 +25,7 @@ inline fun <R> autoreleasepool(block: () -> R): R {
     }
 }
 
-@Deprecated("Use plain Kotlin cast", ReplaceWith("this as T"), DeprecationLevel.WARNING)
+@Deprecated("Use plain Kotlin cast", ReplaceWith("this as T"), DeprecationLevel.ERROR)
 fun <T : ObjCObject> ObjCObject.reinterpret() = @Suppress("DEPRECATION") this.uncheckedCast<T>()
 
 // TODO: null checks

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -316,7 +316,7 @@ internal class Context(config: KonanConfig) : KonanBackendContext(config) {
     lateinit var bitcodeFileName: String
     lateinit var library: KonanLibraryWriter
 
-    val cStubsManager = CStubsManager()
+    val cStubsManager = CStubsManager(config.target)
 
     val coverage = CoverageManager(this)
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
@@ -5,17 +5,13 @@
 
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.backend.konan.descriptors.findPackageView
+import org.jetbrains.kotlin.backend.konan.descriptors.getArgumentValueOrNull
 import org.jetbrains.kotlin.backend.konan.descriptors.getStringValue
 import org.jetbrains.kotlin.backend.konan.descriptors.getStringValueOrNull
 import org.jetbrains.kotlin.backend.konan.ir.*
 import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.incremental.components.NoLookupLocation
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -35,7 +31,6 @@ internal val externalObjCClassFqName = interopPackageName.child(Name.identifier(
 private val objCMethodFqName = interopPackageName.child(Name.identifier("ObjCMethod"))
 private val objCConstructorFqName = FqName("kotlinx.cinterop.ObjCConstructor")
 private val objCFactoryFqName = interopPackageName.child(Name.identifier("ObjCFactory"))
-private val objCBridgeFqName = interopPackageName.child(Name.identifier("ObjCBridge"))
 
 @Deprecated("Use IR version rather than descriptor version")
 fun ClassDescriptor.isObjCClass(): Boolean =
@@ -91,52 +86,21 @@ fun ClassDescriptor.isKotlinObjCClass(): Boolean = this.isObjCClass() && !this.i
 fun IrClass.isKotlinObjCClass(): Boolean = this.isObjCClass() && !this.isExternalObjCClass()
 
 
-data class ObjCMethodInfo(val bridge: FunctionDescriptor,
-                          val selector: String,
+data class ObjCMethodInfo(val selector: String,
                           val encoding: String,
-                          val imp: String?)
-
-private fun CallableDescriptor.getBridgeAnnotation() =
-        this.annotations.findAnnotation(objCBridgeFqName)
+                          val isStret: Boolean)
 
 private fun FunctionDescriptor.decodeObjCMethodAnnotation(): ObjCMethodInfo? {
     assert (this.kind.isReal)
-
     val methodAnnotation = this.annotations.findAnnotation(objCMethodFqName) ?: return null
-    val packageView = this.findPackageView()
-
-    val bridgeName = methodAnnotation.getStringValue("bridge")
-
-    return objCMethodInfoByBridge(packageView, bridgeName)
+    return objCMethodInfo(methodAnnotation)
 }
 
-private fun objCMethodInfoByBridge(packageView: PackageViewDescriptor, bridgeName: String): ObjCMethodInfo {
-    val bridge = packageView.memberScope
-            .getContributedFunctions(Name.identifier(bridgeName), NoLookupLocation.FROM_BACKEND)
-            .single()
-
-    val bridgeAnnotation = bridge.getBridgeAnnotation()!!
-    return ObjCMethodInfo(
-            bridge = bridge,
-            selector = bridgeAnnotation.getStringValue("selector"),
-            encoding = bridgeAnnotation.getStringValue("encoding"),
-            imp = bridgeAnnotation.getStringValueOrNull("imp")
-    )
-}
-
-fun IrSimpleFunction.objCMethodArgValue(argName: String): String? {
-    val methodAnnotation = this.annotations.findAnnotation(objCMethodFqName) ?: return null
-    methodAnnotation.symbol.owner.valueParameters.forEachIndexed { index, parameter ->
-        if (parameter.name.asString() == argName) {
-            val bridgeArgument = methodAnnotation.getValueArgument(index) as IrConst<kotlin.String>
-            return bridgeArgument.value
-        }
-    }
-    return null
-}
-
-fun IrSimpleFunction.hasObjCMethodAnnotation() =
-    this.annotations.findAnnotation(objCMethodFqName) != null
+private fun objCMethodInfo(annotation: AnnotationDescriptor) = ObjCMethodInfo(
+        selector = annotation.getStringValue("selector"),
+        encoding = annotation.getStringValue("encoding"),
+        isStret = annotation.getArgumentValueOrNull<Boolean>("isStret") ?: false
+)
 
 /**
  * @param onlyExternal indicates whether to accept overriding methods from Kotlin classes
@@ -237,15 +201,6 @@ fun ConstructorDescriptor.objCConstructorIsDesignated(): Boolean {
 }
 
 
-fun ConstructorDescriptor.getObjCInitMethod(): FunctionDescriptor? {
-    return this.annotations.findAnnotation(objCConstructorFqName)?.let {
-        val initSelector = it.getStringValue("initSelector")
-        this.constructedClass.unsubstitutedMemberScope.getContributedDescriptors().asSequence()
-                .filterIsInstance<FunctionDescriptor>()
-                .single { it.getExternalObjCMethodInfo()?.selector == initSelector }
-    }
-}
-
 val IrConstructor.isObjCConstructor get() = this.descriptor.annotations.hasAnnotation(objCConstructorFqName)
 
 fun IrConstructor.getObjCInitMethod(): IrSimpleFunction? {
@@ -263,9 +218,7 @@ val IrFunction.hasObjCMethodAnnotation get() = this.descriptor.annotations.hasAn
 
 fun FunctionDescriptor.getObjCFactoryInitMethodInfo(): ObjCMethodInfo? {
     val factoryAnnotation = this.annotations.findAnnotation(objCFactoryFqName) ?: return null
-    val bridgeName = factoryAnnotation.getStringValue("bridge")
-
-    return objCMethodInfoByBridge(this.findPackageView(), bridgeName)
+    return objCMethodInfo(factoryAnnotation)
 }
 
 fun inferObjCSelector(descriptor: FunctionDescriptor): String = if (descriptor.valueParameters.isEmpty()) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/RuntimeNames.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/RuntimeNames.kt
@@ -9,4 +9,5 @@ object RuntimeNames {
     val exportTypeInfoAnnotation = FqName("kotlin.native.internal.ExportTypeInfo")
     val cCall = FqName("kotlinx.cinterop.internal.CCall")
     val independent = FqName("kotlin.native.internal.Independent")
+    val filterExceptions = FqName("kotlin.native.internal.FilterExceptions")
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -127,6 +127,10 @@ private fun createKotlinBridge(
             isSuspend = false
     )
     bridgeDescriptor.bind(bridge)
+    if (isExternal) {
+        bridge.annotations +=
+                irCall(startOffset, endOffset, symbols.filterExceptions.owner.constructors.single(), emptyList())
+    }
     return bridge
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CSyntaxSupport.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CSyntaxSupport.kt
@@ -14,6 +14,10 @@ internal object CTypes {
     fun function(returnType: CType, parameterTypes: List<CType>, variadic: Boolean): CType =
             FunctionCType(returnType, parameterTypes, variadic)
 
+    fun blockPointer(pointee: CType): CType = object : CType {
+        override fun render(name: String): String = pointee.render("^$name")
+    }
+
     val void = simple("void")
     val voidPtr = pointer(void)
     val signedChar = simple("signed char")
@@ -28,6 +32,8 @@ internal object CTypes {
     val double = simple("double")
     val C99Bool = simple("_Bool")
     val char = simple("char")
+
+    val id = simple("id")
 }
 
 private class SimpleCType(private val type: String) : CType {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -184,6 +184,7 @@ internal class KonanSymbols(context: Context, val symbolTable: SymbolTable, val 
     val arrayList = symbolTable.referenceClass(getArrayListClassDescriptor(context))
 
     val symbolName = topLevelClass(RuntimeNames.symbolName)
+    val filterExceptions = topLevelClass(RuntimeNames.filterExceptions)
     val exportForCppRuntime = topLevelClass(RuntimeNames.exportForCppRuntime)
 
     val objCMethodImp = symbolTable.referenceClass(context.interopBuiltIns.objCMethodImp)
@@ -211,6 +212,16 @@ internal class KonanSymbols(context: Context, val symbolTable: SymbolTable, val 
     val interopObjCRetain = interopFunction("objc_retain")
 
     val interopObjcRetainAutoreleaseReturnValue = interopFunction("objc_retainAutoreleaseReturnValue")
+
+    val interopCreateObjCObjectHolder = interopFunction("createObjCObjectHolder")
+
+    val interopCreateKotlinObjectHolder = interopFunction("createKotlinObjectHolder")
+    val interopUnwrapKotlinObjectHolderImpl = interopFunction("unwrapKotlinObjectHolderImpl")
+
+    val interopCreateObjCSuperStruct = interopFunction("createObjCSuperStruct")
+
+    val interopGetMessenger = interopFunction("getMessenger")
+    val interopGetMessengerStret = interopFunction("getMessengerStret")
 
     val interopGetObjCClass = symbolTable.referenceSimpleFunction(context.interopBuiltIns.getObjCClass)
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BinaryInterface.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BinaryInterface.kt
@@ -105,19 +105,6 @@ object KonanMangler : KotlinManglerImpl() {
                         if ((this@platformSpecificFunctionName as? IrSimpleFunction)?.correspondingProperty != null) {
                             append("#Accessor")
                         }
-
-                        // We happen to have the clashing combinations such as
-                        //@ObjCMethod("issueChallengeToPlayers:message:", "objcKniBridge1165")
-                        //external fun GKScore.issueChallengeToPlayers(playerIDs: List<*>?, message: String?): Unit
-                        //@ObjCMethod("issueChallengeToPlayers:message:", "objcKniBridge1172")
-                        //external fun GKScore.issueChallengeToPlayers(playerIDs: List<*>?, message: String?): Unit
-                        // So disambiguate by the name of the bridge for now.
-                        // TODO: idealy we'd never generate such identical declarations.
-
-                        if (this@platformSpecificFunctionName is IrSimpleFunction && this@platformSpecificFunctionName.hasObjCMethodAnnotation()) {
-                            this@platformSpecificFunctionName.objCMethodArgValue("selector")?.let { append("#$it") }
-                            this@platformSpecificFunctionName.objCMethodArgValue("bridge")?.let { append("#$it") }
-                        }
                     }
                 }
             return null

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
@@ -424,6 +424,9 @@ internal class FunctionGenerationContext(val function: LLVMValueRef,
             call(context.llvm.allocArrayFunction, listOf(typeInfo, count), lifetime, exceptionHandler)
 
     fun unreachable(): LLVMValueRef? {
+        if (context.config.debug) {
+            call(context.llvm.llvmTrap, emptyList())
+        }
         val res = LLVMBuildUnreachable(builder)
         currentPositionHolder.setAfterTerminator()
         return res

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -465,6 +465,12 @@ internal class Llvm(val context: Context, val llvmModule: LLVMModuleRef) {
         else -> "__gxx_personality_v0"
     }
 
+    val cxxStdTerminate = externalNounwindFunction(
+            "_ZSt9terminatev", // mangled C++ 'std::terminate'
+            functionType(voidType, false),
+            origin = context.standardLlvmSymbolsOrigin
+    )
+
     val gxxPersonalityFunction = externalNounwindFunction(
             personalityFunctionName,
             functionType(int32Type, true),
@@ -488,6 +494,12 @@ internal class Llvm(val context: Context, val llvmModule: LLVMModuleRef) {
             "llvm.trap",
             functionType(voidType, false),
             "cold", "noreturn", "nounwind"
+    )
+
+    val llvmEhTypeidFor = llvmIntrinsic(
+            "llvm.eh.typeid.for",
+            functionType(int32Type, false, int8TypePtr),
+            "nounwind", "readnone"
     )
 
     val usedFunctions = mutableListOf<LLVMValueRef>()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -296,6 +296,16 @@ internal class Llvm(val context: Context, val llvmModule: LLVMModuleRef) {
         return LLVMAddFunction(llvmModule, "llvm.memcpy.p0i8.p0i8.i32", functionType)!!
     }
 
+    private fun llvmIntrinsic(name: String, type: LLVMTypeRef, vararg attributes: String): LLVMValueRef {
+        val result = LLVMAddFunction(llvmModule, name, type)!!
+        attributes.forEach {
+            val kindId = getLlvmAttributeKindId(it)
+            val attribute = LLVMCreateEnumAttribute(LLVMGetTypeContext(type), kindId, 0)!!
+            LLVMAddAttributeAtIndex(result, LLVMAttributeFunctionIndex, attribute)
+        }
+        return result
+    }
+
     internal fun externalFunction(
             name: String,
             type: LLVMTypeRef,
@@ -473,6 +483,12 @@ internal class Llvm(val context: Context, val llvmModule: LLVMModuleRef) {
 
     val memsetFunction = importMemset()
     //val memcpyFunction = importMemcpy()
+
+    val llvmTrap = llvmIntrinsic(
+            "llvm.trap",
+            functionType(voidType, false),
+            "cold", "noreturn", "nounwind"
+    )
 
     val usedFunctions = mutableListOf<LLVMValueRef>()
     val usedGlobals = mutableListOf<LLVMValueRef>()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -2147,7 +2147,13 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
 
     private fun call(function: IrFunction, llvmFunction: LLVMValueRef, args: List<LLVMValueRef>,
                      resultLifetime: Lifetime): LLVMValueRef {
-        val result = call(llvmFunction, args, resultLifetime)
+        val exceptionHandler = if (function.hasAnnotation(RuntimeNames.filterExceptions)) {
+            functionGenerationContext.filteringExceptionHandler(currentCodeContext)
+        } else {
+            currentCodeContext.exceptionHandler
+        }
+
+        val result = call(llvmFunction, args, resultLifetime, exceptionHandler)
         if (!function.isSuspend && function.returnType.isNothing()) {
             functionGenerationContext.unreachable()
         }
@@ -2175,8 +2181,9 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
     }
 
     private fun call(function: LLVMValueRef, args: List<LLVMValueRef>,
-                     resultLifetime: Lifetime = Lifetime.IRRELEVANT): LLVMValueRef {
-        return functionGenerationContext.call(function, args, resultLifetime, currentCodeContext.exceptionHandler)
+                     resultLifetime: Lifetime = Lifetime.IRRELEVANT,
+                     exceptionHandler: ExceptionHandler = currentCodeContext.exceptionHandler): LLVMValueRef {
+        return functionGenerationContext.call(function, args, resultLifetime, exceptionHandler)
     }
 
     //-------------------------------------------------------------------------//

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/KotlinObjCClassInfoGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/KotlinObjCClassInfoGenerator.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.backend.konan.ir.*
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.util.constructors
-import org.jetbrains.kotlin.ir.util.simpleFunctions
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 internal class KotlinObjCClassInfoGenerator(override val context: Context) : ContextUtils {
@@ -70,8 +69,7 @@ internal class KotlinObjCClassInfoGenerator(override val context: Context) : Con
         objCLLvmDeclarations.bodyOffsetGlobal.setInitializer(Int32(0))
     }
 
-    private fun IrClass.generateMethodDescs(): List<ObjCMethodDesc> =
-            this.generateOverridingMethodDescs() + this.generateImpMethodDescs()
+    private fun IrClass.generateMethodDescs(): List<ObjCMethodDesc> = this.generateImpMethodDescs()
 
     private fun generateInstanceMethodDescs(
             irClass: IrClass
@@ -112,23 +110,6 @@ internal class KotlinObjCClassInfoGenerator(override val context: Context) : Con
             staticData.cStringLiteral(selector),
             staticData.cStringLiteral(encoding)
     )
-
-    private fun generateMethodDesc(info: ObjCMethodInfo) = info.imp?.let { imp ->
-        ObjCMethodDesc(
-                info.selector,
-                info.encoding,
-                context.llvm.externalFunction(
-                        imp,
-                        functionType(voidType),
-                        origin = info.bridge.llvmSymbolOrigin,
-                        independent = true
-                )
-        )
-    }
-
-    private fun IrClass.generateOverridingMethodDescs(): List<ObjCMethodDesc> =
-            this.simpleFunctions().filter { it.isReal }
-                    .mapNotNull { it.getObjCMethodInfo() }.mapNotNull { generateMethodDesc(it) }
 
     private fun IrClass.generateImpMethodDescs(): List<ObjCMethodDesc> = this.declarations
             .filterIsInstance<IrSimpleFunction>()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/LlvmUtils.kt
@@ -277,15 +277,15 @@ fun parseBitcodeFile(path: String): LLVMModuleRef = memScoped {
 }
 
 private val nounwindAttrKindId by lazy {
-    getAttributeKindId("nounwind")
+    getLlvmAttributeKindId("nounwind")
 }
 
 private val noreturnAttrKindId by lazy {
-    getAttributeKindId("noreturn")
+    getLlvmAttributeKindId("noreturn")
 }
 
 private val signextAttrKindId by lazy {
-    getAttributeKindId("signext")
+    getLlvmAttributeKindId("signext")
 }
 
 
@@ -294,12 +294,12 @@ fun isFunctionNoUnwind(function: LLVMValueRef): Boolean {
     return attribute != null
 }
 
-private fun getAttributeKindId(attributeName: String): Int {
-    val nounwindAttrKindId = LLVMGetEnumAttributeKindForName(attributeName, attributeName.length.signExtend())
-    if (nounwindAttrKindId == 0) {
+internal fun getLlvmAttributeKindId(attributeName: String): Int {
+    val attrKindId = LLVMGetEnumAttributeKindForName(attributeName, attributeName.length.signExtend())
+    if (attrKindId == 0) {
         throw Error("Unable to find '$attributeName' attribute kind id")
     }
-    return nounwindAttrKindId
+    return attrKindId
 }
 
 fun setFunctionNoUnwind(function: LLVMValueRef) {

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3098,13 +3098,14 @@ task interop_opengl_teapot(type: RunStandaloneKonanTest) {
 
 task interop_objc_smoke(type: RunInteropKonanTest) {
     disabled = !isAppleTarget(project)
-    goldValue = "84\nFoo\nHello, World!\nKotlin says: Hello, everybody!\nHello from Kotlin\n2, 1\n" +
+    goldValue = "84\nFoo\nDeallocated\n" +
+            "Hello, World!\nKotlin says: Hello, everybody!\nHello from Kotlin\n2, 1\n" +
             "true\ntrue\n" +
             "Global string\nAnother global string\nnull\nglobal object\n" +
             "5\n" +
             "String macro\n" +
             "CFString macro\n" +
-            "Deallocated\nDeallocated\nDeallocated\n"
+            "Deallocated\nDeallocated\n"
 
     if (isAppleTarget(project)) {
         source = "interop/objc/smoke.kt"

--- a/backend.native/tests/interop/objc/smoke.m
+++ b/backend.native/tests/interop/objc/smoke.m
@@ -76,3 +76,47 @@ BOOL unexpectedDeallocation = NO;
   unexpectedDeallocation = YES;
 }
 @end;
+
+static CustomRetainMethodsImpl* retainedCustomRetainMethodsImpl;
+
+@implementation CustomRetainMethodsImpl
+-(id)returnRetained:(id)obj __attribute__((ns_returns_retained)) {
+    return obj;
+}
+
+-(void)consume:(id) __attribute__((ns_consumed)) obj {
+}
+
+-(void)consumeSelf __attribute__((ns_consumes_self)) {
+  retainedCustomRetainMethodsImpl = self; // Retain to detect possible over-release.
+}
+
+-(void (^)(void))returnRetainedBlock:(void (^)(void))block __attribute__((ns_returns_retained)) {
+    return block;
+}
+@end;
+
+@implementation ExceptionThrowerManager
++(void)throwExceptionWith:(id<ExceptionThrower>)thrower {
+    [thrower throwException];
+}
+@end;
+
+@implementation Blocks
++(BOOL)blockIsNull:(void (^)(void))block {
+    return block == nil;
+}
+
++(int (^)(int, int, int, int))same:(int (^)(int, int, int, int))block {
+    return block;
+}
+
++(void (^)(void)) nullBlock {
+    return nil;
+}
+
++(void (^)(void)) notNullBlock {
+    return ^{};
+}
+
+@end;

--- a/runtime/src/main/cpp/ObjCExport.mm
+++ b/runtime/src/main/cpp/ObjCExport.mm
@@ -643,6 +643,12 @@ extern "C" ALWAYS_INLINE OBJ_GETTER(Kotlin_Interop_refFromObjC, id obj) {
   RETURN_RESULT_OF(Kotlin_ObjCExport_refFromObjC, obj);
 }
 
+extern "C" OBJ_GETTER(Kotlin_Interop_CreateObjCObjectHolder, id obj) {
+  RuntimeAssert(obj != nullptr, "wrapped object must not be null");
+  const TypeInfo* typeInfo = theForeignObjCObjectTypeInfo;
+  RETURN_RESULT_OF(AllocInstanceWithAssociatedObject, typeInfo, objc_retain(obj));
+}
+
 extern "C" OBJ_GETTER(Kotlin_ObjCExport_refFromObjC, id obj) {
   if (obj == nullptr) RETURN_OBJ(nullptr);
   id convertible = (id<ConvertibleToKotlin>)obj;

--- a/runtime/src/main/kotlin/kotlin/native/internal/Annotations.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/Annotations.kt
@@ -113,3 +113,13 @@ internal annotation class TypedIntrinsic(val kind: String)
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
 annotation class Independent
+
+/**
+ * Indicates that `@SymbolName external` function can throw foreign exception to be filtered on callsite.
+ *
+ * Note: this annotation describes rather behaviour of the (direct) call than that of the function.
+ * E.g. it doesn't have any effect when calling the function virtually. TODO: rework.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@PublishedApi internal annotation class FilterExceptions

--- a/runtime/src/main/kotlin/kotlin/native/internal/IntrinsicType.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/IntrinsicType.kt
@@ -40,7 +40,7 @@ class IntrinsicType {
         const val OBJC_GET_MESSENGER            = "OBJC_GET_MESSENGER"
         const val OBJC_GET_MESSENGER_STRET      = "OBJC_GET_MESSENGER_STRET"
         const val OBJC_GET_OBJC_CLASS           = "OBJC_GET_OBJC_CLASS"
-        const val OBJC_GET_RECEIVER_OR_SUPER    = "OBJC_GET_RECEIVER_OR_SUPER"
+        const val OBJC_CREATE_SUPER_STRUCT      = "OBJC_CREATE_SUPER_STRUCT"
         const val OBJC_INIT_BY                  = "OBJC_INIT_BY"
         const val OBJC_GET_SELECTOR             = "OBJC_GET_SELECTOR"
 

--- a/runtime/src/main/kotlin/kotlin/native/internal/ObjCExportUtils.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/ObjCExportUtils.kt
@@ -144,7 +144,6 @@ internal class NSDictionaryAsKMap : Map<Any?, Any?>, ObjCObjectWrapper {
 
         override val size: Int get() = this@NSDictionaryAsKMap.size
 
-        @SymbolName("Kotlin_NSSetAsKSet_iterator")
         override fun iterator(): Iterator<Map.Entry<Any?, Any?>> = this@NSDictionaryAsKMap.EntryIterator()
 
         override fun contains(element: Map.Entry<Any?, Any?>): Boolean {


### PR DESCRIPTION
Also
*   Use compiler-generated C stubs when overriding all Objective-C methods
*   Support block types in C stubs generator
*   Generate trap before each unreachable instruction in debug mode