### PR TITLE
Don't print phases twice with -Xlist-phases.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanDriver.kt
@@ -22,10 +22,6 @@ fun runTopLevelPhases(konanConfig: KonanConfig, environment: KotlinCoreEnvironme
     context.environment = environment
     context.phaseConfig.konanPhasesConfig(konanConfig) // TODO: Wrong place to call it
 
-    if (config.get(KonanConfigKeys.LIST_PHASES) ?: false) {
-        context.phaseConfig.list()
-    }
-
     if (konanConfig.infoArgsOnly) return
 
     (toplevelPhase as CompilerPhase<Context, Unit, Unit>).invokeToplevel(context.phaseConfig, context, Unit)


### PR DESCRIPTION
createPhaseConfig already prints out the phases if this flag is present. Remove
it from KonanDriver so it doesn't print twice.