### PR TITLE
Support -[NSOutputStream initToMemory]

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -68,6 +68,13 @@ private fun ObjCMethod.getKotlinParameters(
         stubIrBuilder: StubsBuildingContext,
         forConstructorOrFactory: Boolean
 ): List<FunctionParameterStub> {
+    if (this.isInit && this.parameters.isEmpty() && this.selector != "init") {
+        // Create synthetic Unit parameter, just like Swift does in this case:
+        val parameterName = this.selector.removePrefix("init").removePrefix("With").decapitalize()
+        return listOf(FunctionParameterStub(parameterName, WrapperStubType(KotlinTypes.unit)))
+        // Note: this parameter is explicitly handled in compiler.
+    }
+
     val names = getKotlinParameterNames(forConstructorOrFactory) // TODO: consider refactoring.
     val result = mutableListOf<FunctionParameterStub>()
 

--- a/backend.native/tests/interop/objc/objcSmoke.def
+++ b/backend.native/tests/interop/objc/objcSmoke.def
@@ -1,3 +1,3 @@
 language = Objective-C
-headers = Foundation/NSArray.h Foundation/NSValue.h Foundation/NSString.h
-headerFilter = **/smoke.h Foundation/NSArray.h Foundation/NSValue.h Foundation/NSString.h
+headers = Foundation/NSArray.h Foundation/NSValue.h Foundation/NSString.h Foundation/NSStream.h
+headerFilter = **/smoke.h Foundation/NSArray.h Foundation/NSValue.h Foundation/NSString.h Foundation/NSStream.h

--- a/backend.native/tests/interop/objc/smoke.h
+++ b/backend.native/tests/interop/objc/smoke.h
@@ -213,3 +213,10 @@ id getPrinterProtocolRaw() {
 Protocol* getPrinterProtocol() {
   return @protocol(Printer);
 }
+
+@interface TestInitWithCustomSelector : NSObject
+-(instancetype)initCustom;
+@property BOOL custom;
+
++(instancetype _Nonnull)createCustom;
+@end;

--- a/backend.native/tests/interop/objc/smoke.h
+++ b/backend.native/tests/interop/objc/smoke.h
@@ -220,3 +220,7 @@ Protocol* getPrinterProtocol() {
 
 +(instancetype _Nonnull)createCustom;
 @end;
+
+@interface TestAllocNoRetain : NSObject
+@property BOOL ok;
+@end;

--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -26,6 +26,8 @@ fun run() {
     testMultipleInheritanceClash()
     testClashingWithAny()
     testInitWithCustomSelector()
+    testAllocNoRetain()
+    testNSOutputStreamToMemoryConstructor()
 
     assertEquals(2, ForwardDeclaredEnum.TWO.value)
 
@@ -395,6 +397,35 @@ private class TestInitWithCustomSelectorSubclass : TestInitWithCustomSelector {
     }
 
     companion object : TestInitWithCustomSelectorMeta()
+}
+
+fun testAllocNoRetain() {
+    // Ensure that calling Kotlin constructor generated for Objective-C initializer doesn't result in
+    // redundant retain-release sequence for `alloc` result, since it may provoke specific bugs to reproduce, e.g.
+    // the one found in [[NSOutputStream alloc] initToMemory] sequence where initToMemory deallocates its receiver
+    // forcibly when replacing it with other object: (to be compiled with ARC enabled)
+    /*
+    #import <Foundation/Foundation.h>
+
+    void* mem;
+    NSOutputStream* allocated = nil;
+
+    int main() {
+        allocated = [NSOutputStream alloc];
+        NSOutputStream* initialized = [allocated initToMemory];
+        mem = calloc(1, 0x10); // To corrupt the 'allocated' object header.
+        allocated = nil; // Crashes here in objc_release.
+
+        return 0;
+    }
+     */
+
+    assertTrue(TestAllocNoRetain().ok)
+}
+
+fun testNSOutputStreamToMemoryConstructor() {
+    val stream: Any = NSOutputStream(toMemory = Unit)
+    assertTrue(stream is NSOutputStream)
 }
 
 fun nsArrayOf(vararg elements: Any): NSArray = NSMutableArray().apply {

--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -25,6 +25,7 @@ fun run() {
     testOverrideInit()
     testMultipleInheritanceClash()
     testClashingWithAny()
+    testInitWithCustomSelector()
 
     assertEquals(2, ForwardDeclaredEnum.TWO.value)
 
@@ -372,6 +373,28 @@ fun testClashingWithAny() {
     assertEquals(4, TestClashingWithAny3().hashCode(3))
     assertFalse(TestClashingWithAny3().equals(TestClashingWithAny3()))
     assertTrue(TestClashingWithAny3().equals())
+}
+
+fun testInitWithCustomSelector() {
+    assertFalse(TestInitWithCustomSelector().custom)
+    assertTrue(TestInitWithCustomSelector(custom = Unit).custom)
+
+    val customSubclass: TestInitWithCustomSelector = TestInitWithCustomSelectorSubclass.createCustom()
+    assertTrue(customSubclass is TestInitWithCustomSelectorSubclass)
+    assertTrue(customSubclass.custom)
+
+    // Test side effect:
+    var ok = false
+    assertTrue(TestInitWithCustomSelector(run { ok = true }).custom)
+    assertTrue(ok)
+}
+
+private class TestInitWithCustomSelectorSubclass : TestInitWithCustomSelector {
+    @OverrideInit constructor(custom: Unit) : super(custom) {
+        assertSame(Unit, custom)
+    }
+
+    companion object : TestInitWithCustomSelectorMeta()
 }
 
 fun nsArrayOf(vararg elements: Any): NSArray = NSMutableArray().apply {

--- a/backend.native/tests/interop/objc/smoke.m
+++ b/backend.native/tests/interop/objc/smoke.m
@@ -254,3 +254,25 @@ static CustomRetainMethodsImpl* retainedCustomRetainMethodsImpl;
     return YES;
 }
 @end;
+
+@implementation TestInitWithCustomSelector
+
+-(instancetype)initCustom {
+    if (self = [super init]) {
+        self.custom = YES;
+    }
+    return self;
+}
+
+-(instancetype)init {
+    if (self = [super init]) {
+        self.custom = NO;
+    }
+    return self;
+}
+
++(instancetype)createCustom {
+    return [[self alloc] initCustom];
+}
+
+@end;

--- a/backend.native/tests/interop/objc/smoke.m
+++ b/backend.native/tests/interop/objc/smoke.m
@@ -276,3 +276,16 @@ static CustomRetainMethodsImpl* retainedCustomRetainMethodsImpl;
 }
 
 @end;
+
+@implementation TestAllocNoRetain
+-(instancetype)init {
+    __weak id weakSelf = self;
+    self = [TestAllocNoRetain alloc];
+    if (self = [super init]) {
+        // Ensure that original self value was deallocated:
+        self.ok = (weakSelf == nil);
+        // So it's RC was 1, which means there wasn't redundant retain applied to it.
+    }
+    return self;
+}
+@end;


### PR DESCRIPTION
* Support importing non-conventional parameterless Objective-C init

* Don't emit redundant retain-release sequence for Obj-C `alloc` result when calling Kotlin constructor generated for Objective-C initializer (this is correct but interferes with bug in `NSOutputStream`)

Fix #2522.