### PR TITLE
[kotlin compiler][update] 1.3.60-dev-2180

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,10 @@
 buildKotlinVersion=1.3.60-dev-1210
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2066,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-2066
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2066,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.60-dev-2066
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2180,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-2180
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2180,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-2180
 testKotlinCompilerVersion=1.3.60-dev-1210
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
* 7cae9214d77 - (tag: build-1.3.60-dev-2180) Disable endorsed libraries in plugin (#2536) (4 hours ago) <LepilkinaElena>
* 3120eff6f55 - Update K/N: 1.3.60-dev-12266 (5 hours ago) <Ilya Matveev>
* 45a413c8924 - Gradle, native: Minor fixes (5 hours ago) <Ilya Matveev>
* 60ae03f08b9 - Gradle, native: Don't use deprecated DefaultTask.newOutputFile() (5 hours ago) <Ilya Matveev>
* dda25875d4e - Gradle, native: Use language settings when link from sources (5 hours ago) <Ilya Matveev>
* 57635f7ba38 - Update Kotlin/Native: 1.3.60-dev-12104 (5 hours ago) <Ilya Matveev>
* 7122a9d8197 - Gradle, native: Propagate compilation free args to link tasks (5 hours ago) <Ilya Matveev>
* 20332ae231e - Gradle, native: Pass --progressive to both compile and link tasks (5 hours ago) <Ilya Matveev>
* 90358dee556 - Gradle, native: Allow user to force old behaviour of link tasks (5 hours ago) <Ilya Matveev>
* f07e0594e28 - Gradle, native: Report passing binary-specific args to compilation (5 hours ago) <Ilya Matveev>
* 8d495c4b451 - Gradle, native: Produce binaries from klibs and bump K/N version (5 hours ago) <Ilya Matveev>
* 3a935402a46 - Gradle: Deprecate native extraOpts method in favor of common API (5 hours ago) <Ilya Matveev>
* f01420332f4 - (tag: build-1.3.60-dev-2170) Avoid division in string-to-number conversions (KT-26309) (16 hours ago) <Abduqodiri Qurbonzoda>
* 11f3c4b03f4 - (tag: build-1.3.60-dev-2166) Clarify the error message when File.copyTo fails (KT-27545) (3 days ago) <Abduqodiri Qurbonzoda>
* 27accbb089a - (tag: build-1.3.60-dev-2164) Fix KotlinLintTestGenerated.testParcel +  extensions registrations fixes (3 days ago) <Igor Yakovlev>
* c3265a8bf0c - (tag: build-1.3.60-dev-2150) Decrease Light classes code generation in multithreaded cases by guarding KotlinClassInnerStuffCache, LightClassDataHolder.ForClass cache values calculation with lock (3 days ago) <Vladimir Dolzhenko>
* d3d85d50ab4 - Rewrite KotlinClassInnerStuffCache into Kt, p2 (3 days ago) <Vladimir Dolzhenko>
* 6146b0eb539 - Rewrite KotlinClassInnerStuffCache into Kt, p1 (3 days ago) <Vladimir Dolzhenko>
* b4224854404 - (tag: build-1.3.60-dev-2149) KT-30996: Use the last receiver to complete dsl methods (3 days ago) <Roman Golyshev>
* b2d2ba58112 - (tag: build-1.3.60-dev-2143) Refactor test utils: don't add main-kts to the classpath... (3 days ago) <Ilya Chernikov>
* 49003c98397 - Do not embed script-runtime into main-kts: (3 days ago) <Ilya Chernikov>
* a12ea37ae8e - [minor] Fix non-fatal exception during the embeddable test (3 days ago) <Ilya Chernikov>
* 45f5c42a53d - Add appropriate script extension to the source name, if not provided (3 days ago) <Ilya Chernikov>
* 92778cc5b5a - Set contextClassLoader for the script evaluation (3 days ago) <Ilya Chernikov>
* 939d76fd2ab - Isolate script execution from compiler classloader (3 days ago) <Ilya Chernikov>
* 771f5c13dd4 - Fix imported script functionality in JSR-223/REPL: (3 days ago) <Ilya Chernikov>
* 0fe137d75c7 - Fix script arguments order for imports with implicit receivers (3 days ago) <Ilya Chernikov>
* 8989bfa235f - Fix main-kts jsr223 direct bindings processing (3 days ago) <Ilya Chernikov>
* c5f9e0a3994 - Fix host configuration replacements (3 days ago) <Ilya Chernikov>
* f350c24846d - Implement more general "apply defaults" functionality for host configurations (3 days ago) <Ilya Chernikov>
* e3187217ee7 - (tag: build-1.3.60-dev-2140) Fix executable files for nodejs (3 days ago) <Ilya Goncharov>
* 2fe5feac945 - (tag: build-1.3.60-dev-2138) Remove source map support runtime for webpack (3 days ago) <Ilya Goncharov>
* 8614323f802 - (tag: build-1.3.60-dev-2136) [FIR] Tests. Update some outdated testdata (3 days ago) <Dmitriy Novozhilov>
* b76b4b0229e - [FIR] Pass flow to local functions (3 days ago) <Dmitriy Novozhilov>
* e1947e6884e - [FIR] Don't create synthetic calls for when with only one branch (3 days ago) <Dmitriy Novozhilov>
* 43a873a2ece - [FIR] Make SimpleFlow (old implementation) implement abstract Flow (3 days ago) <Dmitriy Novozhilov>
* 60343c721c6 - [FIR] Make Flow and LogicSystem abstract (3 days ago) <Dmitriy Novozhilov>
* c19da5846c0 - [FIR] Fix processing inPlace lambdas as named arguments (3 days ago) <Dmitriy Novozhilov>
* 3ff185d36ce - [FIR] Dummy fix of lambda functions inside init block (3 days ago) <Dmitriy Novozhilov>
* 0e0e6da9178 - [FIR] Fix passing flow throw loops (3 days ago) <Dmitriy Novozhilov>
* f77a414e93d - [FIR] Fix passing flow throw try expression (3 days ago) <Dmitriy Novozhilov>
* be58e95b2b7 - [FIR] Replace Flow with DelegatingFlow (3 days ago) <Dmitriy Novozhilov>
* 44571fbd8f9 - [FIR] Minor. Extract methods used DataFlowInfo from DataFlowInferenceContext (3 days ago) <Dmitriy Novozhilov>
* 65edf73bee4 - [FIR] Add node for enter to body of when branch (3 days ago) <Dmitriy Novozhilov>
* 531c2b96178 - [FIR] Add supprot of InvocationKind.UNKNOWN for in-place lambdas (3 days ago) <Dmitriy Novozhilov>
* 2f6f07bc7d4 - [FIR] Remove callbacks from stacks in DFA (3 days ago) <Dmitriy Novozhilov>
* beaab19eb95 - [FIR] Replace ControlFlowGraphNodeBuilder with extensions on ControlFlowGraphBuilder (3 days ago) <Dmitriy Novozhilov>
* 15ff86fc507 - [FIR] Refactor DataFlowVariables (3 days ago) <Dmitriy Novozhilov>
* f9d45d2f2a3 - [FIR] Some minor fixes in DFA after review (3 days ago) <Dmitriy Novozhilov>
* 6b7aa21b8f2 - [FIR] Minor. Remove useless creating data flow variables for value parameters (3 days ago) <Dmitriy Novozhilov>
* cb1322eaef6 - [FIR] Add smartcasts on implicit receivers (3 days ago) <Dmitriy Novozhilov>
* f8459f82017 - [FIR] Fix result type of const expressions with expected type (3 days ago) <Dmitriy Novozhilov>
* 546bbceeea7 - [FIR] Reduce coping of flow and inline default value of it (3 days ago) <Dmitriy Novozhilov>
* c2180b9361e - [FIR] Move reporting of errors in modularized tests in separate log file (3 days ago) <Dmitriy Novozhilov>
* 5dc29b90594 - (tag: build-1.3.60-dev-2122) Fix build 183 - add missing functions (4 days ago) <Igor Yakovlev>
* 375920da584 - (tag: build-1.3.60-dev-2121) [FIR] Add gradle property for extending jvmArgs of modularized test (4 days ago) <Simon Ogorodnik>
* 841ed454406 - (tag: build-1.3.60-dev-2120) Fix build 183 - missing imports added (4 days ago) <Igor Yakovlev>
* cb13dd3cdd7 - (tag: build-1.3.60-dev-2112) Add psi2ir tests for 'break' and 'continue' inside 'when' (4 days ago) <Dmitry Petrov>
* f3837e91e30 - Add BE tests for 'break' and 'continue' inside 'when' (4 days ago) <Dmitry Petrov>
* f06f6f4660a - Allow 'break' and 'continue' inside 'when' in 1.4+ (4 days ago) <Dmitry Petrov>
* 55cb9561c26 - (tag: build-1.3.60-dev-2111) Provide better error messages for read-only delegate (4 days ago) <Pavel Kirpichenkov>
* 68bcdaa6c36 - (tag: build-1.3.60-dev-2105) Don't ask for member scope for ILT in `IterableTypesDetection` (4 days ago) <Dmitriy Novozhilov>
* 7472c789c66 - (tag: build-1.3.60-dev-2102) Add tests for obsolete issues (4 days ago) <Mikhail Zarechenskiy>
* 89140be71dd - (tag: build-1.3.60-dev-2098) Minor: better error message (4 days ago) <Natalia Selezneva>
* 6d53636cc9b - Minor: extract classes (4 days ago) <Natalia Selezneva>
* 8f2aaf62c23 - Implement modification stamp for ScriptInitializer (4 days ago) <Natalia Selezneva>
* d6cb857c978 - (tag: build-1.3.60-dev-2097) JVM IR: don't use descriptors to map suspend function types (5 days ago) <Alexander Udalov>
* 34d2d7374ce - Do not use KotlinTypeMapper in enum values/valueOf intrinsic (5 days ago) <Alexander Udalov>
* 8cdec31990e - Do not use KotlinTypeMapper in coroutine inline intrinsics (5 days ago) <Alexander Udalov>
* d16bdded7fb - JVM IR: reuse JVM code for reified type parameter mappings instead of copy-paste (5 days ago) <Alexander Udalov>
* d1df453edc9 - Do not use KotlinTypeMapper in generateTypeOf inline intrinsic (5 days ago) <Alexander Udalov>
* ece09866f05 - Simplify reified operations on type parameters in ExpressionCodegen (5 days ago) <Alexander Udalov>
* 8efbcc53508 - Do not use KotlinTypeMapper when generating JVM assert inline intrinsics (5 days ago) <Alexander Udalov>
* 15bfb7498cb - (tag: build-1.3.60-dev-2096) Minor. Fix target platforms formatting in FacetSettings (5 days ago) <Andrey Uskov>
* a5b21308fdd - (tag: build-1.3.60-dev-2090, tag: build-1.3.60-dev-2089) Minor refactoring for TypeHints properties (KT-22433) (5 days ago) <Nikolay Krasko>
* 36de8f1aa99 - Type hints: don't show for incomplete expressions followed by Unit type expressions (KT-22433) (5 days ago) <Toshiaki Kameyama>
* 6e852837f73 - Folding: fold "when" expression (KT-6314) (5 days ago) <Toshiaki Kameyama>
* cfcecaaeabb - (tag: build-1.3.60-dev-2086) LightClassApplicabilityCheckExtensions refactoring and IdeSerializationPluginApplicabilityExtension fix (5 days ago) <Igor Yakovlev>
* 2b7dee6f8da - (tag: build-1.3.60-dev-2080) Add CodegenApplicabilityCheckerExtension and use it to fallback to Heavy LigthClasses (5 days ago) <Igor Yakovlev>
* f3b7d2fca93 - (tag: build-1.3.60-dev-2076) Fix exception of getting parent for the root package (EA-210820) (5 days ago) <Nikolay Krasko>
* d3f03cc6070 - (tag: build-1.3.60-dev-2075, origin/kishmakov/share-gradle-deb) Remove deprecated usage of BulkFileListener.Adapter (5 days ago) <Nikolay Krasko>
* 7f8774f68e6 - Fix NPE in KotlinIndicesHelper (EA-209799) (5 days ago) <Nikolay Krasko>
* 90511c734da - Fix NPE in JavaToKotlinAction (EA-210821) (5 days ago) <Nikolay Krasko>
* 77399a175ed - (tag: build-1.3.60-dev-2074) Cleanup compiler warnings in compiler tests (5 days ago) <Alexander Udalov>
* 90a37617a42 - (tag: build-1.3.60-dev-2072) [JVM_IR, IR] Remove more needless temporary variables. (5 days ago) <Mads Ager>