### PR TITLE
Don't use private interfaces in stdlib.

### DIFF
--- a/runtime/src/main/kotlin/kotlin/text/Regex.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Regex.kt
@@ -7,7 +7,8 @@ package kotlin.text
 
 import kotlin.text.regex.*
 
-private interface FlagEnum {
+@PublishedApi
+internal interface FlagEnum {
     val value: Int
     val mask: Int
 }


### PR DESCRIPTION
This is a murky area which exists just because jvm allows that.