### PR TITLE
[Inliner] Fixed bug with incorrect eval order

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2874,6 +2874,11 @@ task inline_genericFunctionReference(type: KonanLocalTest) {
     source = "codegen/inline/genericFunctionReference.kt"
 }
 
+task inline_correctOrderFunctionReference(type: KonanLocalTest) {
+    goldValue = "OK\n"
+    source = "codegen/inline/correctOrderFunctionReference.kt"
+}
+
 task classDeclarationInsideInline(type: KonanLocalTest) {
     source = "codegen/inline/classDeclarationInsideInline.kt"
     goldValue = "test1: 1.0\n1\ntest2\n"

--- a/backend.native/tests/codegen/inline/correctOrderFunctionReference.kt
+++ b/backend.native/tests/codegen/inline/correctOrderFunctionReference.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package codegen.inline.correctOrderFunctionReference
+
+import kotlin.test.*
+
+class Foo(val a: String) {
+
+    fun test() = a
+}
+
+inline fun test(a: String, b: () -> String, c: () -> String, d: () -> String, e: String): String {
+    return a + b() + c() + d() + e
+}
+
+var effects = ""
+
+fun create(a: String): Foo {
+    effects += a
+    return Foo(a)
+}
+
+fun create2(a: String, f: () -> String): Foo {
+    effects += a
+    return Foo(a)
+}
+
+fun box(): String {
+    val result = test(create("A").a, create("B")::a, create("C")::test, create2("E", create("D")::test)::test, create("F").a)
+    if (effects != "ABCDEF") return "fail 1: $effects"
+
+    return if (result == "ABCEF") "OK" else "fail 2: $result"
+}
+
+@Test fun runTest() {
+    println(box())
+}


### PR DESCRIPTION
We need to extract to temp locals all bound arguments
of function reference parameters of an inline call to
preserve the correct evaluation order