### PR TITLE
Escape backslash symbol in file path

### DIFF
--- a/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/buildSrc/plugins/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -115,7 +115,7 @@ abstract class KonanTest extends JavaExec {
             def sourcesWriter = sources.newWriter()
             filesToCompile.each { f ->
                 sourcesWriter.write(f.chars().any { Character.isWhitespace(it) }
-                        ? "\"$f\"\n" // escape file name
+                        ? "\"${f.replace("\\", "\\\\")}\"\n" // escape file name
                         : "$f\n")
             }
             sourcesWriter.close()


### PR DESCRIPTION
Escape backslash symbols in file path when using an argfile to pass source file names