### PR TITLE
StringBuilder allocates more during resize

### DIFF
--- a/runtime/src/main/kotlin/kotlin/text/StringBuilder.kt
+++ b/runtime/src/main/kotlin/kotlin/text/StringBuilder.kt
@@ -68,7 +68,7 @@ actual class StringBuilder private constructor (
 
     fun ensureCapacity(capacity: Int) {
         if (capacity > array.size) {
-            var newSize = array.size * 3 / 2
+            var newSize = array.size * 2 + 2
             if (capacity > newSize)
                 newSize = capacity
             array = array.copyOf(newSize)


### PR DESCRIPTION
The current algorithm for `StringBuilder`, when it needs a new Array, it increases the allocation only by 50%. This PR changes that allocation to double in size + 2, similar to the JVM algorithm.