### PR TITLE
Addition of a clarification, to the documentation.

### DIFF
--- a/PLATFORM_LIBS.md
+++ b/PLATFORM_LIBS.md
@@ -36,6 +36,8 @@ cross-compilation targets.  `Kotlin/Native` distribution provides access to
 `OpenGL`, `zlib` and other popular native libraries on
 applicable platforms.
 
+> Note : Some libraries are not included with Kotlin on all operating systems, for example OpenGL is not available directly with Kotlin on Windows.
+
 On Apple platforms `objc` library is provided for interoperability with [Objective-C](https://en.wikipedia.org/wiki/Objective-C).
 
 Inspect the contents of `dist/klib/platform/$target` of the distribution for the details.


### PR DESCRIPTION
Addition of a clarification, to remove the doubt, and not to let believe that Kotlin embarked, indifferently from the platform, the libraries.