### PR TITLE
Actuals for MonoClock, DurationUnit and Duration formatting

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3645,7 +3645,7 @@ KotlinNativeTestKt.createTest(project, 'stdlibTest', KonanGTest) { task ->
             srcFiles sources
             baseDir "$testOutputStdlib/stdlibTest"
             enableMultiplatform true
-            extraOpts '-tr', '-Xuse-experimental=kotlin.ExperimentalStdlibApi', 
+            extraOpts '-tr', '-Xuse-experimental=kotlin.Experimental,kotlin.ExperimentalStdlibApi', 
                     "-friend-modules", project.rootProject.file("${project.properties['konan.home']}/klib/common/stdlib").absolutePath
             extraOpts project.globalTestArgs
         }

--- a/backend.native/tests/stdlib_external/utils.kt
+++ b/backend.native/tests/stdlib_external/utils.kt
@@ -21,3 +21,6 @@ internal actual fun String.removeLeadingPlusOnJava6(): String = this
 internal actual inline fun testOnNonJvm6And7(f: () -> Unit) {
     f()
 }
+
+actual fun testOnJvm(action: () -> Unit) {}
+actual fun testOnJs(action: () -> Unit) {}

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,8 @@ buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds
 remoteRoot=konan_tests
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-1062,branch:default:any,pinned:true/artifacts/content/maven
 kotlinVersion=1.3.50-dev-1062
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-1010,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.50-dev-1010
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-1340,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.50-dev-1340
 testKotlinCompilerVersion=1.3.50-dev-630
 konanVersion=1.3.50
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'

--- a/runtime/src/main/cpp/ToString.cpp
+++ b/runtime/src/main/cpp/ToString.cpp
@@ -108,4 +108,16 @@ OBJ_GETTER(Kotlin_Long_toStringRadix, KLong value, KInt radix) {
   RETURN_RESULT_OF(Kotlin_toStringRadix<KLong>, value, radix)
 }
 
+OBJ_GETTER(Kotlin_DurationValue_formatToExactDecimals, KDouble value, KInt decimals) {
+  char cstring[32];
+  konan::snprintf(cstring, sizeof(cstring), "%.*f", decimals, value);
+  RETURN_RESULT_OF(CreateStringFromCString, cstring)
+}
+
+OBJ_GETTER(Kotlin_DurationValue_formatScientificImpl, KDouble value) {
+  char cstring[16];
+  konan::snprintf(cstring, sizeof(cstring), "%.2e", value);
+  RETURN_RESULT_OF(CreateStringFromCString, cstring)
+}
+
 } // extern "C"

--- a/runtime/src/main/kotlin/kotlin/time/DurationUnit.kt
+++ b/runtime/src/main/kotlin/kotlin/time/DurationUnit.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.time
+
+
+@SinceKotlin("1.3")
+@ExperimentalTime
+public actual enum class DurationUnit(internal val scale: Double) {
+    /**
+     * Time unit representing one nanosecond, which is 1/1000 of a microsecond.
+     */
+    NANOSECONDS(1e0),
+    /**
+     * Time unit representing one microsecond, which is 1/1000 of a millisecond.
+     */
+    MICROSECONDS(1e3),
+    /**
+     * Time unit representing one millisecond, which is 1/1000 of a second.
+     */
+    MILLISECONDS(1e6),
+    /**
+     * Time unit representing one second.
+     */
+    SECONDS(1e9),
+    /**
+     * Time unit representing one minute.
+     */
+    MINUTES(60e9),
+    /**
+     * Time unit representing one hour.
+     */
+    HOURS(3600e9),
+    /**
+     * Time unit representing one day, which is always equal to 24 hours.
+     */
+    DAYS(86400e9);
+}
+
+@SinceKotlin("1.3")
+@ExperimentalTime
+internal actual fun convertDurationUnit(value: Double, sourceUnit: DurationUnit, targetUnit: DurationUnit): Double {
+    val sourceCompareTarget = sourceUnit.scale.compareTo(targetUnit.scale)
+    return when {
+        sourceCompareTarget > 0 -> value * (sourceUnit.scale / targetUnit.scale)
+        sourceCompareTarget < 0 -> value / (targetUnit.scale / sourceUnit.scale)
+        else -> value
+    }
+}

--- a/runtime/src/main/kotlin/kotlin/time/MonoClock.kt
+++ b/runtime/src/main/kotlin/kotlin/time/MonoClock.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.time
+
+import kotlin.system.*
+
+@SinceKotlin("1.3")
+@ExperimentalTime
+public actual object MonoClock : AbstractLongClock(unit = DurationUnit.NANOSECONDS), Clock { // TODO: interface should not be required here
+    override fun read(): Long = getTimeNanos()
+    override fun toString(): String = "Clock(nanoTime)"
+}

--- a/runtime/src/main/kotlin/kotlin/time/formatToDecimals.kt
+++ b/runtime/src/main/kotlin/kotlin/time/formatToDecimals.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin.time
+
+
+@SymbolName("Kotlin_DurationValue_formatToExactDecimals")
+internal actual external fun formatToExactDecimals(value: Double, decimals: Int): String
+
+internal actual fun formatUpToDecimals(value: Double, decimals: Int): String {
+    return formatToExactDecimals(value, decimals).trimEnd('0')
+}
+
+@SymbolName("Kotlin_DurationValue_formatScientificImpl")
+internal external fun formatScientificImpl(value: Double): String
+
+internal actual fun formatScientific(value: Double): String {
+    val result = formatScientificImpl(value)
+    val expIndex = result.indexOf("e+0")
+    return if (expIndex < 0) result else result.removeRange(expIndex + 2, expIndex + 3)
+}


### PR DESCRIPTION
The corresponding common API review: https://upsource.jetbrains.com/kotlin/review/KOTLIN-CR-3003