### PR TITLE
 [kotlin compiler][update] 1.3.60-dev-1448

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/OptimizationPipeline.kt
@@ -61,6 +61,11 @@ private class LlvmPipelineConfiguration(context: Context) {
         KonanTarget.ANDROID_ARM64 -> "cortex-a57"
         KonanTarget.LINUX_MIPS32 -> "mips32r2"
         KonanTarget.LINUX_MIPSEL32 -> "mips32r2"
+        KonanTarget.ANDROID_X64 -> TODO("implement me")
+        KonanTarget.WATCHOS_ARM64 -> TODO("implement me")
+        KonanTarget.WATCHOS_X64 -> TODO("implement me")
+        KonanTarget.TVOS_ARM64 -> TODO("implement me")
+        KonanTarget.TVOS_X64 -> TODO("implement me")
         KonanTarget.WASM32,
         is KonanTarget.ZEPHYR -> error("There is no support for ${target.name} target yet.")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ allprojects {
 
 void setupHostAndTarget() {
     ext.hostName = platformManager.hostName
-    ext.targetList = platformManager.enabled.collect { it.visibleName } as List
+    ext.targetList = platformManager.filteredOutEnabledButNotSupported.collect { it.visibleName } as List
     ext.konanTargetList = platformManager.enabled as List
 }
 

--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -80,7 +80,8 @@ enum DependencyKind {
 
 def platformManager = rootProject.ext.platformManager
 
-platformManager.enabled.each { target ->
+
+platformManager.filteredOutEnabledButNotSupported.each { target ->
     def loader = platformManager.loader(target)
 
     task "${target}Dependencies"(type: NativeDep) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,10 @@
 buildKotlinVersion=1.3.60-dev-1210
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-1210
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.60-dev-1210
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1448,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-1448
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1448,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-1448
 testKotlinCompilerVersion=1.3.60-dev-1210
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
@@ -103,6 +103,12 @@ class ClangArgs(private val configurables: Configurables) : Configurables by con
                             "-Xclang", "-isystem$absoluteTargetSysRoot/include/compat",
                             "-Xclang", "-isystem$absoluteTargetSysRoot/include/libc")
 
+                KonanTarget.ANDROID_X64 -> TODO("implement me")
+                KonanTarget.WATCHOS_ARM64 -> TODO("implement me")
+                KonanTarget.WATCHOS_X64 -> TODO("implement me")
+                KonanTarget.TVOS_ARM64 -> TODO("implement me")
+                KonanTarget.TVOS_X64 -> TODO("implement me")
+
                 is KonanTarget.ZEPHYR ->
                     listOf("-target", targetArg!!,
                         "-fno-rtti",
@@ -243,6 +249,13 @@ class ClangArgs(private val configurables: Configurables) : Configurables by con
                         "-DKONAN_INTERNAL_NOW=1",
                         "-DKONAN_NO_MEMMEM",
                         "-DKONAN_NO_CTORS_SECTION=1")
+
+            KonanTarget.ANDROID_X64 -> TODO("implement me")
+            KonanTarget.WATCHOS_ARM64 -> TODO("implement me")
+            KonanTarget.WATCHOS_X64 -> TODO("implement me")
+            KonanTarget.TVOS_ARM64 -> TODO("implement me")
+            KonanTarget.TVOS_X64 -> TODO("implement me")
+
 
             is KonanTarget.ZEPHYR ->
                 listOf( "-DKONAN_ZEPHYR=1",

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ConfigurablesImpl.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ConfigurablesImpl.kt
@@ -50,7 +50,10 @@ fun loadConfigurables(target: KonanTarget, properties: Properties, baseDir: Stri
             MingwConfigurablesImpl(target, properties, baseDir)
         KonanTarget.WASM32 ->
             WasmConfigurablesImpl(target, properties, baseDir)
+        KonanTarget.ANDROID_X64 -> TODO("unimplemented: $target")
+        KonanTarget.WATCHOS_ARM64, KonanTarget.WATCHOS_X64 -> TODO("unimplemented: $target")
+        KonanTarget.TVOS_ARM64, KonanTarget.TVOS_X64 -> TODO("unimplemented: $target")
         is KonanTarget.ZEPHYR ->
-            ZephyrConfigurablesImpl(target, properties, baseDir)
+                ZephyrConfigurablesImpl(target, properties, baseDir)
     }
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -435,6 +435,11 @@ fun linker(configurables: Configurables): LinkerFlags =
                 MingwLinker(configurables as MingwConfigurables)
             KonanTarget.WASM32 ->
                 WasmLinker(configurables as WasmConfigurables)
+            KonanTarget.ANDROID_X64 -> TODO("implement me")
+            KonanTarget.WATCHOS_ARM64 -> TODO("implement me")
+            KonanTarget.WATCHOS_X64 -> TODO("implement me")
+            KonanTarget.TVOS_ARM64 -> TODO("implement me")
+            KonanTarget.TVOS_X64 -> TODO("implement me")
             is KonanTarget.ZEPHYR ->
                 ZephyrLinker(configurables as ZephyrConfigurables)
         }

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Platform.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Platform.kt
@@ -32,7 +32,7 @@ class Platform(val configurables: Configurables)
 class PlatformManager(distribution: Distribution = Distribution(), experimental: Boolean = false) :
         HostManager(distribution, experimental) {
 
-    private val loaders = enabled.map {
+    private val loaders = filteredOutEnabledButNotSupported.map {
         it to loadConfigurables(it, distribution.properties, DependencyProcessor.defaultDependenciesRoot.absolutePath)
     }.toMap()
 
@@ -44,5 +44,12 @@ class PlatformManager(distribution: Distribution = Distribution(), experimental:
     val hostPlatform = platforms.getValue(host)
 
     fun loader(target: KonanTarget) = loaders.getValue(target)
+
+    /**
+     * TODO: Don't forget to delete this field and replace all its usages to `enabled`.
+     */
+    val filteredOutEnabledButNotSupported
+        get() = enabled.filterNot { it == KonanTarget.ANDROID_X64 || it == KonanTarget.WATCHOS_X64 || it == KonanTarget.WATCHOS_ARM64 ||
+                it == KonanTarget.TVOS_X64 || it == KonanTarget.TVOS_ARM64}
 }
 


### PR DESCRIPTION
* a38651c1ec7 - (tag: build-1.3.60-dev-1448) KT-32366: Add missing 182 bunch file for the `foldingTestUtils.kt` (3 days ago) <Roman Golyshev>
* 5a511dd6352 - (tag: build-1.3.60-dev-1446) Refactor and fix of the run/apply/let/also intention converter (3 days ago) <Igor Yakovlev>
* ef5fcb4e9e5 - (tag: build-1.3.60-dev-1439) Fix test data (3 days ago) <Ilmir Usmanov>
* 37e3c41b57c - (tag: build-1.3.60-dev-1434) KT-32366: Add sync scroll for source and preview editor (3 days ago) <Roman Golyshev>
* e488e920d84 - KT-32366: Add tests for right preview window (3 days ago) <Roman Golyshev>
* bddf87337c1 - KT-32366: Add printing scratch output to preview window (3 days ago) <Roman Golyshev>
* e321ee1396c - KT-32366: Inject `toolWindowHandler` from `InlayScratchOutputHandler` (3 days ago) <Roman Golyshev>
* d0cd4967a76 - KT-32366: Extract text styling variables to `outputStylingUtils` (3 days ago) <Roman Golyshev>
* 358ec2b8bdb - KT-32366: Refactor tests to allow testing of preview window (3 days ago) <Roman Golyshev>
* dd1ace37d25 - KT-32366: Add `TextEditorWithPreview.setLayout` method (3 days ago) <Roman Golyshev>
* 1d6de45db68 - KT-32366: Use `TextEditorWithPreview` as editor for scratch files (3 days ago) <Roman Golyshev>
* 37c6102a037 - KT-32366: Change base of `AbstractScratchLineMarkersTest` (3 days ago) <Roman Golyshev>
* 1177566386d - KT-32366: Get rid of `ScratchTopPanel` in tests (3 days ago) <Roman Golyshev>
* 962260941b2 - KT-32366: Add `TextEditorWithPreview` class from the platform (3 days ago) <Roman Golyshev>
* 54dde777ac6 - KT-32366: Get replace editor with virtual file in `ScratchFile` (3 days ago) <Roman Golyshev>
* 1fc88fc47fd - KT-32366: Refactor `ScratchPanelListener` to `ScratchFileListener` (3 days ago) <Roman Golyshev>
* ea3d070c985 - KT-32366: Refactor `ScratchFileHook` to make ScratchFile creation clear (3 days ago) <Roman Golyshev>
* 70e6f738ebf - KT-32366: Refactor `scratchUtils` to use mostly `ScratchFile` (3 days ago) <Roman Golyshev>
* 6c35c40bb9b - KT-32366: Refactor `ScratchTopPanel` to actions instead of custom UI (3 days ago) <Roman Golyshev>
* 23f662cfe29 - (tag: build-1.3.60-dev-1429) FIR: optimize creation of scope by implicit receiver (3 days ago) <Mikhail Glukhikh>
* 9c3821ddba1 - FIR: add comments & tests for tower resolver, block some receiver pairs (3 days ago) <Mikhail Glukhikh>
* c9a600c5ce1 - FIR: handle imported members from objects more correctly (3 days ago) <Mikhail Glukhikh>
* a4d89b98294 - FIR: handle situations with multiple implicit receivers (3 days ago) <Mikhail Glukhikh>
* 5d6a526eec0 - FIR: more accurate handling of dispatch receiver values (3 days ago) <Mikhail Glukhikh>
* fcb0b1b5eb8 - (tag: build-1.3.60-dev-1427) Add new native targets. (#2538) (3 days ago) <Nikolay Igotti>
* 64d4cca589f - (tag: build-1.3.60-dev-1419) Redundant override: do not report when class has derived property (3 days ago) <Toshiaki Kameyama>
* 729ed1a44e0 - (tag: build-1.3.60-dev-1417) Pull Members Up: fix invalid code format on function with comment and another indent (3 days ago) <Toshiaki Kameyama>
* 7c2f6ecba77 - (tag: build-1.3.60-dev-1416) Redundant curly braces in string template: remove braces for 'this' (3 days ago) <Toshiaki Kameyama>
* 8f2a73b7347 - (tag: build-1.3.60-dev-1415) KT-28471: "Add initializer" quickfix initializes non-null variable with null (3 days ago) <Dereck Bridie>
* c0f896c96a9 - flatMap call could be simplified to flatten(): Fix false positive with Array (3 days ago) <Toshiaki Kameyama>
* 7ff01b02a98 - (tag: build-1.3.60-dev-1411) Make ExperimentalTime annotation documented (4 days ago) <Ilya Gorbunov>
* 2c79b1f89eb - Minor: fix incorrect reference in kdoc (4 days ago) <Ilya Gorbunov>
* daa0d58f4db - (tag: build-1.3.60-dev-1410) Build: Update list of proxied repositories (4 days ago) <Vyacheslav Gerasimov>
* 1cdc68901a9 - Build: Use kotlinx-metadata-jvm from jcenter instead of bintray (4 days ago) <Vyacheslav Gerasimov>
* 96c9efeabb5 - Build: Fix findNonCachedRepositories test (4 days ago) <Vyacheslav Gerasimov>
* 669b6d164c0 - Build: Use cache redirector for buildscript block of :kotlin-reflect (4 days ago) <Vyacheslav Gerasimov>
* d59f2bcc800 - (tag: build-1.3.60-dev-1404) Fix KotlinReflectionInternalError on invoking callBy with defaults in supertypes (4 days ago) <Alexander Udalov>
* cb2e68feced - JVM IR: skip temporary variables in InventNamesForLocalClasses (4 days ago) <Alexander Udalov>
* 312205f376f - Prohibit synchronized methods on interface members (4 days ago) <Alexander Udalov>
* 815ff3c8606 - JVM IR: don't generate ACC_FINAL on DefaultImpls methods (4 days ago) <Alexander Udalov>
* 6f785ec881d - (tag: build-1.3.60-dev-1401) FIR2IR: fix library annotation call generation (4 days ago) <Mikhail Glukhikh>
* 27ccff12c1a - FIR: add resolve for delegated super-type (4 days ago) <Mikhail Glukhikh>
* a9bc3c19d6e - (tag: build-1.3.60-dev-1393) Fix invalid generated Move tests (4 days ago) <Igor Yakovlev>
* f9506db20a4 - (tag: build-1.3.60-dev-1390) Ignore sources which are not LOADs in refinedIntTypeAnalysis (4 days ago) <Ilmir Usmanov>
* 4697822b5af - (tag: build-1.3.60-dev-1389) [FIR] Fix setting return type for `when` and `try` with non applicable candidates (4 days ago) <Dmitriy Novozhilov>
* 6e6ffa12a68 - [WASM] Initial infrastructure (4 days ago) <Svyatoslav Kuzmich>
* 812083ee05e - [WASM] Initial runtime library (4 days ago) <Svyatoslav Kuzmich>
* 1891fa1bf19 - [JS IR BE] Commonize JS lowerings (4 days ago) <Svyatoslav Kuzmich>
* 7bc739359bd - (tag: build-1.3.60-dev-1387) Use JDK_8 when stopping Gradle daemons with version below 5.0 (4 days ago) <Ivan Gavrilovic>
* d13e26d67ee - Add a check that processors from KAPT classpath are not run (4 days ago) <Ivan Gavrilovic>
* 27a9aa5e2b8 - KT-33056: Fix how parent class loader for KAPT processors is found (4 days ago) <Ivan Gavrilovic>
* f3acd8d10c9 - KT-33028, KT-33050: Fix how kapt invokes javac on JDK 9+ (4 days ago) <Ivan Gavrilovic>
* 5846db4eabb - (tag: build-1.3.60-dev-1379) [FIR] Add symbol to FirFunction and all it's inheritors (4 days ago) <Dmitriy Novozhilov>
* e3e1f3c2aab - [FIR] Fix transforming value parameters of anonymous functions (4 days ago) <Dmitriy Novozhilov>
* d8410908661 - [FIR] Don't analyze properties with implicit types twice (4 days ago) <Dmitriy Novozhilov>
* f1e56c4b3e3 - [FIR] Force resolving all declaration while resolving of body with implicit type (4 days ago) <Dmitriy Novozhilov>
* e374242adf3 - [FIR] Fix propagating expected type for binary operator calls (4 days ago) <Dmitriy Novozhilov>
* ba7a137e745 - [FIR] Add fir node for binary && and || (4 days ago) <Dmitriy Novozhilov>
* 908b6ade1d7 - [FIR] Fix incorrect do-while loop transforming order and IR generating (4 days ago) <Dmitriy Novozhilov>
* 42f171a8d2e - [IR] Minor. Extract irBuiltins from IrGeneratorContext to separate interface (4 days ago) <Dmitriy Novozhilov>
* b274c7567ee - [FIR] Minor. Add `transformResult` to `FirWhenBranch` (4 days ago) <Dmitriy Novozhilov>
* a022f857768 - [FIR] Minor. Add `@BaseTransformedType` to `FirWhenBranch` (4 days ago) <Dmitriy Novozhilov>
* f877fe40b3b - [FIR] Fix expected type in invoke completion (4 days ago) <Dmitriy Novozhilov>
* 57a2665b005 - [FIR] Update tests for previous commit (4 days ago) <Dmitriy Novozhilov>
* e48959350cb - [FIR] Infer type of when expressions and try expressions like it is function call (4 days ago) <Dmitriy Novozhilov>
* 741ff958e82 - [FIR] Add util function for extracting return arguments from block (4 days ago) <Dmitriy Novozhilov>
* fe3824d7961 - [FIR] Introduce `FirResolvable` (4 days ago) <Dmitriy Novozhilov>
* beeba23cf04 - [FIR] Minor. Wrap `withScopeCleanup` with try-finally (4 days ago) <Dmitriy Novozhilov>
* e944119f71e - [FIR] Don't use implicit type as expected type of anonymous function (4 days ago) <Dmitriy Novozhilov>
* 78613962463 - [FIR] Add util function for creating functional cone type (4 days ago) <Dmitriy Novozhilov>
* 637fb55a7bf - [FIR] Add implementation of intersection types to Fir type system (4 days ago) <Dmitriy Novozhilov>
* 1708a34eb82 - [FIR] Fix incorrect findCommonIntegerLiteralTypesSuperType dummy implementation (4 days ago) <Dmitriy Novozhilov>
* e6bf3b32635 - [FIR] Render nullability in type renderer, not in fir renderer (4 days ago) <Dmitriy Novozhilov>
* 3e44bc805fe - [FIR] Return error type from common super type if it present (4 days ago) <Dmitriy Novozhilov>
* 6e2958880bd - [FIR] Add forgotten replacing arguments in abbreviated type expansion (4 days ago) <Dmitriy Novozhilov>
* 317e3edba83 - [FIR] Add default upper bound to type parameter in fir deserializer (4 days ago) <Dmitriy Novozhilov>
* 2fe01f9086e - (tag: build-1.3.60-dev-1358) Refactor publishing plugin to lazy tasks API (5 days ago) <Ilya Chernikov>
* 315a9d66a0a - Refactor more tasks to lazy API (5 days ago) <Ilya Chernikov>
* 2ed8fa7624c - Convert main task creating helper to lazy API, refactor accordingly (5 days ago) <Ilya Chernikov>
* 0f41dc814f9 - Switch many common tasks defined in buildSrc to lazy creation (5 days ago) <Ilya Chernikov>
* f74c4fa5380 - Switch all common tasks in the root build script to lazy creation (5 days ago) <Ilya Chernikov>
* 5208318f344 - Fix dependency resolution during gradle project configuration (5 days ago) <Ilya Chernikov>
* 50e758cbb7c - (tag: build-1.3.60-dev-1355) Remove the `@Inclubating` annotation from UnstableApiUsage inspection (5 days ago) <Sergey Igushkin>
* ffd0b438daa - Don't create the Kapt generate stubs output dir in lazy initializer (5 days ago) <Sergey Igushkin>
* cbb8bf2debb - Extract members from Kotlin tasks, don't iterate over them (KT-31713) (5 days ago) <Sergey Igushkin>
* 80fa591f107 - (tag: build-1.3.60-dev-1345) Fix failing test because of slightly different diagnostics for LV=1.2 (5 days ago) <Mikhail Zarechenskiy>
* 5e3a11db8e2 - (tag: build-1.3.60-dev-1327, origin/rr/4u7/publishing-fixes-before) JVM IR: remove property accessor name hack in InterfaceDelegationLowering (5 days ago) <Alexander Udalov>
* 14a6a06166f - JVM IR: do not use GenerationState.typeMapper (5 days ago) <Alexander Udalov>
* f64afbf1525 - JVM IR: reduce usages of IrTypeMapper.kotlinTypeMapper (5 days ago) <Alexander Udalov>
* 0c6ab69b52c - JVM IR: do not use descriptors in IrTypeMapper.writeFormalTypeParameters (5 days ago) <Alexander Udalov>
* 598c6009f24 - JVM IR: extract method signature mapping to MethodSignatureMapper (5 days ago) <Alexander Udalov>
* 6191fc10f0e - JVM IR: introduce IrCallableMethod as a simpler replacement for CallableMethod (5 days ago) <Alexander Udalov>
* 69697172019 - (tag: build-1.3.60-dev-1315) Fix performanceTests compilation errors (5 days ago) <Vladimir Dolzhenko>
* d1cbee44f1a - (tag: build-1.3.60-dev-1309, origin/spec-tests) Move refactoring: suggest file name starting with an uppercase letter (6 days ago) <Burak Eregar>
* 8219d9853c4 - (tag: build-1.3.60-dev-1304) Implement configuration for describing only published runtime dependencies... (6 days ago) <Ilya Chernikov>
* 3d3e86b5fad - (tag: build-1.3.60-dev-1290) Added gradle.kts and annotator gradle.kts autocompletion performance benchmark (6 days ago) <Vladimir Dolzhenko>
* 7c4ed9c29e8 - (tag: build-1.3.60-dev-1286) JVM IR: remove unused code, minor cleanup (6 days ago) <Alexander Udalov>
* 23e79bb32ba - (tag: build-1.3.60-dev-1275) ScriptDefinitionsManager: `safeGetDefinitions` shouldn't catch `ControlFlowException` #EA-210332 Fixed (6 days ago) <Dmitry Gridin>
* ef4bac1b46a - REPL: fix `IllegalArgumentException` Reproduce: select `Pause Output` #EA-209571 Fixed #EA-210364 Fixed #KT-33329 Fixed (6 days ago) <Dmitry Gridin>
* f81fb40164f - HistoryUpdater: cleanup code (6 days ago) <Dmitry Gridin>
* df438377e80 - ReplOutputProcessor: cleanup code (6 days ago) <Dmitry Gridin>
* ab4001a6980 - KotlinCopyPasteReferenceProcessor: fix KNPE #EA-210304 Fixed (6 days ago) <Dmitry Gridin>
* 693f42f33e5 - KotlinCopyPasteReferenceProcessor: cleanup code (6 days ago) <Dmitry Gridin>
* bd5476082bc - extractionModel: cleanup code (6 days ago) <Dmitry Gridin>
* fcff9a43b44 - extractionModel: fix NPE #EA-210243 Fixed (6 days ago) <Dmitry Gridin>
* f87e86d4b31 - CallableBuilder: fix exception #EA-134361 Fixed (6 days ago) <Dmitry Gridin>
* 76b97c38478 - CallableBuilder: cleanup code (6 days ago) <Dmitry Gridin>
* 2b907359908 - generateUtil: fix PIEAE #EA-209598 Fixed #EA-142347 Fixed (6 days ago) <Dmitry Gridin>
* b570f99aae3 - generateUtil: cleanup code (6 days ago) <Dmitry Gridin>
* cf3b92d80e0 - CreateTypeParameterFromUsageFix: fix KNPE for type alias #KT-33302 Fixed #EA-120181 Fixed (6 days ago) <Dmitry Gridin>
* 932765744a9 - CreateTypeParameterFromUsageFix: cleanup code (6 days ago) <Dmitry Gridin>
* 8d2ccb7bcd5 - (tag: build-1.3.60-dev-1268) [IR] Taught inliner to work with inline suspend lambdas (6 days ago) <Igor Chevdar>
* 7ff700ff976 - (tag: build-1.3.60-dev-1260) JVM_IR: lower calls to @JvmStatic functions from other files. (6 days ago) <pyos>
* 24adc09e2d6 - (tag: build-1.3.60-dev-1256) J2K: Change old/new J2K switch checkbox text from "Use New J2K" to "Use New Java to Kotlin Converter" (6 days ago) <Ilya Kirillov>
* ad43bc23ea4 - (tag: build-1.3.60-dev-1244) Minor, add test case on SAM conversion over smart cast (7 days ago) <Alexander Udalov>
* dd0e296af17 - (tag: build-1.3.60-dev-1241) Use KotlinExceptionWithAttachments for ToFromOriginalFileMapper and MainFunctionDetector (7 days ago) <Vladimir Dolzhenko>
* fa29297fb17 - (tag: build-1.3.60-dev-1235) Introduce workaround for back-end exception in the test cases parser code (7 days ago) <victor.petukhov>
* 9487d291da2 - Fail spec box tests if they have `unexpected behaviour` and passed (7 days ago) <victor.petukhov>
* d8e5b068d56 - Relinking spec tests (7 days ago) <victor.petukhov>
* 8465d690f1c - Add spec tests for 'Type system' (introduction and 'kotlin.Any' type) (7 days ago) <victor.petukhov>
* f78faeaa3c6 - Add test for consistency check between the Kotlin specification and spec tests (7 days ago) <victor.petukhov>
* 4f73e100d03 - Add task to generate tests json map (is used for tool 'spec-tests-relinking recommender') (7 days ago) <victor.petukhov>
* 0e439263ce7 - Group spec tests and accompanying functionality into to packages: org.jetbrains.kotlin.spec (tests only) and org.jetbrains.kotlin.spec.utils (accompanying functionality) (7 days ago) <victor.petukhov>
* cf692fb2573 - Implement tests map generator and refactor folder structure to spec tests linking (7 days ago) <victor.petukhov>
* 28da325a113 - Actualize DFA spec tests (7 days ago) <victor.petukhov>
* c43df559653 - (tag: build-1.3.60-dev-1228) Type parameters are placed before the name of the function (7 days ago) <SatoShun>
* 9c861a111f9 - Fix move refactoring conflict window output (7 days ago) <Igor Yakovlev>
* ae3f36ebde7 - Change ExtractDeclarationFromCurrentFileIntention applicability range (7 days ago) <Igor Yakovlev>