### PR TITLE
[kotlin compiler][update] 1.3.60-dev-2011

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,10 @@
 buildKotlinVersion=1.3.60-dev-1210
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1867,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-1867
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1867,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.60-dev-1867
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2011,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-2011
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2011,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-2011
 testKotlinCompilerVersion=1.3.60-dev-1210
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
* e7d09099791 - (HEAD -> master, origin/master, origin/HEAD) JVM_IR: Fix null-constant comparison with primitive types. (2 hours ago) <Kristoffer Andersen>
* e21da3a61a5 - Avoid resolving array-set method several times (3 hours ago) <Mikhail Zarechenskiy>
* f8449bf15a8 - [NI] Clear partially resolved calls after resolve of top-level call (3 hours ago) <Mikhail Zarechenskiy>
* f305475e3f0 - Make "nothing to inline" diagnostic shorter (3 hours ago) <Mikhail Zarechenskiy>
* dc25f7b7ace - [NI] Minor, remove unneeded computation of constant evaluator (3 hours ago) <Mikhail Zarechenskiy>
* 3569eaabcf8 - Rename FirJavaElementFinder.kt.as34 to FirJavaElementFinder.kt.183 (3 hours ago) <Denis Zharkov>
* 62a1ea643ab - (tag: build-1.3.60-dev-1981) Add additional tests for bound receivers in callable references (3 days ago) <Steven Schäfer>
* d89d68e3df9 - JVM IR: Cache SAM wrappers in top-level classes and use proper naming scheme (3 days ago) <Steven Schäfer>
* 2be4abe9a66 - Refactoring: Consistently use Symbols in JvmSymbols (3 days ago) <Steven Schäfer>
* c77fa1ecd60 - JVM IR: Fixes in SAM lowering (3 days ago) <Steven Schäfer>
* 829102b3e3e - (tag: build-1.3.60-dev-1980, tag: build-1.3.60-dev-1973) FIR: Fix exception in inference (3 days ago) <Denis Zharkov>
* 8c52ff31b3e - Add bunch for AS34: FirJavaElementFinder (3 days ago) <Denis Zharkov>
* 3f0887dc0c5 - FIR: Do not try building light classes for invalid names (3 days ago) <Denis Zharkov>
* 106b6c901dd - FIR: Get rid of FirRegularClass::setCallbackOnSupertypesComputed (3 days ago) <Denis Zharkov>
* 122c229a8b0 - FIR: Add possibility to run SupertypeResolverTransformer ad-hoc (3 days ago) <Denis Zharkov>
* d9d6c38c2bd - FIR: Introduce FirClassLikeDeclaration::supertypesComputationStatus (3 days ago) <Denis Zharkov>
* 6058f9d2864 - FIR: Avoid recursions while building Java enhancement scopes (3 days ago) <Denis Zharkov>
* 7f5c4d90fd7 - FIR: make "collectSuperTypes" recursion-resistant (3 days ago) <Denis Zharkov>
* 1f23184db99 - FIR: Get rid of code duplication in SupertypesUtils.kt (3 days ago) <Denis Zharkov>
* bf610323cfb - Support basic light-classes basic with FIR for CLI (3 days ago) <Denis Zharkov>
* e7410348a76 - (tag: build-1.3.60-dev-1971) JVM IR: Fix visibility for @InlineOnly functions (3 days ago) <Steven Schäfer>
* ee45933e330 - JVM IR: Create local classes in PropertyReferenceLowering (3 days ago) <Steven Schäfer>
* 626f4c94f60 - Handle special case visibility rules in LocalDeclarationsLowering (3 days ago) <Steven Schäfer>
* 9a938b07ba9 - (tag: build-1.3.60-dev-1967) KT-17689: Fix `TypeAliasQualifier` to provide enum entries descriptors (3 days ago) <Roman Golyshev>
* f419d2eb30e - (tag: build-1.3.60-dev-1965) KT-33585: Add synchronization between scratch editor and preview (3 days ago) <Roman Golyshev>
* d12d9d86bc9 - KT-33585: Refactor `KtsScratchFileEditorWithPreview` and its output handlers (3 days ago) <Roman Golyshev>
* edb700b898d - (tag: build-1.3.60-dev-1962) Switch to 192 platform (3 days ago) <Nikolay Krasko>
* 650a6e5cc4c - (tag: build-1.3.60-dev-1961) MakeOverriddenMemberOpenFix: should update actual members #KT-32586 Fixed (3 days ago) <Dmitry Gridin>
* 58d303afcc1 - MakeOverriddenMemberOpenFix: cleanup code (3 days ago) <Dmitry Gridin>
* 3f451d7eafd - (tag: build-1.3.60-dev-1959) Switch off SAM adapter conversion for constructors in completion (3 days ago) <Natalia Selezneva>
* f7b8c7f76ed - Check that project isn't disposed showing notification for scripts (3 days ago) <Natalia Selezneva>
* fb01f7be5ed - Rename ScriptDependenciesManager to ScriptConfigurationManager (3 days ago) <Natalia Selezneva>
* fa6b5b567b1 - Fix org.jetbrains.kotlin.idea.script.ScriptConfigurationHighlightingTestGenerated.Highlighting.testThrowingResolver (3 days ago) <Natalia Selezneva>
* 961e8c2c74c - Refactor the mechanism how script configurations are updated (3 days ago) <Natalia Selezneva>
* dc46f73ecf8 - Rewrite scripting related API to PsiFile instead of VirtualFile (3 days ago) <Natalia Selezneva>
* 5b48dcca4f3 - ResultWithDiagnostics: remove unused equals and hashCode (3 days ago) <Sergey Rostov>
* 91f39a0ecf9 - (tag: build-1.3.60-dev-1957) FIR [optimization]: eliminate some unnecessary ScopeSessions (3 days ago) <Mikhail Glukhikh>
* 7ede26e8f45 - (tag: build-1.3.60-dev-1956) IrCompileKotlinAgainstInlineKotlin tests (3 days ago) <Georgy Bronnikov>
* 0807987ef73 - (tag: build-1.3.60-dev-1951) Update 192 to release version (4 days ago) <Nikolay Krasko>
* 655e77b0dd1 - Update lz4 for 192 in :compiler:incremental-compilation (4 days ago) <Nikolay Krasko>
* 7968ecef1cd - (tag: build-1.3.60-dev-1944, origin/prr/4u7/wip) Initial import of benchmarks from https://github.com/dzharkov/kotlin-compiler-benchmarks (4 days ago) <Ilya Ryzhenkov>
* 1bd5b68b4a4 - Build: Instrument only java tasks for main & test source sets (4 days ago) <Vyacheslav Gerasimov>
* 50eb98194a3 - (tag: build-1.3.60-dev-1940) Build: Move dependencies.properties to the root build directory (4 days ago) <Vyacheslav Gerasimov>
* 20626e4aaf9 - (tag: build-1.3.60-dev-1938) Make ReturnableBlockLowering common (4 days ago) <pyos>
* ae8c93de6a1 - (tag: build-1.3.60-dev-1937) Support symlinked JAVA_HOME (4 days ago) <Sascha Peilicke>
* 98f72e58bd1 - (tag: build-1.3.60-dev-1936) FIR deserializer: use class type parameters in constructor directly (4 days ago) <Mikhail Glukhikh>
* 6a7ebe89289 - FIR substitution: do not create fake overrides if types aren't changed (4 days ago) <Mikhail Glukhikh>
* 5386cfe2545 - FIR2IR: support fake overridden properties (4 days ago) <Mikhail Glukhikh>
* 687db20029b - FIR: support fake overrides for properties (4 days ago) <Mikhail Glukhikh>
* 5741ff5d86e - FIR: split default importing scopes into low/high priority ones (4 days ago) <Mikhail Glukhikh>
* 044dfd14cec - FIR: more accurate type checking in typeFromCallee (4 days ago) <Mikhail Glukhikh>
* c27ed0cfd34 - (tag: build-1.3.60-dev-1926) Update ReadMe for gradle-plugin-integration-tests (4 days ago) <Ilya Goncharov>
* 5deaca9ace8 - Fix building tests for fir:lightTree in 192 branch (4 days ago) <Nikolay Krasko>
* 7bdde7cad34 - Disable HierarchicalMultiplatformProjectImportingTest in Android Studio (KT-33067) (4 days ago) <Nikolay Krasko>
* 48d666daea5 - (tag: build-1.3.60-dev-1923) Make platforms order reproducible in iml-files (4 days ago) <Andrey Uskov>
* a843c23f205 - (tag: build-1.3.60-dev-1921) Completion: add root prefix support #KT-10340 Fixed (4 days ago) <Dmitry Gridin>
* 7a4c3e4d6a7 - BaseDeclarationInsertHandler: fix `startOffset` (4 days ago) <Dmitry Gridin>
* c4a11016002 - KtSimpleNameReference: add root prefix support to `bindToFqName` function (4 days ago) <Dmitry Gridin>
* 2e781a7a270 - KtSimpleNameReference: cleanup code (4 days ago) <Dmitry Gridin>
* dd2bd320ba1 - ShortenReferences: add root prefix support #KT-9204 Fixed (4 days ago) <Dmitry Gridin>
* 0c81173b71d - idea-core.Utils: add extension to `FqName` to support root prefix (4 days ago) <Dmitry Gridin>
* 953aaadee1c - idea-core.Utils: cleanup code (4 days ago) <Dmitry Gridin>
* 14ad6284d9d - QualifiedExpressionResolver: add root prefix resolve for IDE analysis (4 days ago) <Dmitry Gridin>
* 68d20dae669 - QualifierExpressionResolver: cleanup code (4 days ago) <Dmitry Gridin>
* 4224d109e2f - AnalysisFlags: add flag `ideMode` for IDE specific analysis (4 days ago) <Dmitry Gridin>
* 106452b5f0b - (tag: build-1.3.60-dev-1919) Add list of modules available via dependsOn in FacetSettings (4 days ago) <Andrey Uskov>
* 4642127c282 - Introduce versioning of multiplatform in KotlinFacetSettings (4 days ago) <Andrey Uskov>
* 75f9532959b - (tag: build-1.3.60-dev-1914) [IR] Avoid duplicate IR elements in for loops lowering. (4 days ago) <Mads Ager>
* 4ce6a54236f - (tag: build-1.3.60-dev-1907) YarnSetupTask: Fix setup() to be a Gradle TaskAction (4 days ago) <Sebastian Schuberth>
* 0040298eac5 - (tag: build-1.3.60-dev-1889, origin/rr/romart/fix_master) Fix master  - improve assertion message  - compare correct file paths  - fix C JS BE testData (5 days ago) <Roman Artemev>