### PR TITLE
[kotlin compiler][update] 1.3.70-dev-1666

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
@@ -6,8 +6,6 @@
 package org.jetbrains.kotlin.backend.konan
 
 import llvm.*
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.backend.konan.ir.KonanSymbols
 import org.jetbrains.kotlin.backend.konan.llvm.*
 import org.jetbrains.kotlin.descriptors.Modality
@@ -16,6 +14,8 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -7,8 +7,6 @@ package org.jetbrains.kotlin.backend.konan
 
 import llvm.*
 import org.jetbrains.kotlin.backend.common.DumpIrTreeWithDescriptorsVisitor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedTypeParameterDescriptor
 import org.jetbrains.kotlin.backend.konan.descriptors.*
 import org.jetbrains.kotlin.backend.konan.ir.KonanIr
 import org.jetbrains.kotlin.library.SerializedMetadata
@@ -46,9 +44,10 @@ import java.lang.System.out
 import kotlin.LazyThreadSafetyMode.PUBLICATION
 import kotlin.reflect.KProperty
 import org.jetbrains.kotlin.backend.common.ir.copyTo
-import org.jetbrains.kotlin.backend.common.serialization.KotlinMangler
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExport
 import org.jetbrains.kotlin.backend.konan.llvm.coverage.CoverageManager
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedTypeParameterDescriptor
 import org.jetbrains.kotlin.ir.symbols.impl.IrTypeParameterSymbolImpl
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.konan.library.KonanLibraryLayout

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
@@ -5,8 +5,6 @@
 
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlockBody
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
@@ -17,6 +15,8 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.impl.IrTryImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -5,11 +5,8 @@
 
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedClassDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedFieldDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.ir.addSimpleDelegatingConstructor
 import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
+import org.jetbrains.kotlin.backend.common.ir.addSimpleDelegatingConstructor
 import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.descriptors.ClassKind
@@ -19,6 +16,9 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFieldImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedClassDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedFieldDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrClassSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -1,9 +1,5 @@
 package org.jetbrains.kotlin.backend.konan.cgen
 
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedClassConstructorDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedClassDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
 import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
 import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
@@ -29,7 +25,6 @@ import org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
-import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionReferenceImpl
@@ -47,6 +42,7 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.util.OperatorNameConventions
 import org.jetbrains.kotlin.backend.konan.getObjCMethodInfo
+import org.jetbrains.kotlin.ir.descriptors.*
 
 internal interface KotlinStubs {
     val irBuiltIns: IrBuiltIns

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -1,7 +1,5 @@
 package org.jetbrains.kotlin.backend.konan.cgen
 
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
 import org.jetbrains.kotlin.backend.common.lower.irBlock
 import org.jetbrains.kotlin.backend.common.lower.irThrow
@@ -14,6 +12,8 @@ import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrTryImpl

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -8,8 +8,6 @@ package org.jetbrains.kotlin.backend.konan.lower
 import org.jetbrains.kotlin.backend.common.AbstractValueUsageTransformer
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.atMostOne
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedPropertyDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.backend.common.ir.copyTo
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.konan.*
@@ -23,6 +21,8 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFieldImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrPropertyImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedPropertyDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrBlockImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -7,8 +7,6 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.DeclarationContainerLoweringPass
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlockBody
@@ -21,6 +19,8 @@ import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
-import org.jetbrains.kotlin.backend.common.descriptors.*
 import org.jetbrains.kotlin.backend.common.ir.*
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.konan.Context
@@ -23,6 +22,9 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedClassConstructorDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedClassDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DeepCopyIrTreeWithDescriptors.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DeepCopyIrTreeWithDescriptors.kt
@@ -5,12 +5,11 @@
 
 package org.jetbrains.kotlin.backend.konan.lower
 
-import org.jetbrains.kotlin.backend.common.descriptors.*
 import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.descriptors.*
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.types.*

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedFieldDescriptor
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
 import org.jetbrains.kotlin.backend.konan.Context
@@ -17,6 +16,7 @@ import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFieldImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedFieldDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrLocalDelegatedPropertyReference
 import org.jetbrains.kotlin.ir.expressions.IrPropertyReference

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -6,8 +6,6 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedClassConstructorDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.backend.common.ir.copyTo
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
 import org.jetbrains.kotlin.backend.konan.Context
@@ -18,6 +16,8 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedClassConstructorDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FinallyBlocksLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FinallyBlocksLowering.kt
@@ -7,8 +7,6 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.common.*
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
@@ -26,6 +24,8 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrVariableSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrSimpleType

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlockBody
@@ -18,6 +17,7 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -6,8 +6,6 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.FileLoweringPass
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.backend.common.ir.copyTo
 import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
 import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
@@ -32,6 +30,8 @@ import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrDelegatingConstructorCallImpl

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -1,7 +1,5 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.backend.common.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.common.ir.isSuspend
 import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
@@ -16,6 +14,8 @@ import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrSetVariableImpl

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -5,9 +5,6 @@
 
 package org.jetbrains.kotlin.backend.konan.lower
 
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedClassConstructorDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedClassDescriptor
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
 import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
 import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
@@ -28,6 +25,9 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedClassConstructorDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedClassDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.symbols.impl.IrClassSymbolImpl

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanDeserializeDescriptorReference.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanDeserializeDescriptorReference.kt
@@ -3,11 +3,13 @@ package org.jetbrains.kotlin.backend.konan.serialization
 import org.jetbrains.kotlin.backend.common.serialization.*
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.util.KotlinMangler
+import org.jetbrains.kotlin.ir.util.UniqId
 
 class KonanDescriptorReferenceDeserializer(
-    currentModule: ModuleDescriptor,
-    mangler: KotlinMangler,
-    builtIns: IrBuiltIns,
-    resolvedForwardDeclarations: MutableMap<UniqId, UniqId>
+        currentModule: ModuleDescriptor,
+        mangler: KotlinMangler,
+        builtIns: IrBuiltIns,
+        resolvedForwardDeclarations: MutableMap<UniqId, UniqId>
 ): DescriptorReferenceDeserializer(currentModule, mangler, builtIns, resolvedForwardDeclarations),
    DescriptorUniqIdAware by DeserializedDescriptorUniqIdAware

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.backend.konan.descriptors.isFromInteropLibrary
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.util.UniqId
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
 private class KonanDeclarationTable(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -26,6 +26,8 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.util.SymbolTable
+import org.jetbrains.kotlin.ir.util.UniqId
+
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
 class KonanIrLinker(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -6,8 +6,6 @@
 package org.jetbrains.kotlin.ir.util
 
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
-import org.jetbrains.kotlin.backend.common.descriptors.*
-import org.jetbrains.kotlin.backend.common.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.backend.common.descriptors.substitute
 import org.jetbrains.kotlin.backend.konan.KonanBackendContext
 import org.jetbrains.kotlin.backend.konan.KonanCompilationException
@@ -27,6 +25,8 @@ import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.*
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.descriptors.WrappedFieldDescriptor
+import org.jetbrains.kotlin.ir.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1526,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-dev-1526
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1526,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-dev-1526
-kotlinStdlibTestsVersion=1.3.70-dev-1526
-testKotlinCompilerVersion=1.3.70-dev-1526
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1666,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-dev-1666
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1666,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.70-dev-1666
+kotlinStdlibTestsVersion=1.3.70-dev-1666
+testKotlinCompilerVersion=1.3.70-dev-1666
 konanVersion=1.3.70
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/performance/build.gradle
+++ b/performance/build.gradle
@@ -16,19 +16,19 @@ def rootBuildDirectory = rootProject.projectDir
 
 task konanRun {
     subprojects.each {
-        dependsOn it.getTasksByName('konanRun', true)[0]
+        dependsOn "${it.path}:konanRun"
     }
 }
     
 task jvmRun {
     subprojects.each {
-        dependsOn it.getTasksByName('jvmRun', true)[0]
+        dependsOn "${it.path}:jvmRun"
     }
 }
 
 task clean {
     subprojects.each {
-        dependsOn it.getTasksByName('clean', true)[0]
+        dependsOn "${it.path}:clean"
     }
     doLast {
         delete "${buildDir.absolutePath}"
@@ -187,8 +187,10 @@ task mergeJvmReports {
 }
 
 subprojects.each {
-    it.getTasksByName('jvmJsonReport', true)[0].finalizedBy mergeJvmReports
-    it.getTasksByName('konanJsonReport', true)[0].finalizedBy mergeNativeReports
+    it.afterEvaluate {
+        it.jvmJsonReport.finalizedBy mergeJvmReports
+        it.konanJsonReport.finalizedBy mergeNativeReports
+    }
 }
 
 task teamCityStat(type:Exec) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,19 +31,21 @@ include ':backend.native:tests'
 include ':backend.native:debugger-tests'
 include ':utilities'
 
-include ':performance'
-include ':performance:ring'
-include ':performance:cinterop'
-include ':performance:helloworld'
-include ':performance:numerical'
-include ':performance:videoplayer'
-include ':performance:framework'
-if (System.getProperty("os.name") == "Mac OS X") {
-    include ':performance:objcinterop'
-    include ':performance:swiftinterop'
-    if (hasProperty("runExcludedBenchmarks")) {
-        include ':performance:KotlinVsSwift'
-        include ':performance:KotlinVsSwift:ring'
+if (hasProperty("konan.home") || hasProperty("org.jetbrains.kotlin.native.home")) {
+    include ':performance'
+    include ':performance:ring'
+    include ':performance:cinterop'
+    include ':performance:helloworld'
+    include ':performance:numerical'
+    include ':performance:videoplayer'
+    include ':performance:framework'
+    if (System.getProperty("os.name") == "Mac OS X") {
+        include ':performance:objcinterop'
+        include ':performance:swiftinterop'
+        if (hasProperty("runExcludedBenchmarks")) {
+            include ':performance:KotlinVsSwift'
+            include ':performance:KotlinVsSwift:ring'
+        }
     }
 }
 


### PR DESCRIPTION
* ba93bdb14df - (tag: build-1.3.70-dev-1666) JVM_IR: keep the $default suffix for stubs for @JvmName functions (3 days ago) <pyos>
* 23dfade24f6 - (tag: build-1.3.70-dev-1664) JVM IR: Fix inlining of inline class properties in external modules (3 days ago) <Steven Schäfer>
* fa62d0c3256 - (tag: build-1.3.70-dev-1656) Don't clear InBlockModifications on CanceledException (3 days ago) <Vladimir Dolzhenko>
* 92dae5d8a9e - (tag: build-1.3.70-dev-1653) [NI] Split substitution of inferred type parametes into two steps (3 days ago) <Pavel Kirpichenkov>
* b6af13f18de - [NI] Add missing substitution of known type parameters (3 days ago) <Pavel Kirpichenkov>
* 3122f2704c7 - [Minor] Refactor resulting descriptor substitution in call transformer (3 days ago) <Pavel Kirpichenkov>
* ea66f020356 - [Minor] Rename fresh variable substitutor in resolved atom (3 days ago) <Pavel Kirpichenkov>
* 25f3de2085d - (tag: build-1.3.70-dev-1651) Use more stable kotlin dependency in tests for enabling inline classes flag (3 days ago) <victor.petukhov>
* 4438dd282fa - (tag: build-1.3.70-dev-1647) [kotlinx-metadata-klib] Bugfixes: (3 days ago) <Sergey Bogolepov>
* 95399b3a414 - (tag: build-1.3.70-dev-1639, origin/rr/gradle/ilgonmic/debugger-js) Introduce `kotlinx-metadata-klib`. (3 days ago) <Sergey Bogolepov>
* d91453fb7a5 - (tag: build-1.3.70-dev-1635) Do not preprocess apiVersionIsAtLeast calls inlined into kotlin package (3 days ago) <Ilya Gorbunov>
* 352a10a0ed1 - (tag: build-1.3.70-dev-1629) Do not fail tests on unknown version of gradle Kotlin plugin (4 days ago) <Andrey Uskov>
* e963b719216 - Tests of import with latest gradle plugin are implemented (4 days ago) <Andrey Uskov>
* 51590ef1b76 - Migrate import tests to annotation-driven determination of target kotlin plugin versions (4 days ago) <Andrey Uskov>
* d05f8932334 - Import tests with gradle 5.6.4 were added (4 days ago) <Andrey Uskov>
* a51e2ca4d63 - Limit initial heap of gradle daemon in import tests (4 days ago) <Andrey Uskov>
* 1f2767ae211 - Remove gradle testing import from gradle 3.x (4 days ago) <Andrey Uskov>
* 48f6207d26e - Support annotation-based declaration of target plugin and gradle version in gradle importing tests (4 days ago) <Andrey Uskov>
* 14aa0eae71a - Extract kotlin gradle plugin versions to constants in tests (4 days ago) <Andrey Uskov>
* 633005fb575 - (tag: build-1.3.70-dev-1627) KT-25732 Perform keywords completion earlier to complete them before freeze (4 days ago) <Roman Golyshev>
* 36ca280b86b - (tag: build-1.3.70-dev-1624) Fix compilation error in ResolveInlineCalls.kt (4 days ago) <Alexander Udalov>
* 635add48238 - FIR substitution: generate fake overrides for accessor symbols (4 days ago) <Mikhail Glukhikh>
* bd70daa3d18 - FIR Java: use definitely not-null types for type parameters (4 days ago) <Mikhail Glukhikh>
* 63f38bb28ab - FIR [rendering only]: render fake overrides for properties (4 days ago) <Mikhail Glukhikh>
* 4733c78a6aa - (tag: build-1.3.70-dev-1621) [FIR] Add `toString()` to `ErrorTypeConstructor` and `ConeClassifierLookupTag` (4 days ago) <Dmitriy Novozhilov>
* 944be132deb - [FIR-TEST] Add test with calling constructor of type with aliased import (4 days ago) <Dmitriy Novozhilov>
* d9fe70f97c7 - [FIR] Fix binding overrides with flexible types in arguments (4 days ago) <Dmitriy Novozhilov>
* 3a7251a90ba - [FIR-TEST] Add test with problems in mapping getter name to property name (4 days ago) <Dmitriy Novozhilov>
* 6f9e576502f - [FIR-TEST] Add test with ambiguity on accidental override property (4 days ago) <Dmitriy Novozhilov>
* f43d77d4225 - [FIR-TEST] Move `nestedClassConstructor` test to `problems` test suite (4 days ago) <Dmitriy Novozhilov>
* 2409a74fb56 - [FIR-TEST] Add test for problem with += and java synthetic property (4 days ago) <Dmitriy Novozhilov>
* 11063a25a86 - [FIR] Replace FirEmptyDiagnostic with FirStubDiagnostic (4 days ago) <Dmitriy Novozhilov>
* ee20f888378 - [FIR] Propagate smartcasts in safe calls chain (4 days ago) <Dmitriy Novozhilov>
* 833648d8e03 - [FIR] Fix smartcasts on receivers of implict invoke call (4 days ago) <Dmitriy Novozhilov>
* 660bcce90a0 - [FIR] Add smartcasts for reassigned vars (4 days ago) <Dmitriy Novozhilov>
* 2a74e37e28b - [FIR] Ignore expected type for resolve constant expressions (4 days ago) <Dmitriy Novozhilov>
* 6a3c07688f7 - Add print of detailed stack trace to NonFir modularized test (4 days ago) <Dmitriy Novozhilov>
* a235dd2891e - (tag: build-1.3.70-dev-1618) IR: move defaultParameterDeclarationsCache access up one level (4 days ago) <pyos>
* 70f09a75318 - IR: make DefaultArgumentStubGenerator a few lines shorter (4 days ago) <pyos>
* 2b2dd097a37 - IR: refactor DefaultParameterInjector (4 days ago) <pyos>
* 7a2715da447 - IR: refactor generateDefaultsFunction (4 days ago) <pyos>
* 29a14e2330f - (tag: build-1.3.70-dev-1616) JVM_IR: resolve inline fake overrides before codegen (4 days ago) <pyos>
* 1b2091d536f - (tag: build-1.3.70-dev-1612) Fix: KLIB reading error on Windows (4 days ago) <Dmitriy Dolovov>
* 77950c54107 - (tag: build-1.3.70-dev-1607) [Gradle, JS] Remove redundant from kotlin-test-js-runner (4 days ago) <Ilya Goncharov>
* 6a6bef0f6c0 - [Debugger, JS] Remove kotlin source map support from tests and build (4 days ago) <Ilya Goncharov>
* 35cb412dc31 - [Gradle, JS] Fix source map support initializing for mocha (4 days ago) <Ilya Goncharov>
* 4e427d2ce41 - [Gradle, JS] Fix source map support initializing for nodejs (4 days ago) <Ilya Goncharov>
* 20e33806ec9 - [Debugger, JS] Provide possibility to debug mocha tests (4 days ago) <Ilya Goncharov>
* 30b4622a455 - (tag: build-1.3.70-dev-1601) Remove invalid unused reference (4 days ago) <Igor Yakovlev>
* c905bbca362 - (tag: build-1.3.70-dev-1597) Scripting: invalidate caches on roots changes (4 days ago) <Sergey Rostov>
* b0327964b76 - (tag: build-1.3.70-dev-1590) Fix compilation on 183 and as34 (4 days ago) <Denis Zharkov>
* c7e9a6c5d90 - (tag: build-1.3.70-dev-1587) Add new script dependency resolvers (4 days ago) <Anatoly Nikitin>
* 81e2e119e29 - Fix propagation of dependency resolution failure reports during script compilation (4 days ago) <Anatoly Nikitin>
* 744dfc6bf93 - (tag: build-1.3.70-dev-1585) Minor. Pass proper timeout to logger (4 days ago) <Mikhael Bogdanov>
* 4281fd6bd59 - (tag: build-1.3.70-dev-1584) Don't write nop for extension lambda during inline (4 days ago) <Mikhael Bogdanov>
* b757224df11 - (tag: build-1.3.70-dev-1583) Scripting: invalidate caches on roots changes (4 days ago) <Sergey Rostov>
* df0c250fd8e - Scripting: fix lost caches clearing call (4 days ago) <Sergey Rostov>
* 542f21b7017 - Scripting, minor: cache firstScriptSdk (4 days ago) <Sergey Rostov>
* ab3f9586b39 - (tag: build-1.3.70-dev-1580) Suspend function calls highlighting added. (4 days ago) <Vladimir Ilmov>
* 46423443e9d - 'it' parameter highlighting fixed for chain usage. (4 days ago) <Vladimir Ilmov>
* fb9fb2e0484 - (tag: build-1.3.70-dev-1578) JVM IR: minor, remove obsolete code (5 days ago) <Alexander Udalov>
* 180e7187523 - JVM IR: minor, repurpose JvmBackendContext.getLocalClassInfo to store Type (5 days ago) <Alexander Udalov>
* 6be9101675e - JVM IR: add jvmLocalClassExtractionPhase to lift out local classes from initializers (5 days ago) <Alexander Udalov>
* c5159d9cbe6 - (tag: build-1.3.70-dev-1576) IR: Add UniqId to IrSymbol (5 days ago) <Georgy Bronnikov>
* 1647279a8c0 - IR: move UniqId to ir.tree module (5 days ago) <Georgy Bronnikov>
* 76016b1a3c5 - IR: move KotlnMangler to ir.tree module (5 days ago) <Georgy Bronnikov>
* 92ebb092a2a - JvmMangler (5 days ago) <Georgy Bronnikov>
* 2f5442800b6 - Move WrappedDescriptors to ir.tree module (5 days ago) <Georgy Bronnikov>
*   cb112821835 - (tag: build-1.3.70-dev-1573) Merge pull request #2516 from t-kameyama/KT-18539 (5 days ago) <igoriakovlev>
|\  
| * 4d9b19da82d - Remove comments from function/property implementation template (5 days ago) <Toshiaki Kameyama>
* 3429c070164 - (tag: build-1.3.70-dev-1564) Fix Native dependencies not transformed when imported from a source set (5 days ago) <Sergey Igushkin>
* 94f66c237bd - (minor) replace the predicate for intermediate source set (5 days ago) <Sergey Igushkin>
* bcabbcf3e15 - Add Native stdlib to intermediate source set dependencies (5 days ago) <Dmitry Savvinov>
* 1ccda6a8d48 - Add fast find usages for data class components (5 days ago) <Igor Yakovlev>
* 6d9c00addd3 - (tag: build-1.3.70-dev-1558) Do not add preparation task to project import if registry option is switched off (5 days ago) <Natalia Selezneva>
* 455b9f852da - (tag: build-1.3.70-dev-1554) [NI] Disable caching of LHS expression types for "+=" operators (5 days ago) <Mikhail Zarechenskiy>
* 4973baae4ee - (tag: build-1.3.70-dev-1551) [JVM IR] Fix JvmOverloads+Parameterless Main (5 days ago) <Kristoffer Andersen>
* b4185c9d472 - (tag: build-1.3.70-dev-1543) ScriptClassRootsCache: load configuration if it is not cached (5 days ago) <Sergey Rostov>
* a84e9480511 - Scripting: pass KtFile to ScriptConfigurationLoader (5 days ago) <Sergey Rostov>
* 9a231bbbfa4 - (tag: build-1.3.70-dev-1537) Update trailing lambda quickfix, add tests (5 days ago) <Pavel Kirpichenkov>
* f1934fa49d1 -  Amend "Terminate preceding call with semicolon" quickfix (5 days ago) <Pavel Kirpichenkov>
* 0f638db3e56 - (tag: build-1.3.70-dev-1536) FIR: Turn SupertypeSupplier into a class (5 days ago) <Denis Zharkov>
* 56b5d170ebb - FIR: Minor. Rename FirSupertypeResolverTransformerAdapter -> FirSupertypeResolverTransformer (5 days ago) <Denis Zharkov>
* 3a4f9e9109e - FIR: Drop FirClassLikeDeclaration::supertypesComputationStatus (5 days ago) <Denis Zharkov>
* 2fba6b54a0a - FIR: Minor. Drop old FirSupertypeResolverTransformer (5 days ago) <Denis Zharkov>
* 3f7bffa6fdf - FIR: Do not use FirClass::supertypesComputationStatus (5 days ago) <Denis Zharkov>
* 5e0e78e555e - FIR: Rewrite supertype resolution (5 days ago) <Denis Zharkov>