### PR TITLE
Deprecate former String <-> ByteArray conversion api

### DIFF
--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeUtils.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeUtils.kt
@@ -20,9 +20,9 @@ import kotlin.native.internal.Intrinsic
 import kotlin.native.internal.TypedIntrinsic
 import kotlin.native.internal.IntrinsicType
 
-internal fun decodeFromUtf8(bytes: ByteArray): String = bytes.stringFromUtf8()
+internal fun decodeFromUtf8(bytes: ByteArray): String = bytes.decodeToString()
 
-fun encodeToUtf8(str: String): ByteArray = str.toUtf8()
+fun encodeToUtf8(str: String): ByteArray = str.encodeToByteArray()
 
 @TypedIntrinsic(IntrinsicType.INTEROP_BITS_TO_FLOAT)
 external fun bitsToFloat(bits: Int): Float

--- a/runtime/src/main/kotlin/kotlin/Exceptions.kt
+++ b/runtime/src/main/kotlin/kotlin/Exceptions.kt
@@ -166,7 +166,7 @@ public actual open class NumberFormatException : IllegalArgumentException {
     actual constructor(message: String?) : super(message)
 }
 
-// TODO: Deprecate and replace with CharacterCodingException
+@Deprecated("Use CharacterCodingException instead", ReplaceWith("CharacterCodingException"))
 public open class IllegalCharacterConversionException : IllegalArgumentException {
 
     constructor(): super()

--- a/runtime/src/main/kotlin/kotlin/native/Text.kt
+++ b/runtime/src/main/kotlin/kotlin/native/Text.kt
@@ -5,9 +5,20 @@
 
 package kotlin.native
 
+
 /**
  * Converts an UTF-8 array into a [String]. Replaces invalid input sequences with a default character.
  */
+@Deprecated("Use decodeToString instead", ReplaceWith("decodeToString()"))
+public fun ByteArray.stringFromUtf8() : String {
+    @Suppress("DEPRECATION")
+    return this.stringFromUtf8(0, this.size)
+}
+
+/**
+ * Converts an UTF-8 array into a [String]. Replaces invalid input sequences with a default character.
+ */
+@Deprecated("Use decodeToString instead", ReplaceWith("decodeToString(start, start + size)"))
 public fun ByteArray.stringFromUtf8(start: Int = 0, size: Int = this.size) : String {
     checkBoundsIndexes(start, start + size, this.size)
     return stringFromUtf8Impl(start, size)
@@ -20,12 +31,24 @@ internal external fun ByteArray.stringFromUtf8Impl(start: Int, size: Int) : Stri
  * Converts an UTF-8 array into a [String].
  * @throws [IllegalCharacterConversionException] if the input is invalid.
  */
+@Deprecated("Use decodeToString instead", ReplaceWith("decodeToString(throwOnInvalidSequence = true)"))
+public fun ByteArray.stringFromUtf8OrThrow() : String {
+    @Suppress("DEPRECATION")
+    return this.stringFromUtf8OrThrow(0, this.size)
+}
+
+/**
+ * Converts an UTF-8 array into a [String].
+ * @throws [IllegalCharacterConversionException] if the input is invalid.
+ */
+@Deprecated("Use decodeToString instead", ReplaceWith("decodeToString(start, start + size, throwOnInvalidSequence = true)"))
 @UseExperimental(ExperimentalStdlibApi::class)
 public fun ByteArray.stringFromUtf8OrThrow(start: Int = 0, size: Int = this.size) : String {
     checkBoundsIndexes(start, start + size, this.size)
     try {
         return stringFromUtf8OrThrowImpl(start, size)
     } catch (e: CharacterCodingException) {
+        @Suppress("DEPRECATION")
         throw IllegalCharacterConversionException()
     }
 }
@@ -36,6 +59,16 @@ internal external fun ByteArray.stringFromUtf8OrThrowImpl(start: Int, size: Int)
 /**
  * Converts a [String] into an UTF-8 array. Replaces invalid input sequences with a default character.
  */
+@Deprecated("Use encodeToByteArray instead", ReplaceWith("encodeToByteArray()"))
+public fun String.toUtf8() : ByteArray {
+    @Suppress("DEPRECATION")
+    return this.toUtf8(0, this.length)
+}
+
+/**
+ * Converts a [String] into an UTF-8 array. Replaces invalid input sequences with a default character.
+ */
+@Deprecated("Use encodeToByteArray instead", ReplaceWith("encodeToByteArray(start, start + size)"))
 public fun String.toUtf8(start: Int = 0, size: Int = this.length) : ByteArray {
     checkBoundsIndexes(start, start + size, this.length)
     return toUtf8Impl(start, size)
@@ -48,12 +81,24 @@ internal external fun String.toUtf8Impl(start: Int, size: Int) : ByteArray
  * Converts a [String] into an UTF-8 array.
  * @throws [IllegalCharacterConversionException] if the input is invalid.
  */
+@Deprecated("Use encodeToByteArray instead", ReplaceWith("encodeToByteArray(throwOnInvalidSequence = true)"))
+public fun String.toUtf8OrThrow() : ByteArray {
+    @Suppress("DEPRECATION")
+    return this.toUtf8OrThrow(0, this.length)
+}
+
+/**
+ * Converts a [String] into an UTF-8 array.
+ * @throws [IllegalCharacterConversionException] if the input is invalid.
+ */
+@Deprecated("Use encodeToByteArray instead", ReplaceWith("encodeToByteArray(start, start + size, throwOnInvalidSequence = true)"))
 @UseExperimental(ExperimentalStdlibApi::class)
 public fun String.toUtf8OrThrow(start: Int = 0, size: Int = this.length) : ByteArray {
     checkBoundsIndexes(start, start + size, this.length)
     try {
         return toUtf8OrThrowImpl(start, size)
     } catch (e: CharacterCodingException) {
+        @Suppress("DEPRECATION")
         throw IllegalCharacterConversionException()
     }
 }

--- a/runtime/src/main/kotlin/kotlin/native/Text.kt
+++ b/runtime/src/main/kotlin/kotlin/native/Text.kt
@@ -42,7 +42,6 @@ public fun ByteArray.stringFromUtf8OrThrow() : String {
  * @throws [IllegalCharacterConversionException] if the input is invalid.
  */
 @Deprecated("Use decodeToString instead", ReplaceWith("decodeToString(start, start + size, throwOnInvalidSequence = true)"))
-@UseExperimental(ExperimentalStdlibApi::class)
 public fun ByteArray.stringFromUtf8OrThrow(start: Int = 0, size: Int = this.size) : String {
     checkBoundsIndexes(start, start + size, this.size)
     try {
@@ -92,7 +91,6 @@ public fun String.toUtf8OrThrow() : ByteArray {
  * @throws [IllegalCharacterConversionException] if the input is invalid.
  */
 @Deprecated("Use encodeToByteArray instead", ReplaceWith("encodeToByteArray(start, start + size, throwOnInvalidSequence = true)"))
-@UseExperimental(ExperimentalStdlibApi::class)
 public fun String.toUtf8OrThrow(start: Int = 0, size: Int = this.length) : ByteArray {
     checkBoundsIndexes(start, start + size, this.length)
     try {

--- a/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt
@@ -71,7 +71,6 @@ internal fun ThrowNotImplementedError(): Nothing {
 
 @ExportForCppRuntime
 internal fun ThrowCharacterCodingException(): Nothing {
-    @UseExperimental(ExperimentalStdlibApi::class)
     throw CharacterCodingException()
 }
 

--- a/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt
@@ -159,7 +159,7 @@ fun KonanObjectToUtf8Array(value: Any?): ByteArray {
         is DoubleArray -> value.contentToString()
         else -> value.toString()
     }
-    return string.toUtf8()
+    return string.encodeToByteArray()
 }
 
 @TypedIntrinsic(IntrinsicType.LIST_OF_INTERNAL)

--- a/runtime/src/main/kotlin/kotlin/text/CharacterCodingException.kt
+++ b/runtime/src/main/kotlin/kotlin/text/CharacterCodingException.kt
@@ -9,7 +9,6 @@ package kotlin.text
  *  The exception thrown when a character encoding or decoding error occurs.
  */
 @SinceKotlin("1.3")
-@ExperimentalStdlibApi
 public actual open class CharacterCodingException(message: String?) : Exception(message) {
     actual constructor() : this(null)
 }

--- a/runtime/src/main/kotlin/kotlin/text/Strings.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Strings.kt
@@ -241,7 +241,6 @@ public actual fun String(chars: CharArray, offset: Int, length: Int): String {
  * Concatenates characters in this [CharArray] into a String.
  */
 @SinceKotlin("1.3")
-@ExperimentalStdlibApi
 public actual fun CharArray.concatToString(): String = fromCharArray(this, 0, size)
 
 /**
@@ -254,7 +253,6 @@ public actual fun CharArray.concatToString(): String = fromCharArray(this, 0, si
  * @throws IllegalArgumentException if [startIndex] is greater than [endIndex].
  */
 @SinceKotlin("1.3")
-@ExperimentalStdlibApi
 public actual fun CharArray.concatToString(startIndex: Int, endIndex: Int): String {
     checkBoundsIndexes(startIndex, endIndex, size)
     return fromCharArray(this, startIndex, endIndex - startIndex)
@@ -270,7 +268,6 @@ public actual fun CharArray.concatToString(startIndex: Int, endIndex: Int): Stri
  * @throws IllegalArgumentException if [startIndex] is greater than [endIndex].
  */
 @SinceKotlin("1.3")
-@ExperimentalStdlibApi
 public actual fun String.toCharArray(startIndex: Int, endIndex: Int): CharArray {
     checkBoundsIndexes(startIndex, endIndex, length)
     return toCharArray(this, startIndex, endIndex - startIndex)
@@ -282,7 +279,6 @@ public actual fun String.toCharArray(startIndex: Int, endIndex: Int): CharArray 
  * Malformed byte sequences are replaced by the replacement char `\uFFFD`.
  */
 @SinceKotlin("1.3")
-@ExperimentalStdlibApi
 public actual fun ByteArray.decodeToString(): String = stringFromUtf8Impl(0, size)
 
 /**
@@ -297,7 +293,6 @@ public actual fun ByteArray.decodeToString(): String = stringFromUtf8Impl(0, siz
  * @throws CharacterCodingException if the byte array contains malformed UTF-8 byte sequence and [throwOnInvalidSequence] is true.
  */
 @SinceKotlin("1.3")
-@ExperimentalStdlibApi
 public actual fun ByteArray.decodeToString(startIndex: Int, endIndex: Int, throwOnInvalidSequence: Boolean): String {
     checkBoundsIndexes(startIndex, endIndex, size)
     return if (throwOnInvalidSequence)
@@ -312,7 +307,6 @@ public actual fun ByteArray.decodeToString(startIndex: Int, endIndex: Int, throw
  * Any malformed char sequence is replaced by the replacement byte sequence.
  */
 @SinceKotlin("1.3")
-@ExperimentalStdlibApi
 public actual fun String.encodeToByteArray(): ByteArray = toUtf8Impl(0, length)
 
 /**
@@ -327,7 +321,6 @@ public actual fun String.encodeToByteArray(): ByteArray = toUtf8Impl(0, length)
  * @throws CharacterCodingException if this string contains malformed char sequence and [throwOnInvalidSequence] is true.
  */
 @SinceKotlin("1.3")
-@ExperimentalStdlibApi
 public actual fun String.encodeToByteArray(startIndex: Int, endIndex: Int, throwOnInvalidSequence: Boolean): ByteArray {
     checkBoundsIndexes(startIndex, endIndex, length)
     return if (throwOnInvalidSequence)

--- a/samples/echoServer/src/echoServerMain/kotlin/EchoServer.kt
+++ b/samples/echoServer/src/echoServerMain/kotlin/EchoServer.kt
@@ -22,7 +22,7 @@ fun main(args: Array<String>) {
     memScoped {
 
         val buffer = ByteArray(1024)
-        val prefixBuffer = "echo: ".toUtf8()
+        val prefixBuffer = "echo: ".encodeToByteArray()
         val serverAddr = alloc<sockaddr_in>()
 
         val listenFd = socket(AF_INET, SOCK_STREAM, 0)

--- a/samples/libcurl/src/libcurlMain/kotlin/CUrl.kt
+++ b/samples/libcurl/src/libcurlMain/kotlin/CUrl.kt
@@ -45,7 +45,7 @@ class CUrl(url: String)  {
 
 fun CPointer<ByteVar>.toKString(length: Int): String {
     val bytes = this.readBytes(length)
-    return bytes.stringFromUtf8()
+    return bytes.decodeToString()
 }
 
 fun header_callback(buffer: CPointer<ByteVar>?, size: size_t, nitems: size_t, userdata: COpaquePointer?): size_t {

--- a/samples/videoplayer/src/videoPlayerMain/kotlin/DecoderWorker.kt
+++ b/samples/videoplayer/src/videoPlayerMain/kotlin/DecoderWorker.kt
@@ -34,7 +34,7 @@ private fun Int.checkAVError() {
     if (this != 0) {
         val buffer = ByteArray(1024)
         av_strerror(this, buffer.refTo(0), buffer.size.convert())
-        throw Error("AVError: ${buffer.stringFromUtf8()}")
+        throw Error("AVError: ${buffer.decodeToString()}")
     }
 }
 

--- a/samples/weather_function/function/src/main/kotlin/org/example/weather_func/curl.kt
+++ b/samples/weather_function/function/src/main/kotlin/org/example/weather_func/curl.kt
@@ -91,4 +91,4 @@ fun writeCallback(buffer: CPointer<ByteVar>?, size: size_t, totalItems: size_t, 
     return responseSize
 }
 
-private fun CPointer<ByteVar>.toKString(length: Int) = readBytes(length).stringFromUtf8()
+private fun CPointer<ByteVar>.toKString(length: Int) = readBytes(length).decodeToString()


### PR DESCRIPTION
Deprecated api are replaced as follows:
```
bytes.stringFromUtf8() -> bytes.decodeToString()
bytes.stringFromUtf8(1) -> bytes.decodeToString(1, 1 + this.size)
bytes.stringFromUtf8(start = 2) -> bytes.decodeToString(startIndex = 2, endIndex = 2 + this.size)
bytes.stringFromUtf8(size = 3) -> bytes.decodeToString(0, 0 + 3)
bytes.stringFromUtf8(1, 3) -> bytes.decodeToString(1, 1 + 3)
bytes.stringFromUtf8(start = 1, size = 3) -> bytes.decodeToString(startIndex = 1, endIndex = 1 + 3)
bytes.stringFromUtf8(size = 3, start = 1) -> bytes.decodeToString(startIndex = 1, endIndex = 1 + 3)

bytes.stringFromUtf8OrThrow() -> bytes.decodeToString(throwOnInvalidSequence = true)
bytes.stringFromUtf8OrThrow(1) -> bytes.decodeToString(1, 1 + this.size, throwOnInvalidSequence = true)
bytes.stringFromUtf8OrThrow(start = 2) -> bytes.decodeToString(startIndex = 2, endIndex = 2 + this.size, throwOnInvalidSequence = true)
bytes.stringFromUtf8OrThrow(size = 3) -> bytes.decodeToString(0, 0 + 3, throwOnInvalidSequence = true)
bytes.stringFromUtf8OrThrow(1, 3) -> bytes.decodeToString(1, 1 + 3, throwOnInvalidSequence = true)
bytes.stringFromUtf8OrThrow(start = 1, size = 3) -> bytes.decodeToString(startIndex = 1, endIndex = 1 + 3, throwOnInvalidSequence = true)
bytes.stringFromUtf8OrThrow(size = 3, start = 1) -> bytes.decodeToString(startIndex = 1, endIndex = 1 + 3, throwOnInvalidSequence = true)
```