### PR TITLE
Interop: Use package name in wrapper names

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGeneratorImpl.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/SimpleBridgeGeneratorImpl.kt
@@ -248,6 +248,6 @@ class SimpleBridgeGeneratorImpl(
     }
 
     companion object {
-        private val INVALID_CLANG_IDENTIFIER_REGEX = "[^a-zA-Z1-9_]".toRegex()
+        internal val INVALID_CLANG_IDENTIFIER_REGEX = "[^a-zA-Z1-9_]".toRegex()
     }
 }


### PR DESCRIPTION
Linking two interop libraries containing the same declaration
causes a 'symbol multiply defined' error. This patch fixes it
by using FQ-names for wrapper functions.