### PR TITLE
[kotlin compiler][update] 1.3.70-dev-1438

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1244,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-dev-1244
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1244,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-dev-1244
-kotlinStdlibTestsVersion=1.3.70-dev-1244
-testKotlinCompilerVersion=1.3.70-dev-1244
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1438,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-dev-1438
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1438,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.70-dev-1438
+kotlinStdlibTestsVersion=1.3.70-dev-1438
+testKotlinCompilerVersion=1.3.70-dev-1438
 konanVersion=1.3.70
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 0c190f60400 - (HEAD -> master, tag: build-1.3.70-dev-1438, origin/master, origin/HEAD) Enable `-Xuse-mixed-named-arguments` feature for compiler project (10 hours ago) <Dmitriy Novozhilov>
* be4ae5d7ba5 - Upgrade kotlin version in gradle configuration testdata (10 hours ago) <Dmitriy Novozhilov>
* d485ea44e8e - Update bootstrap version (10 hours ago) <Dmitriy Novozhilov>
* ba77e5eba89 - (tag: build-1.3.70-dev-1436) #KT-29622: Fix bunches for 191 and earlier idea versions (29 hours ago) <Vadim Brilyantov>
* 66eeeb47053 - Add Focus Mode support to kotlin language (29 hours ago) <Vadim Brilyantov>
* f7ef16d2d55 - (tag: build-1.3.70-dev-1433) Regenerate tests (2 days ago) <Alexander Udalov>
* f9b66d57cf5 - (tag: build-1.3.70-dev-1431) Fix test data for -Xuse-mixed-named-arguments (2 days ago) <Alexander Udalov>
* 228fdb4436b - (tag: build-1.3.70-dev-1428) Don't optimize null checks for unsafe primitive type boxes as well (2 days ago) <Alexander Udalov>
* b80e1573818 - JVM, JVM IR: Don't optimize null-checks based on nullability information (2 days ago) <Steven Schäfer>
* de082543f19 - (tag: build-1.3.70-dev-1426) Minor, ignore another test with java.util.function on JDK 6 (2 days ago) <Alexander Udalov>
* 9b3e64257f6 - Minor, ignore test with java.util.function on JDK 6 (2 days ago) <Alexander Udalov>
* e89a87b2e33 - (tag: build-1.3.70-dev-1425) KT-29926: Support completion of suspend lambda body and parameters (2 days ago) <Roman Golyshev>
* da4097f488b - KT-29926: Support completion of suspend lambda parameters in the body (2 days ago) <Roman Golyshev>
* 84b9044187b - KT-29926: Get rid of `filterFunctionExpected` (2 days ago) <Roman Golyshev>
* e2b91cfec72 - (tag: build-1.3.70-dev-1416) Properties with custom property declarations highlighting rule. (2 days ago) <Vladimir Ilmov>
* bf37572b935 - (tag: build-1.3.70-dev-1414) Offload heavy part of KotlinNativeABICompatibilityChecker to non-EDT thread pool (2 days ago) <Dmitriy Dolovov>
* d97aeb9fe0e - Build KotlinNativeABICompatibilityChecker notifications in a separate function (2 days ago) <Dmitriy Dolovov>
* 526e7e463b6 - (tag: build-1.3.70-dev-1410) Mute flaky failure in KotlinGotoImplementationMultiModuleTestGenerated in 193 (2 days ago) <Nikolay Krasko>
* ce1e57d798e - Mute IdeReplCompletionTestGenerated tests in 193 (KT-34825) (2 days ago) <Nikolay Krasko>
* 93aba85f51d - (tag: build-1.3.70-dev-1407) Fix FIR built-ins test (2 days ago) <Mikhail Glukhikh>
* 5313c964c68 - (tag: build-1.3.70-dev-1406) [FIR] Fix SOF in fir consistency checker (2 days ago) <Dmitriy Novozhilov>
* bc453e5917a - [FIR] Fix testdata forgotten in e910653d (2 days ago) <Dmitriy Novozhilov>
* e6b005a7dc6 - Disable `-Xuse-mixed-named-arguments` feature for compiler project (2 days ago) <Dmitriy Novozhilov>
* 45523a57679 - Fix `-Xuse-mixed-named-arguments` compiler arg (2 days ago) <Dmitriy Novozhilov>
* 8561f08f063 - (tag: build-1.3.70-dev-1404) [JVM_IR] Reintroduce non-IEEE comparisons (2 days ago) <Kristoffer Andersen>
* 0675b54e117 - (tag: build-1.3.70-dev-1403) Minor, add regression test for KT-34766 (2 days ago) <Alexander Udalov>
* ea543eac13e - (tag: build-1.3.70-dev-1401) [IC KLIB] Fix after rebase (2 days ago) <Roman Artemev>
* 3e3cb8734b1 - [IC] Unmute IC klib tests (2 days ago) <Roman Artemev>
* b11d69b7195 - [IC] Temporary restore removed method to fix proto comparison tests (2 days ago) <Roman Artemev>
* a91ed694bfa - [IC KLIB] Use new klib argument (2 days ago) <Roman Artemev>
* eb5e954e2a4 - Minor: adjust formatting (2 days ago) <Alexey Tsvetkov>
* d776e921117 - Use Klib JS serializer protocol for IC (2 days ago) <Alexey Tsvetkov>
* 6e9cd85b54b - Exclude some proto messages from proto comparison in IC (2 days ago) <Alexey Tsvetkov>
* ac9b7fa268c - Exclude some proto fields from proto comparison in IC (2 days ago) <Alexey Tsvetkov>
* 28e6219b0be - Fix proto comparison for fields mapped to type table (2 days ago) <Alexey Tsvetkov>
* c694752b4f0 - Generate Klib JS extensions for proto comparison (2 days ago) <Alexey Tsvetkov>
* 83f060ad3e5 - Minor: add functions to distinguish initial and incremental builds when debugging IC tests (2 days ago) <Alexey Tsvetkov>
* 537199e0fa5 - Minor: replace UsefulTestCase with KtUsefulTestCase (2 days ago) <Alexey Tsvetkov>
* 72c4be785d7 - [JS IR] Add proper extension point in FE to customize incremental data loading  - fix IC klib (2 days ago) <Roman Artemev>
* 21c436c64c7 - Klib metadata cached package fragment and package fragment provider (2 days ago) <Alexander Gorshenev>
* 1bced5d2a25 - [KLIB IC] Fix file index allocation, make them stable between recompilations (2 days ago) <Roman Artemev>
* ab506c1579b - (tag: build-1.3.70-dev-1399) Frontend: Avoid retypechecking the right hand side of assignment operators (2 days ago) <Steven Schäfer>
* 41c81d25a0f - FIR body resolve: use nested classifier scopes only via member scopes (2 days ago) <Mikhail Glukhikh>
* f0130d04602 - FIR (minor): remove unnecessary withScopeCleanup call (2 days ago) <Mikhail Glukhikh>
* cf153590799 - (tag: build-1.3.70-dev-1397) Decrease number of forked test processes on local machine (2 days ago) <Mikhael Bogdanov>
* 7c9578116bf - (tag: build-1.3.70-dev-1396) JVM IR: Fix types in LateInitLowering (2 days ago) <Steven Schäfer>
* 3ee013aac64 - (tag: build-1.3.70-dev-1389) Change compiler flag for enabling mixed named argumetns in compiler project (2 days ago) <Dmitriy Novozhilov>
* 5b1cc7d8d52 - Update bootstrap version (2 days ago) <Dmitriy Novozhilov>
* e910653d6f4 - [FIR] Add pretty rendering of functional types (2 days ago) <Dmitriy Novozhilov>
* 18dc6524043 - [FIR] Get rid of `operation` in `FirVariableAssignment` (2 days ago) <Dmitriy Novozhilov>
* b5210e6a9b0 - [FIR] Fix building fir for += with complex rhs (2 days ago) <Dmitriy Novozhilov>
* cadc2dfe4da - [FIR] Fix generating fir for `invoke` calls (2 days ago) <Dmitriy Novozhilov>
* ff32eab3d10 - (tag: build-1.3.70-dev-1387) [NI] Run call checkers on resolved calls for callable references (2 days ago) <Pavel Kirpichenkov>
* f444702cf32 - (tag: build-1.3.70-dev-1385) JVM: Always invoke get()/charAt() in optimized for-loop over CharSequence.withIndex(), even if element variable is unused in destructuring declaration. (2 days ago) <Mark Punzalan>
* 411dc5d60e5 - (tag: build-1.3.70-dev-1383) FIR nested classifier scope building: optimize companion search (3 days ago) <Mikhail Glukhikh>
* 48938a20a7e - Raw FIR: add synthesized Enum.valueOf() function (3 days ago) <Mikhail Glukhikh>
* 1978db9d0e6 - (tag: build-1.3.70-dev-1379) Move codegen tests on old language versions under oldLanguageVersions/ (3 days ago) <Alexander Udalov>
* c3729c81899 - Reorganize codegen tests for old language versions (3 days ago) <Alexander Udalov>
* dcd72b06d85 - (tag: build-1.3.70-dev-1378) JVM IR: Implement CHECK_NOT_NULL as a lowering (3 days ago) <Steven Schäfer>
* ea6c43dabd4 - (tag: build-1.3.70-dev-1377) Mute inline testMultipleInExpression because of unstable order of usages in 193 (3 days ago) <Nikolay Krasko>
* fe9c5cac454 - Fix TypedHandlerTest in 193 (3 days ago) <Nikolay Krasko>
* f6bdaf992e7 - Fix jps build in buildSrc by explicitly using mutable set (3 days ago) <Nikolay Krasko>
* c053bd213ac - Don't assert order of todo items to fix platform update to 193 (3 days ago) <Nikolay Krasko>
* b2a61eb5e6f - Additional mute for IdeReplCompletionTestGenerated.testFunctions in 193 (3 days ago) <Nikolay Krasko>
* 2aa251fd0c5 - Remove deprecated API from InlayScratchFileRenderer (3 days ago) <Nikolay Krasko>
* 9fb95e776eb - (tag: build-1.3.70-dev-1372) [HIGHLIGHT] Specific keyword rules for val,var highlighting. (3 days ago) <Vladimir Ilmov>
* 34ea47a8686 - (tag: build-1.3.70-dev-1369) Extract Konan Gradle model into a separate JAR file (3 days ago) <Dmitriy Dolovov>
* fb9f43c1190 - (tag: build-1.3.70-dev-1368) JVM_IR: fix load check in inliner (should accept primitives too) (3 days ago) <pyos>
* 4164b620e87 - (tag: build-1.3.70-dev-1364) Minor, remove obsolete directives and suppressions from contracts test data (3 days ago) <Alexander Udalov>
* 66e19b13ce4 - IR: create shared variables for val-variables when needed (3 days ago) <Alexander Udalov>
* 5c4b47c3361 - (tag: build-1.3.70-dev-1362) [native-gradle-plugin] Disabled native daemon for tests for now (3 days ago) <Igor Chevdar>
* 83331a0afb3 - [native-gradle-plugin] Test fix (3 days ago) <Igor Chevdar>
* ecb001d5db8 - Bumped K/N version (3 days ago) <Igor Chevdar>
* d36effd7252 - [native-gradle-plugin] Run konan directly from the gradle process (3 days ago) <Igor Chevdar>
* d755002ac46 - (tag: build-1.3.70-dev-1360) Advance bootstrap to 1.3.70-dev-1231 (3 days ago) <Nikolay Krasko>
* 0ea64c8d4b9 - Avoid using js dist library during jps build as it absent in bootstrap (3 days ago) <Nikolay Krasko>
* 155a760ee92 - Revert "Revert [JS IR] commits that failed build" (3 days ago) <Nikolay Krasko>
* 181d023e3ce - (tag: build-1.3.70-dev-1358) JVM IR: Remove JvmBackendContext.getTopLevelClass (3 days ago) <Steven Schäfer>
* 1ac753602e4 - JVM IR: Avoid getTopLevelClass in CollectionStubMethodLowering (3 days ago) <Steven Schäfer>
* f9ff3771e53 - JVM IR: Avoid getTopLevelClass in AddContinuationLowering (3 days ago) <Steven Schäfer>
* 481d4d72b90 - JVM IR: Avoid getTopLevelClass in JvmSymbols (3 days ago) <Steven Schäfer>
* d0c261c7792 - Ensure the correct functions (with correct params) are being used in ForLoopsLowering. (3 days ago) <Mark Punzalan>
* 21178a4f1a3 - Fix issue getting the `size` property from Collection bounded type parameters, when lowering for-loops over Collection.indices. (3 days ago) <Mark Punzalan>
* 30679ebfafc - (tag: build-1.3.70-dev-1355) FIR Java: implement correct type matching in SuperTypeScope (3 days ago) <Mikhail Glukhikh>
* 7fffd3d0f26 - Fix using method removed from 193 in old J2K (3 days ago) <Ilya Kirillov>
* 39db76b2ab1 - "Indent raw string" intention: do not suggest in const (3 days ago) <Toshiaki Kameyama>
* 688a2185fa4 - (tag: build-1.3.70-dev-1353) Tests for Kapt3 with JVM_IR backend (3 days ago) <Georgy Bronnikov>
* 4d9839a790c - (tag: build-1.3.70-dev-1348) JavaClassUseSiteMemberScope: add mutable vs non-mutable type matching (3 days ago) <Mikhail Glukhikh>
* 61c337588bc - (tag: build-1.3.70-dev-1339) Revert testdata accidentally committed in 665405c4 (3 days ago) <Dmitriy Novozhilov>
* 4f8a8f84ba9 - [FIR] Update some testdata in fir visualizer test (3 days ago) <Dmitriy Novozhilov>
* abf41f87a11 - [FIR] Fix rendering of local variables in Visualizer (3 days ago) <Dmitriy Novozhilov>
* f0ba9c3c40d - [FIR] Make file separator in `AbstractVisualizer` OS independent (3 days ago) <Dmitriy Novozhilov>
* 581504aac5d - (tag: build-1.3.70-dev-1337) Raw FIR: add synthesized Enum.values() function #KT-24076 Fixed (4 days ago) <Mikhail Glukhikh>
* 6e0148c7a8f - FIR: cleanup of DataClassUtils: remove redundant status field assignments (4 days ago) <Mikhail Glukhikh>
* 3b100e57f20 - (tag: build-1.3.70-dev-1331) Change NO_EXPLICIT_VISIBILITY_IN_API_MODE diagnostic range to 'declaration modifiers + name'. (4 days ago) <Leonid Startsev>
* 24688f35034 - Do not disable 'redundant visibility modifier' inspection completely in Explicit API mode. (4 days ago) <Leonid Startsev>
* 5ab262c9775 - Skip explicit API inspection for data class properties and add inspection for public API in interfaces (4 days ago) <Leonid Startsev>
* ebb7e434c82 - Explicit Api mode: Renamings after design discussions (4 days ago) <Leonid Startsev>
* 7fada51c42a - Add quickfix for setting explicit public visibility for diagnostic reported in API mode (4 days ago) <Leonid Startsev>
* 2b708093c0b - Add explicit return type check for API mode (4 days ago) <Leonid Startsev>
* 7058492b558 - Explicit Api mode: prototype with check for missing explicit visibility (4 days ago) <Leonid Startsev>
* a7d60fbf2dc - (tag: build-1.3.70-dev-1329) JVM IR: minor, fix IR builder scope for multifile bridges (4 days ago) <Alexander Udalov>
* 7a2c467bb59 - JVM IR: remove obsolete hack in JvmMultifileClass facade generation (4 days ago) <Alexander Udalov>
* 5d8aac456f9 - (tag: build-1.3.70-dev-1326) JVM_IR: create temporaries for complex super constructor arguments (4 days ago) <pyos>
* 42f75b32474 - JVM_IR: have SAM wrapper constructors accept FunctionN (4 days ago) <pyos>
* 862197d7135 - JVM_IR: create temporaries for complex SAM conversion arguments (4 days ago) <pyos>
* 650e2501bbd - (tag: build-1.3.70-dev-1315) [NI] Prioritize variables with trivial constraints over complex ones (4 days ago) <Mikhail Zarechenskiy>
* 5582fd40567 - [NI] Discard `DefNotNull` types inside invariant positions (4 days ago) <Mikhail Zarechenskiy>
* 4fc1bd9ec57 - (tag: build-1.3.70-dev-1313) Support inlining functions with KT-28064 style objects (4 days ago) <pyos>
* 27e1a54d4eb - (tag: build-1.3.70-dev-1310) [FIR] Add `descriptors.runtime` as dependency to psi2fir test (4 days ago) <Dmitriy Novozhilov>
* 665405c4357 - [FIR] Add discriminating generics into ConeOverloadConflictResolver (4 days ago) <Dmitriy Novozhilov>
* 86a8412b055 - (tag: build-1.3.70-dev-1307) Don't try loading PSI tree in IDE mode via stubs (e.g. decompiled code) (4 days ago) <Mikhail Zarechenskiy>
* aff9ae2ecfc - (tag: build-1.3.70-dev-1304) FIR resolve bench: collect unique problems also from callee, ignore empty problems (4 days ago) <Mikhail Glukhikh>
* bd1127cfa31 - (tag: build-1.3.70-dev-1300) FIR: resolve lambda arguments even if an outer call is unresolved (4 days ago) <Mikhail Glukhikh>
* 3b4edb39018 - Don't recreate FirSpecificTypeResolverTransformer during type resolve stage (4 days ago) <Mikhail Glukhikh>
* 3dd34214377 - Temporary: resolve type to kotlin/reflect/Function instead of kotlin/Function (4 days ago) <Mikhail Glukhikh>
* 60e6d2e5211 - Resolve local declaration statuses & types inside bodies in FirBodyResolveTransformer (4 days ago) <Mikhail Glukhikh>
* 668a2a58be0 - FIR: switch off body visiting in status & type resolve transformers (breaks many tests) (4 days ago) <Mikhail Glukhikh>
* d6daf321a25 - FIR: render implicit built-in type references as resolved ones (4 days ago) <Mikhail Glukhikh>
* 7f4b568021d - (tag: build-1.3.70-dev-1289) Mark new KClass.cast/safeCast extensions as low-priority (5 days ago) <Alexander Udalov>
* 3c7b0e6cccc - (tag: build-1.3.70-dev-1288) Fix gradle runtime dependency issue for completion-ranking-kotlin library (5 days ago) <Nikolay Krasko>
* 279deb3a788 - Mention navigation fails asserts in 193 in common file (KT-34542) (5 days ago) <Nikolay Krasko>
* 5ca3698d139 - Remute JoinLinesTestGenerated tests in 193 (KT-34408) (5 days ago) <Nikolay Krasko>
* 651a70ae547 - Remute MultiLineStringIndentTestGenerated tests in 193 (KT-34566) (5 days ago) <Nikolay Krasko>
* c50e60f90f3 - More mutes for 193 branch (5 days ago) <Nikolay Krasko>
* 5d19b2c3c44 - Allow to mute tests with spaces in names (5 days ago) <Nikolay Krasko>
* e3c6a1fbd87 - (tag: build-1.3.70-dev-1284) Updating progress for optimize imports (5 days ago) <Alexander Podkhalyuzin>
* d2ae39489f4 - (tag: build-1.3.70-dev-1283) SmartPointers in Smart Completion for anonymous object generation (5 days ago) <Alexander Podkhalyuzin>
* d321f4626f7 - (tag: build-1.3.70-dev-1281) Formatter: fix line break before `OperationReference` in elvis #KT-22362 Fixed (5 days ago) <Dmitry Gridin>
* 247619c5658 - Formatter: fix line break between label and property #KT-22273 Fixed (5 days ago) <Dmitry Gridin>
* 7f1935b82ed - formatter: cleanup code (5 days ago) <Dmitry Gridin>
* 0098588a6bb - NodeIndentStrategy: remove code duplication (5 days ago) <Dmitry Gridin>
* 196dd25637f - ProjectCodeStyleImporter: fix deprecated elements (5 days ago) <Dmitry Gridin>
* f2289c216c3 - (tag: build-1.3.70-dev-1277) Fix type of IllegalArgumentException call for illegal step in StepHandler. (5 days ago) <Mark Punzalan>
* ca4784ffd35 - (tag: build-1.3.70-dev-1271) Fix CLI testdata broken in 7f58162a (5 days ago) <Dmitriy Novozhilov>
* c58ca27b2e9 - (tag: build-1.3.70-dev-1269) [FIR] Introduce `ResolutionMode` as data for body resolve instead of `Any?` (5 days ago) <Dmitriy Novozhilov>
* 7f58162abc9 - Add `-Xuse-mixed-named-arguments` compiler flag (5 days ago) <Dmitriy Novozhilov>
* 23d492646d6 - [FIR] Update testdata of SAM conversions diagnostics tests after lambda resolution fix (5 days ago) <Dmitriy Novozhilov>
* 010dae454ec - [FIR] Fix extracting parameters from extension function types (5 days ago) <Dmitriy Novozhilov>
* 9c8d6fb49bc - [FIR] Check for lambda arguments that expected type is functional type (5 days ago) <Dmitriy Novozhilov>
* 297d07f465b - [FIR] Refactor fir resolve tests (5 days ago) <Dmitriy Novozhilov>
* 66abbe1aadb - [FIR] Fix testdata in fir diagnostic tests broken in 01f09af6 (5 days ago) <Dmitriy Novozhilov>
* 704e6e96fa0 - (tag: build-1.3.70-dev-1268) Fir2Ir: Produce IR_TEMPORARY_VARIABLE origins (5 days ago) <Steven Schäfer>
* 733c7579aab - Normalize names of temporary variables in IrTextTests (5 days ago) <Steven Schäfer>
* 740f851a106 - (tag: build-1.3.70-dev-1263) Revert [JS IR] commits that failed build (5 days ago) <Nikolay Krasko>
* 722f7ff0566 - (tag: build-1.3.70-dev-1254) Now using Kotlin setting instead of Java one (5 days ago) <Alexander Podkhalyuzin>
* efaf7791337 - (tag: build-1.3.70-dev-1248) Minor, fix test data for kotlinx.serialization bytecode text test (6 days ago) <Alexander Udalov>