### PR TITLE
[kotlin compiler][update] 1.3.60-dev-2497

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,10 +18,10 @@
 buildKotlinVersion=1.3.60-dev-1210
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-1210,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2384,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-2384
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2384,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.60-dev-2384
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2497,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.60-dev-2497
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2497,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.60-dev-2497
 testKotlinCompilerVersion=1.3.60-dev-1210
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
* 594f4a6f560 - (HEAD -> master, origin/master, origin/HEAD) New flag for KotlinNativeCompilation to enable endorsed libraries (#2618) (46 minutes ago) <LepilkinaElena>
* b8cce67d2ea - KT-19355 fix for "Variable expected" error after J2K for increment/decrement of an object field (65 minutes ago) <Alex Chmyr>
* 748e458ad75 - "Override members": add semicolon between enum entry and function (3 hours ago) <Toshiaki Kameyama>
* 7fcca71b4bf - `Replace with dot call` quickfix: don't break formatting (3 hours ago) <Toshiaki Kameyama>
* 7b56733bdab - Reforma ReplaceCallFix (3 hours ago) <Toshiaki Kameyama>
* 78affdd2b46 - (tag: build-1.3.60-dev-2485) Fix old testdata: add missing operator modifier (9 hours ago) <Mikhail Zarechenskiy>
* a98c6109582 - (tag: build-1.3.60-dev-2483) Fix KotlinCodeStyleSettings and IDEKotlinBinaryClassCache.kt 191 compilation (12 hours ago) <Vladimir Dolzhenko>
* c961de7289a - (tag: build-1.3.60-dev-2482) Fix kotlinRefactoringUtil.kt.193 compilation (13 hours ago) <Vladimir Dolzhenko>
* b00858a886e - (tag: build-1.3.60-dev-2474) Start local var scope for destructuring variables after init. (17 hours ago) <Mads Ager>
* d54bc3a4bb9 - 193: Fix tests compilation for 193 platform (17 hours ago) <Vyacheslav Gerasimov>
* a8c72b7e844 - (tag: build-1.3.60-dev-2461) Do not resolve services in static initializers in IDEKotlinBinaryClassCache, KT-33973 (17 hours ago) <Vladimir Dolzhenko>
* 6f739db3b13 - Fixed KotlinCodeInsightWorkspaceSettings plugin service description for 193 (18 hours ago) <Vladimir Dolzhenko>
* cb569f84932 - Do not use resolving to understand which method we use in "replace get or set inspection" (18 hours ago) <Ilya Kirillov>
* 4e27d2e6582 - New J2K: do not use global write action for some post-processings which may use resolving while applying (18 hours ago) <Ilya Kirillov>
* 74ba5b210ac - New J2K: do not analyze code for post-processings in edt thread (18 hours ago) <Ilya Kirillov>
* e6f2e0041c0 - New J2K: get rid of generalInspectionPostProcessing (18 hours ago) <Ilya Kirillov>
* a4cf7a912b6 - Split some non applicability based inspections into isApplicable and apply (18 hours ago) <Ilya Kirillov>
* 3724e2bb029 - New J2K: convert all custom post-processing to applicability based ones (18 hours ago) <Ilya Kirillov>
* 509fcb17c73 - New J2K: consider empty/singleton children list when comparing trees in default arguments conversion (18 hours ago) <Ilya Kirillov>
* 704b3bd2e67 - New J2K: always print real fqNames for static calls (18 hours ago) <Ilya Kirillov>
* f9fac0acf56 - New J2K: do not save import statements in files as we print fqNames for calls (18 hours ago) <Ilya Kirillov>
* e3b7b41544f - Minor: rename globalFacade -> facadeForModules (18 hours ago) <Dmitry Savvinov>
* 937d041bc3e - Minor: rename file ResolverForProjectImpl.kt -> AbstractResolverForProject (18 hours ago) <Dmitry Savvinov>
* bef33e971ff - Make ResolverForProject own BuiltInsCache (18 hours ago) <Dmitry Savvinov>
* bfacc1a3c5f - Introduce AbstractResolverForProject (18 hours ago) <Dmitry Savvinov>
* 48719c40501 - Minor: extract ResolverForProjectImpl into separate file (18 hours ago) <Dmitry Savvinov>
* 1e288c03c3a - Minor: fix typos in KDoc (18 hours ago) <Dmitry Savvinov>
* 4f700f5df3e - Minor: drop unused parameter from createFacadeForScriptDependencies (18 hours ago) <Dmitry Savvinov>
* 8ff4a925623 - Fix serialization of data nodes tree (19 hours ago) <Andrey Uskov>
* 41f75192444 - Fix old j2k test data to actual one (19 hours ago) <Ilya Kirillov>
* 8b0aeb9a55f - (tag: build-1.3.60-dev-2454) Do not resolve services in non-default ctors (19 hours ago) <Vladimir Dolzhenko>
* 0e1e1e350f4 - (tag: build-1.3.60-dev-2452) "Convert lambda to reference": do not remove required backticks (19 hours ago) <Toshiaki Kameyama>
* 44edd94fea9 - "Create member function" quick fix: do not add redundant semicolons after enum entry (20 hours ago) <Toshiaki Kameyama>
* 0497f0cba40 - (tag: build-1.3.60-dev-2451) "Create enum constant" quick fix: add before semicolon (20 hours ago) <Toshiaki Kameyama>
* 30c41e67207 - "Create type parameter from usage": don't suggest for not extension property (20 hours ago) <Toshiaki Kameyama>
* 68609401c4f - Reformat CreateTypeParameterByUnresolvedRefActionFactory (20 hours ago) <Toshiaki Kameyama>
* 5b666ff33f3 - "Create type parameter from usage": don't remove backticks if necessary (20 hours ago) <Toshiaki Kameyama>
* bfc698a5216 - (tag: build-1.3.60-dev-2446) Add comment for log-reporter and its necessity (21 hours ago) <Ilya Goncharov>
* 09e2ebe60a7 - Both js targets use one TC service message classes (21 hours ago) <Ilya Goncharov>
* 7d4b43f8190 - Remove annoying spaces in karma-teamcity-reporter (21 hours ago) <Ilya Goncharov>
* b4e3cf1d7aa - Move teamcity reporting only to nodejs (21 hours ago) <Ilya Goncharov>
* 46e82468e49 - Provide logging through kotlin-test=js-runner (21 hours ago) <Ilya Goncharov>
* f0e72c4d71f - Remove mangling for kotlin-test-js-runner (21 hours ago) <Ilya Goncharov>
* e59d1a0ef15 - Use terser instead of uglify (21 hours ago) <Ilya Goncharov>
* 784ba69b7af - (tag: build-1.3.60-dev-2444) "Cleanup code": remove 'final' keyword for overridden function with non-canonical modifiers order (21 hours ago) <Toshiaki Kameyama>
* f49d5da9293 - (tag: build-1.3.60-dev-2440) JVM IR: Fix enum constructor visibility (22 hours ago) <Steven Schäfer>
* 52dc469657c - (tag: build-1.3.60-dev-2439) JVM IR: Generate synthetic methods for type aliases with annotations (22 hours ago) <Kristoffer Andersen>
* acd1cc5a570 - (tag: build-1.3.60-dev-2434) [KLIB] Normalize path string to keep file order on Windows OS (23 hours ago) <romanart>
* 1ee827bfc80 - (tag: build-1.3.60-dev-2432) Import quick fix: support `provideDelegate` #KT-28049 Fixed (23 hours ago) <Dmitry Gridin>
* 79199260b9d - Import quick fix: suggest for operator extension function called from name reference (23 hours ago) <Toshiaki Kameyama>
* 998adfb0985 - (tag: build-1.3.60-dev-2431) Move variable declaration into `when`: don't report when property has 'break' or 'continue' (23 hours ago) <Toshiaki Kameyama>
* 877e583a96c - Move variable declaration into `when`: don't report when property has 'return' or 'throw' (23 hours ago) <Toshiaki Kameyama>
* d9d04fc5562 - (tag: build-1.3.60-dev-2417) "Create enum constant" quick fix: do not add redundant empty line (26 hours ago) <Toshiaki Kameyama>
* 5dddc464a5e - (tag: build-1.3.60-dev-2413) Completion: add tests for case with overloaded function with lambda with receiver parameter Relates to #KT-31073 (2 days ago) <Dmitry Gridin>
* e3ce7999930 - Refactoring: change signature should affected expect/actual #KT-33972 Fixed (2 days ago) <Dmitry Gridin>
* 484dda478e2 - AbstractIntentionTest: should check `startInWriteAction` flag (2 days ago) <Dmitry Gridin>
* 667e9a33e88 - AbstractIntentionTest: cleanup code (2 days ago) <Dmitry Gridin>
* cbdda6f9a82 - KotlinChangeSignatureData: cleanup code (2 days ago) <Dmitry Gridin>
* 7271e658510 - (tag: build-1.3.60-dev-2411) Don't store hard references to psi elements in transferable data (KT-33802) (2 days ago) <Nikolay Krasko>
* f8bd3518dc7 - (tag: build-1.3.60-dev-2406) UL method and parameter Move&Rename refactoring (2 days ago) <Igor Yakovlev>
* fc70fd05fc5 - Enable kotlin.collections support for UL classes (2 days ago) <Igor Yakovlev>
* 286702a99c3 - (tag: build-1.3.60-dev-2404) Format code for NoArgPlugin (2 days ago) <Igor Yakovlev>
* 1deba19e1c2 - Refactoring NoArg compiler plugin (2 days ago) <Igor Yakovlev>
* 027c60080b9 - (tag: build-1.3.60-dev-2403) Added KotlinCodeInsightWorkspaceSettings in place of sharing kotlin settings with java CodeInsightSettings (2 days ago) <Vladimir Dolzhenko>
* 6b5a73ffa90 - (tag: build-1.3.60-dev-2402) Enable resolve in dispatch thread check for copy-paste tests (2 days ago) <Nikolay Krasko>
* ee4ab967a4f - Force resolve check for dispatch thread instead of isWriteAccessAllowed (2 days ago) <Nikolay Krasko>
* 9f81de293f0 - Minor: add intention name to test failure (2 days ago) <Nikolay Krasko>
* fabd3368564 - (tag: build-1.3.60-dev-2396) Update K/N: 1.3.60-dev-12485 (2 days ago) <Ilya Matveev>
* 17e2359a415 - (tag: build-1.3.60-dev-2389) Added copy-paste performance tests (2 days ago) <Vladimir Dolzhenko>