### PR TITLE
Switch to new LocalDeclarationLower

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -155,7 +155,8 @@ internal val sharedVariablesPhase = makeKonanFileLoweringPhase(
 internal val localFunctionsPhase = makeKonanFileOpPhase(
         op = { context, irFile ->
             LocalDelegatedPropertiesLowering().lower(irFile)
-            LocalDeclarationsLowering(context).runOnFilePostfix(irFile)
+            LocalDeclarationsLowering(context).lower(irFile)
+            LocalClassPopupLowering(context).lower(irFile)
         },
         name = "LocalFunctions",
         description = "Local function lowering",


### PR DESCRIPTION
Switch to new LocalDeclarationLower

 Actually class popuper was extracted from it to separate lower.
 Use it to keep old behavior