### PR TITLE
Fix missing include

### DIFF
--- a/runtime/src/main/cpp/Memory.cpp
+++ b/runtime/src/main/cpp/Memory.cpp
@@ -43,6 +43,10 @@
 // Auto-adjust GC thresholds.
 #define GC_ERGONOMICS 1
 
+#if COLLECT_STATISTIC
+#include <algorithm>
+#endif
+
 namespace {
 
 // Granularity of arena container chunks.


### PR DESCRIPTION
In case of COLLECT_STATISTIC option being equal to 1
compilation fails because of missing '#include <algorithm>'