### PR TITLE
[platformLibs] move ctype.h to platform.posix on all platforms

### DIFF
--- a/platformLibs/src/platform/android/posix.def
+++ b/platformLibs/src/platform/android/posix.def
@@ -1,6 +1,6 @@
 depends =
 package = platform.posix
-headers = alloca.h ar.h assert.h complex.h dirent.h dlfcn.h err.h errno.h fcntl.h \
+headers = alloca.h ar.h assert.h complex.h ctype.h dirent.h dlfcn.h err.h errno.h fcntl.h \
     fenv.h fnmatch.h fts.h ftw.h getopt.h grp.h inttypes.h libgen.h limits.h \
     locale.h math.h memory.h netdb.h paths.h poll.h \
     pthread.h pwd.h regex.h resolv.h sched.h search.h semaphore.h setjmp.h signal.h \

--- a/platformLibs/src/platform/ios/darwin.def
+++ b/platformLibs/src/platform/ios/darwin.def
@@ -6,7 +6,7 @@ headers = AppleTextureEncoder.h AssertMacros.h Availability.h AvailabilityIntern
     TargetConditionals.h __cxxabi_config.h _locale.h _types.h _wctype.h \
     aio.h asl.h bitstring.h bzlib.h \
     cache.h cache_callbacks.h checkint.h compression.h copyfile.h \
-    cpio.h ctype.h cxxabi.h db.h \
+    cpio.h cxxabi.h db.h \
     dns.h dns_sd.h dns_util.h execinfo.h \
     fmtmsg.h fstab.h \
     gethostuuid.h glob.h ifaddrs.h inttypes.h iso646.h \

--- a/platformLibs/src/platform/ios/posix.def
+++ b/platformLibs/src/platform/ios/posix.def
@@ -1,6 +1,6 @@
 depends =
 package = platform.posix
-headers = alloca.h assert.h complex.h dirent.h dlfcn.h err.h errno.h fcntl.h \
+headers = alloca.h assert.h complex.h ctype.h dirent.h dlfcn.h err.h errno.h fcntl.h \
     fenv.h float.h fnmatch.h fts.h ftw.h getopt.h grp.h inttypes.h libgen.h limits.h \
     locale.h math.h memory.h netdb.h paths.h poll.h \
     pthread.h pwd.h regex.h resolv.h sched.h search.h semaphore.h setjmp.h signal.h \

--- a/platformLibs/src/platform/linux/linux.def
+++ b/platformLibs/src/platform/linux/linux.def
@@ -1,6 +1,6 @@
 package = platform.linux
 headers = aio.h aliases.h a.out.h argp.h argz.h byteswap.h cpio.h crypt.h \
-	ctype.h elf.h endian.h envz.h error.h execinfo.h features.h fmtmsg.h \
+	elf.h endian.h envz.h error.h execinfo.h features.h fmtmsg.h \
 	fpu_control.h \
 	fstab.h _G_config.h gconv.h glob.h gnu-versions.h \
 	gshadow.h ieee754.h ifaddrs.h langinfo.h lastlog.h \

--- a/platformLibs/src/platform/linux/posix.def
+++ b/platformLibs/src/platform/linux/posix.def
@@ -1,5 +1,5 @@
 package = platform.posix
-headers = alloca.h ar.h assert.h complex.h dirent.h dlfcn.h err.h errno.h fcntl.h \
+headers = alloca.h ar.h assert.h complex.h ctype.h dirent.h dlfcn.h err.h errno.h fcntl.h \
     fenv.h fnmatch.h fts.h ftw.h getopt.h grp.h inttypes.h libgen.h limits.h \
     locale.h math.h memory.h netdb.h paths.h poll.h \
     pthread.h pwd.h regex.h resolv.h sched.h search.h semaphore.h setjmp.h sgtty.h signal.h \

--- a/platformLibs/src/platform/mingw/posix.def
+++ b/platformLibs/src/platform/mingw/posix.def
@@ -1,5 +1,5 @@
 package = platform.posix
-headers = assert.h complex.h dirent.h errno.h fcntl.h \
+headers = assert.h complex.h ctype.h dirent.h errno.h fcntl.h \
     fenv.h float.h ftw.h getopt.h inttypes.h libgen.h limits.h \
     locale.h math.h memory.h pthread.h sched.h search.h semaphore.h \
     setjmp.h signal.h stdint.h stdio.h stdlib.h string.h \

--- a/platformLibs/src/platform/osx/darwin.def
+++ b/platformLibs/src/platform/osx/darwin.def
@@ -6,7 +6,7 @@ headers = AppleTextureEncoder.h AssertMacros.h Availability.h AvailabilityIntern
     TargetConditionals.h __cxxabi_config.h _locale.h _types.h _wctype.h \
     aio.h asl.h bitstring.h bzlib.h \
     cache.h cache_callbacks.h checkint.h compression.h copyfile.h \
-    cpio.h ctype.h cxxabi.h db.h \
+    cpio.h cxxabi.h db.h \
     dns.h dns_sd.h dns_util.h execinfo.h \
     fmtmsg.h fstab.h \
     gethostuuid.h glob.h ifaddrs.h inttypes.h iso646.h \

--- a/platformLibs/src/platform/osx/posix.def
+++ b/platformLibs/src/platform/osx/posix.def
@@ -1,6 +1,6 @@
 depends =
 package = platform.posix
-headers = alloca.h ar.h assert.h complex.h dirent.h dlfcn.h err.h errno.h fcntl.h \
+headers = alloca.h ar.h assert.h complex.h ctype.h dirent.h dlfcn.h err.h errno.h fcntl.h \
     fenv.h float.h fnmatch.h fts.h ftw.h getopt.h grp.h inttypes.h libgen.h limits.h \
     locale.h math.h memory.h netdb.h paths.h poll.h \
     pthread.h pwd.h regex.h resolv.h sched.h search.h semaphore.h setjmp.h sgtty.h signal.h \

--- a/platformLibs/src/platform/tvos/darwin.def
+++ b/platformLibs/src/platform/tvos/darwin.def
@@ -6,7 +6,7 @@ headers = AppleTextureEncoder.h AssertMacros.h Availability.h AvailabilityIntern
     TargetConditionals.h __cxxabi_config.h _locale.h _types.h _wctype.h \
     aio.h asl.h bitstring.h bzlib.h \
     cache.h cache_callbacks.h checkint.h compression.h copyfile.h \
-    cpio.h ctype.h cxxabi.h db.h \
+    cpio.h cxxabi.h db.h \
     dns.h dns_sd.h dns_util.h execinfo.h \
     fmtmsg.h fstab.h \
     gethostuuid.h glob.h ifaddrs.h inttypes.h iso646.h \

--- a/platformLibs/src/platform/tvos/posix.def
+++ b/platformLibs/src/platform/tvos/posix.def
@@ -1,6 +1,6 @@
 depends =
 package = platform.posix
-headers = alloca.h assert.h complex.h dirent.h dlfcn.h err.h errno.h fcntl.h \
+headers = alloca.h assert.h complex.h ctype.h dirent.h dlfcn.h err.h errno.h fcntl.h \
     fenv.h float.h fnmatch.h fts.h ftw.h getopt.h grp.h inttypes.h libgen.h limits.h \
     locale.h math.h memory.h netdb.h paths.h poll.h \
     pthread.h pwd.h regex.h resolv.h sched.h search.h semaphore.h setjmp.h signal.h \

--- a/platformLibs/src/platform/watchos/darwin.def
+++ b/platformLibs/src/platform/watchos/darwin.def
@@ -6,7 +6,7 @@ headers =  AssertMacros.h Availability.h AvailabilityInternal.h \
     TargetConditionals.h __cxxabi_config.h _locale.h _types.h _wctype.h \
     aio.h asl.h bitstring.h bzlib.h \
     cache.h cache_callbacks.h checkint.h compression.h copyfile.h \
-    cpio.h ctype.h cxxabi.h db.h \
+    cpio.h cxxabi.h db.h \
     dns.h dns_sd.h dns_util.h execinfo.h \
     fmtmsg.h fstab.h \
     gethostuuid.h glob.h ifaddrs.h inttypes.h iso646.h \

--- a/platformLibs/src/platform/watchos/posix.def
+++ b/platformLibs/src/platform/watchos/posix.def
@@ -1,6 +1,6 @@
 depends =
 package = platform.posix
-headers = alloca.h assert.h complex.h dirent.h dlfcn.h err.h errno.h fcntl.h \
+headers = alloca.h assert.h complex.h ctype.h dirent.h dlfcn.h err.h errno.h fcntl.h \
     fenv.h float.h fnmatch.h fts.h ftw.h getopt.h grp.h inttypes.h libgen.h limits.h \
     locale.h math.h memory.h netdb.h paths.h poll.h \
     pthread.h pwd.h regex.h resolv.h sched.h search.h semaphore.h setjmp.h signal.h \


### PR DESCRIPTION
Functions like `isalpha`, `isdigit`, etc was there since UNIX times, and should be on all POSIX compatible platform.