### PR TITLE
Fix incorrect package replacement

### DIFF
--- a/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -444,11 +444,10 @@ class RunExternalTestGroup extends OldKonanTest {
                     if (line.contains("$pkg.") && ! (line =~ packagePattern || line =~ importRegex)
                             && ! vars.contains(pkg)) {
                         def idx = 0
-                        while ((idx = line.indexOf(pkg, idx)) >= 0) {
-                            if (!Character.isJavaIdentifierPart(line.charAt(idx - 1))) {
-                                line = line.substring(0, idx) + "$sourceName.$pkg" + line.substring(idx + pkg.length())
-                                idx += sourceName.length() + pkg.length() + 1
-                            }
+                        while ((idx = line.indexOf(pkg, idx)) >= 0 &&
+                                !Character.isJavaIdentifierPart(line.charAt(idx - 1))) {
+                            line = line.substring(0, idx) + "$sourceName.$pkg" + line.substring(idx + pkg.length())
+                            idx += sourceName.length() + pkg.length() + 1
                         }
                     }
                 }

--- a/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -444,10 +444,13 @@ class RunExternalTestGroup extends OldKonanTest {
                     if (line.contains("$pkg.") && ! (line =~ packagePattern || line =~ importRegex)
                             && ! vars.contains(pkg)) {
                         def idx = 0
-                        while ((idx = line.indexOf(pkg, idx)) >= 0 &&
-                                !Character.isJavaIdentifierPart(line.charAt(idx - 1))) {
-                            line = line.substring(0, idx) + "$sourceName.$pkg" + line.substring(idx + pkg.length())
-                            idx += sourceName.length() + pkg.length() + 1
+                        while ((idx = line.indexOf(pkg, idx)) >= 0) {
+                            if (!Character.isJavaIdentifierPart(line.charAt(idx - 1))) {
+                                line = line.substring(0, idx) + "$sourceName.$pkg" + line.substring(idx + pkg.length())
+                                idx += sourceName.length() + pkg.length() + 1
+                            } else {
+                                idx += pkg.length()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
should check that current occurrence  is not a part of identifier. Otherwise it can incorrectly replace one package with another one with name being substring of the first one. ("another"/"other" packages)