### PR TITLE
[kotlin compiler][update] 1.3.60-dev-2384 

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
@@ -23,6 +23,7 @@ val CompilerOutputKind.isFinalBinary: Boolean get() = when (this) {
     CompilerOutputKind.PROGRAM, CompilerOutputKind.DYNAMIC,
     CompilerOutputKind.STATIC, CompilerOutputKind.FRAMEWORK -> true
     CompilerOutputKind.LIBRARY, CompilerOutputKind.BITCODE -> false
+    CompilerOutputKind.DYNAMIC_CACHE, CompilerOutputKind.STATIC_CACHE -> TODO("$this unsupported")
 }
 
 val CompilerOutputKind.involvesBitcodeGeneration: Boolean
@@ -36,6 +37,7 @@ val CompilerOutputKind.involvesLinkStage: Boolean
         CompilerOutputKind.PROGRAM, CompilerOutputKind.DYNAMIC,
         CompilerOutputKind.STATIC, CompilerOutputKind.FRAMEWORK -> true
         CompilerOutputKind.LIBRARY, CompilerOutputKind.BITCODE -> false
+        CompilerOutputKind.DYNAMIC_CACHE, CompilerOutputKind.STATIC_CACHE -> TODO("$this unsupported")
     }
 
 internal fun produceCStubs(context: Context) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,10 @@
 buildKotlinVersion=1.3.60-dev-1210
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2180,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-2180
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2180,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.60-dev-2180
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2384,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-2384
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2384,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-2384
 testKotlinCompilerVersion=1.3.60-dev-1210
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
* 63e5d4fe956 - Tests: rewrite some AbstractScriptConfigurationTest to the new script infrastructure (2 hours ago) <Natalia Selezneva>
* eca7bbdb8ce - Scripts: Check if file is in all script dependencies class files scope instead of searching for module info (2 hours ago) <Natalia Selezneva>
* 245b2aecb31 - "Replace guard clause with kotlin's function call" inspection : decrease severity to INFORMATION (3 hours ago) <Toshiaki Kameyama>
* 573e7f2eee9 - Run JDK11 tests for KAPT only if JDK11 is available (3 hours ago) <Ivan Gavrilovic>
* 6e7f0464719 - Fix gradle integeration tests (3 hours ago) <Ivan Gavrilovic>
* 92dcb542072 - (tag: build-1.3.60-dev-2377, origin/kishmakov/gd/protocol-extension) "Redundant overriding method" inspection: do not report when overriding package private method (6 hours ago) <Toshiaki Kameyama>
* 25799447a6d - (tag: build-1.3.60-dev-2370) Minor, use slightly less internal argument to enable inline classes (2 days ago) <Alexander Udalov>
* e4609a99683 - (tag: build-1.3.60-dev-2368) JVM IR: Cache inline class replacements at the module level (3 days ago) <Steven Schäfer>
* f40f9611c34 - (tag: build-1.3.60-dev-2362) JVM IR: Fix spread operator on unsigned array type (3 days ago) <Steven Schäfer>
* 1a50a3cbb15 - (tag: build-1.3.60-dev-2358) [NI] Avoid computing few things for simple calls without type variables (3 days ago) <Mikhail Zarechenskiy>
* 7bd65c0bcdb - [NI] Avoid collecting possible types for call expressions (3 days ago) <Mikhail Zarechenskiy>
* a83225218f9 - [NI] Fix checks for infix/operator conventions (3 days ago) <Mikhail Zarechenskiy>
* f45a49b122d - (tag: build-1.3.60-dev-2355) Remove uncapturing in type mismatch diagnostics (3 days ago) <Pavel Kirpichenkov>
* 5c904250bef - (tag: build-1.3.60-dev-2348) Gradle, native: Update a K/N version in tests (3 days ago) <Ilya Matveev>
* 31aa4e47385 - (tag: build-1.3.60-dev-2346) Rename kotlin-test-nodejs-runner to kotlin-test-js-runner (3 days ago) <Ilya Goncharov>
* 10c36ae5c5a - Change naming from commin cli.ts to concrete platform nodejs.ts (3 days ago) <Ilya Goncharov>
* c2b5df83f6d - Add filtering feature to karma testing (3 days ago) <Ilya Goncharov>
* 09a602d8ade - Move common logic of js test running on upper level (js) (3 days ago) <Ilya Goncharov>
* e750bd302d1 - Add karma input for kotlin-test-nodejs-runner (3 days ago) <Ilya Goncharov>
* e2428561248 - Enable cli description to have free args title (3 days ago) <Ilya Goncharov>
* 80ea91f574a - Extract Adapter getting to common place (3 days ago) <Ilya Goncharov>
* b44249255ca - Extract default cli parser to common place (3 days ago) <Ilya Goncharov>
* f0af4756a91 - Fix accuracy for regex filtering for nodejs testing (3 days ago) <Ilya Goncharov>
* e2aecee9251 - Fix exact test filtering for nodejs (3 days ago) <Ilya Goncharov>
* a62863128cb - (tag: build-1.3.60-dev-2344) Fix exception from ProjectResolutionFacade when switching some definition off in settings (3 days ago) <Natalia Selezneva>
* 3ad7f516bed - Add caret to test to check exception in ProjectResolutionFacade that can happen during resolving of symbol from script dependencies (3 days ago) <Natalia Selezneva>
* 5872a47c0e2 - Scripts: rehighlighting should be called for opened scripts after changing script definitions (3 days ago) <Natalia Selezneva>
* 3ac099fc9a3 - Fix freeze during script definitions update (KT-32513) (3 days ago) <Natalia Selezneva>
* 1b645838554 - (tag: build-1.3.60-dev-2342) Gradle, native: Embed bitcode for watchOS and tvOS (3 days ago) <Ilya Matveev>
* 2819ab4ae9d - (tag: build-1.3.60-dev-2341) Avoid division in string-to-unsigned conversions (KT-26309) (4 days ago) <Abduqodiri Qurbonzoda>
* d66f07a84ec - (tag: build-1.3.60-dev-2340) CollectionsKt.windowed throws IllegalArgumentException (4 days ago) <Abduqodiri Qurbonzoda>
* a7b984bcbfa - (tag: build-1.3.60-dev-2339) JVM IR: fix generation of generic multi-file delegates (4 days ago) <Alexander Udalov>
* acbe5c4e210 - JVM IR: fix IOOBE from remapTypeParameters for synthetic property annotations method (4 days ago) <Alexander Udalov>
* c972bf58829 - (tag: build-1.3.60-dev-2336) Add [JPS] IDEA (No ProcessCanceledException) configuration (4 days ago) <Igor Yakovlev>
* f1d31c82215 - (tag: build-1.3.60-dev-2331) JVM_IR: Minor. Unmute tests (4 days ago) <Ilmir Usmanov>
* 06d0e8a521a - JVM_IR: Support suspend functions with extension receivers (4 days ago) <Ilmir Usmanov>
* 2bfd17d8fb2 - JVM_IR: Minor. Unmute test. (4 days ago) <Ilmir Usmanov>
* 63f6d515bc0 - JVM_IR: Generate correct invoke of numbered suspend lambda (4 days ago) <Ilmir Usmanov>
* 587fcafc858 - JVM_IR: Support continuation crossing inline lambda boundaries (4 days ago) <Ilmir Usmanov>
* 0cdfe89a26e - (tag: build-1.3.60-dev-2326) KT-33052: Fix KAPT stub generation for enums on JDK11 (4 days ago) <Ivan Gavrilovic>
* 58efa34a33f - KT-31291: KAPT - make sure ASM version is not inlined (4 days ago) <Ivan Gavrilovic>
* 60fa632d026 - KT-33515: Remove Kotlin sources generated by KAPT (4 days ago) <Ivan Gavrilovic>
* 434fb75eb7d - Incremental KAPT: when unable to process incremental changes, run non-incrementally (4 days ago) <Ivan Gavrilovic>
* b59fba67071 - (tag: build-1.3.60-dev-2322) Fix mocha run (4 days ago) <Ilya Goncharov>
* 9d01c87c517 - (tag: build-1.3.60-dev-2311) KotlinElementActionsFactory: cleanup JvmElementActionsFactory API (KT-33779) (4 days ago) <Nicolay Mitropolsky>
* 3bcbcbfd478 - (tag: build-1.3.60-dev-2303, tag: build-1.3.60-dev-2302) Fix read action in 'processLightClassLocalImplementations' (EA-210464) (5 days ago) <Vladimir Dolzhenko>
* 81c9edfff4e - Get rid of implicit resolve within statsInfo for KotlinAddImportAction (EA-210670) (5 days ago) <Vladimir Dolzhenko>
* 3a1d649b300 - (tag: build-1.3.60-dev-2300) Don't trigger refresh of vfs in 'getOutsiderFileOrigin' (EA-209420) (5 days ago) <Vladimir Dolzhenko>
* 507857d4524 - (tag: build-1.3.60-dev-2298) [IR] Support Collection<*>.indices in for loop lowering. (5 days ago) <Mads Ager>
* 76ab631214d - (tag: build-1.3.60-dev-2297) psi2ir: Optimize generated data class members (5 days ago) <Steven Schäfer>
* 7ccf314808c - Minor: Remove dead conditional in psi2ir (5 days ago) <Steven Schäfer>
* ce3ef4e4d02 - (tag: build-1.3.60-dev-2295) Add more tests for inline class equality with nullable arguments (5 days ago) <Steven Schäfer>
* 1833a69c87d - JVM: Optimize inline class equality with nullable arguments (5 days ago) <Steven Schäfer>
* eda4953cb39 - JVM IR: Optimize inline class equality with nullable arguments (5 days ago) <Steven Schäfer>
* d8646e29b73 - Add additional Result api test (5 days ago) <Steven Schäfer>
* 49efa5fbc42 - Split up Result API boxing tests (5 days ago) <Steven Schäfer>
* 2e53e36fd54 - JVM: Do not use equals-impl0 methods generated by older compiler versions (5 days ago) <Steven Schäfer>
* b85b2d9af89 - Add more tests for inline class equality (5 days ago) <Steven Schäfer>
* cdc5e1347b9 - JVM: Avoid boxing in inline class equality (5 days ago) <Steven Schäfer>
* f53b28e8a38 - JVM: Generate equals-impl0 method for inline classes (5 days ago) <Steven Schäfer>
* 2c7da67600c - JVM IR: Avoid boxing in inline class equality (5 days ago) <Steven Schäfer>
* b85a4753581 - JVM IR: Generate equals-impl0 method for inline classes (5 days ago) <Steven Schäfer>
* e4456127e47 - JVM IR: Don't use JS IR specific inlineClasses.kt (5 days ago) <Steven Schäfer>
* 475079611d1 - JVM IR: Avoid parameter null-checks in inline class impl methods (5 days ago) <Steven Schäfer>
* cdd3f823966 - JVM IR: Use correct scope owner in JvmInlineClassLowering (5 days ago) <Steven Schäfer>
* 2afbeaa3533 - (tag: build-1.3.60-dev-2293) Drop resolve on 'collectTransferableData' and reworked MoveDeclarations QuickFix (EA-210670) (5 days ago) <Vladimir Dolzhenko>
* 6ef434a711f - (tag: build-1.3.60-dev-2292) JVM IR: add -Xir-check-local-names to check names for consistency (5 days ago) <Alexander Udalov>
* 530c1411c35 - Remove IR backend-specific code from KotlinTypeMapper (5 days ago) <Alexander Udalov>
* 3d79e77df3c - (tag: build-1.3.60-dev-2291) Add async profiler to perfTests (5 days ago) <Vladimir Dolzhenko>
* 0f4176a88e4 - (tag: build-1.3.60-dev-2285) [Pill] Fix pill after refactoring reflect (5 days ago) <Ilya Chernikov>
* aa77f6c245e - (tag: build-1.3.60-dev-2283) Improve KParameter.toString for instance and extension receiver parameter (5 days ago) <Alexander Udalov>
* 59186b26176 - Psi2ir: ignore unresolved class literals in annotations (5 days ago) <Alexander Udalov>
* c69997491fd - JVM IR: generate file annotations on file facade classes (5 days ago) <Alexander Udalov>
* 565099d9415 - (tag: build-1.3.60-dev-2280) fix new test name (5 days ago) <Kevin Bierhoff>
* bc207ed8dbd - fix for KT-29471 (5 days ago) <Kevin Bierhoff>
* 220a8f28727 - (tag: build-1.3.60-dev-2277) Clear internal caches in PerModulePackageCacheService on dispose (KT-33802) (5 days ago) <Nikolay Krasko>
* 4387862d206 - Remap android home directory to allow parallel test execution (KT-33870) (5 days ago) <Nikolay Krasko>
* dfde3b40765 - (tag: build-1.3.60-dev-2274) Rename collector of debugger events (5 days ago) <Anton Yalyshev>
* 61eb9faecd7 - Move status of evaluation from eventId to context for better data analytics (5 days ago) <Anton Yalyshev>
* 2bdbed978ba - (tag: build-1.3.60-dev-2272) FIR: Support SAM constructors (5 days ago) <Denis Zharkov>
* b3e96a1fcf5 - FIR: Merge FirTopLevelDeclaredMemberScope into FirSelfImportingScope (5 days ago) <Denis Zharkov>
* 391346ae460 - FIR: Pass BodyResolveComponents to ScopeTowerLevel (5 days ago) <Denis Zharkov>
* fb4b6b8290a - FIR: Move constructor processing from scopes to tower resolvers (5 days ago) <Denis Zharkov>
* 08a8a9fa610 - FIR: Move SamResolver to BodyResolveComponents (5 days ago) <Denis Zharkov>
* 5ebde93eb93 - FIR: Provide BodyResolveComponents instead of InferenceComponents to resolution (5 days ago) <Denis Zharkov>
* 5567620563e - FIR: Support SAM conversion (5 days ago) <Denis Zharkov>
* f501730d86b - Minor. Reformat Arguments.kt in fir (5 days ago) <Denis Zharkov>
* 9d517d914b9 - Minor. Get rid of redundant elvis operand in AbstractConeSubstitutor::substituteOrNull (5 days ago) <Denis Zharkov>
* 6e51bed30cd - FIR: Support lambda inference from platform types (5 days ago) <Denis Zharkov>
* d787df3880e - Minor. Reformat ConeKotlinType::isBuiltinFunctionalType (5 days ago) <Denis Zharkov>
* 0431c21f9a5 - (tag: build-1.3.60-dev-2265) [NI] Remove unneeded computation of possible types for return type (6 days ago) <Mikhail Zarechenskiy>
* d47fc858687 - [NI] Minor, small improvements around KotlinCall creation (6 days ago) <Mikhail Zarechenskiy>
* 971b02494c1 - [NI] Minor, simplify code a bit for sub calls preparation (6 days ago) <Mikhail Zarechenskiy>
* 7e8784dca1d - [NI] Simplify code that capture types from expression (6 days ago) <Mikhail Zarechenskiy>
* 6327f657a5d - (tag: build-1.3.60-dev-2260) 193: Add bunches for 193 platform (6 days ago) <Vyacheslav Gerasimov>
* 381f6d82260 - 193: Inline removed parents method in UastLightIdentifier (6 days ago) <Vyacheslav Gerasimov>
* 7fe25e922c4 - 193: Fix nullability in KotlinImportOptimizer (6 days ago) <Vyacheslav Gerasimov>
* c220ad4b009 - Build: Add dsl constants for 193 platform (6 days ago) <Vyacheslav Gerasimov>
* df570ec2a2c - (tag: build-1.3.60-dev-2257) Add CompilerOutputKind.DYNAMIC_CACHE and .STATIC_CACHE for Native BE (6 days ago) <Svyatoslav Scherbina>
* 0e3f0c98e54 - (tag: build-1.3.60-dev-2256) JVM_IR: Support inline suspend lambdas (6 days ago) <Ilmir Usmanov>
* 61ae98df40a - (tag: build-1.3.60-dev-2250) [FIR] Add default visitors and transformers with useful part of visited hierarchy (6 days ago) <Dmitriy Novozhilov>
* e70c1d69596 - [FIR] Remove default visited hierarchy (6 days ago) <Dmitriy Novozhilov>
* 9b32bd71384 - (tag: build-1.3.60-dev-2247) Do special insert even for custom trimIndent() function to avoid using resolve (KT-31810) (6 days ago) <Nikolay Krasko>
* 147f805c569 - Paste inside indented `.trimIndent()` raw string: respect indentation (KT-31810) (6 days ago) <Toshiaki Kameyama>
* d3b826c71d4 - (tag: build-1.3.60-dev-2246) Improve class name generation for scripts and REPL snippets (6 days ago) <Ilya Chernikov>
* 6de05bb2c77 - Drop hardcoded extraction of the snippet id from script name (6 days ago) <Ilya Chernikov>
* dd953e0f667 - Deduplicating classloaders and classpath entries on constructing script classloader (6 days ago) <Ilya Chernikov>
* df3fbaf4173 - (tag: build-1.3.60-dev-2242) Add various configuration parameters to Non Fir modularized tests (6 days ago) <Simon Ogorodnik>
* f3a0632b9a7 - [FIR] Fix dump html for each pass (6 days ago) <Simon Ogorodnik>
* 0531bd4fe61 - (tag: build-1.3.60-dev-2240) KT-29229 Intrinsify 'in' operator for unsigned integer ranges (6 days ago) <Dmitry Petrov>
* 5426071102c - (tag: build-1.3.60-dev-2236) Add dependency classloader to the evaluation classloader: (6 days ago) <Ilya Chernikov>
* 61d517fb319 - Implement script dependencies resolution directly from classloader (6 days ago) <Ilya Chernikov>
* f8db150a2b5 - [minor] Drop some usages of kotlin reflection in scripting compiler plugin (6 days ago) <Ilya Chernikov>
* 689a5cbdf52 - Add descriptors.runtime to the compiler... (6 days ago) <Ilya Chernikov>
* 8dce22c335e - (tag: build-1.3.60-dev-2232) New J2K: use proper resolution facade when getting class reference in inference post-processing (6 days ago) <Ilya Kirillov>
* cfd476ca7e6 - New J2K: correctly convert main method with varargs argument (6 days ago) <Ilya Kirillov>
* 5d6cf34045b - New J2K: consider that type argument may be null in inference post-processing (6 days ago) <Ilya Kirillov>
* 934d491c1c9 - New J2K: use `Any?` instead of star projection for raw supertypes (6 days ago) <Ilya Kirillov>
* c6e0356a591 - Do not search for getter usages for every "may be const" quickfix invocation (6 days ago) <Ilya Kirillov>
* 1b3c5f5d379 - New J2K: use proper progress indicator for showing progress (6 days ago) <Ilya Kirillov>
* 2916be6a538 - Remove duplicating interface in J2K (6 days ago) <Ilya Kirillov>
* 1cf348baba5 - Do not commit document on non-kotlin files when trying to perform j2k conversion (6 days ago) <Ilya Kirillov>
* 13b16cfe759 - (tag: build-1.3.60-dev-2229) Refactoring: get rid of firSafeNullable, enhance getSymbolByLookupTag (6 days ago) <Mikhail Glukhikh>
* 0493432723c - Remove some usages of FirBasedSymbol (6 days ago) <Mikhail Glukhikh>
* a1f4a4572a1 - (tag: build-1.3.60-dev-2224) Check cancelation in KotlinJavaPsiFacade.findPackage() (7 days ago) <Matthew Gharrity>
* 0a1b3a8455a - (tag: build-1.3.60-dev-2217, origin/rr/kirpichenkov/kt7354) Clearify diagnostic messages that involve internal visibilities (7 days ago) <Pavel Kirpichenkov>
* fc4865a4409 - (tag: build-1.3.60-dev-2214) Don't extend to comments when a comment is being moved (KT-23461) (7 days ago) <Nikolay Krasko>
* 11de99f9d72 - Minor refactoring for KotlinExpressionMover (KT-23461) (7 days ago) <Nikolay Krasko>
* ed28a062854 - Move statement: move expression over comments (KT-23461) (7 days ago) <Toshiaki Kameyama>
* 20c45a8382f - (tag: build-1.3.60-dev-2213) FIR general refactoring: get rid of ConeSymbols (7 days ago) <Mikhail Glukhikh>
* c1c46daa017 - (tag: build-1.3.60-dev-2211) Use en_US.UTF-8 locale instead of default locale to work around errors (7 days ago) <Ilmir Usmanov>
* 1951ff80546 - JVM_IR: Minor. Unmute tests (7 days ago) <Ilmir Usmanov>
* a3284326af2 - JVM_IR: Do not box/unbox result in continuations (7 days ago) <Ilmir Usmanov>
* 402a77126f4 - JVM_IR: Support inline suspend functions (7 days ago) <Ilmir Usmanov>
* 2ec3417e0eb - JVM_IR: Move suspend functions into view transformation to codegen phase (7 days ago) <Ilmir Usmanov>
* 6b36833ee21 - (tag: build-1.3.60-dev-2210) Highlight usages: highlight declaration/usage on call of function with lambda argument (KT-30824) (7 days ago) <Toshiaki Kameyama>
* 26bef2d1090 - Fix muted usage highlighter test by ignoring irrelevant highlighting (7 days ago) <Nikolay Krasko>
* 7b8abc54572 - Move statement: enable expression ended with semicolon (KT-8581) (7 days ago) <Toshiaki Kameyama>
* 5259af157af - (tag: build-1.3.60-dev-2206) JVM IR: workaround correspondingPropertySymbol absence after deep copy (7 days ago) <Alexander Udalov>
* b782cf6bdbe - JVM IR: workaround KotlinTypeMapper usages in boxing optimization on inline classes (7 days ago) <Alexander Udalov>
* c425bd0e0ba - JVM IR: do not use KotlinTypeMapper in BuilderFactoryForDuplicateSignatureDiagnostics (7 days ago) <Alexander Udalov>
* 3a0c41dca40 - JVM IR: do not use KotlinTypeMapper indirectly in CallableReferenceLowering (7 days ago) <Alexander Udalov>
* 26874a6e1eb - JVM IR: do not use KotlinTypeMapper in MethodSignatureMapper (7 days ago) <Alexander Udalov>
* ee976020bc2 - JVM IR: add KotlinTypeMapperBase, do not use KotlinTypeMapper in metadata serialization (7 days ago) <Alexander Udalov>
* bd8ea9412dc - JVM IR: implement MethodSignatureMapper.mapFunctionName directly (7 days ago) <Alexander Udalov>
* 36c242764f2 - JVM IR: implement MethodSignatureMapper.mapSignature directly (7 days ago) <Alexander Udalov>
* 46ced326b8f - JVM IR: minimize usages of some methods in MethodSignatureMapper (7 days ago) <Alexander Udalov>
* 4dc1d61c380 - JVM IR: do not remove overridden symbols in BridgeLowering (7 days ago) <Alexander Udalov>
* 45929f57b6e - Minor, add test on name mangling of private multi-file part members (7 days ago) <Alexander Udalov>
* cb482571cb4 - (tag: build-1.3.60-dev-2205) Build: Fix javadocJar task configuration (7 days ago) <Vyacheslav Gerasimov>
* cec37cf78a6 - (tag: build-1.3.60-dev-2202) Add supertype type arguments to super() call in deserialization ctor (7 days ago) <Leonid Startsev>
* 0b669e72b07 - Do not report error about 'initializer required for @Transient properties' on lateinit vars (7 days ago) <Leonid Startsev>
* 4e516d7c94c - Fix IR validation warnings in serialization plugin (7 days ago) <Leonid Startsev>
* d3f1cf1cdde - (tag: build-1.3.60-dev-2197) Gradle, native: Don't ignore exit codes of K/N tests (7 days ago) <Ilya Matveev>
* 9d257a1ed80 - (tag: build-1.3.60-dev-2196) JVM IR: generate call to checkNotNull in IrCheckNotNull since 1.4 (7 days ago) <Alexander Udalov>
* acc86be0436 - (tag: build-1.3.60-dev-2186) Extend karma-teamcity-reporter to log browser's output (7 days ago) <Ilya Goncharov>
* 8fbdb15626f - Show suppressed output in case of karma launch failed (7 days ago) <Ilya Goncharov>
* 425582bb4b4 - Use only custom karma reporter (7 days ago) <Ilya Goncharov>
* ddbae988418 - Remove redundant marker of browser log starting (7 days ago) <Ilya Goncharov>
* 355f847ee0e - Add parse of karma log to find browser's messages (7 days ago) <Ilya Goncharov>
* 8c46fab6d80 - Add own reporter that reports only browser log in specific format (7 days ago) <Ilya Goncharov>
* 9bb5022eb47 - Move nested classes (7 days ago) <Ilya Goncharov>
* 6277267563b - Make KarmaConfig as data class (7 days ago) <Ilya Goncharov>
* 8f7c5c13f83 - Parse karma problem to fail task (7 days ago) <Ilya Goncharov>
* 3d67b952f80 - Parse browser output to log (7 days ago) <Ilya Goncharov>
* c8d087d744d - (tag: build-1.3.60-dev-2181) [FIR] Tests. Save failed tests into testdata (7 days ago) <Dmitriy Novozhilov>