### PR TITLE
Don't omit Objective-C default library linking if category method used

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -639,6 +639,11 @@ internal class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfo
             call: IrFunctionAccessExpression,
             method: IrSimpleFunction
     ): IrExpression = generateWithStubs(call) {
+        if (method.parent !is IrClass) {
+            // Category-provided.
+            this@InteropLoweringPart1.context.llvmImports.add(method.llvmSymbolOrigin)
+        }
+
         this.generateObjCCall(
                 this@genLoweredObjCMethodCall,
                 method,


### PR DESCRIPTION
(was broken in #2846).