### PR TITLE
Set declaration parent in SharedVariableManager.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/KonanSharedVariablesManager.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/KonanSharedVariablesManager.kt
@@ -79,6 +79,7 @@ internal class KonanSharedVariablesManager(val context: KonanBackendContext) : S
                 sharedVariableDescriptor, refConstructorCall.type
         ).apply {
             initializer = refConstructorCall
+            parent = originalDeclaration.parent
         }
     }
 


### PR DESCRIPTION
This is part of https://github.com/JetBrains/kotlin/pull/2242

As part of that PR I changed the place where the parent field is set in SharedVariablesManager. The parent has to be set based on the original declaration, because of possibly nested declarations. This is the same fix for kotlin-native.