### PR TITLE
Add empty inline rule

### DIFF
--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/resolve/konan/platform/KonanPlatformConfigurator.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/resolve/konan/platform/KonanPlatformConfigurator.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlin.resolve.konan.platform
 
 import org.jetbrains.kotlin.container.StorageComponentContainer
+import org.jetbrains.kotlin.container.useInstance
 import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -15,6 +16,7 @@ object KonanPlatformConfigurator : PlatformConfiguratorBase(
     additionalCallCheckers = listOf(SuperCallWithDefaultArgumentsChecker())
 ) {
     override fun configureModuleComponents(container: StorageComponentContainer) {
+        container.useInstance(NativeInliningRule)
     }
 }
 


### PR DESCRIPTION
Adds a rule to suppress a warning that says that expected impact is insignificant.
This rule was removed by https://github.com/JetBrains/kotlin-native/pull/3030/commits/4a83c63816b27c809905cb92f82c33620c52fba6#diff-8b5b5cc1a2722c47ae02aa59181fbb04L39