### PR TITLE
[kotlin compiler][update] 1.3.60-dev-1666

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,10 @@
 buildKotlinVersion=1.3.60-dev-1210
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1448,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-1448
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1448,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.60-dev-1448
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1666,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-1666
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1666,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-1666
 testKotlinCompilerVersion=1.3.60-dev-1210
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
* 63892891db9 - (tag: build-1.3.60-dev-1666) Add internal move refactoring testing action (4 days ago) <Igor Yakovlev>
* 3951fde0813 - Save 'Search for references' checkbox state on move of kotlin file (4 days ago) <Igor Yakovlev>
* eca2707dbf5 - Refactor of Move Refactoring (4 days ago) <Igor Yakovlev>
* d6c5fbace02 - (tag: build-1.3.60-dev-1658) [IR][inliner] prevent of parameters location information loss (4 days ago) <Vasily Levchenko>
* a2fcefd4567 - (tag: build-1.3.60-dev-1655) Added fallback for LightClasses getOwnFields, getOwnMethods if dummy resolve failed (KT-27243, KT-33561) (4 days ago) <Vladimir Dolzhenko>
* 78b0d5750bb - (tag: build-1.3.60-dev-1622) New J2K: consider literal expressions in data class conversion & fix names conflict (4 days ago) <Ilya Kirillov>
* 405a3beeab8 - New J2K: move helper functions to corresponding files & use better names for tree nodes files (4 days ago) <Ilya Kirillov>
* 64ecbd1418d - New J2K: use internal getStrictParentOfType instead of custom one (4 days ago) <Ilya Kirillov>
* 2f5fa49c52c - New J2K: remove unused abstractions for conversions running (4 days ago) <Ilya Kirillov>
* 131df660878 - New J2K: check if method reference has functional type on PsiType instead of JKType (4 days ago) <Ilya Kirillov>
* ca0cc130976 - New J2K: retrieve constructor call return type correctly (4 days ago) <Ilya Kirillov>
* 982e7fdd86b - New J2K: do not shorten class references for some Java primitive class wrappers classes (4 days ago) <Ilya Kirillov>
* fd2ad897997 - (tag: build-1.3.60-dev-1613) JVM IR: Write ACC_DEPRECATED flags (5 days ago) <Steven Schäfer>
* a90ac2438d2 - Set correct field visibility in psi2ir (5 days ago) <Steven Schäfer>
* 6c7a9046630 - (tag: build-1.3.60-dev-1612) Psi2Ir: Mark accessors with no bodies as default accessors. (5 days ago) <Mads Ager>
* fda37eaaaed - (tag: build-1.3.60-dev-1605) [minor] Rearrange test utils for easier reuse (5 days ago) <Ilya Chernikov>
* 947867286cb - [minor] Fix potential problems with sequence, add a todo (5 days ago) <Ilya Chernikov>
* c9b25cad01a - Fix classpath handling when evaluating legacy scripts from kotlinc (5 days ago) <Ilya Chernikov>
* 31c56d7794e - Set java.class.path property in runner and loader (5 days ago) <Ilya Chernikov>
* 08720a3dc6b - Set thread context classloader in the kotlin runner (5 days ago) <Ilya Chernikov>
* d3f32c0d8a1 - Set thread context classloader in preloader (5 days ago) <Ilya Chernikov>
* 7b2f39530a1 - Fix invalid testdata for ConvertToScopeIntention applicability (5 days ago) <Igor Yakovlev>
* cf39803074a - (tag: build-1.3.60-dev-1592) Pass cacheRedirectorEnabled flag to performance test gradle import (5 days ago) <Vyacheslav Gerasimov>
* b04fbbd43ba - Fix `testUnusedSymbol_class_inspectionData_Inspections_test` test (5 days ago) <Dmitry Gridin>
* 1e72116a9c6 - (tag: build-1.3.60-dev-1576) Fix test data for intention tests (5 days ago) <Igor Yakovlev>
* 55f46109261 - (tag: build-1.3.60-dev-1575) Tests: fix `invalidBundleOrProperty` test for 183 #KT-32860 Fixed (5 days ago) <Dmitry Gridin>
* d4e4a4c3e7c - (tag: build-1.3.60-dev-1562) To ordinary string literal: remove 'trimIndent()' if string is single line (6 days ago) <Toshiaki Kameyama>
* fbe66c3496d - (tag: build-1.3.60-dev-1558) JVM IR: fix another naming inconsistency with old backend (6 days ago) <Alexander Udalov>
* fec8dbf6df9 - JVM IR: do not use AsmUtil.putJavaLangClassInstance (6 days ago) <Alexander Udalov>
* 23eb6daae9b - JVM IR: remove MethodSignatureMapper.mapImplementationOwner (6 days ago) <Alexander Udalov>
* aea9642ea04 - JVM IR: implement MethodSignatureMapper.mapToCallableMethod directly (6 days ago) <Alexander Udalov>
* e0823e20c78 - JVM IR: do not use AsmUtil.genToString (6 days ago) <Alexander Udalov>
* bf40b724516 - JVM IR: remove unneeded usages of MethodSignatureMapper.mapToCallableMethod (6 days ago) <Alexander Udalov>
* 0f1a15daf13 - JVM IR: add lowering to remove calls to KFunction{n}.invoke (6 days ago) <Alexander Udalov>
* 2b4424b5648 - JVM IR: replace function accesses in multi-file parts (6 days ago) <Alexander Udalov>
* 21b2487290f - (tag: build-1.3.60-dev-1549) Minor: add an additional message for further investigation EA-141821 (6 days ago) <Zalim Bashorov>
* b78ba71224b - (tag: build-1.3.60-dev-1542) [FIR] Set mem-limit 8g (6 days ago) <Simon Ogorodnik>
* 6a9fb469859 - [FIR] Make fir modularized test depends on dist (6 days ago) <Simon Ogorodnik>
* 5ef4a01a457 - [FIR] Fix module qualified names (6 days ago) <Simon Ogorodnik>
* 9338a3c086f - [FIR] Filter out common modules (6 days ago) <Simon Ogorodnik>
* b99d9e0e0b2 - [FIR] Disambiguate module names (6 days ago) <Simon Ogorodnik>
* 95303895837 - [FIR] Group multiple pass logs into one (6 days ago) <Simon Ogorodnik>
* 4c246faddb8 - [FIR] Fix redeclaration (6 days ago) <Simon Ogorodnik>
* 8c31a0be079 - [FIR] Add filter param (6 days ago) <Simon Ogorodnik>
* 2ca1e5c8c78 - [FIR] Pass properties to test (6 days ago) <Simon Ogorodnik>
* 96627fc1aec - [FIR] Add parameters to modularized tests (6 days ago) <Simon Ogorodnik>
* e9b2e74b15a - (tag: build-1.3.60-dev-1528) escapeXML: fix bunch for 183 (6 days ago) <Dmitry Gridin>
* ea02d0c6323 - (tag: build-1.3.60-dev-1525) ExpectActualUtils: `repairSuperTypeList` should consider type parameters (6 days ago) <Dmitry Gridin>
* 03141be11ed - ExpectActualUtils: update `repairAnnotationEntries` for more cases with annotations (6 days ago) <Dmitry Gridin>
* ba0ba3422dd - CreateExpectedFix: rename `isCorrectAndHaveNonPrivate` to `isCorrectAndHaveNonPrivateModifier` (6 days ago) <Dmitry Gridin>
* 3c6da0bfe68 - TypeAccessibilityChecker: rename `existingFqNames` to `existingTypeNames` and add comments (6 days ago) <Dmitry Gridin>
* 531f695404e - CreateExpectedFix: remove recursive call from `findAndApplyExistingClasses` (6 days ago) <Dmitry Gridin>
* 35d64f85f84 - TypeAccessibilityCheckerImpl: `explicitParameters` change return type to `Sequence` (6 days ago) <Dmitry Gridin>
* aa135bc5050 - TypeAccessibilityCheckerImpl: move visibility check for `KtNamedDeclaration` to outside (6 days ago) <Dmitry Gridin>
* eaa28fd4ede - CreateExpect: fix build for a33 (6 days ago) <Dmitry Gridin>
* 27d7ee85180 - TypeAccessibilityChecker: move to idea-analysis module (6 days ago) <Dmitry Gridin>
* 56a74456603 - CreateExpect: should prefer type aliases #KT-32571 Fixed (6 days ago) <Dmitry Gridin>
* 5928a36fa27 - CreateExpect: should save receiver annotations #KT-32694 Fixed (6 days ago) <Dmitry Gridin>
* 42ef9d634a2 - ExpectActualUtils: merge generateFunction with generateProperty to generateCallable & remove old checker (6 days ago) <Dmitry Gridin>
* 90b82c96ebf - TypeAccessibilityChecker: fix `incorrectTypes` for descriptor (6 days ago) <Dmitry Gridin>
* 1c98cb763e9 - addRemoveModifier: shouldn't add extra new line #KT-26635 Fixed (6 days ago) <Dmitry Gridin>
* 0458a22f783 - TypeAccessibilityChecker: fix case with unresolved type params (6 days ago) <Dmitry Gridin>
* 4ed56908af8 - CreateExpect: add `actual` modifier to original class if needed (6 days ago) <Dmitry Gridin>
* 73ae993d81a - TypeAccessibilityChecker: add more tests (6 days ago) <Dmitry Gridin>
* 84d167b7bdc - TypeAccessibilityChecker: add logs for tests (6 days ago) <Dmitry Gridin>
* 7c850e44d27 - CreateExpectedFix: add escaping for error text (6 days ago) <Dmitry Gridin>
* 3617f3d2479 - TypeAccessibilityChecker: fix callable with upper bound (6 days ago) <Dmitry Gridin>
* 46fefde09c2 - ExpectActualUtils: introduce TypeAccessibilityChecker #KT-28537 Fixed #KT-28538 Fixed #KT-28549 Fixed #KT-28620 Fixed #KT-31433 Fixed #KT-31475 Fixed #KT-32642 Fixed #KT-32768 Fixed #KT-33150 Fixed (6 days ago) <Dmitry Gridin>
* d1b33485a42 - ExpectActualUtils: rename checkTypeInSequence to incorrectTypesInSequence & change return type (6 days ago) <Dmitry Gridin>
* 18f0bbe8f19 - QuickFixMultiModule: change tests structure (6 days ago) <Dmitry Gridin>
* 02fd137cec0 - SimpleTestClassModel: add `deep` field (6 days ago) <Dmitry Gridin>
* 65ce4aed1a9 - TestGenerationDSL: cleanup code (6 days ago) <Dmitry Gridin>
* bddf768d591 - CreateExpect: fix case with parameters in constructor without var/val (6 days ago) <Dmitry Gridin>
* 1b718761b28 - AbstractQuickFixMultiModuleTest: support multiline errors `SHOULD_FAIL_WITH` (6 days ago) <Dmitry Gridin>
* 3f7c983f043 - CreateExpectFix: fix selection for primary constructor (6 days ago) <Dmitry Gridin>
* 4a049b9b012 - GenerateTests: cleanup code (6 days ago) <Dmitry Gridin>
* 1748906d9a1 - ExpectActualUtils: should add annotations (6 days ago) <Dmitry Gridin>
* 5e60ea22723 - ExpectActualUtils: should remove `override` (6 days ago) <Dmitry Gridin>
* 75619056769 - ExpectActualUtils: add type accessibility check for supertypes (6 days ago) <Dmitry Gridin>
* 8e9952e203b - multiplatformUtil: implement Module.toDescriptor() (6 days ago) <Dmitry Gridin>
* 755f7e8739e - elementRenderingUtils: override visitor for KtTypeReference, KtParameterList, KtParameter (6 days ago) <Dmitry Gridin>
* c17e19b0043 - elementRenderingUtils: cleanup code (6 days ago) <Dmitry Gridin>
* 2b32c9d2f95 - ExpectActualUtils: add type arguments accessibility check for constructors (6 days ago) <Dmitry Gridin>
* e59571c4826 - ExpectActualUtils: add type arguments accessibility check for top level classes (6 days ago) <Dmitry Gridin>
* bad9459978d - ExpectActualUtils: add type arguments accessibility check (6 days ago) <Dmitry Gridin>
* 5884c658579 - ExpectActualUtils: add type accessibility check (6 days ago) <Dmitry Gridin>
* dffb44c11c6 - Create actual/expect quick fix should render super type correctly (6 days ago) <Dmitry Gridin>
* a21375508d7 - ExpectActualUtils: drop `missedDeclarations` parameter from `generateClassOrObject` function (6 days ago) <Dmitry Gridin>
* 22f8b9f475b - (tag: build-1.3.60-dev-1518) Remove codegen tests on inline classes based on type parameters (6 days ago) <Alexander Udalov>
* 6bf16a96e12 - (tag: build-1.3.60-dev-1515) Add more tests for type operators on the jvm (6 days ago) <Steven Schäfer>
* b6ea135e704 - Add a TypeOperatorLowering for JVM_IR (6 days ago) <Steven Schäfer>
* 39ba4625400 - (tag: build-1.3.60-dev-1508, tag: build-1.3.60-dev-1502) JVM IR: remove unneeded part of a hack for inlining $default methods (7 days ago) <Alexander Udalov>
* 34400add227 - Minor, add IrCallableMethod.toString (7 days ago) <Alexander Udalov>
* dd74794f972 - Minor, add message to exception thrown in parentAsClass (7 days ago) <Alexander Udalov>
* a3c3ab08fdc - (tag: build-1.3.60-dev-1468) Override/Implement members: place members in the same order as super class members (7 days ago) <Toshiaki Kameyama>