### PR TITLE
Add CoreLocation platform library on macOS

### DIFF
--- a/platformLibs/src/platform/osx/CoreLocation.def
+++ b/platformLibs/src/platform/osx/CoreLocation.def
@@ -1,0 +1,7 @@
+depends = ApplicationServices CFNetwork CoreFoundation CoreGraphics CoreServices CoreText DiskArbitration Foundation IOKit ImageIO Security darwin libkern osx posix
+language = Objective-C
+package = platform.CoreLocation
+modules = CoreLocation
+
+compilerOpts = -framework CoreLocation
+linkerOpts = -framework CoreLocation


### PR DESCRIPTION
Fix #3041