### PR TITLE
[kotlin compiler][update] 1.3.70-dev-224

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@
 buildKotlinVersion=1.3.60-dev-2755
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2755,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2755,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.60-dev-2755
+kotlinCompilerRepo=https://kotlin.bintray.com/kotlin-dev
+kotlinVersion=1.3.70-dev-224
 kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_dev_Compiler),number:1.3.60-dev-2755,branch:default:any,pinned:true/artifacts/content/maven
 kotlinStdlibVersion=1.3.60-dev-2755
 kotlinStdlibTestsVersion=1.3.60-dev-2755


### PR DESCRIPTION
* eda42064281 - (tag: build-1.3.70-dev-208) New J2K: convert Integer.MAX_VALUE to Int.MAX_VALUE (2 days ago) <Toshiaki Kameyama>
* 0b76f60b630 - (tag: build-1.3.70-dev-204) JVM IR: Handle NonInlinedConst (2 days ago) <Steven Schäfer>
* e40636f6ab1 - (tag: build-1.3.70-dev-203) re-generate for debug information tests (2 days ago) <Jiaxiang Chen>
* 74e4e8b18e8 - enable test generator to generate tests using JUnit 4 infrastructure (2 days ago) <Jiaxiang Chen>
* 2c78f1fe85a - debug information test: instantiate a single thread for all tests under same test class (2 days ago) <Jiaxiang Chen>
* 0a2812f83bb - Add a JVM backend debug information test, this commit is for verifying line numbers for stepping. (2 days ago) <Jiaxiang Chen>
* f17e9ba9feb - (tag: build-1.3.70-dev-200, origin/rr/ayalyshev/KT-27587-partial-revert) Return older android.tools.build version, as we have problems with newer one (3 days ago) <Anton Yalyshev>
* daa25dd56a4 - (tag: build-1.3.70-dev-195) 193: Fix AbstractResolveByStubTest fixture configuration (3 days ago) <Vyacheslav Gerasimov>
* a5d668a0939 - 193: Fix AbstractInlineTest fixture configuration (3 days ago) <Vyacheslav Gerasimov>
* c07833f13a8 - 193: Fix AbstractNameSuggestionProviderTest fixture configuration (3 days ago) <Vyacheslav Gerasimov>
* 04ee38c913e - 193: Fix AbstractParameterInfoTest fixture configuration (3 days ago) <Vyacheslav Gerasimov>
* 1392e7574cf - 193: Fix AbstractKotlinGotoTest fixture configuration (3 days ago) <Vyacheslav Gerasimov>
* 98f8e0c8000 - 193: Fix code fragment tests fixture configuration (3 days ago) <Vyacheslav Gerasimov>
* f7d12efc240 - (tag: build-1.3.70-dev-193) Memoize absent classifier names in FIR star importing scopes (3 days ago) <Mikhail Glukhikh>
* 6d8aa69878b - FIR: rename CallResolver to FirTowerResolver (3 days ago) <Mikhail Glukhikh>
* 16de3257d5e - FIR abstract importing scope: return NONE when we have no top-level callables (3 days ago) <Mikhail Glukhikh>
* 7ba40ac963e - Memoize absent function/property names in FirSuperTypeScope (3 days ago) <Mikhail Glukhikh>
* 840ecf1a777 - Don't enter twice top-level scopes w/out particular name in FIR tower resolver (3 days ago) <Mikhail Glukhikh>
* e276e8d9f38 - Don't enter twice local scopes w/out particular name in FIR tower resolver (3 days ago) <Mikhail Glukhikh>
* e48428d39d3 - FIR ScopeSession: use HashMap instead of LinkedHashMap (3 days ago) <Mikhail Glukhikh>
* 813e35643c6 - FIR resolve: fix constructor handling in qualifier scope (3 days ago) <Mikhail Glukhikh>
* 26e82027714 - FIR: add 'isInner' parameter to constructors (3 days ago) <Mikhail Glukhikh>
* aad9cbbf01b - [JS IR BE] Fix tests failing due to reduced runtime (3 days ago) <Anton Bannykh>
* b2fb81e9cc4 - Temp ignore tests on missing source file (3 days ago) <Ilya Goncharov>
* 6688df8f6af - Fix webpack delimiter and add test on short path in stack trace (3 days ago) <Ilya Goncharov>
* f7ba1c56e2b - Source-map-loader resolves relative paths into absolute even (3 days ago) <Ilya Goncharov>
* f3db846bce8 - Add tests for source-map-loader (3 days ago) <Ilya Goncharov>
* e8efe5407d1 - Add patched kotlin-source-map-loader (3 days ago) <Ilya Goncharov>
* dad9958adf2 - 193: Fix test fixture configuration (3 days ago) <Vyacheslav Gerasimov>
* 3f1d3dab14d - 193: Request StubComputationTracker as component from project (3 days ago) <Vyacheslav Gerasimov>
* fa9125df7d8 - Set JVM 1.8 for test source set as well #KT-34154 Fixed (3 days ago) <Anton Yalyshev>
* d2c2128aadd - Fix test logging for Windows (3 days ago) <Ilya Goncharov>
* f950a0246ce - New J2K: handle correctly short names which are imported by default in kotlin (like List or Result) (3 days ago) <Ilya Kirillov>
* 81341e3fd3a - New J2K: add hack for incorrect comment parsing in J2K (KT-16845) (3 days ago) <Ilya Kirillov>
* 008b916755f - avoid unnecessary usage of private API class HighlightSession (3 days ago) <Alexey Kudravtsev>
* 354e5d86ee2 - JVM_IR: use correct descriptor type in JvmStaticAnnotationLowering (3 days ago) <pyos>
* 1f5a760ac8d - Add typings field for DtsResolver (3 days ago) <Ilya Goncharov>
* b7e5d9faaea - Update annotation rendering in diagnostics (3 days ago) <Pavel Kirpichenkov>
* 2a99687a95f - Advance 193 bunch to 193.4099 (3 days ago) <Kirill Shmakov>
* f1f4bc6c2aa - Fix IdeRegression.testImplementingMutableSet test data (3 days ago) <Igor Yakovlev>
* 58e9b756f12 - (rr/minamoto/ir/inliner-no-local-object-copier) Add tests for processing karma stack traces (4 days ago) <Ilya Goncharov>
* 4b5877f3b56 - JVM_IR, codegen: handle names for classes within local classes (4 days ago) <Georgy Bronnikov>
*   cd251458bdb - Merge pull request #2647 from JetBrains/kishmakov/gd/review (4 days ago) <Kirill Shmakov>
|\
| * 1310796a169 - (origin/kishmakov/gd/review) Advance 193 bunch (5 days ago) <Kirill Shmakov>
* 5da75897e4b - Minor: regenerate IdeLightClassTestGenerated (4 days ago) <Natalia Selezneva>
* b8258bfc713 - Drop TestCaseWithTempDir usage from scripting compiler plugin tests (4 days ago) <Ilya Chernikov>
* cb5622fc8b4 - [minor] Fix URL conversion to the file (4 days ago) <Ilya Chernikov>
* 3fec15202f5 - [minor] fix source root creation from imported scripts: (4 days ago) <Ilya Chernikov>
* 5d7f18b1b91 - [JS] Support wrapped and dynamic types in typeOf (4 days ago) <Svyatoslav Kuzmich>
* 030aaee1176 - (tag: build-1.3.60-dev-2864) Mute completion tests (KT-32919) (4 days ago) <Nikolay Krasko>
* eaa07dac178 - CreateExpect: shouldn't generate expect declaration from actual function with `private`, `lateinit` or `const` #KT-33930 Fixed (4 days ago) <Dmitry Gridin>
* 9da6dcf840e - DescriptorRenderer: shouldn't render `private` modifier by default #KT-31587 Fixed (4 days ago) <Dmitry Gridin>
* 847295bf1cf - CreateExpect: shouldn't generate expect declaration from actual function with default implementation from interface #KT-32737 Fixed (4 days ago) <Dmitry Gridin>
* e9f8693a73f - as34: Mute several inspection/intention tests in as34 (KT-32856) (4 days ago) <Nikolay Krasko>
* 7e87357ed03 - (tag: build-1.3.60-dev-2857) FIR2IR: fix top-level parent settings thus fixing Cli.testFirHello (4 days ago) <Mikhail Glukhikh>
* 1b7b546249b - (tag: build-1.3.60-dev-2855) Tests: fix some tests in quickfix (4 days ago) <Dmitry Gridin>
* f74b3e6ecec - (tag: build-1.3.60-dev-2854) SymbolBasedClassifierType: fix exception in case with not found class (4 days ago) <Mikhail Glukhikh>
* 6b8f4b4b4e3 - SymbolBasedClass: cleanup code (4 days ago) <Mikhail Glukhikh>
* ac1b957f8db - Symbol based types: cleanup code (4 days ago) <Mikhail Glukhikh>
* 4bb5fbaa4d6 - JavacWrapper: add output directory to classpath to see Kotlin files (4 days ago) <Mikhail Glukhikh>
* b75e6309326 - JavacWrapper: minor renames to make code clearer (4 days ago) <Mikhail Glukhikh>
* 0c662a5a349 - JavacWrapper: remove code duplication around getVisibility (4 days ago) <Mikhail Glukhikh>
* 298a30d2458 - Minor: run javac-mode compileJava after destroying of generation state (4 days ago) <Mikhail Glukhikh>
* bbd8fb8b232 - JavacWrapper: add support for JvmPackageName annotation (4 days ago) <Mikhail Glukhikh>
* e8cf0b5d4f0 - Add test for kotlin.streams function usage in Kotlin code (4 days ago) <Mikhail Glukhikh>
* f6ff5808527 - Cleanup code: JavacWrapper (4 days ago) <Mikhail Glukhikh>
* 2bec60a3ddc - Fix potential NPE in JavacWrapper (4 days ago) <Mikhail Glukhikh>
* d252e795be0 - (tag: build-1.3.60-dev-2851, origin/rr/yakovlev/removed_UL_fallback_to_L) Remove unnecessary fallback LigthClasses from UL (5 days ago) <Igor Yakovlev>
* d5e4227a1de - Revert commit and additional workaround to diagnostics problem (5 days ago) <Igor Yakovlev>
* 32a8fe1ca92 - Fix IdeRegression.testImplementingMutableSet test data (5 days ago) <Igor Yakovlev>
* 107ab060422 - (tag: build-1.3.60-dev-2820) Minor: make diagnostic tests usable with IDEA & JPS (5 days ago) <Dmitry Petrov>
* a633a336276 - KT-14513 Don't generate delegated property metadata when unused (5 days ago) <Dmitry Petrov>
* 92ba298e685 - KT-14513 DELEGATED_PROPERTIES -> DELEGATED_PROPERTIES_WITH_METADATA (5 days ago) <Dmitry Petrov>
* 3989f351ff4 - (tag: build-1.3.60-dev-2818, tag: build-1.3.60-dev-2816) Use modules instead of files for MPP diagnostic (5 days ago) <Dmitry Savvinov>
* 45737e51fb7 - Minor: let 'Renderer'-helper return more specific type (5 days ago) <Dmitry Savvinov>
* 8bfd30fc69d - Minor: reformat IdeRenderers.kt (5 days ago) <Dmitry Savvinov>
* 249e5da53bd - Add internal action to toggle analysis mode (5 days ago) <Dmitry Savvinov>
* f7eb294b80c - Configure facets depending on MPP version in tests setup (5 days ago) <Dmitry Savvinov>
* 182f5fafada - Take dependsOn-graph from corresponding property for MPP.M3 (5 days ago) <Dmitry Savvinov>
* 958a7d9315e - Refactor MPP versioning (5 days ago) <Dmitry Savvinov>
* dbd352e2ba1 - Minor: simplify condition in KotlinFacetSettings (5 days ago) <Dmitry Savvinov>
* e38ff8753e8 - (tag: build-1.3.60-dev-2812) JVM_IR: support type parameters in @JvmOverload functions (5 days ago) <Georgy Bronnikov>
* 7467c809702 - (tag: build-1.3.60-dev-2810) Fix bunch rule (5 days ago) <Nikolay Krasko>
* 343502125b2 - Rename ResolveInWriteActionManager -> ResolveInDispatchThreadManager (5 days ago) <Nikolay Krasko>
* ea56a5e8b1e - (tag: build-1.3.60-dev-2809) Unmute some JVM_IR inlining tests (5 days ago) <pyos>
* 6163a8cf561 - IR: keep source container when making functions static (5 days ago) <pyos>
* 35a0fc40a67 - Don't create redundant copies in DefaultArgumentStubGenerator (5 days ago) <pyos>
* 8bf5afbba25 - JVM_IR: lift pre-super() computations out of anonymous objects (5 days ago) <pyos>
* fa54b2cb819 - JVM_IR: improve scope detection in accessor generation. (5 days ago) <pyos>
* d86e87d35ee - Add quickfix to change object to class (5 days ago) <Toshiaki Kameyama>
* 6a329210cb4 - (tag: build-1.3.60-dev-2803) Convert to anonymous object: fix wrong replacement when SAM is nested interface (5 days ago) <Toshiaki Kameyama>
* 2e3428bbe72 - (tag: build-1.3.60-dev-2801) JVM_IR: incorporate validation into jvmPhases (5 days ago) <Georgy Bronnikov>
* 05527fbc9ac - Fix all IR element duplication warnings/errors in JVM IR. (5 days ago) <Mark Punzalan>
* ac7e955d3e7 - (tag: build-1.3.60-dev-2800) Change parameter type quick fix: don't use qualified name (5 days ago) <Toshiaki Kameyama>
* c463fad3b74 - (tag: build-1.3.60-dev-2793) KT-34000: Allow autoimport to suggest fixes in qualified expressions (5 days ago) <Roman Golyshev>
* b2d21653424 - (tag: build-1.3.60-dev-2786) Add "Remove redundant label" quick fix for REDUNDANT_LABEL_WARNING (5 days ago) <Toshiaki Kameyama>
* 18df5d9db0b - (tag: build-1.3.60-dev-2778) Support mixed positioned/named arguments in AddNameToArgumentIntention (5 days ago) <Denis Zharkov>
* e54d2c7c32f - Support named arguments in their own position (5 days ago) <Denis Zharkov>
* bd6481b9e86 - (tag: build-1.3.60-dev-2776) Add support for settings.gradle.kts configuring kotlin in project (KT-34114) (5 days ago) <Natalia Selezneva>
* fac49df1779 - Invoke in CompilerSettingsListeners in invokeLater (5 days ago) <Natalia Selezneva>
* 217f681b6e8 - (tag: build-1.3.60-dev-2772) JVM IR: Use WrappedClassDescriptor in class builder. (5 days ago) <Steven Schäfer>
* be002fc4176 - (tag: build-1.3.60-dev-2768, origin/rr/gogabr/repair-jvm-static-with-defaults) JVM_IR: do not copy bodies when creating static functions (6 days ago) <Georgy Bronnikov>
* 4920d71d70b - JVM_IR: set dispatchReceiverParameter of imported JvmStatic object methods to null (6 days ago) <Georgy Bronnikov>
* c7904b273fe - (tag: build-1.3.60-dev-2760) FIR: fix FirArraySetCall.acceptChildren thus fixing visitConsistencyTest (6 days ago) <Mikhail Glukhikh>
* 7e47be97656 - (tag: build-1.3.60-dev-2758) Add kotlin js test runner as required dependency for Karma (6 days ago) <Ilya Goncharov>