### PR TITLE
[kotlin compiler][update] 1.3.60-dev-346

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,11 +18,11 @@
 buildKotlinVersion=1.3.50-dev-787
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-787,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-206,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-206
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-2110,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.50-dev-2110
-testKotlinCompilerVersion=1.3.60-dev-206
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-346,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-346
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-346,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-346
+testKotlinCompilerVersion=1.3.60-dev-346
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.workers.max=4


### PR DESCRIPTION
* 2c61572c501 - (HEAD -> master, tag: build-1.3.60-dev-346, origin/master, origin/HEAD) Build: Fix artifact pattern for Android Studio bintray repo (3 дня назад) <Vyacheslav Gerasimov>
* 10f5204f677 - (tag: build-1.3.60-dev-344) as36: Fix groovy-all dependency version (3 дня назад) <Vyacheslav Gerasimov>
* aed9b134556 - (tag: build-1.3.60-dev-338) Fix jvm-host-embeddable artefact generation (3 дня назад) <Ilya Chernikov>
* 333c7ff6881 - Filter out local classes on JSR-223  properties mapping (3 дня назад) <Ilya Chernikov>
* 2ae19e1d42c - (tag: build-1.3.60-dev-330) Run :kotlin-gradle-plugin:validateTaskProperties on every install (3 дня назад) <Alexey Tsvetkov>
* aff66b6a296 - (tag: build-1.3.60-dev-327) Make KotlinJpsBuildTestBase abstract (3 дня назад) <Alexey Tsvetkov>
* ce9ed269189 - [DEBUGGER] Improve computation of source position for breakpoint in KotlinLineBreakpointType more precise. (3 дня назад) <Roman Artemev>
* 2e0ec3b4909 - (tag: build-1.3.60-dev-319) AbstractFindUsagesTest: add read lock (3 дня назад) <Dmitry Gridin>
* dbb9b3b6fdd - AbstractFindUsagesTest: cleanup code (3 дня назад) <Dmitry Gridin>
* 58f294a7572 - (tag: build-1.3.60-dev-317) Fix kotlin compiler tests in 192 (KT-32193) (3 дня назад) <Nikolay Krasko>
* 3729c4e7705 - (tag: build-1.3.60-dev-315) JVM: simplify choice of wrapped receiver descriptors (3 дня назад) <Georgy Bronnikov>
* a10e57eaecd - (tag: build-1.3.60-dev-314) JavaOutsideModuleDetector: should refresh notification after move #KT-32967 Fixed (3 дня назад) <Dmitry Gridin>
* 4c8d0acb5d0 - CreateExpectFix: shouldn't suggest create expect property with `lateinit` or `const` modifier #KT-32705 Fixed (3 дня назад) <Dmitry Gridin>
* a858607face - (tag: build-1.3.60-dev-313) Fix script classpath utility functions that use classpath filtering by "keys" (3 дня назад) <Ilya Chernikov>
* ec3ccf1ba88 - Properly handle REPL snippets with exceptions ... (3 дня назад) <Ilya Chernikov>
* 288fdc09528 - Add a handler for providing evaluation context for scripts (3 дня назад) <Ilya Chernikov>
* 2a5c4a2409b - Move caching to after all configuration refinements and ... (3 дня назад) <Ilya Chernikov>
* e41bbe93286 - Introducing transient properties in scripting API (3 дня назад) <Ilya Chernikov>
* 5fe843d7540 - Refactor main-kts build scripts - fix red code in IDEA (3 дня назад) <Ilya Chernikov>
* 42dde50b6b8 - Implement base zip cache with tests... (3 дня назад) <Ilya Chernikov>
* c7eb9e95206 - Move caching tests into a dedicated class (3 дня назад) <Ilya Chernikov>
* ef230339363 - Add net.jpountz and one.util.streamex to the list of shadowed packages (3 дня назад) <Ilya Chernikov>
* cefd4a35c5b - Fix and test evaluation of scripts with default configurations (3 дня назад) <Ilya Chernikov>
* 961607673da - [minor] Refactor properties collection builder: (3 дня назад) <Ilya Chernikov>
* 0af52f2fa6d - Implement composable refinement handlers... (3 дня назад) <Ilya Chernikov>
* 65e6d3b0ff6 - [minor] Add a small diagnostics handling utility fun (3 дня назад) <Ilya Chernikov>
* 0072f8c2658 - Improve JSR-223 engine diagnostics (3 дня назад) <Ilya Chernikov>
* b68ab0d968b - Add test on repl with implicit receiver (3 дня назад) <Ilya Chernikov>
* a13d452cd89 - Implement JSR223 host in the main-kts jar (3 дня назад) <Ilya Chernikov>
* 0108a76e997 - Extract arguments calculation for base JSR223 engine into an argument (3 дня назад) <Ilya Chernikov>
* e8fa139dc84 - Move direct properties configuration code into public functions in scripting host jar (3 дня назад) <Ilya Chernikov>
* 89a53fe028b - (tag: build-1.3.60-dev-312) Safe get of registry key in KotlinAndroidGradleMPPModuleDataService (3 дня назад) <Andrey Uskov>
* 5f2aca58569 - Fix NewMultiplatformProjectImportingTest in bunch 183 (3 дня назад) <Andrey Uskov>
* e25b3153199 - (tag: build-1.3.60-dev-310) Introduce `-Xpolymorphic-signature` compiler flag as more priority than `-XXLanguage:+PolymorphicSignature` (3 дня назад) <Victor Petukhov>
* 944ee8fcd50 - Introduce `-Xinline-classes` compiler flag as more priority than `-XXLanguage:+InlineClasses` (3 дня назад) <Victor Petukhov>
* 45644c224ef - (tag: build-1.3.60-dev-308) JPS: Add temporary non caching jps storage for 192 (3 дня назад) <Mikhail Mazurkevich>
* 584d441587a - (tag: build-1.3.60-dev-306) Fix import when android gradle plugin is involved in IDEA 183 (4 дня назад) <Andrey Uskov>
* 91365d9fadb - Fix import library dependencies when transitive MPP are involved (4 дня назад) <Andrey Uskov>
* 0b8ad5c6c0b - Fixed setting production-on-test flag if project was not build (4 дня назад) <Andrey Uskov>
* 17dec7b389a - Add transitive test dependencies on MPP with jvmWithJava on import (4 дня назад) <Andrey Uskov>
* 86a26f0ccab - Add jvmWithJava IDE import test (4 дня назад) <Andrey Uskov>
* 6c0469cee0e - Fix importing transitive dependencies on MPP project (4 дня назад) <Andrey Uskov>
* 8592396a9ad - Fix combobox size in facet settings tab (KT-32784) (4 дня назад) <Andrey Uskov>
* 9ce9b5945e3 - Fix order of platforms in Facets (KT-32783) (4 дня назад) <Andrey Uskov>
* b8400a16f0b - (tag: build-1.3.60-dev-304) Fix webpack dsl with closure (4 дня назад) <ilgonmic>
* deb6b7105a4 - Remove duplicated source-map-loader configuring and cleanup kotlin webpack config writer (4 дня назад) <ilgonmic>
* 3b78ef9cb2b - (tag: build-1.3.60-dev-296) as36: Add bunches for AS 3.6 C6 based on 192 platform (4 дня назад) <Vyacheslav Gerasimov>
* 5c6dedc623b - Build: Add repo for prerelease Android Studio (4 дня назад) <Vyacheslav Gerasimov>
* ccff347ffc8 - (tag: build-1.3.60-dev-294) Kapt: Attach generated Kotlin sources in 'compilation' mode (KT-32535) (4 дня назад) <Yan Zhulanow>
* 1c63d3aa2f4 - KT-32210: Handle long compiler plugin options (4 дня назад) <Ivan Gavrilovic>
* 4b9a8527453 - (tag: build-1.3.60-dev-293) Sort source to output mapping before writing to caches (4 дня назад) <Alexey Tsvetkov>
* afa10cc1253 - Rewrite test of relocatable JPS IC caches (4 дня назад) <Alexey Tsvetkov>
* 98aad3e00c9 - Extract EnableICFixture (4 дня назад) <Alexey Tsvetkov>
* a4c62d156f1 - Make lookup storage addAll order independent (4 дня назад) <Alexey Tsvetkov>
* 57caca4b0e3 - Improve exception message for directories comparison in tests (4 дня назад) <Alexey Tsvetkov>
* 6914a9dd3dc - (tag: build-1.3.60-dev-289) KotlinFindUsagesHandler: fix read access (flaky tests) (4 дня назад) <Dmitry Gridin>
* 66fdc148be4 - (tag: build-1.3.60-dev-278) Revert strong references for compiler only (4 дня назад) <Alexander Podkhalyuzin>
* f3112f752da - Inherit max metaspace size of client VM for Kotlin compile daemon (4 дня назад) <Alexey Tsvetkov>
* 5c99243c107 - (tag: build-1.3.60-dev-277) Substitute kotlin-reflect with kotlin-reflect-api in compile classpath (4 дня назад) <Alexey Tsvetkov>
* 33b7745b175 - Find only non-default shadow jars in findShadowJarsInClasspath diagnostic (4 дня назад) <Alexey Tsvetkov>
* e91eefe709c - Remove unnecessary dependencies on kotlin-compiler-runner (4 дня назад) <Alexey Tsvetkov>
* cd641c90472 - Set source and target compatibility in buildSrc (4 дня назад) <Alexey Tsvetkov>
* a7403b7ee7a - Do not fork java compile tasks when current JDK can be used (4 дня назад) <Alexey Tsvetkov>
* a372f181d20 - Check JDK env vars once during configuration when not syncing (4 дня назад) <Alexey Tsvetkov>
* a20627fa2c8 - Set sourceCompatibility and targetCompatibility for JavaCompile tasks (4 дня назад) <Alexey Tsvetkov>
* a35d4058923 - (tag: build-1.3.60-dev-271) Do not generate accessor if private function is accessed from (4 дня назад) <Ilmir Usmanov>
* b3e80e6a14a - (tag: build-1.3.60-dev-269) Look for classfile in implementing modules when building inline function (4 дня назад) <Ilmir Usmanov>
* 58db64a4782 - (tag: build-1.3.60-dev-267) J2K: Fix old J2K test data's error messages which has changed due to new inference (4 дня назад) <Ilya Kirillov>
* 4e5e14046df - New J2K: use old J2K for evaluate expression instead of new one (4 дня назад) <Ilya Kirillov>
* e795e4b73d7 - New J2K: add conversion of binary literals & fix conversion of octal ones (4 дня назад) <Ilya Kirillov>
* 72a09ab59bd - New J2K: correctly convert number literals with underscores (4 дня назад) <Ilya Kirillov>
* 4ead8203952 - New J2K: correctly print comments for qualified expression (4 дня назад) <Ilya Kirillov>
* 2bd5a1f1960 - New J2K: separate nullability inference from common one & nullability bug fixes (4 дня назад) <Ilya Kirillov>
* d7960caf89f - New J2K: move all symbols definitions to `symbols` package (4 дня назад) <Ilya Kirillov>
* f79b282c601 - New J2K: add better support of implicit functional interfaces (4 дня назад) <Ilya Kirillov>
* 96ca4712a01 - New J2K: consider in-context declarations while performing conversion on copy-paste plain text conversion (4 дня назад) <Ilya Kirillov>
* c865d749651 - New J2K: remove unused dependencies from nj2k modules (4 дня назад) <Ilya Kirillov>
* 1bbdd0bf150 - New J2K: remove unused classes (4 дня назад) <Ilya Kirillov>
* 6e04b1549ca - New J2K: remove JKVisitor with type parameters (4 дня назад) <Ilya Kirillov>
* 9c8905ccb6b - (tag: build-1.3.60-dev-265) Patch serializable class with addtional annotation (4 дня назад) <Leonid Startsev>
* 3896992b12a - Fixes for IR serialization plugin (4 дня назад) <Leonid Startsev>
* 6494227c644 - Change order in SerializableProperties initialization logic (4 дня назад) <Leonid Startsev>
* 822b4556e35 - Rewrite IDE check whether serialization plugin is enabled (4 дня назад) <Leonid Startsev>
* 2381aa330a3 - (tag: build-1.3.60-dev-261) FIR: fix delegate expression consistency tests (4 дня назад) <Mikhail Glukhikh>
* d32e5065c53 - FIR: implementation of delegateProvider in delegate resolve (4 дня назад) <Mikhail Glukhikh>
* 213f951da3f - FIR: partial implementation of delegate resolve #KT-32217 Fixed (4 дня назад) <Mikhail Glukhikh>
* 63b7fa70f9e - FIR2IR: add extension receiver parameters to functions (4 дня назад) <Mikhail Glukhikh>
* be3fe9495cb - (tag: build-1.3.60-dev-255) Report non-incremental annotation processors correctly (5 дней назад) <Ivan Gavrilovic>
* ad352355deb - KT-23880: Enable incremental APT mode with KAPT by default (5 дней назад) <Ivan Gavrilovic>
* a108af76d66 - Mark property as output instead of local state when needed (5 дней назад) <Ivan Gavrilovic>
* 5a2ff866913 - Handle classpath snapshot changes better (5 дней назад) <Ivan Gavrilovic>
* f66b4758675 - (tag: build-1.3.60-dev-253) Create wrapped receiver descriptors where needed (5 дней назад) <Georgy Bronnikov>
* 46b98a1e982 - (tag: build-1.3.60-dev-247) [JS BE] Make sourceMap generation more precise (5 дней назад) <Roman Artemev>
* 12a1b0296b3 - (tag: build-1.3.60-dev-244) Clean up useless code (5 дней назад) <Kirill Shmakov>
* d3bc2ec855a - (tag: build-1.3.60-dev-239) Remove internal jdk to fix flaky MavenUpdateConfigurationQuickFixTest (5 дней назад) <Nikolay Krasko>
* 61763737130 - Test data update for JavaWithGroovyInvoke since 183 (5 дней назад) <Nikolay Krasko>
* 5f9660cd337 - (tag: build-1.3.60-dev-229, tag: build-1.3.60-dev-227, tag: build-1.3.60-dev-224) `KtLightParameter` introduced as interface (5 дней назад) <Nicolay Mitropolsky>
* 50158e508a5 - `org.jetbrains.kotlin.asJava.elements.LightParameter` converted to Kotlin (5 дней назад) <Nicolay Mitropolsky>
* 7dcd3849e05 - `org.jetbrains.kotlin.asJava.elements.LightParameter` converted to Kotlin: Rename .java to .kt (5 дней назад) <Nicolay Mitropolsky>
* 8982a49dcbf - renaming `KtLightParameter` to `KtLightParameterImpl` (5 дней назад) <Nicolay Mitropolsky>
* 4a20a440a7d - (tag: build-1.3.60-dev-222, tag: build-1.3.60-dev-221) Cleanup: remove redundant semicolon (5 дней назад) <Anton Yalyshev>
* 6d53151256f - Add statistics (FUS) collector for IDE Settings. At the moment - New Inference only. (5 дней назад) <Anton Yalyshev>
* 56b6b957d1a - (tag: build-1.3.60-dev-210) Generate line numbers for RHS of elvis expression if both LHS and RHS (6 дней назад) <Ilmir Usmanov>
* 1f36f60f439 - (tag: build-1.3.60-dev-209) JVM IR: remove CrIrType, use class container in callable reference lowerings (6 дней назад) <Alexander Udalov>