### PR TITLE
String <-> CharArray, ByteArray conversions

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3472,10 +3472,10 @@ task coverage_basic_library(type: RunStandaloneKonanTest) {
 
 task buildKonanStdlibTests(type: BuildKonanTest) {
     outputSourceSetName = "testOutputStdlib"
-    flags = [ "-Xmulti-platform", "-friend-modules",  project.rootProject.file("${project.properties['konan.home']}/klib/common/stdlib") ]
+    flags = [ "-Xmulti-platform", '-Xuse-experimental=kotlin.ExperimentalStdlibApi', "-friend-modules",  project.rootProject.file("${project.properties['konan.home']}/klib/common/stdlib") ]
     def testSources = externalStdlibTestsDir.absolutePath
     compileList = [ "$testSources/stdlib/test", "$testSources/stdlib/common",
-                    "stdlib_external/utils.kt", "stdlib_external/jsCollectionFactoriesActuals.kt" ]
+                    "stdlib_external/utils.kt", "stdlib_external/text/StringEncodingTestNative.kt", "stdlib_external/jsCollectionFactoriesActuals.kt" ]
     excludeList = [ "$testSources/stdlib/test/internalAnnotations.kt" ]
 }
 

--- a/backend.native/tests/runtime/text/utf8.kt
+++ b/backend.native/tests/runtime/text/utf8.kt
@@ -66,7 +66,7 @@ fun <T: Any> checkThrows(e: KClass<T>, string: String, action: () -> Unit) {
     assertTrue(e.isInstance(exception),"""
                 Wrong exception was thrown for string: $string
                 Expected: ${e.qualifiedName}
-                Actual: ${exception::class.qualifiedName}
+                Actual: ${exception::class.qualifiedName}: $exception}
     """.trimIndent())
 }
 

--- a/backend.native/tests/runtime/text/utf8.kt
+++ b/backend.native/tests/runtime/text/utf8.kt
@@ -197,7 +197,7 @@ fun test16to8CustomBorders() {
     checkThrows(IndexOutOfBoundsException::class, "Hello") { "Hello".toUtf8(-1, 4)}
     checkThrows(IndexOutOfBoundsException::class, "Hello") { "Hello".toUtf8(5, 10)}
     checkThrows(IndexOutOfBoundsException::class, "Hello") { "Hello".toUtf8(2, 10)}
-    checkThrows(IndexOutOfBoundsException::class, "Hello") { "Hello".toUtf8(3, -2)}
+    checkThrows(IllegalArgumentException::class, "Hello") { "Hello".toUtf8(3, -2)}
 
 
     // Test manual conversion with an exception if an input is invalid and custom borders.
@@ -228,7 +228,7 @@ fun test16to8CustomBorders() {
     checkThrows(IndexOutOfBoundsException::class, "Hello") { "Hello".toUtf8OrThrow(-1, 4)}
     checkThrows(IndexOutOfBoundsException::class, "Hello") { "Hello".toUtf8OrThrow(5, 10)}
     checkThrows(IndexOutOfBoundsException::class, "Hello") { "Hello".toUtf8OrThrow(2, 10)}
-    checkThrows(IndexOutOfBoundsException::class, "Hello") { "Hello".toUtf8OrThrow(3, -2)}
+    checkThrows(IllegalArgumentException::class, "Hello") { "Hello".toUtf8OrThrow(3, -2)}
 }
 
 fun testPrint() {
@@ -294,8 +294,6 @@ fun test8to16CustomBorders() {
             intArrayOf('H'.toInt(), 'e'.toInt(), 'l'.toInt(), 'l'.toInt(), 'o'.toInt()), 3, 2)
     checkUtf8to16Replacing("",
             intArrayOf('H'.toInt(), 'e'.toInt(), 'l'.toInt(), 'l'.toInt(), 'o'.toInt()), 0, 0)
-    checkUtf8to16Replacing("",
-            intArrayOf('H'.toInt(), 'e'.toInt(), 'l'.toInt(), 'l'.toInt(), 'o'.toInt()), 10, 0)
 
     checkUtf8to16Replacing("\uD800\uDC00\uD800\uDC00",
             intArrayOf(-16, -112, -128, -128, -16, -112, -128, -128, -16, -112, -128, -128, -16, -112, -128, -128),
@@ -323,7 +321,8 @@ fun test8to16CustomBorders() {
     checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8(-1, 4)}
     checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8(5, 10)}
     checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8(2, 10)}
-    checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8(3, -2)}
+    checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8(10, 0)}
+    checkThrows(IllegalArgumentException::class, "Hello") { helloArray.stringFromUtf8(3, -2)}
 
     // Conversion with throwing
     checkUtf8to16Throwing("He",
@@ -334,8 +333,6 @@ fun test8to16CustomBorders() {
             intArrayOf('H'.toInt(), 'e'.toInt(), 'l'.toInt(), 'l'.toInt(), 'o'.toInt()), 3, 2)
     checkUtf8to16Throwing("",
             intArrayOf('H'.toInt(), 'e'.toInt(), 'l'.toInt(), 'l'.toInt(), 'o'.toInt()), 0, 0)
-    checkUtf8to16Throwing("",
-            intArrayOf('H'.toInt(), 'e'.toInt(), 'l'.toInt(), 'l'.toInt(), 'o'.toInt()), 10, 0)
 
     checkUtf8to16Throwing("\uD800\uDC00\uD800\uDC00",
             intArrayOf(-16, -112, -128, -128, -16, -112, -128, -128, -16, -112, -128, -128, -16, -112, -128, -128),
@@ -361,7 +358,8 @@ fun test8to16CustomBorders() {
     checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8OrThrow(-1, 4)}
     checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8OrThrow(5, 10)}
     checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8OrThrow(2, 10)}
-    checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8OrThrow(3, -2)}
+    checkThrows(IndexOutOfBoundsException::class, "Hello") { helloArray.stringFromUtf8OrThrow(10, 0)}
+    checkThrows(IllegalArgumentException::class, "Hello") { helloArray.stringFromUtf8OrThrow(3, -2)}
 }
 // endregion
 

--- a/backend.native/tests/stdlib_external/text/StringEncodingTestNative.kt
+++ b/backend.native/tests/stdlib_external/text/StringEncodingTestNative.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package test.text
+
+
+internal actual val surrogateCodePointDecoding: String = "\uFFFD".repeat(3)
+
+internal actual val surrogateCharEncoding: ByteArray = byteArrayOf(0xEF.toByte(), 0xBF.toByte(), 0xBD.toByte())

--- a/backend.native/tests/stdlib_external/utils.kt
+++ b/backend.native/tests/stdlib_external/utils.kt
@@ -17,3 +17,7 @@ public actual fun assertTypeEquals(expected: Any?, actual: Any?) {
 }
 
 internal actual fun String.removeLeadingPlusOnJava6(): String = this
+
+internal actual inline fun testOnNonJvm6And7(f: () -> Unit) {
+    f()
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,9 @@
 buildKotlinVersion=1.3.40-dev-2251
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.40-dev-2251,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.40-dev-2423,branch:default:true,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.40-dev-2423
-testKotlinVersion=1.3.40-dev-2423
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-44,branch:default:true,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.50-dev-44
+testKotlinVersion=1.3.50-dev-44
 # See https://teamcity.jetbrains.com/project.html?projectId=Kotlin_KotlinNativeShared&tab=projectOverview
 sharedRepo=https://dl.bintray.com/jetbrains/kotlin-native-dependencies
 sharedVersion=1.0-dev-50

--- a/runtime/src/main/cpp/Exceptions.h
+++ b/runtime/src/main/cpp/Exceptions.h
@@ -52,8 +52,8 @@ void RUNTIME_NORETURN ThrowNumberFormatException();
 void RUNTIME_NORETURN ThrowOutOfMemoryError();
 // Throws not implemented error.
 void RUNTIME_NORETURN ThrowNotImplementedError();
-// Throws illegal character conversion exception (used in UTF8/UTF16 conversions).
-void RUNTIME_NORETURN ThrowIllegalCharacterConversionException();
+// Throws character coding exception (used in UTF8/UTF16 conversions).
+void RUNTIME_NORETURN ThrowCharacterCodingException();
 void RUNTIME_NORETURN ThrowIllegalArgumentException();
 void RUNTIME_NORETURN ThrowIllegalStateException();
 void RUNTIME_NORETURN ThrowInvalidMutabilityException(KConstRef where);

--- a/runtime/src/main/cpp/KString.cpp
+++ b/runtime/src/main/cpp/KString.cpp
@@ -51,6 +51,9 @@ OBJ_GETTER(utf8ToUtf16Impl, const char* rawString, const char* end, uint32_t cha
 template<utf16to8 conversion>
 OBJ_GETTER(utf16ToUtf8Impl, KString thiz, KInt start, KInt size) {
   RuntimeAssert(thiz->type_info() == theStringTypeInfo, "Must use String");
+  if (start < 0 || size < 0 || (size > static_cast<KInt>(thiz->count_) - start)) {
+    ThrowArrayIndexOutOfBoundsException();
+  }
   const KChar* utf16 = CharArrayAddressOfElementAt(thiz, start);
   KStdString utf8;
   conversion(utf16, utf16 + size, back_inserter(utf8));
@@ -773,6 +776,9 @@ KInt Kotlin_String_getStringLength(KString thiz) {
 const char* byteArrayAsCString(KConstRef thiz, KInt start, KInt size) {
   const ArrayHeader* array = thiz->array();
   RuntimeAssert(array->type_info() == theByteArrayTypeInfo, "Must use a byte array");
+  if (start < 0 || size < 0 || size > array->count_ - start) {
+    ThrowArrayIndexOutOfBoundsException();
+  }
   return reinterpret_cast<const char*>(ByteArrayAddressOfElementAt(array, start));
 }
 
@@ -803,6 +809,9 @@ OBJ_GETTER(Kotlin_String_toUtf8OrThrow, KString thiz, KInt start, KInt size) {
 OBJ_GETTER(Kotlin_String_fromCharArray, KConstRef thiz, KInt start, KInt size) {
   const ArrayHeader* array = thiz->array();
   RuntimeAssert(array->type_info() == theCharArrayTypeInfo, "Must use a char array");
+  if (start < 0 || size < 0 || size > array->count_ - start) {
+    ThrowArrayIndexOutOfBoundsException();
+  }
 
   if (size == 0) {
     RETURN_RESULT_OF0(TheEmptyString);

--- a/runtime/src/main/cpp/utf8/with_replacement.h
+++ b/runtime/src/main/cpp/utf8/with_replacement.h
@@ -37,13 +37,13 @@ uint32_t next(octet_iterator &it, const octet_iterator end, uint32_t replacement
         case internal::UTF8_OK :
             return cp;
         case internal::INVALID_LEAD :
+        case internal::INVALID_CODE_POINT :
+        case internal::OVERLONG_SEQUENCE :
             it++;
             return replacement;
         case internal::NOT_ENOUGH_ROOM :
         case internal::INCOMPLETE_SEQUENCE :
-        case internal::OVERLONG_SEQUENCE :
-        case internal::INVALID_CODE_POINT :
-            // The whole invalid sequence is replaced with one replacement codepoint.
+            // The whole incomplete sequence is replaced with one replacement codepoint.
             for (it++; it < end && utf8::internal::is_trail(*it); it++);
             return replacement;
     }

--- a/runtime/src/main/kotlin/kotlin/Exceptions.kt
+++ b/runtime/src/main/kotlin/kotlin/Exceptions.kt
@@ -166,6 +166,7 @@ public actual open class NumberFormatException : IllegalArgumentException {
     actual constructor(message: String?) : super(message)
 }
 
+// TODO: Deprecate and replace with CharacterCodingException
 public open class IllegalCharacterConversionException : IllegalArgumentException {
 
     constructor(): super()

--- a/runtime/src/main/kotlin/kotlin/native/Text.kt
+++ b/runtime/src/main/kotlin/kotlin/native/Text.kt
@@ -20,12 +20,13 @@ internal external fun ByteArray.stringFromUtf8Impl(start: Int, size: Int) : Stri
  * Converts an UTF-8 array into a [String].
  * @throws [IllegalCharacterConversionException] if the input is invalid.
  */
+@UseExperimental(ExperimentalStdlibApi::class)
 public fun ByteArray.stringFromUtf8OrThrow(start: Int = 0, size: Int = this.size) : String {
     checkBoundsIndexes(start, start + size, this.size)
     try {
         return stringFromUtf8OrThrowImpl(start, size)
-    } catch (e: Throwable) {
-        throw IllegalCharacterConversionException(e.message)
+    } catch (e: CharacterCodingException) {
+        throw IllegalCharacterConversionException()
     }
 }
 
@@ -47,12 +48,13 @@ internal external fun String.toUtf8Impl(start: Int, size: Int) : ByteArray
  * Converts a [String] into an UTF-8 array.
  * @throws [IllegalCharacterConversionException] if the input is invalid.
  */
+@UseExperimental(ExperimentalStdlibApi::class)
 public fun String.toUtf8OrThrow(start: Int = 0, size: Int = this.length) : ByteArray {
     checkBoundsIndexes(start, start + size, this.length)
     try {
         return toUtf8OrThrowImpl(start, size)
-    } catch (e: Throwable) {
-        throw IllegalCharacterConversionException(e.message)
+    } catch (e: CharacterCodingException) {
+        throw IllegalCharacterConversionException()
     }
 }
 

--- a/runtime/src/main/kotlin/kotlin/native/Text.kt
+++ b/runtime/src/main/kotlin/kotlin/native/Text.kt
@@ -8,40 +8,65 @@ package kotlin.native
 /**
  * Converts an UTF-8 array into a [String]. Replaces invalid input sequences with a default character.
  */
-public fun ByteArray.stringFromUtf8(start: Int = 0, size: Int = this.size) : String =
-        stringFromUtf8Impl(start, size)
+public fun ByteArray.stringFromUtf8(start: Int = 0, size: Int = this.size) : String {
+    checkBoundsIndexes(start, start + size, this.size)
+    return stringFromUtf8Impl(start, size)
+}
 
 @SymbolName("Kotlin_ByteArray_stringFromUtf8")
-private external fun ByteArray.stringFromUtf8Impl(start: Int, size: Int) : String
+internal external fun ByteArray.stringFromUtf8Impl(start: Int, size: Int) : String
 
 /**
  * Converts an UTF-8 array into a [String].
  * @throws [IllegalCharacterConversionException] if the input is invalid.
  */
-public fun ByteArray.stringFromUtf8OrThrow(start: Int = 0, size: Int = this.size) : String =
-        stringFromUtf8OrThrowImpl(start, size)
+public fun ByteArray.stringFromUtf8OrThrow(start: Int = 0, size: Int = this.size) : String {
+    checkBoundsIndexes(start, start + size, this.size)
+    try {
+        return stringFromUtf8OrThrowImpl(start, size)
+    } catch (e: Throwable) {
+        throw IllegalCharacterConversionException(e.message)
+    }
+}
 
 @SymbolName("Kotlin_ByteArray_stringFromUtf8OrThrow")
-private external fun ByteArray.stringFromUtf8OrThrowImpl(start: Int, size: Int) : String
+internal external fun ByteArray.stringFromUtf8OrThrowImpl(start: Int, size: Int) : String
 
 /**
  * Converts a [String] into an UTF-8 array. Replaces invalid input sequences with a default character.
  */
-public fun String.toUtf8(start: Int = 0, size: Int = this.length) : ByteArray =
-        toUtf8Impl(start, size)
+public fun String.toUtf8(start: Int = 0, size: Int = this.length) : ByteArray {
+    checkBoundsIndexes(start, start + size, this.length)
+    return toUtf8Impl(start, size)
+}
 
 @SymbolName("Kotlin_String_toUtf8")
-private external fun String.toUtf8Impl(start: Int, size: Int) : ByteArray
+internal external fun String.toUtf8Impl(start: Int, size: Int) : ByteArray
 
 /**
  * Converts a [String] into an UTF-8 array.
  * @throws [IllegalCharacterConversionException] if the input is invalid.
  */
-public fun String.toUtf8OrThrow(start: Int = 0, size: Int = this.length) : ByteArray =
-        toUtf8OrThrowImpl(start, size)
+public fun String.toUtf8OrThrow(start: Int = 0, size: Int = this.length) : ByteArray {
+    checkBoundsIndexes(start, start + size, this.length)
+    try {
+        return toUtf8OrThrowImpl(start, size)
+    } catch (e: Throwable) {
+        throw IllegalCharacterConversionException(e.message)
+    }
+}
+
+internal fun checkBoundsIndexes(startIndex: Int, endIndex: Int, size: Int) {
+    if (startIndex < 0 || endIndex > size) {
+        throw IndexOutOfBoundsException("startIndex: $startIndex, endIndex: $endIndex, size: $size")
+    }
+    if (startIndex > endIndex) {
+        throw IllegalArgumentException("startIndex: $startIndex > endIndex: $endIndex")
+    }
+}
 
 @SymbolName("Kotlin_String_toUtf8OrThrow")
-private external fun String.toUtf8OrThrowImpl(start: Int, size: Int) : ByteArray
+internal external fun String.toUtf8OrThrowImpl(start: Int, size: Int) : ByteArray
 
 @SymbolName("Kotlin_String_fromCharArray")
 internal external fun fromCharArray(array: CharArray, start: Int, size: Int) : String

--- a/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt
@@ -70,8 +70,9 @@ internal fun ThrowNotImplementedError(): Nothing {
 }
 
 @ExportForCppRuntime
-internal fun ThrowIllegalCharacterConversionException(): Nothing {
-    throw IllegalCharacterConversionException()
+internal fun ThrowCharacterCodingException(): Nothing {
+    @UseExperimental(ExperimentalStdlibApi::class)
+    throw CharacterCodingException()
 }
 
 @ExportForCppRuntime

--- a/runtime/src/main/kotlin/kotlin/text/CharacterCodingException.kt
+++ b/runtime/src/main/kotlin/kotlin/text/CharacterCodingException.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package kotlin.text
+
+/**
+ *  The exception thrown when a character encoding or decoding error occurs.
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+public actual open class CharacterCodingException(message: String?) : Exception(message) {
+    actual constructor() : this(null)
+}

--- a/runtime/src/main/kotlin/kotlin/text/Strings.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Strings.kt
@@ -175,10 +175,12 @@ public actual external fun String.toUpperCase(): String
 public actual external fun String.toLowerCase(): String
 
 /**
- * Returns a new character array containing the characters from this string.
+ * Returns a [CharArray] containing characters of this string.
  */
+public actual fun String.toCharArray(): CharArray = toCharArray(this, 0, length)
+
 @SymbolName("Kotlin_String_toCharArray")
-public external fun String.toCharArray(): CharArray
+private external fun toCharArray(string: String, start: Int, size: Int): CharArray
 
 /**
  * Returns a copy of this string having its first letter uppercased, or the original string,
@@ -228,7 +230,111 @@ public actual fun String(chars: CharArray): String = fromCharArray(chars, 0, cha
  * @throws IndexOutOfBoundsException if either [offset] or [length] are less than zero
  * or `offset + length` is out of [chars] array bounds.
  */
-public actual fun String(chars: CharArray, offset: Int, length: Int): String = fromCharArray(chars, offset, length)
+public actual fun String(chars: CharArray, offset: Int, length: Int): String {
+    if (offset < 0 || length < 0 || offset + length > chars.size)
+        throw ArrayIndexOutOfBoundsException()
+
+    return fromCharArray(chars, offset, length)
+}
+
+/**
+ * Concatenates characters in this [CharArray] into a String.
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+public actual fun CharArray.concatToString(): String = fromCharArray(this, 0, size)
+
+/**
+ * Concatenates characters in this [CharArray] or its subrange into a String.
+ *
+ * @param startIndex the beginning (inclusive) of the subrange of characters, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange of characters, size of this array by default.
+ *
+ * @throws IndexOutOfBoundsException if [startIndex] is less than zero or [endIndex] is greater than the size of this array.
+ * @throws IllegalArgumentException if [startIndex] is greater than [endIndex].
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+public actual fun CharArray.concatToString(startIndex: Int, endIndex: Int): String {
+    checkBoundsIndexes(startIndex, endIndex, size)
+    return fromCharArray(this, startIndex, endIndex - startIndex)
+}
+
+/**
+ * Returns a [CharArray] containing characters of this string or its substring.
+ *
+ * @param startIndex the beginning (inclusive) of the substring, 0 by default.
+ * @param endIndex the end (exclusive) of the substring, length of this string by default.
+ *
+ * @throws IndexOutOfBoundsException if [startIndex] is less than zero or [endIndex] is greater than the length of this string.
+ * @throws IllegalArgumentException if [startIndex] is greater than [endIndex].
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+public actual fun String.toCharArray(startIndex: Int, endIndex: Int): CharArray {
+    checkBoundsIndexes(startIndex, endIndex, length)
+    return toCharArray(this, startIndex, endIndex - startIndex)
+}
+
+/**
+ * Decodes a string from the bytes in UTF-8 encoding in this array.
+ *
+ * Malformed byte sequences are replaced by the replacement char `\uFFFD`.
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+public actual fun ByteArray.decodeToString(): String = stringFromUtf8Impl(0, size)
+
+/**
+ * Decodes a string from the bytes in UTF-8 encoding in this array or its subrange.
+ *
+ * @param startIndex the beginning (inclusive) of the subrange to decode, 0 by default.
+ * @param endIndex the end (exclusive) of the subrange to decode, size of this array by default.
+ * @param throwOnInvalidSequence specifies whether to throw an exception on malformed byte sequence or replace it by the replacement char `\uFFFD`.
+ *
+ * @throws IndexOutOfBoundsException if [startIndex] is less than zero or [endIndex] is greater than the size of this array.
+ * @throws IllegalArgumentException if [startIndex] is greater than [endIndex].
+ * @throws CharacterCodingException if the byte array contains malformed UTF-8 byte sequence and [throwOnInvalidSequence] is true.
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+public actual fun ByteArray.decodeToString(startIndex: Int, endIndex: Int, throwOnInvalidSequence: Boolean): String {
+    checkBoundsIndexes(startIndex, endIndex, size)
+    return if (throwOnInvalidSequence)
+        stringFromUtf8OrThrowImpl(startIndex, endIndex - startIndex)
+    else
+        stringFromUtf8Impl(startIndex, endIndex - startIndex)
+}
+
+/**
+ * Encodes this string to an array of bytes in UTF-8 encoding.
+ *
+ * Any malformed char sequence is replaced by the replacement byte sequence.
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+public actual fun String.encodeToByteArray(): ByteArray = toUtf8Impl(0, length)
+
+/**
+ * Encodes this string or its substring to an array of bytes in UTF-8 encoding.
+ *
+ * @param startIndex the beginning (inclusive) of the substring to encode, 0 by default.
+ * @param endIndex the end (exclusive) of the substring to encode, length of this string by default.
+ * @param throwOnInvalidSequence specifies whether to throw an exception on malformed char sequence or replace.
+ *
+ * @throws IndexOutOfBoundsException if [startIndex] is less than zero or [endIndex] is greater than the length of this string.
+ * @throws IllegalArgumentException if [startIndex] is greater than [endIndex].
+ * @throws CharacterCodingException if this string contains malformed char sequence and [throwOnInvalidSequence] is true.
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+public actual fun String.encodeToByteArray(startIndex: Int, endIndex: Int, throwOnInvalidSequence: Boolean): ByteArray {
+    checkBoundsIndexes(startIndex, endIndex, length)
+    return if (throwOnInvalidSequence)
+        toUtf8OrThrowImpl(startIndex, endIndex - startIndex)
+    else
+        toUtf8Impl(startIndex, endIndex - startIndex)
+}
 
 @SymbolName("Kotlin_String_compareToIgnoreCase")
 internal external fun compareToIgnoreCase(thiz: String, other: String): Int


### PR DESCRIPTION
This is another take on PR #2950 with the following differences:
- Kotlin compiler is updated to 1.3.50-dev-44
- correct experimental stdlib api opt-in in tests
- shorter copyright headers
- bound checks in CPP implementations are restored because we need to examine their usages in Kotlin/Native codebase more thoroughly.