### PR TITLE
Change implementation of assertFailsWith to make it inline

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,8 @@ buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds
 remoteRoot=konan_tests
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-328,branch:default:true,pinned:true/artifacts/content/maven
 kotlinVersion=1.3.50-dev-328
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-328,branch:default:true,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.50-dev-328
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-368,branch:default:true,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.50-dev-368
 testKotlinCompilerVersion=1.3.50-dev-328
 # See https://teamcity.jetbrains.com/project.html?projectId=Kotlin_KotlinNativeShared&tab=projectOverview
 sharedRepo=https://dl.bintray.com/jetbrains/kotlin-native-dependencies

--- a/runtime/src/main/kotlin/kotlin/test/Assertions.kt
+++ b/runtime/src/main/kotlin/kotlin/test/Assertions.kt
@@ -22,30 +22,20 @@ public actual inline fun todo(block: () -> Unit) {
     println("TODO")
 }
 
-/**
- * Asserts that a [block] fails with a specific exception of type [exceptionClass] being thrown.
- *
- * If the assertion fails, the specified [message] is used unless it is null as a prefix for the failure message.
- *
- * @return An exception of the expected exception type [T] that successfully caught.
- * The returned exception can be inspected further, for example by asserting its property values.
- */
-public actual fun <T : Throwable> assertFailsWith(exceptionClass: KClass<T>, message: String?, block: () -> Unit): T {
-    try {
-        block()
-    } catch (e: Throwable) {
-        if (exceptionClass.isInstance(e)) {
-            @Suppress("UNCHECKED_CAST")
-            return e as T
-        }
-
-        @Suppress("INVISIBLE_MEMBER")
-        asserter.fail(messagePrefix(message) + "Expected an exception of ${exceptionClass.qualifiedName} to be thrown, but was $e")
-    }
-
-    @Suppress("INVISIBLE_MEMBER")
-    val msg = messagePrefix(message)
-    asserter.fail(msg + "Expected an exception of ${exceptionClass.qualifiedName} to be thrown, but was completed successfully.")
+@PublishedApi
+internal actual fun <T : Throwable> checkResultIsFailure(exceptionClass: KClass<T>, message: String?, blockResult: Result<Unit>): T {
+    blockResult.fold(
+            onSuccess = {
+                asserter.fail(messagePrefix(message) + "Expected an exception of ${exceptionClass.qualifiedName} to be thrown, but was completed successfully.")
+            },
+            onFailure = { e ->
+                if (exceptionClass.isInstance(e)) {
+                    @Suppress("UNCHECKED_CAST")
+                    return e as T
+                }
+                asserter.fail(messagePrefix(message) + "Expected an exception of ${exceptionClass.qualifiedName} to be thrown, but was $e")
+            }
+    )
 }
 
 internal actual fun lookupAsserter(): Asserter = DefaultAsserter


### PR DESCRIPTION
The function 'assertFailsWith' itself was moved to common, see the commit https://github.com/JetBrains/kotlin/commit/22694fa6b01e862ecf408ba04f585ecdc9c26f16 for the common changes.