### PR TITLE
Support escaped arguments in argfiles.

### DIFF
--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -213,13 +213,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
     companion object {
         @JvmStatic fun main(args: Array<String>) {
             profile("Total compiler main()") {
-                val options = args.flatMap {
-                    if (it.startsWith('@')) {
-                        File(it.substring(1)).readStrings()
-                    }
-                    else listOf(it)
-                }
-                CLITool.doMain(K2Native(), options.toTypedArray())
+                CLITool.doMain(K2Native(), args)
             }
         }
     }


### PR DESCRIPTION
This is already fixed in `K2JVMCompiler` (KT-26122).

Without this change `K2Native` would read the argfile line
`'-Xdump-perf=/tmp/perf'` as a file name rather than a `-Xdump-prefs` flag.