### PR TITLE
[kotlin compiler][update] 1.3.60-dev-2038

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,10 @@
 buildKotlinVersion=1.3.60-dev-1210
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2011,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-2011
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2011,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.60-dev-2011
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2038,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-2038
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2038,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-2038
 testKotlinCompilerVersion=1.3.60-dev-1210
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
* 89d49479aba - (tag: build-1.3.60-dev-2038) [util-io][properties] close file stream after save property operation ends. (15 hours ago) <Vasily Levchenko>
* cc40387788f - (tag: build-1.3.60-dev-2030) YarnSetupTask: Remove a too coarse "onlyIf" in the "init" block (20 hours ago) <Sebastian Schuberth>
* 85ff979bd40 - (tag: build-1.3.60-dev-2023) Use `PARTIAL` mode in analyzer to provide lambda return value hints (21 hours ago) <Mikhail Zarechenskiy>
* d253cd50321 - (tag: build-1.3.60-dev-2018) Ignore external annotations in AbstractResolveByStubTest (KT-33732) (22 hours ago) <Nikolay Krasko>
* 80b5c76d98c - Minor: fix warnings in AbstractResolveByStubTest (22 hours ago) <Nikolay Krasko>