### PR TITLE
Add Throwable.getStackTraceAddresses() 

### DIFF
--- a/runtime/src/main/kotlin/kotlin/Throwable.kt
+++ b/runtime/src/main/kotlin/kotlin/Throwable.kt
@@ -5,6 +5,7 @@
 
 package kotlin
 
+import kotlin.native.concurrent.freeze
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.internal.ExportTypeInfo
 import kotlin.native.internal.NativePtrArray
@@ -28,7 +29,7 @@ public open class Throwable(open val message: String?, open val cause: Throwable
     private val stackTrace = getCurrentStackTrace()
 
     private val stackTraceStrings: Array<String> by lazy {
-        getStackTraceStrings(stackTrace)
+        getStackTraceStrings(stackTrace).freeze()
     }
 
     public fun getStackTrace(): Array<String> = stackTraceStrings

--- a/runtime/src/main/kotlin/kotlin/Throwable.kt
+++ b/runtime/src/main/kotlin/kotlin/Throwable.kt
@@ -34,6 +34,9 @@ public open class Throwable(open val message: String?, open val cause: Throwable
 
     public fun getStackTrace(): Array<String> = stackTraceStrings
 
+    internal fun Throwable.getStackTraceAddressesInternal(): List<Long> =
+            (0 until stackTrace.size).map { index -> stackTrace[index].toLong() }
+
     public fun printStackTrace(): Unit = dumpStackTrace { println(it) }
 
     internal fun dumpStackTrace(): String = buildString {

--- a/runtime/src/main/kotlin/kotlin/native/ThrowableExtensions.kt
+++ b/runtime/src/main/kotlin/kotlin/native/ThrowableExtensions.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+package kotlin.native
+
+public fun Throwable.getStackTraceAddresses(): List<Long> =
+        this.getStackTraceAddressesInternal()

--- a/runtime/src/main/kotlin/kotlin/native/internal/NativePtr.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/NativePtr.kt
@@ -52,6 +52,9 @@ internal class NativePtrArray {
     @SymbolName("Kotlin_NativePtrArray_set")
     external public operator fun set(index: Int, value: NativePtr): Unit
 
+    val size: Int
+        get() = getArrayLength()
+
     @SymbolName("Kotlin_NativePtrArray_getArrayLength")
     external private fun getArrayLength(): Int
 }


### PR DESCRIPTION
To allow integration with third-party crash analytic tools.

Also fix Throwable.getStackTrace() implementation.