### PR TITLE
[kotlin compiler][update] 1.3.70-dev-1244

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
@@ -72,7 +72,8 @@ internal val Context.getBoxFunction: (IrClass) -> IrSimpleFunction by Context.la
             isExternal = false,
             isTailrec = false,
             isSuspend = false,
-            isExpect = false
+            isExpect = false,
+            isFakeOverride = false
     ).also { function ->
         function.valueParameters.add(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(
@@ -124,7 +125,8 @@ internal val Context.getUnboxFunction: (IrClass) -> IrSimpleFunction by Context.
             isExternal = false,
             isTailrec = false,
             isSuspend = false,
-            isExpect = false
+            isExpect = false,
+            isFakeOverride = false
     ).also { function ->
         function.valueParameters.add(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -141,7 +141,8 @@ internal class SpecialDeclarationsFactory(val context: Context) : KotlinMangler 
                 isTailrec = false,
                 isSuspend = function.isSuspend,
                 returnType = returnType,
-                isExpect = false
+                isExpect = false,
+                isFakeOverride = false
         ).apply {
             descriptor.bind(this)
             parent = function.parent

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -192,6 +192,7 @@ internal class SpecialDeclarationsFactory(val context: Context) : KotlinMangler 
 }
 
 internal class Context(config: KonanConfig) : KonanBackendContext(config) {
+    override val lateinitNullableFields = mutableMapOf<IrField, IrField>()
     lateinit var frontendServices: FrontendServices
     lateinit var environment: KotlinCoreEnvironment
     lateinit var bindingContext: BindingContext

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
@@ -40,7 +40,8 @@ internal fun makeEntryPoint(context: Context): IrFunction {
             isExternal = false,
             isTailrec = false,
             isSuspend = false,
-            isExpect = false
+            isExpect = false,
+            isFakeOverride = false
     ).also { function ->
         function.valueParameters.add(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -76,7 +76,8 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
                     Visibilities.PRIVATE,
                     isFinal = true,
                     isExternal = false,
-                    isStatic = false
+                    isStatic = false,
+                    isFakeOverride = false
             ).apply {
                 it.bind(this)
                 parent = implObject
@@ -96,7 +97,8 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
                     isExternal = false,
                     isTailrec = false,
                     isSuspend = false,
-                    isExpect = false
+                    isExpect = false,
+                    isFakeOverride = false
             ).apply {
                 it.bind(this)
                 parent = implObject

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -571,7 +571,8 @@ private fun KotlinStubs.createFakeKotlinExternalFunction(
             isExternal = true,
             isTailrec = false,
             isSuspend = false,
-            isExpect = false
+            isExpect = false,
+            isFakeOverride = false
     )
     bridgeDescriptor.bind(bridge)
 
@@ -1261,7 +1262,8 @@ private class ObjCBlockPointerValuePassing(
                 overriddenInvokeMethod.name,
                 Visibilities.PUBLIC, Modality.FINAL,
                 returnType = functionType.arguments.last().typeOrNull!!,
-                isInline = false, isExternal = false, isTailrec = false, isSuspend = false, isExpect = false
+                isInline = false, isExternal = false, isTailrec = false, isSuspend = false, isExpect = false,
+                isFakeOverride = false
         )
         invokeMethodDescriptor.bind(invokeMethod)
         invokeMethod.overriddenSymbols += overriddenInvokeMethod.symbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -116,7 +116,8 @@ private fun createKotlinBridge(
             isExternal = isExternal,
             isTailrec = false,
             isSuspend = false,
-            isExpect = false
+            isExpect = false,
+            isFakeOverride = false
     )
     bridgeDescriptor.bind(bridge)
     if (isExternal) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -394,7 +394,8 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
                 Visibilities.PRIVATE,
                 isFinal = true,
                 isExternal = false,
-                isStatic = false
+                isStatic = false,
+                isFakeOverride = false
         )
         irField.parent = declaration
 
@@ -502,7 +503,8 @@ private val Context.getLoweredInlineClassConstructor: (IrConstructor) -> IrSimpl
             isTailrec = false,
             isSuspend = false,
             returnType = irConstructor.returnType,
-            isExpect = false
+            isExpect = false,
+            isFakeOverride = false
     ).apply {
         descriptor.bind(this)
         parent = irConstructor.parent

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -83,7 +83,8 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                                 isTailrec = false,
                                 isSuspend = false,
                                 returnType = context.irBuiltIns.anyNType,
-                                isExpect = false
+                                isExpect = false,
+                                isFakeOverride = false
                     ).apply {
                             it.bind(this)
                         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
@@ -309,7 +309,8 @@ internal class CallableReferenceLowering(val context: Context): FileLoweringPass
                     isExternal = false,
                     isTailrec = false,
                     isSuspend = superFunction.isSuspend,
-                    isExpect = false
+                    isExpect = false,
+                    isFakeOverride = false
             ).apply {
                 it.bind(this)
                 val function = this

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
@@ -101,7 +101,8 @@ internal class PropertyDelegationLowering(val context: Context) : FileLoweringPa
                     Visibilities.PRIVATE,
                     isFinal = true,
                     isExternal = false,
-                    isStatic = true
+                    isStatic = true,
+                    isFakeOverride = false
             ).apply {
                 it.bind(this)
                 parent = irFile

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FinallyBlocksLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FinallyBlocksLowering.kt
@@ -187,6 +187,7 @@ internal class FinallyBlocksLowering(val context: Context): FileLoweringPass, Ir
                 false,
                 false,
                 false,
+                false,
                 false)
         )
         return descriptor

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
@@ -108,7 +108,8 @@ internal class InitializersLowering(val context: CommonBackendContext) : ClassLo
                         isSuspend = false,
                         isExternal = false,
                         isTailrec = false,
-                        isExpect = false
+                        isExpect = false,
+                        isFakeOverride = false
                 ).apply {
                     it.bind(this)
                     parent = irClass

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -234,7 +234,8 @@ internal class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfo
                 isExternal = false,
                 isTailrec = false,
                 isSuspend = false,
-                isExpect = false
+                isExpect = false,
+                isFakeOverride = false
         ).also { result ->
             resultDescriptor.bind(result)
             result.parent = irClass
@@ -376,7 +377,8 @@ internal class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfo
                     isExternal = false,
                     isTailrec = false,
                     isSuspend = false,
-                    isExpect = false
+                    isExpect = false,
+                    isFakeOverride = false
             ).apply {
                 it.bind(this)
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -488,7 +488,8 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
                 isExternal = false,
                 isTailrec = false,
                 isSuspend = false,
-                isExpect = false
+                isExpect = false,
+                isFakeOverride = false
         ).apply {
             it.bind(this)
         }
@@ -507,7 +508,8 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
                 isExternal = false,
                 isTailrec = false,
                 isSuspend = false,
-                isExpect = false
+                isExpect = false,
+                isFakeOverride = false
         ).apply {
             it.bind(this)
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -350,7 +350,8 @@ internal class TestProcessor (val context: Context) {
                 isExternal = false,
                 isTailrec = false,
                 isSuspend = false,
-                isExpect = false
+                isExpect = false,
+                isFakeOverride = false
         ).apply {
             descriptor.bind(this)
             parent = owner
@@ -387,7 +388,8 @@ internal class TestProcessor (val context: Context) {
                 isExternal = false,
                 isTailrec = false,
                 isSuspend = false,
-                isExpect = false
+                isExpect = false,
+                isFakeOverride = false
         ).apply {
             descriptor.bind(this)
             parent = owner

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -73,7 +73,8 @@ internal fun IrFile.addTopLevelInitializer(expression: IrExpression, context: Ko
             Visibilities.PRIVATE,
             isFinal = true,
             isExternal = false,
-            isStatic = true
+            isStatic = true,
+            isFakeOverride = false
     ).apply {
         descriptor.bind(this)
 
@@ -366,6 +367,7 @@ fun createField(
             type,
             Visibilities.PRIVATE,
             !isMutable,
+            false,
             false,
             false
     ).apply {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,15 +18,16 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1108,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-dev-1108
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1108,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-dev-1108
-kotlinStdlibTestsVersion=1.3.70-dev-1108
-testKotlinCompilerVersion=1.3.70-dev-1108
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1244,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-dev-1244
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1244,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.70-dev-1244
+kotlinStdlibTestsVersion=1.3.70-dev-1244
+testKotlinCompilerVersion=1.3.70-dev-1244
 konanVersion=1.3.70
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.workers.max=4
 
 # Uncomment to enable composite build
 #kotlinProjectPath=<insert the path to Kotlin project root here>
+


### PR DESCRIPTION
* 51459adb8c8 - (tag: build-1.3.70-dev-1244) Add integration test for Kapt3+IR (10 hours ago) <Georgy Bronnikov>
* 195f225e36c - Run Kapt3 with old backend, even if IR is specified in configuration (10 hours ago) <Georgy Bronnikov>
* b9f88350dd9 - (tag: build-1.3.70-dev-1231) [JS IR] Build hybrid versions of stdlib and kotlin.test (3 days ago) <Svyatoslav Kuzmich>
* d872b27663a - [JS IR] Add gradle plugin integration tests (3 days ago) <Svyatoslav Kuzmich>
* bc47594c7af - Update bootstrap (3 days ago) <Svyatoslav Kuzmich>
* 1b8df45bfe0 - [JS IR] Support generating both IR and pre-IR libraries (3 days ago) <Svyatoslav Kuzmich>
* 62d204f4d62 - Support trailing comma ^KT-34743 Fixed (3 days ago) <victor.petukhov>
* e638b9fd12b - (tag: build-1.3.70-dev-1228) K/N performance gradle plugin. Added options and right code size for … (#2752) (3 days ago) <LepilkinaElena>
* 8c079706a54 - (tag: build-1.3.70-dev-1227) Add tests for case when result of tail-call suspend function returning (3 days ago) <Ilmir Usmanov>
* ca527444cbf - Return Unit manually in callSuspend and callSuspendBy if callable (3 days ago) <Ilmir Usmanov>
* 04441da0957 - Replace result on stack with Unit if callee is suspend function (3 days ago) <Ilmir Usmanov>
* 3b088818a55 - (tag: build-1.3.70-dev-1222) Build: Add sources and javadocs to Kotlin Plugin publication (3 days ago) <Vyacheslav Gerasimov>
* 579645bcfa3 - Build: Publish ide-common as separate artifact in KotlinPlugin publication (3 days ago) <Vyacheslav Gerasimov>
* 7401a7c63fe - Build: Fix dependencies of ide-common (3 days ago) <Vyacheslav Gerasimov>
* 1e63101a27a - (tag: build-1.3.70-dev-1216) FIR2IR: fix testData after rebase (3 days ago) <Dmitry Petrov>
* 6cde86139cf - IR: isFakeOverride: fix testData after rebase (3 days ago) <Dmitry Petrov>
* 35b9f43608d - IR: use isFakeOverride (3 days ago) <Dmitry Petrov>
* f79909d7249 - IR serialization: isFakeOverride in proto (3 days ago) <Dmitry Petrov>
* 5c390d94262 - IR serialization: IrField.isFakeOverride (3 days ago) <Dmitry Petrov>
* ce960539400 - JVM_IR: IrField.isFakeOverride (3 days ago) <Dmitry Petrov>
* 0b26f326749 - JS_IR: IrField.isFakeOverride (3 days ago) <Dmitry Petrov>
* 6101f006114 - IR BE common: IrField.isFakeOverride (3 days ago) <Dmitry Petrov>
* 3fcdbf2c881 - FIR2IR: IrField.isFakeOverride (3 days ago) <Dmitry Petrov>
* edaa42ea46c - IR: IrField.isFakeOverride (3 days ago) <Dmitry Petrov>
* e9337ec8f20 - IR serialization: IrProperty.isFakeOverride (3 days ago) <Dmitry Petrov>
* da63d16c338 - IR BE common: IrProperty.isFakeOverride (3 days ago) <Dmitry Petrov>
* 8b8b96bff40 - FIR2IR: IrProperty.isFakeOverride (3 days ago) <Dmitry Petrov>
* 82c527c2cc4 - IR: IrProperty.isFakeOverride (3 days ago) <Dmitry Petrov>
* 26820577678 - IR tests: update testData for IrSimpleFunction.isFakeOverride (3 days ago) <Dmitry Petrov>
* 65e6a848312 - IR tests: check IrSimpleFunction.isFakeOverride (3 days ago) <Dmitry Petrov>
* 46745adfd9d - FIR2IR: IrSimpleFunction.isFakeOverride (3 days ago) <Dmitry Petrov>
* d23f13e3dcb - IR serialization: IrSimpleFunction.isFakeOverride (3 days ago) <Dmitry Petrov>
* 5831b08a6e3 - JVM_IR: IrSimpleFunction.isFakeOverride (3 days ago) <Dmitry Petrov>
* f24278941d9 - JS_IR: IrSimpleFunction.isFakeOverride (3 days ago) <Dmitry Petrov>
* b36d8f556a4 - IR BE common: IrSimpleFunction.isFakeOverride (3 days ago) <Dmitry Petrov>
* 843fb884596 - IR: IrSimpleFunction.isFakeOverride (3 days ago) <Dmitry Petrov>
* 01f09af608e - (tag: build-1.3.70-dev-1214) [FIR] Fix generated name for `FirErrorNameReferenceImpl` (3 days ago) <Dmitriy Novozhilov>
* 829227255dd - [FIR] Add rendering of error numbers per file/package/module in HTML dump (3 days ago) <Dmitriy Novozhilov>
* 528e538b2a1 - [FIR] Remove duplicating diagnostics from error function calls (3 days ago) <Dmitriy Novozhilov>
* a3ae629f53f - Fix bunch file in 193 (3 days ago) <Nikolay Krasko>
* ffafd96f1b1 - Fix url for developers builds (KT-34246) (3 days ago) <Nikolay Krasko>
* 955300dd342 - (tag: build-1.3.70-dev-1211) Deserializer: Fix initialization of private top-levels (3 days ago) <Ilya Matveev>
* 073578bf1cc - (tag: build-1.3.70-dev-1205) [FIR] Fix Fir2Ir testdata broken in a501e514 (3 days ago) <Dmitriy Novozhilov>
* 098616ac76b - [FIR] Add dependency of `:descriptors.runtime` to `:fir2ir` module (3 days ago) <Dmitriy Novozhilov>
* 1b44566e6fd - [FIR] Fix compilation error in lightTree module (3 days ago) <Dmitriy Novozhilov>
* 27c70eedd93 - (tag: build-1.3.70-dev-1204, tag: build-1.3.70-dev-1203, tag: build-1.3.70-dev-1202) Enable MixedNamedArgumentsInTheirOwnPosition feature in compiler module (3 days ago) <Dmitriy Novozhilov>
* 09fa15c22b9 - [FIR] Support old FE-like multifile tests (3 days ago) <Dmitriy Novozhilov>
* 65eed24dbb7 - [FIR] Add diagnostics reporting to FIR resolve tests (3 days ago) <Dmitriy Novozhilov>
* 38bb9f78d64 - [FIR] Add diagnostic collector component that collects diagnostics from error nodes (3 days ago) <Dmitriy Novozhilov>
* 0428916d3c4 - [FIR] Add error nodes to default transformer and visitors (3 days ago) <Dmitriy Novozhilov>
* a501e514c9e - [FIR] Add meaningful diagnostics in all error elements (3 days ago) <Dmitriy Novozhilov>
* 7503449e8df - [FIR] Add kind to diagnostics reported by RawFirBuilder (3 days ago) <Dmitriy Novozhilov>
* 8b5f568a150 - [FIR] Introduce `FirDiagnostic` in FIR instead of errorReason (3 days ago) <Dmitriy Novozhilov>
* 8eabe08e7aa - [FIR] Move components into separate package (3 days ago) <Dmitriy Novozhilov>
* f72fa875832 - [FIR] Add old FE-like diagnostic tests (3 days ago) <Dmitriy Novozhilov>
* 8b900624d30 - [FIR] Add bridge for diagnostics from old FE to ConeDiagnostic (3 days ago) <Dmitriy Novozhilov>
* 9b77dec99c5 - [FIR] Add prototype of diagnostic collector (3 days ago) <Dmitriy Novozhilov>
* e909b63d30f - (tag: build-1.3.70-dev-1196) Revert "Fix GradleConfiguratorTest" (4 days ago) <Andrey Uskov>
* fd2b75e39b2 - Fixed import of MPP project with single Android target (4 days ago) <Andrey Uskov>
* 5c3b00cd0c9 - Improve performance of import in Android Studio (4 days ago) <Andrey Uskov>
* e8e04ca98ea - (tag: build-1.3.70-dev-1194) Do not use new stdlib API in reflection implementation (4 days ago) <Alexander Udalov>
* 72591e34b3a - (tag: build-1.3.70-dev-1192, tag: build-1.3.70-dev-1188) Support android_x64/86 in cinterop definitions (4 days ago) <Kirill Shmakov>
* 4c21b234b17 - (tag: build-1.3.70-dev-1182) Fixed compilation in 191 (4 days ago) <Alexander Podkhalyuzin>
* 7b8fbb5fea1 - (tag: build-1.3.70-dev-1181) Fixed freezes with add unambiguous imports on the fly (4 days ago) <Alexander Podkhalyuzin>
* 24d620657b6 - (tag: build-1.3.70-dev-1175) Java doesn't have extension methods, so we don't need to look for imports for qualified references (4 days ago) <Alexander Podkhalyuzin>
* 95ac0e328fb - (tag: build-1.3.70-dev-1172) Build: Extract bootstrap teamcity url to parameter (4 days ago) <Vyacheslav Gerasimov>
* f641e2a1391 - (tag: build-1.3.70-dev-1170) RedundantRequireNotNullCallInspection: should use `BodyResolveMode.PARTIAL_WITH_CFA` instead of `BodyResolveMode.PARTIAL` #KT-34672 Fixed (4 days ago) <Dmitry Gridin>
* 04c8c888eec - KotlinLightCodeInsightFixtureTestCase: remove deprecated call for 193 (4 days ago) <Dmitry Gridin>
* 17429d333e9 - Create expect/actual should move cursor to target declaration #KT-34411 Fixed (4 days ago) <Dmitry Gridin>
* 8e2943ae2ac - (tag: build-1.3.70-dev-1169) Temporary increase timeout to avoid NPE (4 days ago) <Mikhael Bogdanov>
* 7c4033f0bfd - (tag: build-1.3.70-dev-1168) Deserializer: Fix initialization order (4 days ago) <Ilya Matveev>
* 78b29349c99 - (tag: build-1.3.70-dev-1167) Fix lateinit `isInitialized` check in multi-file case (4 days ago) <Roman Artemev>
* d75b9380890 - Formatter: don't format elvis operator in string template (4 days ago) <Toshiaki Kameyama>
* bcee8ce04bf - (tag: build-1.3.70-dev-1165) KT-34692: Invoke `ScratchAction::update` without `invokeLater` (4 days ago) <Roman Golyshev>
* 28ec74648ef - (tag: build-1.3.70-dev-1163) Use ML completion extension point from 193 platform (4 days ago) <Roman Golyshev>
* b30a9e1d3e6 - (tag: build-1.3.70-dev-1155) [NI] Remove capturing from supertypes during computation of CST (4 days ago) <Mikhail Zarechenskiy>
* e8907c078d8 - [NI] Don't recreate subtyping context every time (4 days ago) <Mikhail Zarechenskiy>
* de009a2ff25 - [NI] Minor, use singleton instead of creating anonymous object (4 days ago) <Mikhail Zarechenskiy>
* 77577dfa6f2 - [FIR] Introduce `ConeStubType` to have subtyping for non-fixed variables (4 days ago) <Mikhail Zarechenskiy>
* 01ad9c47c8f - [NI] Fix subtyping between integer literal types and intersection ones (4 days ago) <Mikhail Zarechenskiy>
* e0fb586aafb - [NI] Don't loose diagnostic after type variable fixation (4 days ago) <Mikhail Zarechenskiy>
* ca8da225698 - [NI] Improve CST algorithm to handle non-fixed variables (4 days ago) <Mikhail Zarechenskiy>
* ba6648d5352 - Minor, reformat `Annotations.kt` file (4 days ago) <Mikhail Zarechenskiy>
* 2ff36c808e7 - (tag: build-1.3.70-dev-1154) Minor: mute testEa35963 in WASM (4 days ago) <Dmitry Petrov>
* 8b2fdca706a - FIR2IR: fix testData (4 days ago) <Dmitry Petrov>
* b1b70e503c2 - JVM IR: Improve codegen for try/catch statements (4 days ago) <Steven Schäfer>
* af74fd047a9 - psi2ir: Consistently use type unit for statements (4 days ago) <Steven Schäfer>
* 0da4b060740 - psi2ir: Fix return insertion (4 days ago) <Steven Schäfer>
* b3e733ea4ff - 193: More mutes in 193 (SurroundWithTestGenerated, KT-34689, KT-34542, KT-34672) (4 days ago) <Nikolay Krasko>
* f7c775a0809 - 193: Mute tests for find usages in libraries in 193 (KT-34542) (4 days ago) <Nikolay Krasko>
* 7e5316b9f17 - Fix completion test for Java in 193 (4 days ago) <Nikolay Krasko>
* 42312c3060f - Fix GradleConfiguratorTest.testProjectWithModule in 193 (4 days ago) <Nikolay Krasko>
* 0d2e790b32d - Fix IdeaModuleInfoTest.testSdkForScript in 193 (4 days ago) <Nikolay Krasko>
* c9793e4bf46 - Fix IdeaModuleInfo tests in 193 (4 days ago) <Nikolay Krasko>
* 4ef063c656f - Log information about failed test (4 days ago) <Nikolay Krasko>
* 201859be92d - Mute RedundantRequireNotNullCall tests in 193 (KT-34672) (4 days ago) <Nikolay Krasko>
* bed2e21a1a5 - Mute CoroutineNonBlockingontextDetectionTest tests in 193 (KT-34659) (4 days ago) <Nikolay Krasko>
* 1811b795033 - Mute custom navigation tests (KT-34542) (4 days ago) <Nikolay Krasko>
* a835f07d519 - (tag: build-1.3.70-dev-1153) JVM_IR: don't regenerate objects in lambdas inlined into objects (4 days ago) <pyos>
* eeadc95bc1d - (tag: build-1.3.70-dev-1152) [Gradle, JS] Remove check on duplicated targets (4 days ago) <Ilya Goncharov>
* 1074a0ef695 - (tag: build-1.3.70-dev-1151) JVM_IR: Fix Inline CallableReferences with Varargs (4 days ago) <Kristoffer Andersen>
* 5360a7a3fe7 - (tag: build-1.3.70-dev-1147) Fix GradleConfiguratorTest (5 days ago) <Andrey Uskov>
* 33cacb87d3e - Fix import tests for IDE 183 (5 days ago) <Andrey Uskov>
* 4b2834c4a8a - (tag: build-1.3.70-dev-1146) Provide incremental analysis of a file when it is applicable (5 days ago) <Vladimir Dolzhenko>
* c7bd6d8ede5 - (tag: build-1.3.70-dev-1144) Support watchos and tvos in cinterop definitions (5 days ago) <Kirill Shmakov>
* 08f9dd2aeae - (tag: build-1.3.70-dev-1136) [Gradle, JS] Fix entry for webpack (with Configuration Avoidance broke) (5 days ago) <Ilya Goncharov>
* 6f91c0e6792 - [FIR] Don't check `@ExtensionFunction` in fir consistency tests (5 days ago) <Dmitriy Novozhilov>
* ad9bf62b2f7 - [FIR] Remove adding annotations from bounds to type parameter in lightTree2Fir (5 days ago) <Dmitriy Novozhilov>
* 36ad065792a - [FIR] Fix testdata broken after d2b895d8 (5 days ago) <Dmitriy Novozhilov>
* ddd25c703af - (tag: build-1.3.70-dev-1127) SmartPointers in Introduce Variable refactoring (5 days ago) <Alexander Podkhalyuzin>
* aa604d0854f - (tag: build-1.3.70-dev-1126) Fixed new/old type inference diff, sometimes causes problems in JPS (5 days ago) <Alexander Podkhalyuzin>
* 607249e899f - Make computeTasksAndResolveCall public for compiler plugins (5 days ago) <Stanislav Erokhin>
* 17bd5476668 - (tag: build-1.3.70-dev-1121) Build: Fix internalKotlinRepo url for JPS build (5 days ago) <Vyacheslav Gerasimov>
* 28187da7500 - (tag: build-1.3.70-dev-1112, tag: build-1.3.70-dev-1110) Fix compilation of :idea:compileTestKotlin (5 days ago) <Alexander Udalov>