### PR TITLE
Add kotlinx.cinterop.getOriginalKotlinClass(objCClass/objCProtocol)

### DIFF
--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
@@ -27,6 +27,8 @@ interface ObjCClass : ObjCObject
 interface ObjCClassOf<T : ObjCObject> : ObjCClass // TODO: T should be added to ObjCClass and all meta-classes instead.
 typealias ObjCObjectMeta = ObjCClass
 
+interface ObjCProtocol : ObjCObject
+
 @ExportTypeInfo("theForeignObjCObjectTypeInfo")
 @kotlin.native.internal.Frozen
 internal open class ForeignObjCObject : kotlin.native.internal.ObjCObjectWrapper

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCKClassSupport.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCKClassSupport.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package kotlinx.cinterop
+
+import kotlin.native.internal.KClassImpl
+import kotlin.reflect.KClass
+
+/**
+ * If [objCClass] is a class generated to Objective-C header for Kotlin class,
+ * returns [KClass] for that original Kotlin class.
+ *
+ * Otherwise returns `null`.
+ */
+fun getOriginalKotlinClass(objCClass: ObjCClass): KClass<*>? {
+    val typeInfo = getTypeInfoForClass(objCClass.objcPtr())
+    if (typeInfo.isNull()) return null
+
+    return KClassImpl<Any>(typeInfo)
+}
+
+/**
+ * If [objCProtocol] is a protocol generated to Objective-C header for Kotlin class,
+ * returns [KClass] for that original Kotlin class.
+ *
+ * Otherwise returns `null`.
+ */
+fun getOriginalKotlinClass(objCProtocol: ObjCProtocol): KClass<*>? {
+    val typeInfo = getTypeInfoForProtocol(objCProtocol.objcPtr())
+    if (typeInfo.isNull()) return null
+
+    return KClassImpl<Any>(typeInfo)
+}
+
+@SymbolName("Kotlin_ObjCInterop_getTypeInfoForClass")
+private external fun getTypeInfoForClass(ptr: NativePtr): NativePtr
+
+@SymbolName("Kotlin_ObjCInterop_getTypeInfoForProtocol")
+private external fun getTypeInfoForProtocol(ptr: NativePtr): NativePtr

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
@@ -191,6 +191,7 @@ object KotlinTypes {
     val objCObjectMeta by InteropClassifier
     val objCClass by InteropClassifier
     val objCClassOf by InteropClassifier
+    val objCProtocol by InteropClassifier
 
     val cValuesRef by InteropClassifier
 

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -490,6 +490,11 @@ abstract class ObjCContainerStub(stubGenerator: StubGenerator,
             supers.add(classifier.type)
         }
 
+        if (!isMeta && container.isProtocolClass()) {
+            // TODO: map Protocol type to ObjCProtocol instead.
+            supers.add(KotlinTypes.objCProtocol.type)
+        }
+
         val keywords = when (container) {
             is ObjCClass -> "open class"
             is ObjCProtocol -> "interface"
@@ -689,4 +694,9 @@ private fun genProtocolGetter(
     stubGenerator.simpleBridgeGenerator.insertNativeBridge(nativeBacked, emptyList(), builder.lines)
 
     return functionName
+}
+
+private fun ObjCClassOrProtocol.isProtocolClass(): Boolean = when (this) {
+    is ObjCClass -> (name == "Protocol" || binaryName == "Protocol")
+    is ObjCProtocol -> false
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 internal val interopPackageName = InteropFqNames.packageName
 internal val objCObjectFqName = interopPackageName.child(Name.identifier("ObjCObject"))
 private val objCClassFqName = interopPackageName.child(Name.identifier("ObjCClass"))
+private val objCProtocolFqName = interopPackageName.child(Name.identifier("ObjCProtocol"))
 internal val externalObjCClassFqName = interopPackageName.child(Name.identifier("ExternalObjCClass"))
 private val objCMethodFqName = interopPackageName.child(Name.identifier("ObjCMethod"))
 private val objCConstructorFqName = FqName("kotlinx.cinterop.ObjCConstructor")
@@ -69,6 +70,12 @@ fun ClassDescriptor.isObjCForwardDeclaration(): Boolean =
 fun ClassDescriptor.isObjCMetaClass(): Boolean = this.getAllSuperClassifiers().any {
     it.fqNameSafe == objCClassFqName
 }
+
+fun IrClass.isObjCProtocolClass(): Boolean =
+        this.fqNameSafe == objCProtocolFqName
+
+fun ClassDescriptor.isObjCProtocolClass(): Boolean =
+        this.fqNameSafe == objCProtocolFqName
 
 fun FunctionDescriptor.isObjCClassMethod() =
         this.containingDeclaration.let { it is ClassDescriptor && it.isObjCClass() }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.backend.konan
 
+import org.jetbrains.kotlin.backend.konan.descriptors.findPackage
 import org.jetbrains.kotlin.backend.konan.descriptors.getArgumentValueOrNull
 import org.jetbrains.kotlin.backend.konan.descriptors.getStringValue
 import org.jetbrains.kotlin.backend.konan.descriptors.getStringValueOrNull
@@ -34,6 +35,7 @@ internal val externalObjCClassFqName = interopPackageName.child(Name.identifier(
 private val objCMethodFqName = interopPackageName.child(Name.identifier("ObjCMethod"))
 private val objCConstructorFqName = FqName("kotlinx.cinterop.ObjCConstructor")
 private val objCFactoryFqName = interopPackageName.child(Name.identifier("ObjCFactory"))
+private val objcnamesForwardDeclarationsPackageName = Name.identifier("objcnames")
 
 @Deprecated("Use IR version rather than descriptor version")
 fun ClassDescriptor.isObjCClass(): Boolean =
@@ -60,6 +62,9 @@ fun IrClass.isExternalObjCClass(): Boolean = this.isObjCClass() &&
             it.annotations.hasAnnotation(externalObjCClassFqName) ||
             it.descriptor.annotations.hasAnnotation(externalObjCClassFqName)
         }
+
+fun ClassDescriptor.isObjCForwardDeclaration(): Boolean =
+        this.findPackage().fqName.startsWith(objcnamesForwardDeclarationsPackageName)
 
 fun ClassDescriptor.isObjCMetaClass(): Boolean = this.getAllSuperClassifiers().any {
     it.fqNameSafe == objCClassFqName

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1403,6 +1403,15 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
                 call(isClass, listOf(objCObject)).let {
                     functionGenerationContext.icmpNe(it, Int8(0).llvm)
                 }
+            } else if (dstClass.isObjCProtocolClass()) {
+                // Note: it is not clear whether this class should be looked up this way.
+                // clang does the same, however swiftc uses dynamic lookup.
+                val protocolClass =
+                        functionGenerationContext.getObjCClass("Protocol", context.standardLlvmSymbolsOrigin)
+                call(
+                        context.llvm.Kotlin_Interop_IsObjectKindOfClass,
+                        listOf(objCObject, protocolClass)
+                )
             } else {
                 kTrue
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -800,9 +800,9 @@ internal class ObjCExportTranslatorImpl(
     private tailrec fun mapObjCObjectReferenceTypeIgnoringNullability(descriptor: ClassDescriptor): ObjCNonNullReferenceType {
         // TODO: more precise types can be used.
 
-        if (descriptor.isObjCMetaClass()) return ObjCIdType
+        if (descriptor.isObjCMetaClass()) return ObjCMetaClassType
 
-        if (descriptor.isExternalObjCClass()) {
+        if (descriptor.isExternalObjCClass() || descriptor.isObjCForwardDeclaration()) {
             return if (descriptor.isInterface) {
                 val name = descriptor.name.asString().removeSuffix("Protocol")
                 generator?.referenceProtocol(name)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -801,16 +801,15 @@ internal class ObjCExportTranslatorImpl(
         // TODO: more precise types can be used.
 
         if (descriptor.isObjCMetaClass()) return ObjCMetaClassType
+        if (descriptor.isObjCProtocolClass()) return foreignClassType("Protocol")
 
         if (descriptor.isExternalObjCClass() || descriptor.isObjCForwardDeclaration()) {
             return if (descriptor.isInterface) {
                 val name = descriptor.name.asString().removeSuffix("Protocol")
-                generator?.referenceProtocol(name)
-                ObjCProtocolType(name)
+                foreignProtocolType(name)
             } else {
                 val name = descriptor.name.asString()
-                generator?.referenceClass(name)
-                ObjCClassType(name)
+                foreignClassType(name)
             }
         }
 
@@ -819,6 +818,16 @@ internal class ObjCExportTranslatorImpl(
         }
 
         return ObjCIdType
+    }
+
+    private fun foreignProtocolType(name: String): ObjCProtocolType {
+        generator?.referenceProtocol(name)
+        return ObjCProtocolType(name)
+    }
+
+    private fun foreignClassType(name: String): ObjCClassType {
+        generator?.referenceClass(name)
+        return ObjCClassType(name)
     }
 
     internal fun mapFunctionTypeIgnoringNullability(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
@@ -89,6 +89,10 @@ class ObjCBlockPointerType(
     })
 }
 
+object ObjCMetaClassType : ObjCNonNullReferenceType() {
+    override fun render(attrsAndName: String): String = "Class".withAttrsAndName(attrsAndName)
+}
+
 class ObjCPrimitiveType(
         val cName: String
 ) : ObjCType() {

--- a/backend.native/tests/framework/values/expectedLazy.h
+++ b/backend.native/tests/framework/values/expectedLazy.h
@@ -526,6 +526,22 @@ __attribute__((swift_name("MyAbstractList")))
 @interface ValuesMyAbstractList : NSObject
 @end;
 
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("TestKClass")))
+@interface ValuesTestKClass : KotlinBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (id<ValuesKotlinKClass> _Nullable)getKotlinClassClazz:(Class)clazz __attribute__((swift_name("getKotlinClass(clazz:)")));
+- (id<ValuesKotlinKClass> _Nullable)getKotlinClassProtocol:(Protocol *)protocol __attribute__((swift_name("getKotlinClass(protocol:)")));
+- (BOOL)isTestKClassKClass:(id<ValuesKotlinKClass>)kClass __attribute__((swift_name("isTestKClass(kClass:)")));
+- (BOOL)isIKClass:(id<ValuesKotlinKClass>)kClass __attribute__((swift_name("isI(kClass:)")));
+@end;
+
+__attribute__((swift_name("TestKClassI")))
+@protocol ValuesTestKClassI
+@required
+@end;
+
 @interface ValuesEnumeration (ValuesKt)
 - (ValuesEnumeration *)getAnswer __attribute__((swift_name("getAnswer()")));
 @end;

--- a/backend.native/tests/framework/values/expectedLazy.h
+++ b/backend.native/tests/framework/values/expectedLazy.h
@@ -600,6 +600,8 @@ __attribute__((swift_name("ValuesKt")))
 + (void (^)(void))asNothingBlockBlock:(id _Nullable (^)(void))block __attribute__((swift_name("asNothingBlock(block:)")));
 + (void (^ _Nullable)(void))getNullBlock __attribute__((swift_name("getNullBlock()")));
 + (BOOL)isBlockNullBlock:(void (^ _Nullable)(void))block __attribute__((swift_name("isBlockNull(block:)")));
++ (void)takeForwardDeclaredClassObj:(ForwardDeclaredClass *)obj __attribute__((swift_name("takeForwardDeclaredClass(obj:)")));
++ (void)takeForwardDeclaredProtocolObj:(id<ForwardDeclared>)obj __attribute__((swift_name("takeForwardDeclaredProtocol(obj:)")));
 @property (class, readonly) double dbl __attribute__((swift_name("dbl")));
 @property (class, readonly) float flt __attribute__((swift_name("flt")));
 @property (class, readonly) int32_t integer __attribute__((swift_name("integer")));

--- a/backend.native/tests/framework/values/values.kt
+++ b/backend.native/tests/framework/values/values.kt
@@ -423,3 +423,6 @@ object UnitBlockCoercionImpl : UnitBlockCoercion<() -> Unit> {
 }
 
 abstract class MyAbstractList : List<Any?>
+
+fun takeForwardDeclaredClass(obj: objcnames.classes.ForwardDeclaredClass) {}
+fun takeForwardDeclaredProtocol(obj: objcnames.protocols.ForwardDeclaredProtocol) {}

--- a/backend.native/tests/framework/values/values.kt
+++ b/backend.native/tests/framework/values/values.kt
@@ -11,7 +11,9 @@ package conversions
 import kotlin.native.concurrent.freeze
 import kotlin.native.concurrent.isFrozen
 import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+import kotlinx.cinterop.*
 
 // Constants
 const val dbl: Double = 3.14
@@ -426,3 +428,13 @@ abstract class MyAbstractList : List<Any?>
 
 fun takeForwardDeclaredClass(obj: objcnames.classes.ForwardDeclaredClass) {}
 fun takeForwardDeclaredProtocol(obj: objcnames.protocols.ForwardDeclaredProtocol) {}
+
+class TestKClass {
+    fun getKotlinClass(clazz: ObjCClass) = getOriginalKotlinClass(clazz)
+    fun getKotlinClass(protocol: ObjCProtocol) = getOriginalKotlinClass(protocol)
+
+    fun isTestKClass(kClass: KClass<*>): Boolean = (kClass == TestKClass::class)
+    fun isI(kClass: KClass<*>): Boolean = (kClass == TestKClass.I::class)
+
+    interface I
+}

--- a/backend.native/tests/framework/values/values.swift
+++ b/backend.native/tests/framework/values/values.swift
@@ -583,6 +583,27 @@ func testGH2959() throws {
   try assertEquals(actual: GH2959().getI(id: 2959)[0].id, expected: 2959)
 }
 
+func testKClass() throws {
+  let test = TestKClass()
+
+  let testKClass = test.getKotlinClass(clazz: TestKClass.self)!
+  try assertTrue(test.isTestKClass(kClass: testKClass))
+  try assertFalse(test.isI(kClass: testKClass))
+  try assertEquals(actual: testKClass.simpleName, expected: "TestKClass")
+
+  let iKClass = test.getKotlinClass(protocol: TestKClassI.self)!
+  try assertFalse(test.isTestKClass(kClass: iKClass))
+  try assertTrue(test.isI(kClass: iKClass))
+  try assertEquals(actual: iKClass.simpleName, expected: "I")
+
+  try assertTrue(test.getKotlinClass(clazz: NSObject.self) == nil)
+  try assertTrue(test.getKotlinClass(clazz: PureSwiftClass.self) == nil)
+  try assertTrue(test.getKotlinClass(clazz: PureSwiftKotlinInterfaceImpl.self) == nil)
+  try assertTrue(test.getKotlinClass(clazz: Base123.self) == nil)
+
+  try assertTrue(test.getKotlinClass(protocol: NSObjectProtocol.self) == nil)
+}
+
 // See https://github.com/JetBrains/kotlin-native/issues/2931
 func testGH2931() throws {
     for i in 0..<50000 {
@@ -646,6 +667,7 @@ class ValuesTests : TestProvider {
             TestCase(name: "TestGH2945", method: withAutorelease(testGH2945)),
             TestCase(name: "TestGH2830", method: withAutorelease(testGH2830)),
             TestCase(name: "TestGH2959", method: withAutorelease(testGH2959)),
+            TestCase(name: "TestKClass", method: withAutorelease(testKClass)),
             TestCase(name: "TestGH2931", method: withAutorelease(testGH2931)),
         ]
     }

--- a/backend.native/tests/interop/objc/smoke.h
+++ b/backend.native/tests/interop/objc/smoke.h
@@ -205,3 +205,11 @@ NSObject* createNSObject() {
 -(int)hashCode:(int)p;
 -(BOOL)equals;
 @end;
+
+id getPrinterProtocolRaw() {
+  return @protocol(Printer);
+}
+
+Protocol* getPrinterProtocol() {
+  return @protocol(Printer);
+}

--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -151,6 +151,11 @@ fun testTypeOps() {
     assertTrue(NSObject.asAny() is ObjCClass)
     assertTrue(NSObject.asAny() is ObjCClassOf<*>)
 
+    assertFalse(Any() is ObjCProtocol)
+    assertTrue(getPrinterProtocolRaw() is ObjCProtocol)
+    val printerProtocol = getPrinterProtocol()!!
+    assertTrue(printerProtocol.asAny() is ObjCProtocol)
+
     assertEquals(3u, ("foo" as NSString).length())
     assertEquals(4u, ((1..4).joinToString("") as NSString).length())
     assertEquals(2u, (listOf(0, 1) as NSArray).count())

--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -144,6 +144,13 @@ fun testTypeOps() {
     assertTrue(NSValue.asAny() is NSObjectProtocolMeta)
     assertFalse(NSValue.asAny() is NSObjectProtocol) // Must be true, but not implemented properly yet.
 
+    assertFalse(Any() is ObjCClass)
+    assertFalse(Any() is ObjCClassOf<*>)
+    assertFalse(NSObject().asAny() is ObjCClass)
+    assertFalse(NSObject().asAny() is ObjCClassOf<*>)
+    assertTrue(NSObject.asAny() is ObjCClass)
+    assertTrue(NSObject.asAny() is ObjCClassOf<*>)
+
     assertEquals(3u, ("foo" as NSString).length())
     assertEquals(4u, ((1..4).joinToString("") as NSString).length())
     assertEquals(2u, (listOf(0, 1) as NSArray).count())

--- a/runtime/src/main/cpp/ObjCExport.mm
+++ b/runtime/src/main/cpp/ObjCExport.mm
@@ -350,6 +350,22 @@ static void addProtocolForInterface(Class clazz, const TypeInfo* interfaceInfo) 
   }
 }
 
+extern "C" const TypeInfo* Kotlin_ObjCInterop_getTypeInfoForClass(Class clazz) {
+  const TypeInfo* candidate = getAssociatedTypeInfo(clazz);
+
+  if (candidate != nullptr && (candidate->flags_ & TF_OBJC_DYNAMIC) == 0) {
+    return candidate;
+  } else {
+    return nullptr;
+  }
+}
+
+extern "C" const TypeInfo* Kotlin_ObjCInterop_getTypeInfoForProtocol(Protocol* protocol) {
+  const ObjCTypeAdapter* typeAdapter = findProtocolAdapter(protocol);
+
+  return (typeAdapter != nullptr) ? typeAdapter->kotlinTypeInfo : nullptr;
+}
+
 static const TypeInfo* getOrCreateTypeInfo(Class clazz);
 
 static void initializeClass(Class clazz) {
@@ -714,7 +730,7 @@ static const TypeInfo* createTypeInfo(
   TypeInfo* result = (TypeInfo*)konanAllocMemory(sizeof(TypeInfo) + vtable.size() * sizeof(void*));
   result->typeInfo_ = result;
 
-  result->flags_ = 0;
+  result->flags_ = TF_OBJC_DYNAMIC;
 
   result->instanceSize_ = superType->instanceSize_;
   result->superType_ = superType;

--- a/runtime/src/main/cpp/TypeInfo.h
+++ b/runtime/src/main/cpp/TypeInfo.h
@@ -55,7 +55,8 @@ enum Konan_RuntimeType {
 enum Konan_TypeFlags {
   TF_IMMUTABLE = 1 << 0,
   TF_ACYCLIC   = 1 << 1,
-  TF_INTERFACE = 1 << 2
+  TF_INTERFACE = 1 << 2,
+  TF_OBJC_DYNAMIC = 1 << 3
 };
 
 enum Konan_MetaFlags {

--- a/runtime/src/main/kotlin/kotlin/native/internal/NativePtr.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/NativePtr.kt
@@ -26,6 +26,8 @@ class NativePtr @PublishedApi internal constructor(private val value: NonNullNat
     override fun hashCode() = this.toLong().hashCode()
 
     override fun toString() = "0x${this.toLong().toString(16)}"
+
+    internal fun isNull(): Boolean = (value == null)
 }
 
 @PublishedApi


### PR DESCRIPTION
Enables getting KClass for Kotlin classes produced to Objective-C header.

Also add other minor improvements.