### PR TITLE
Initialize ObjCExport during runtime init too

### DIFF
--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -15,8 +15,8 @@ fun main(args: Array<String>) {
 }
 
 fun run() {
-    testTypeOps()
     testConversions()
+    testTypeOps()
     testWeakRefs()
     testExceptions()
     testBlocks()
@@ -191,6 +191,7 @@ fun testConversions() {
     testMethodsOfAny(emptyList<Nothing>(), NSArray())
     testMethodsOfAny(listOf(1, "foo"), nsArrayOf(1, "foo"))
     testMethodsOfAny(42, NSNumber.numberWithInt(42), 17)
+    testMethodsOfAny(true, NSNumber.numberWithBool(true), false)
 }
 
 fun testMethodsOfAny(kotlinObject: Any, equalNsObject: NSObject, otherObject: Any = Any()) {

--- a/runtime/src/main/cpp/ObjCExport.mm
+++ b/runtime/src/main/cpp/ObjCExport.mm
@@ -36,6 +36,7 @@
 #import <dispatch/dispatch.h>
 
 #import "ObjCExport.h"
+#import "ObjCExportInit.h"
 #import "ObjCExportPrivate.h"
 #import "MemoryPrivate.hpp"
 #import "Runtime.h"
@@ -321,7 +322,7 @@ static void initTypeAdapters() {
   initTypeAdaptersFrom(Kotlin_ObjCExport_sortedProtocolAdapters, Kotlin_ObjCExport_sortedProtocolAdaptersNum);
 }
 
-extern "C" void Kotlin_ObjCExport_initialize() {
+static void Kotlin_ObjCExport_initializeImpl() {
   initTypeAdapters();
 
   SEL toKotlinSelector = Kotlin_ObjCExport_toKotlinSelector;
@@ -361,6 +362,13 @@ extern "C" void Kotlin_ObjCExport_initialize() {
       RuntimeAssert(added, "Unable to add 'releaseAsAssociatedObject' method to SwiftObject class");
     }
   }
+}
+
+extern "C" void Kotlin_ObjCExport_initialize() {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    Kotlin_ObjCExport_initializeImpl();
+  });
 }
 
 static OBJ_GETTER(SwiftObject_toKotlinImp, id self, SEL cmd) {

--- a/runtime/src/main/cpp/ObjCExport.mm
+++ b/runtime/src/main/cpp/ObjCExport.mm
@@ -364,6 +364,10 @@ static void Kotlin_ObjCExport_initializeImpl() {
   }
 }
 
+// Initializes ObjCExport for current process (if not initialized yet).
+// Generally this is equal to some "binary patching" (which is usually done at link time
+// but postponed until runtime here due to various reasons):
+// adds methods to Objective-C classes, initializes static memory with "constant" values etc.
 extern "C" void Kotlin_ObjCExport_initialize() {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{

--- a/runtime/src/main/cpp/ObjCExportInit.h
+++ b/runtime/src/main/cpp/ObjCExportInit.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+#ifndef RUNTIME_OBJCEXPORTINIT_H
+#define RUNTIME_OBJCEXPORTINIT_H
+
+#if KONAN_OBJC_INTEROP
+
+extern "C" void Kotlin_ObjCExport_initialize(void);
+
+#endif // KONAN_OBJC_INTEROP
+
+#endif // RUNTIME_OBJCEXPORTINIT_H

--- a/runtime/src/main/cpp/ObjCExportPrivate.h
+++ b/runtime/src/main/cpp/ObjCExportPrivate.h
@@ -19,7 +19,6 @@
 @end;
 
 extern "C" void Kotlin_ObjCExport_initializeClass(Class clazz);
-extern "C" void Kotlin_ObjCExport_initialize(void);
 extern "C" const TypeInfo* Kotlin_ObjCExport_getAssociatedTypeInfo(Class clazz);
 extern "C" OBJ_GETTER(Kotlin_ObjCExport_convertUnmappedObjCObject, id obj);
 extern "C" SEL Kotlin_ObjCExport_toKotlinSelector;

--- a/runtime/src/main/cpp/Runtime.cpp
+++ b/runtime/src/main/cpp/Runtime.cpp
@@ -19,6 +19,7 @@
 #include "Exceptions.h"
 #include "KAssert.h"
 #include "Memory.h"
+#include "ObjCExportInit.h"
 #include "Porting.h"
 #include "Runtime.h"
 #include "Worker.h"
@@ -97,6 +98,11 @@ RuntimeState* initRuntime() {
   if (firstRuntime) {
     isMainThread = 1;
     konan::consoleInit();
+
+#if KONAN_OBJC_INTEROP
+    Kotlin_ObjCExport_initialize();
+#endif
+
     InitOrDeinitGlobalVariables(INIT_GLOBALS);
   }
   InitOrDeinitGlobalVariables(INIT_THREAD_LOCAL_GLOBALS);

--- a/runtime/src/objc/cpp/ObjCExportClasses.mm
+++ b/runtime/src/objc/cpp/ObjCExportClasses.mm
@@ -21,6 +21,7 @@
 #import <dispatch/dispatch.h>
 
 #import "ObjCExport.h"
+#import "ObjCExportInit.h"
 #import "ObjCExportPrivate.h"
 #import "MemoryPrivate.hpp"
 #import "Runtime.h"


### PR DESCRIPTION
as it may be required during execution of Kotlin code calling Obj-C.