### PR TITLE
Fix invalid isEqual swift_name.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -389,7 +389,7 @@ internal class ObjCExportNamerImpl(
         methodSwiftNames.forceAssign(toString, "description()")
 
         methodSelectors.forceAssign(equals, "isEqual:")
-        methodSwiftNames.forceAssign(equals, "isEqual(:)")
+        methodSwiftNames.forceAssign(equals, "isEqual(_:)")
     }
 
     private fun FunctionDescriptor.getMangledName(forSwift: Boolean): String {


### PR DESCRIPTION
This resolves the following warning when importing frameworks:
```
./hello.framework/Headers/hello.h:150:63: warning: 'swift_name' attribute has invalid identifier for parameter name [-Wswift-name-attribute]
- (BOOL)isEqual:(id _Nullable)other __attribute__((swift_name("isEqual(:)")));
```