### PR TITLE
Ensure produced Objective-C header doesn't make warnings

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -604,7 +604,7 @@ internal class ObjCExportTranslatorImpl(
     private fun buildMethod(method: FunctionDescriptor, baseMethod: FunctionDescriptor, objCExportScope: ObjCExportScope): ObjCMethod {
         fun collectParameters(baseMethodBridge: MethodBridge, method: FunctionDescriptor): List<ObjCParameter> {
             fun unifyName(initialName: String, usedNames: Set<String>): String {
-                var unique = initialName
+                var unique = initialName.toValidObjCSwiftIdentifier()
                 while (unique in usedNames || unique in cKeywords) {
                     unique += "_"
                 }
@@ -986,8 +986,7 @@ abstract class ObjCExportHeaderGenerator internal constructor(
         add("#pragma clang diagnostic push")
         listOf(
                 "-Wunknown-warning-option",
-                "-Wnullability",
-                "-Wswift-name-attribute"
+                "-Wnullability"
         ).forEach {
             add("#pragma clang diagnostic ignored \"$it\"")
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -889,7 +889,7 @@ internal class ObjCExportTranslatorImpl(
                 ObjCValueType.UNSIGNED_LONG_LONG -> ObjCPrimitiveType("uint64_t")
                 ObjCValueType.FLOAT -> ObjCPrimitiveType("float")
                 ObjCValueType.DOUBLE -> ObjCPrimitiveType("double")
-                ObjCValueType.POINTER -> ObjCPointerType(ObjCVoidType)
+                ObjCValueType.POINTER -> ObjCPointerType(ObjCVoidType, kotlinType.binaryRepresentationIsNullable())
             }
             // TODO: consider other namings.
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -977,6 +977,15 @@ abstract class ObjCExportHeaderGenerator internal constructor(
         }
 
         add("NS_ASSUME_NONNULL_BEGIN")
+        add("#pragma clang diagnostic push")
+        listOf(
+                "-Wunknown-warning-option",
+                "-Wnullability",
+                "-Wnullability-completeness",
+                "-Wswift-name-attribute"
+        ).forEach {
+            add("#pragma clang diagnostic ignored \"$it\"")
+        }
         add("")
 
         stubs.forEach {
@@ -984,6 +993,7 @@ abstract class ObjCExportHeaderGenerator internal constructor(
             add("")
         }
 
+        add("#pragma clang diagnostic pop")
         add("NS_ASSUME_NONNULL_END")
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -96,6 +96,7 @@ internal open class ObjCExportNameTranslatorImpl(
     private fun getClassOrProtocolSwiftName(
             ktClassOrObject: KtClassOrObject
     ): String = buildString {
+        val ownName = ktClassOrObject.name!!.toIdentifier()
         val outerClass = ktClassOrObject.getStrictParentOfType<KtClassOrObject>()
         if (outerClass != null) {
             append(getClassOrProtocolSwiftName(outerClass))
@@ -119,12 +120,12 @@ internal open class ObjCExportNameTranslatorImpl(
             }
 
             if (importAsMember) {
-                append(".").append(ktClassOrObject.name!!)
+                append(".").append(ownName)
             } else {
-                append(ktClassOrObject.name!!.capitalize())
+                append(ownName.capitalize())
             }
         } else {
-            append(ktClassOrObject.name)
+            append(ownName)
         }
     }
 }
@@ -133,7 +134,8 @@ private class ObjCExportNamingHelper(
         private val topLevelNamePrefix: String
 ) {
 
-    fun translateFileName(fileName: String): String = PackagePartClassUtils.getFilePartShortName(fileName)
+    fun translateFileName(fileName: String): String =
+            PackagePartClassUtils.getFilePartShortName(fileName).toIdentifier()
 
     fun translateFileName(file: KtFile): String = translateFileName(file.name)
 
@@ -328,10 +330,11 @@ internal class ObjCExportNamerImpl(
 
                     else -> true
                 }
+                val ownName = descriptor.name.asString().toIdentifier()
                 if (importAsMember) {
-                    append(".").append(descriptor.name.asString())
+                    append(".").append(ownName)
                 } else {
-                    append(descriptor.name.asString().capitalize())
+                    append(ownName.capitalize())
                 }
             } else if (containingDeclaration is PackageFragmentDescriptor) {
                 appendTopLevelClassBaseName(descriptor)
@@ -364,7 +367,7 @@ internal class ObjCExportNamerImpl(
                 val containingDeclaration = descriptor.containingDeclaration
                 if (containingDeclaration is ClassDescriptor) {
                     append(getClassOrProtocolObjCName(containingDeclaration))
-                            .append(descriptor.name.asString().capitalize())
+                            .append(descriptor.name.asString().toIdentifier().capitalize())
 
                 } else if (containingDeclaration is PackageFragmentDescriptor) {
                     append(topLevelNamePrefix).appendTopLevelClassBaseName(descriptor)
@@ -379,7 +382,7 @@ internal class ObjCExportNamerImpl(
         configuration.getAdditionalPrefix(descriptor.module)?.let {
             append(it)
         }
-        append(descriptor.name.asString())
+        append(descriptor.name.asString().toIdentifier())
     }
 
     override fun getSelector(method: FunctionDescriptor): String = methodSelectors.getOrPut(method) {
@@ -400,7 +403,7 @@ internal class ObjCExportNamerImpl(
                             1 -> ""
                             else -> "value"
                         }
-                        else -> it!!.name.asString()
+                        else -> it!!.name.asString().toIdentifier()
                     }
                     MethodBridgeValueParameter.ErrorOutParameter -> "error"
                     is MethodBridgeValueParameter.KotlinResultOutParameter -> "result"
@@ -451,7 +454,7 @@ internal class ObjCExportNamerImpl(
                             1 -> "_"
                             else -> "value"
                         }
-                        else -> it!!.name.asString()
+                        else -> it!!.name.asString().toIdentifier()
                     }
                     MethodBridgeValueParameter.ErrorOutParameter -> continue@parameters
                     is MethodBridgeValueParameter.KotlinResultOutParameter -> "result"
@@ -482,7 +485,7 @@ internal class ObjCExportNamerImpl(
         assert(mapper.isObjCProperty(property))
 
         StringBuilder().apply {
-            append(property.name.asString())
+            append(property.name.asString().toIdentifier())
         }.mangledSequence {
             append('_')
         }
@@ -492,7 +495,7 @@ internal class ObjCExportNamerImpl(
         assert(descriptor.kind == ClassKind.OBJECT)
 
         return objectInstanceSelectors.getOrPut(descriptor) {
-            val name = descriptor.name.asString().decapitalize().mangleIfSpecialFamily("get")
+            val name = descriptor.name.asString().decapitalize().toIdentifier().mangleIfSpecialFamily("get")
 
             StringBuilder(name).mangledBySuffixUnderscores()
         }
@@ -506,7 +509,7 @@ internal class ObjCExportNamerImpl(
             val name = descriptor.name.asString().split('_').mapIndexed { index, s ->
                 val lower = s.toLowerCase()
                 if (index == 0) lower else lower.capitalize()
-            }.joinToString("").mangleIfSpecialFamily("the")
+            }.joinToString("").toIdentifier().mangleIfSpecialFamily("the")
 
             StringBuilder(name).mangledBySuffixUnderscores()
         }
@@ -515,7 +518,7 @@ internal class ObjCExportNamerImpl(
     override fun getTypeParameterName(typeParameterDescriptor: TypeParameterDescriptor): String {
         return genericTypeParameterNameMapping.getOrPut(typeParameterDescriptor) {
             StringBuilder().apply {
-                append(typeParameterDescriptor.name.asString())
+                append(typeParameterDescriptor.name.asString().toIdentifier())
             }.mangledSequence {
                 append('_')
             }
@@ -580,7 +583,7 @@ internal class ObjCExportNamerImpl(
             is PropertyGetterDescriptor -> this.correspondingProperty.name.asString()
             is PropertySetterDescriptor -> "set${this.correspondingProperty.name.asString().capitalize()}"
             else -> this.name.asString()
-        }
+        }.toIdentifier()
 
         return candidate.mangleIfSpecialFamily("do")
     }
@@ -825,3 +828,17 @@ internal fun abbreviate(name: String): String {
 
     return normalizedName
 }
+
+// Note: most usages of this method rely on the fact that concatenation of valid identifiers is valid identifier.
+// This may sometimes be a bit conservative (since it requires mangling non-first character as if it was first);
+// ignore this for simplicity as having Kotlin identifiers starting from digits is supposed to be rare case.
+internal fun String.toValidObjCSwiftIdentifier(): String {
+    if (this.isEmpty()) return "__"
+
+    return this.replace('$', '_') // TODO: handle more special characters.
+            .let { if (it.first().isDigit()) "_$it" else it }
+            .let { if (it == "_") "__" else it }
+}
+
+// Private shortcut.
+private fun String.toIdentifier(): String = this.toValidObjCSwiftIdentifier()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -802,6 +802,10 @@ private fun ObjCExportMapper.canHaveSameName(first: PropertyDescriptor, second: 
         return false
     }
 
+    if (first.name != second.name) {
+        return false
+    }
+
     return bridgePropertyType(first) == bridgePropertyType(second)
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/objcTypes.kt
@@ -130,3 +130,11 @@ internal enum class ObjCValueType(val encoding: String) {
     DOUBLE("d"),
     POINTER("^v")
 }
+
+internal fun ObjCType.makeNullableIfReferenceOrPointer(): ObjCType = when (this) {
+    is ObjCPointerType -> ObjCPointerType(this.pointee, nullable = true)
+
+    is ObjCNonNullReferenceType -> ObjCNullableReferenceType(this)
+
+    is ObjCNullableReferenceType, is ObjCRawType, is ObjCPrimitiveType, ObjCVoidType -> this
+}

--- a/backend.native/tests/framework/values/expectedLazy.h
+++ b/backend.native/tests/framework/values/expectedLazy.h
@@ -297,7 +297,7 @@ __attribute__((swift_name("Bridge")))
 - (ValuesKotlinNothing * _Nullable)foo1AndReturnError:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("foo1()")));
 - (BOOL)foo2AndReturnResult:(int32_t * _Nullable)result error:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("foo2(result:)")));
 - (BOOL)foo3AndReturnError:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("foo3()")));
-- (BOOL)foo4AndReturnResult:(ValuesKotlinNothing ** _Nullable)result error:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("foo4(result:)")));
+- (BOOL)foo4AndReturnResult:(ValuesKotlinNothing * _Nullable * _Nullable)result error:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("foo4(result:)")));
 @end;
 
 __attribute__((objc_subclassing_restricted))

--- a/backend.native/tests/framework/values/expectedLazy.h
+++ b/backend.native/tests/framework/values/expectedLazy.h
@@ -571,6 +571,28 @@ __attribute__((swift_name("TestSR10177Workaround")))
 @required
 @end;
 
+__attribute__((swift_name("TestClashes1")))
+@protocol ValuesTestClashes1
+@required
+@property (readonly) int32_t clashingProperty __attribute__((swift_name("clashingProperty")));
+@end;
+
+__attribute__((swift_name("TestClashes2")))
+@protocol ValuesTestClashes2
+@required
+@property (readonly) id clashingProperty __attribute__((swift_name("clashingProperty")));
+@property (readonly) id clashingProperty_ __attribute__((swift_name("clashingProperty_")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("TestClashesImpl")))
+@interface ValuesTestClashesImpl : KotlinBase <ValuesTestClashes1, ValuesTestClashes2>
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+@property (readonly) int32_t clashingProperty __attribute__((swift_name("clashingProperty")));
+@property (readonly) ValuesInt *clashingProperty_ __attribute__((swift_name("clashingProperty_")));
+@end;
+
 @interface ValuesEnumeration (ValuesKt)
 - (ValuesEnumeration *)getAnswer __attribute__((swift_name("getAnswer()")));
 @end;

--- a/backend.native/tests/framework/values/expectedLazy.h
+++ b/backend.native/tests/framework/values/expectedLazy.h
@@ -593,6 +593,54 @@ __attribute__((swift_name("TestClashesImpl")))
 @property (readonly) ValuesInt *clashingProperty_ __attribute__((swift_name("clashingProperty_")));
 @end;
 
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("TestInvalidIdentifiers")))
+@interface ValuesTestInvalidIdentifiers : KotlinBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+- (int32_t)a_d_d_1:(int32_t)_1 _2:(int32_t)_2 _3:(int32_t)_3 __attribute__((swift_name("a_d_d(_1:_2:_3:)")));
+@property NSString *_status __attribute__((swift_name("_status")));
+@property (readonly) unichar __ __attribute__((swift_name("__")));
+@property (readonly) unichar __ __attribute__((swift_name("__")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("TestInvalidIdentifiers._Foo")))
+@interface ValuesTestInvalidIdentifiers_Foo : KotlinBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("TestInvalidIdentifiers.Bar_")))
+@interface ValuesTestInvalidIdentifiersBar_ : KotlinBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("TestInvalidIdentifiers.E")))
+@interface ValuesTestInvalidIdentifiersE : ValuesKotlinEnum
++ (instancetype)alloc __attribute__((unavailable));
++ (instancetype)allocWithZone:(struct _NSZone *)zone __attribute__((unavailable));
+@property (class, readonly) ValuesTestInvalidIdentifiersE *_4_ __attribute__((swift_name("_4_")));
+@property (class, readonly) ValuesTestInvalidIdentifiersE *_5_ __attribute__((swift_name("_5_")));
+@property (class, readonly) ValuesTestInvalidIdentifiersE *__ __attribute__((swift_name("__")));
+@property (class, readonly) ValuesTestInvalidIdentifiersE *__ __attribute__((swift_name("__")));
+- (instancetype)initWithName:(NSString *)name ordinal:(int32_t)ordinal __attribute__((swift_name("init(name:ordinal:)"))) __attribute__((objc_designated_initializer)) __attribute__((unavailable));
+- (int32_t)compareToOther:(ValuesTestInvalidIdentifiersE *)other __attribute__((swift_name("compareTo(other:)")));
+@property (readonly) int32_t value __attribute__((swift_name("value")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("TestInvalidIdentifiers.Companion_")))
+@interface ValuesTestInvalidIdentifiersCompanion_ : KotlinBase
++ (instancetype)alloc __attribute__((unavailable));
++ (instancetype)allocWithZone:(struct _NSZone *)zone __attribute__((unavailable));
++ (instancetype)companion_ __attribute__((swift_name("init()")));
+@property (readonly) int32_t _42 __attribute__((swift_name("_42")));
+@end;
+
 @interface ValuesEnumeration (ValuesKt)
 - (ValuesEnumeration *)getAnswer __attribute__((swift_name("getAnswer()")));
 @end;

--- a/backend.native/tests/framework/values/values.kt
+++ b/backend.native/tests/framework/values/values.kt
@@ -451,3 +451,20 @@ abstract class ForwardC1 {
 }
 
 interface TestSR10177Workaround
+
+interface TestClashes1 {
+    val clashingProperty: Int
+}
+
+interface TestClashes2 {
+    val clashingProperty: Any
+    val clashingProperty_: Any
+}
+
+class TestClashesImpl : TestClashes1, TestClashes2 {
+    override val clashingProperty: Int
+        get() = 1
+
+    override val clashingProperty_: Int
+        get() = 2
+}

--- a/backend.native/tests/framework/values/values.kt
+++ b/backend.native/tests/framework/values/values.kt
@@ -468,3 +468,26 @@ class TestClashesImpl : TestClashes1, TestClashes2 {
     override val clashingProperty_: Int
         get() = 2
 }
+
+class TestInvalidIdentifiers {
+    class `$Foo`
+    class `Bar$`
+
+    fun `a$d$d`(`$1`: Int, `2`: Int, `3`: Int): Int = `$1` + `2` + `3`
+
+    var `$status`: String = ""
+
+    enum class E(val value: Int) {
+        `4$`(4),
+        `5$`(5),
+        `_`(6),
+        `__`(7)
+    }
+
+    companion object `Companion$` {
+        val `42` = 42
+    }
+
+    val `$` = '$'
+    val `_` = '_'
+}

--- a/backend.native/tests/framework/values/values.swift
+++ b/backend.native/tests/framework/values/values.swift
@@ -613,6 +613,16 @@ func testSR10177Workaround() throws {
     try assertTrue(String(describing: test).contains("TestSR10177WorkaroundDerived"))
 }
 
+func testClashes() throws {
+    let test = TestClashesImpl()
+    let test1: TestClashes1 = test
+    let test2: TestClashes2 = test
+
+    try assertEquals(actual: 1, expected: test1.clashingProperty)
+    try assertEquals(actual: 1, expected: test2.clashingProperty_ as! Int32)
+    try assertEquals(actual: 2, expected: test2.clashingProperty__ as! Int32)
+}
+
 // See https://github.com/JetBrains/kotlin-native/issues/2931
 func testGH2931() throws {
     for i in 0..<50000 {
@@ -678,6 +688,7 @@ class ValuesTests : TestProvider {
             TestCase(name: "TestGH2959", method: withAutorelease(testGH2959)),
             TestCase(name: "TestKClass", method: withAutorelease(testKClass)),
             TestCase(name: "TestSR10177Workaround", method: withAutorelease(testSR10177Workaround)),
+            TestCase(name: "TestClashes", method: withAutorelease(testClashes)),
             TestCase(name: "TestGH2931", method: withAutorelease(testGH2931)),
         ]
     }

--- a/backend.native/tests/framework/values/values.swift
+++ b/backend.native/tests/framework/values/values.swift
@@ -623,6 +623,27 @@ func testClashes() throws {
     try assertEquals(actual: 2, expected: test2.clashingProperty__ as! Int32)
 }
 
+func testInvalidIdentifiers() throws {
+    let test = TestInvalidIdentifiers()
+
+    try assertTrue(TestInvalidIdentifiers._Foo() is TestInvalidIdentifiers._Foo)
+    try assertFalse(TestInvalidIdentifiers.Bar_() is TestInvalidIdentifiers._Foo)
+
+    try assertEquals(actual: 42, expected: test.a_d_d(_1: 13, _2: 14, _3: 15))
+
+    test._status = "OK"
+    try assertEquals(actual: "OK", expected: test._status)
+
+    try assertEquals(actual: TestInvalidIdentifiers.E._4_.value, expected: 4)
+    try assertEquals(actual: TestInvalidIdentifiers.E._5_.value, expected: 5)
+    try assertEquals(actual: TestInvalidIdentifiers.E.__.value, expected: 6)
+    try assertEquals(actual: TestInvalidIdentifiers.E.___.value, expected: 7)
+
+    try assertEquals(actual: TestInvalidIdentifiers.Companion_()._42, expected: 42)
+
+    try assertEquals(actual: Set([test.__, test.___]), expected: Set(["$".utf16.first, "_".utf16.first]))
+}
+
 // See https://github.com/JetBrains/kotlin-native/issues/2931
 func testGH2931() throws {
     for i in 0..<50000 {
@@ -689,6 +710,7 @@ class ValuesTests : TestProvider {
             TestCase(name: "TestKClass", method: withAutorelease(testKClass)),
             TestCase(name: "TestSR10177Workaround", method: withAutorelease(testSR10177Workaround)),
             TestCase(name: "TestClashes", method: withAutorelease(testClashes)),
+            TestCase(name: "TestInvalidIdentifiers", method: withAutorelease(testInvalidIdentifiers)),
             TestCase(name: "TestGH2931", method: withAutorelease(testGH2931)),
         ]
     }

--- a/buildSrc/plugins/src/main/kotlin/org/jetbrains/kotlin/FrameworkTest.kt
+++ b/buildSrc/plugins/src/main/kotlin/org/jetbrains/kotlin/FrameworkTest.kt
@@ -74,7 +74,12 @@ open class FrameworkTest : DefaultTask() {
         // Compile swift sources
         val sources = swiftSources.map { Paths.get(it).toString() } +
                 listOf(provider.toString(), swiftMain)
-        val options = listOf("-g", "-Xlinker", "-rpath", "-Xlinker", frameworkParentDirPath, "-F", frameworkParentDirPath)
+        val options = listOf(
+                "-g",
+                "-Xlinker", "-rpath", "-Xlinker", frameworkParentDirPath,
+                "-F", frameworkParentDirPath,
+                "-Xcc", "-Werror" // To fail compilation on warnings in framework header.
+        )
         val testExecutable = Paths.get(testOutput, frameworkName, "swiftTestExecutable")
         compileSwift(project, project.testTarget, sources, options, testExecutable, fullBitcode)
 


### PR DESCRIPTION
Fix bugs, add improvements and suppress some "legitimate" warnings to achieve that.