### PR TITLE
Fix import packages in external tests

### DIFF
--- a/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -443,9 +443,12 @@ class RunExternalTestGroup extends OldKonanTest {
                     }
                     if (line.contains("$pkg.") && ! (line =~ packagePattern || line =~ importRegex)
                             && ! vars.contains(pkg)) {
-                        def idx = line.indexOf("$pkg")
-                        if (! (idx > 0 && Character.isJavaIdentifierPart(line.charAt(idx - 1))) ) {
-                            line = line.substring(0, idx) + "$sourceName.$pkg" + line.substring(idx + pkg.length())
+                        def idx = 0
+                        while ((idx = line.indexOf(pkg, idx)) >= 0) {
+                            if (!Character.isJavaIdentifierPart(line.charAt(idx - 1))) {
+                                line = line.substring(0, idx) + "$sourceName.$pkg" + line.substring(idx + pkg.length())
+                                idx += sourceName.length() + pkg.length() + 1
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Replace all occurrences of the package name in full qualified names in the line. 