### PR TITLE
Get rid of yet another descriptor usage in lowerings

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -277,6 +277,12 @@ task slackReportNightly(type:NightlyReporter) {
     externalWindowsReport = "external_windows_results/reports.json"
 }
 
+task localDelegatedPropertyLink(type: LinkKonanTest) {
+    goldValue = "OK\n"
+    source = "lower/local_delegated_property_link/main.kt"
+    lib = "lower/local_delegated_property_link/lib.kt"
+}
+
 task sum (type:RunKonanTest) {
     source = "codegen/function/sum.kt"
 }

--- a/backend.native/tests/lower/local_delegated_property_link/lib.kt
+++ b/backend.native/tests/lower/local_delegated_property_link/lib.kt
@@ -1,0 +1,8 @@
+fun foo(): String{
+    val bar: String by lazy {
+        "OK"
+    }
+
+    return bar
+}
+

--- a/backend.native/tests/lower/local_delegated_property_link/main.kt
+++ b/backend.native/tests/lower/local_delegated_property_link/main.kt
@@ -1,0 +1,3 @@
+fun main() {
+    println(foo())
+}


### PR DESCRIPTION
Add a test for local delegated property

An additional fix and a native test for #KT-32170