### PR TITLE
Don't explicitly resolve 'kotlinCommonSources' configuration

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -171,7 +171,7 @@ def commonSrc = file('build/stdlib')
 
 task unzipStdlibSources(type: CopyCommonSources) {
     outputDir commonSrc
-    sourcePaths configurations.kotlinCommonSources.files
+    sourcePaths configurations.kotlinCommonSources
 }
 
 final List<File> stdLibSrc = [


### PR DESCRIPTION
in ':backend.native:unzipStdlibSources' task. This breaks composite build with Kotlin.