### PR TITLE
Fix isolation between dynamic Objective-C classes in multiple frameworks

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -253,6 +253,13 @@ internal class ObjCExportCodeGenerator(
 
         emitTypeAdapters()
 
+        // Replace runtime global with weak linkage:
+        replaceExternalWeakOrCommonGlobal(
+                "Kotlin_ObjCInterop_uniquePrefix",
+                codegen.staticData.cStringLiteral(namer.topLevelNamePrefix),
+                context.standardLlvmSymbolsOrigin
+        )
+
         emitSelectorsHolder()
 
         emitStaticInitializers()

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3540,7 +3540,8 @@ interopTest("interop_objc_smoke") {
             "5\n" +
             "String macro\n" +
             "CFString macro\n" +
-            "Deallocated\nDeallocated\n"
+            "Deallocated\nDeallocated\n" +
+            "Class TestExportObjCClass34 has multiple implementations. Which one will be used is undefined.\n"
 
     source = "interop/objc/smoke.kt"
     interop = 'objcSmoke'

--- a/backend.native/tests/framework/multiple/framework1/first.kt
+++ b/backend.native/tests/framework/multiple/framework1/first.kt
@@ -15,6 +15,17 @@ class I1Impl : I1 {
     override fun getFortyTwo(): Int = 42
 }
 
+fun getI1() = object : I1 {
+    override fun getFortyTwo(): Int = 42
+}
+
 class C
 
 fun getUnit(): Unit? = Unit
+
+/*
+// Disabled for now to avoid depending on platform libs.
+fun getAnonymousObject() = object : platform.darwin.NSObject() {}
+class NamedObject : platform.darwin.NSObject()
+fun getNamedObject() = NamedObject()
+ */

--- a/backend.native/tests/framework/multiple/framework2/second.kt
+++ b/backend.native/tests/framework/multiple/framework2/second.kt
@@ -13,6 +13,17 @@ interface I2 {
 
 fun getFortyTwoFrom(i2: I2): Int = i2.getFortyTwo()
 
+fun getI2() = object : I2 {
+    override fun getFortyTwo(): Int = 42
+}
+
 class C
 
 fun isUnit(obj: Any?): Boolean = (obj === Unit)
+
+/*
+// Disabled for now to avoid depending on platform libs.
+fun getAnonymousObject() = object : platform.darwin.NSObject() {}
+class NamedObject : platform.darwin.NSObject()
+fun getNamedObject() = NamedObject()
+ */

--- a/backend.native/tests/framework/multiple/multiple.swift
+++ b/backend.native/tests/framework/multiple/multiple.swift
@@ -25,7 +25,7 @@ func testInteraction() throws {
     try assertEquals(actual: SecondKt.getFortyTwoFrom(i2: I1Impl()), expected: 42)
 }
 
-func testIsolation() throws {
+func testIsolation1() throws {
     try assertFalse(SecondKt.isUnit(obj: FirstKt.getUnit()))
 
     // Ensure frameworks don't share the same runtime (state):
@@ -36,6 +36,20 @@ func testIsolation() throws {
     try assertTrue(Second.RuntimeState().consumeChange())
 }
 
+func testIsolation2() throws {
+    try assertEquals(actual: FirstKt.getI1().getFortyTwo(), expected: 42)
+    try assertEquals(actual: SecondKt.getI2().getFortyTwo(), expected: 42)
+}
+
+func testIsolation3() throws {
+#if false // Disabled for now to avoid depending on platform libs.
+    FirstKt.getAnonymousObject()
+    SecondKt.getAnonymousObject()
+    FirstKt.getNamedObject()
+    SecondKt.getNamedObject()
+#endif
+}
+
 class MultipleFrameworksTests : TestProvider {
     var tests: [TestCase] = []
 
@@ -43,7 +57,9 @@ class MultipleFrameworksTests : TestProvider {
         tests = [
             TestCase(name: "TestClashingNames", method: withAutorelease(testClashingNames)),
             TestCase(name: "TestInteraction", method: withAutorelease(testInteraction)),
-            TestCase(name: "TestIsolation", method: withAutorelease(testIsolation)),
+            TestCase(name: "TestIsolation1", method: withAutorelease(testIsolation1)),
+            TestCase(name: "TestIsolation2", method: withAutorelease(testIsolation2)),
+            TestCase(name: "TestIsolation3", method: withAutorelease(testIsolation3)),
         ]
         providers.append(self)
     }

--- a/backend.native/tests/interop/objc/objcSmoke.def
+++ b/backend.native/tests/interop/objc/objcSmoke.def
@@ -1,3 +1,4 @@
 language = Objective-C
 headers = Foundation/NSArray.h Foundation/NSValue.h Foundation/NSString.h Foundation/NSStream.h
-headerFilter = **/smoke.h Foundation/NSArray.h Foundation/NSValue.h Foundation/NSString.h Foundation/NSStream.h
+headerFilter = **/smoke.h Foundation/NSArray.h Foundation/NSValue.h Foundation/NSString.h Foundation/NSStream.h \
+    objc/objc.h

--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -445,9 +445,16 @@ private const val TestExportObjCClass1Name = "TestExportObjCClass"
 
 @ExportObjCClass class TestExportObjCClass2 : NSObject()
 
+const val TestExportObjCClass34Name = "TestExportObjCClass34"
+@ExportObjCClass(TestExportObjCClass34Name) class TestExportObjCClass3 : NSObject()
+@ExportObjCClass(TestExportObjCClass34Name) class TestExportObjCClass4 : NSObject()
+
 fun testExportObjCClass() {
     assertEquals(TestExportObjCClass1Name, TestExportObjCClass1().objCClassName)
     assertEquals("TestExportObjCClass2", TestExportObjCClass2().objCClassName)
+
+    assertTrue((TestExportObjCClass3().objCClassName == TestExportObjCClass34Name)
+            xor (TestExportObjCClass4().objCClassName == TestExportObjCClass34Name))
 }
 
 private val Any.objCClassName: String

--- a/backend.native/tests/interop/objc/smoke.kt
+++ b/backend.native/tests/interop/objc/smoke.kt
@@ -28,6 +28,7 @@ fun run() {
     testInitWithCustomSelector()
     testAllocNoRetain()
     testNSOutputStreamToMemoryConstructor()
+    testExportObjCClass()
 
     assertEquals(2, ForwardDeclaredEnum.TWO.value)
 
@@ -438,6 +439,19 @@ fun testNSOutputStreamToMemoryConstructor() {
     val stream: Any = NSOutputStream(toMemory = Unit)
     assertTrue(stream is NSOutputStream)
 }
+
+private const val TestExportObjCClass1Name = "TestExportObjCClass"
+@ExportObjCClass(TestExportObjCClass1Name) class TestExportObjCClass1 : NSObject()
+
+@ExportObjCClass class TestExportObjCClass2 : NSObject()
+
+fun testExportObjCClass() {
+    assertEquals(TestExportObjCClass1Name, TestExportObjCClass1().objCClassName)
+    assertEquals("TestExportObjCClass2", TestExportObjCClass2().objCClassName)
+}
+
+private val Any.objCClassName: String
+    get() = object_getClassName(this)!!.toKString()
 
 fun nsArrayOf(vararg elements: Any): NSArray = NSMutableArray().apply {
     elements.forEach {

--- a/runtime/src/main/cpp/ObjCExport.mm
+++ b/runtime/src/main/cpp/ObjCExport.mm
@@ -17,6 +17,7 @@
 #import "Types.h"
 #import "Memory.h"
 #include "Natives.h"
+#include "ObjCInterop.h"
 
 #if KONAN_OBJC_INTEROP
 
@@ -976,12 +977,13 @@ static void addVirtualAdapters(Class clazz, const ObjCTypeAdapter* typeAdapter) 
 static Class createClass(const TypeInfo* typeInfo, Class superClass) {
   RuntimeAssert(typeInfo->superType_ != nullptr, "");
 
-  char classNameBuffer[64];
-  snprintf(classNameBuffer, sizeof(classNameBuffer), "kobjcc%d", anonymousClassNextId++);
-  const char* className = classNameBuffer;
+  int classIndex = (anonymousClassNextId++);
+  KStdString className = Kotlin_ObjCInterop_getUniquePrefix();
+  className += "_kobjcc";
+  className += std::to_string(classIndex);
 
-  Class result = objc_allocateClassPair(superClass, className, 0);
-  RuntimeAssert(result != nullptr, "");
+  Class result = objc_allocateClassPair(superClass, className.c_str(), 0);
+  RuntimeCheck(result != nullptr, "");
 
   // TODO: optimize by adding virtual adapters only for overridden methods.
 

--- a/runtime/src/main/cpp/ObjCInterop.cpp
+++ b/runtime/src/main/cpp/ObjCInterop.cpp
@@ -26,7 +26,18 @@
 #include "MemoryPrivate.hpp"
 
 #include "Natives.h"
+#include "ObjCInterop.h"
+#include "Types.h"
 #include "Utils.h"
+
+// Replaced in ObjCExportCodeGenerator.
+__attribute__((weak)) const char* Kotlin_ObjCInterop_uniquePrefix = nullptr;
+
+const char* Kotlin_ObjCInterop_getUniquePrefix() {
+  auto result = Kotlin_ObjCInterop_uniquePrefix;
+  RuntimeCheck(result != nullptr, "unique prefix is not initialized");
+  return result;
+}
 
 extern "C" {
 
@@ -99,6 +110,7 @@ struct ObjCMethodDescription {
 
 struct KotlinObjCClassInfo {
   const char* name;
+  int exported;
 
   const char* superclassName;
   const char** protocolNames;
@@ -129,6 +141,34 @@ static void AddMethods(Class clazz, const struct ObjCMethodDescription* methods,
 static SimpleMutex classCreationMutex;
 static int anonymousClassNextId = 0;
 
+static Class allocateClass(const KotlinObjCClassInfo* info) {
+  Class superclass = Kotlin_Interop_getObjCClass(info->superclassName);
+  size_t extraBytes = sizeof(struct KotlinClassData);
+
+  if (info->exported) {
+    RuntimeCheck(info->name != nullptr, "exported Objective-C class must have a name");
+    Class result = objc_allocateClassPair(superclass, info->name, extraBytes);
+    if (result != nullptr) return result;
+    // Similar to how Objective-C runtime handles this:
+    fprintf(stderr, "Class %s has multiple implementations. Which one will be used is undefined.\n", info->name);
+  }
+
+  KStdString className = Kotlin_ObjCInterop_getUniquePrefix();
+
+  if (info->name != nullptr) {
+    className += info->name;
+  } else {
+    className += "_kobjc";
+  }
+
+  int classId = anonymousClassNextId++;
+  className += std::to_string(classId);
+
+  Class result = objc_allocateClassPair(superclass, className.c_str(), extraBytes);
+  RuntimeCheck(result != nullptr, "Failed to allocate Objective-C class");
+  return result;
+}
+
 void* CreateKotlinObjCClass(const KotlinObjCClassInfo* info) {
   LockGuard<SimpleMutex> lockGuard(classCreationMutex);
 
@@ -137,15 +177,8 @@ void* CreateKotlinObjCClass(const KotlinObjCClassInfo* info) {
     return createdClass;
   }
 
-  char classNameBuffer[64];
-  const char* className = info->name;
-  if (className == nullptr) {
-    snprintf(classNameBuffer, sizeof(classNameBuffer), "kobjc%d", anonymousClassNextId++);
-    className = classNameBuffer;
-  }
+  Class newClass = allocateClass(info);
 
-  Class superclass = Kotlin_Interop_getObjCClass(info->superclassName);
-  Class newClass = objc_allocateClassPair(superclass, className, sizeof(struct KotlinClassData));
   RuntimeAssert(newClass != nullptr, "Failed to allocate Objective-C class");
 
   Class newMetaclass = object_getClass(reinterpret_cast<id>(newClass));

--- a/runtime/src/main/cpp/ObjCInterop.h
+++ b/runtime/src/main/cpp/ObjCInterop.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+#ifndef RUNTIME_OBJCINTEROP_H
+#define RUNTIME_OBJCINTEROP_H
+
+#if KONAN_OBJC_INTEROP
+
+const char* Kotlin_ObjCInterop_getUniquePrefix();
+
+#endif // KONAN_OBJC_INTEROP
+
+#endif // RUNTIME_OBJCINTEROP_H


### PR DESCRIPTION
Also add test and improve handling duplicates for `@ExportObjCClass`.