### PR TITLE
[kotlin compiler][update] 1.3.60-dev-1210

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,11 +18,11 @@
 buildKotlinVersion=1.3.50-dev-787
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.50-dev-787,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1120,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-1120
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-570,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.60-dev-570
-testKotlinCompilerVersion=1.3.60-dev-346
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-1210
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-1210
+testKotlinCompilerVersion=1.3.60-dev-1210
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.workers.max=4


### PR DESCRIPTION
* e9e3df23fc5 - (HEAD -> master, tag: build-1.3.60-dev-1210, origin/master, origin/HEAD) Fix typos and improve grammar in stdlib readmes (#2527) (3 days ago) <Yanis Batura>
* ad8bcda99e4 - (tag: build-1.3.60-dev-1206) [IR] Merged K/N inliner with the common one (3 days ago) <Igor Chevdar>
* 32153c26a86 - (tag: build-1.3.60-dev-1198, origin/rr/4u7/publishing-fixes-before) Build: Rewrite upload_plugins.gradle in Kotlin (3 days ago) <Vyacheslav Gerasimov>
* af2cd36c3d8 - Build: Rename upload_plugins.gradle -> kts (3 days ago) <Vyacheslav Gerasimov>
* fba22606e69 - (tag: build-1.3.60-dev-1197) Introduce erroneous operators ClockMark.minus/compareTo(ClockMark) (3 days ago) <Ilya Gorbunov>
* ac07cb686bc - Change status of ExperimentalTime API to a more risky one (3 days ago) <Ilya Gorbunov>
* a9854025078 - Introduce ClockMark.hasPassedNow, hasNotPassedNow functions (3 days ago) <Ilya Gorbunov>
* 44195d436ed - Rename: Clock.markNow, ClockMark.elapsedNow (3 days ago) <Ilya Gorbunov>
* a493d46a6e6 - Make effectively private properties actually private to avoid accessors (3 days ago) <Ilya Gorbunov>
* f889d25287b - Introduce TestClock.plusAssign(Duration) and hide implementation details (3 days ago) <Ilya Gorbunov>
* 4de9361c376 - Introduce Duration.isPositive method (3 days ago) <Ilya Gorbunov>
* 4befca95d6f - (tag: build-1.3.60-dev-1176) Add an ability to switch between old and new J2K via settings window (3 days ago) <Ilya Kirillov>
* 3b8da0afe47 - (tag: build-1.3.60-dev-1175) Update dukat dependency to 0.0.16 (3 days ago) <Shagen Ogandzhanian>
* 1aa8e28dd87 - (tag: build-1.3.60-dev-1155) Add JvmOverloads to KtLightClassImpl (4 days ago) <Igor Yakovlev>
* 8e6a80bed72 - (tag: build-1.3.60-dev-1154) Add test logs specific for IC with JS IR (4 days ago) <Alexey Tsvetkov>
* 12c209d3606 - Do not compare output for IC with JS IR BE (4 days ago) <Alexey Tsvetkov>
* 3366ac4b186 - Save incremental data with KLIB compiler (4 days ago) <Alexey Tsvetkov>
* fc495100499 - Add tests for IC with JS IR BE (4 days ago) <Alexey Tsvetkov>
* 9572800ef72 - Add missing dependency (4 days ago) <Alexey Tsvetkov>
* b5a407371c4 - (tag: build-1.3.60-dev-1145) Update the year in LICENSE.txt (4 days ago) <Stanislav Erokhin>
* d59b910403e - (tag: build-1.3.60-dev-1139) Add tests for obsolete issues (4 days ago) <Mikhail Zarechenskiy>
* 1969ad6e9d9 - [NI] Take into account use-site variance for constraint from LHS of CR (4 days ago) <Mikhail Zarechenskiy>
* 0620762b976 - (tag: build-1.3.60-dev-1137) Enable new inference explicitly for MPP tests with type refinement (4 days ago) <Mikhail Zarechenskiy>
* 735e1ecec1d - Disable new inference for IDE analysis by default in releases (4 days ago) <Mikhail Zarechenskiy>
* 69942681a3f - Refactoring: move `versioning.kt` file to `idea-analysis` module (4 days ago) <Mikhail Zarechenskiy>
* 50e7ff40975 - Refactoring: move `isSnapshot` function closer to similar ones (4 days ago) <Mikhail Zarechenskiy>
* 2c0d6ab1a51 - (tag: build-1.3.60-dev-1135) [Compatibility] Restore GradleBuildScriptManipulator.addKotlinLibraryToModuleBuildScript(scope, libraryDescriptor) #KT-33336 Fixed (4 days ago) <Dmitry Gridin>
* 63895483fdb - (tag: build-1.3.60-dev-1131) Fix take method from iterating one extra element (KT-32024) (4 days ago) <Abduqodiri Qurbonzoda>
* 01a613dca40 - (tag: build-1.3.60-dev-1129) Add tests for floating-point to integral conversion (4 days ago) <Abduqodiri Qurbonzoda>
* 432828a2dbf - Clarify floating-point to integral conversion rounding behaviour (4 days ago) <Abduqodiri Qurbonzoda>
* fd5bf338614 - (tag: build-1.3.60-dev-1128) Removed asserts for mirror files for java stubs on kt files (5 days ago) <Igor Yakovlev>
* 8cfdd140bb6 - (tag: build-1.3.60-dev-1121) Upgrade plugin-repository-rest-client & use token auth (5 days ago) <Vyacheslav Gerasimov>