### PR TITLE
[kotlin compiler][update] 1.3.70-dev-2113

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1272,6 +1272,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
             IrTypeOperator.NOT_INSTANCEOF            -> evaluateNotInstanceOf(value)
             IrTypeOperator.SAM_CONVERSION            -> TODO(ir2string(value))
             IrTypeOperator.IMPLICIT_DYNAMIC_CAST     -> TODO(ir2string(value))
+            IrTypeOperator.REINTERPRET_CAST          -> TODO(ir2string(value))
         }
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/CapturedTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/CapturedTypes.kt
@@ -45,7 +45,8 @@ private val FAKE_CAPTURED_TYPE_CLASS_DESCRIPTOR
                         this, Annotations.EMPTY, 
                         false, Variance.IN_VARIANCE, 
                         Name.identifier("Projection"), 
-                        /* index = */ 0
+                        /* index = */ 0,
+                        LockBasedStorageManager.NO_LOCKS
                     ).let(::listOf)
             )
             createTypeConstructor()

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1666,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-dev-1666
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1666,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-dev-1666
-kotlinStdlibTestsVersion=1.3.70-dev-1666
-testKotlinCompilerVersion=1.3.70-dev-1666
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2113,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-dev-2113
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2113,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.70-dev-2113
+kotlinStdlibTestsVersion=1.3.70-dev-2113
+testKotlinCompilerVersion=1.3.70-dev-2113
 konanVersion=1.3.70
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,21 +31,19 @@ include ':backend.native:tests'
 include ':backend.native:debugger-tests'
 include ':utilities'
 
-if (hasProperty("konan.home") || hasProperty("org.jetbrains.kotlin.native.home")) {
-    include ':performance'
-    include ':performance:ring'
-    include ':performance:cinterop'
-    include ':performance:helloworld'
-    include ':performance:numerical'
-    include ':performance:videoplayer'
-    include ':performance:framework'
-    if (System.getProperty("os.name") == "Mac OS X") {
-        include ':performance:objcinterop'
-        include ':performance:swiftinterop'
-        if (hasProperty("runExcludedBenchmarks")) {
-            include ':performance:KotlinVsSwift'
-            include ':performance:KotlinVsSwift:ring'
-        }
+include ':performance'
+include ':performance:ring'
+include ':performance:cinterop'
+include ':performance:helloworld'
+include ':performance:numerical'
+include ':performance:videoplayer'
+include ':performance:framework'
+if (System.getProperty("os.name") == "Mac OS X") {
+    include ':performance:objcinterop'
+    include ':performance:swiftinterop'
+    if (hasProperty("runExcludedBenchmarks")) {
+        include ':performance:KotlinVsSwift'
+        include ':performance:KotlinVsSwift:ring'
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,7 @@ include ':backend.native:tests'
 include ':backend.native:debugger-tests'
 include ':utilities'
 
-if (hasProperty("org.jetbrains.kotlin.native.home") || hasProperty("kotlin.native.home")) {
+if (hasProperty("konan.home") || hasProperty("org.jetbrains.kotlin.native.home")) {
     include ':performance'
     include ':performance:ring'
     include ':performance:cinterop'


### PR DESCRIPTION
* 249789d6ebb - (tag: build-1.3.70-dev-2113) Formatter: add test for enum entry with comment Relates to #KT-15980 (7 hours ago) <Dmitry Gridin>
* 97c8b2074ec - (tag: build-1.3.70-dev-2104) [JS] Set correct EXPECTED_REACHABLE_NODES (18 hours ago) <Roman Artemev>
* 12f29bacab7 - (tag: build-1.3.70-dev-2101) Exclude checking for unimplemented method for binary origin classes (21 hours ago) <Igor Yakovlev>
* 8d5e5210a6e - (tag: build-1.3.70-dev-2099) JVM_IR: Copy annotations to suspend function views. (21 hours ago) <Mads Ager>
* 3d1061ee3cb - (tag: build-1.3.70-dev-2094) Uast: `KotlinUMethodWithFakeLightDelegate` 183-related fixes (22 hours ago) <Nicolay Mitropolsky>
* c5fb51bd858 - 191: Uast: `KotlinUMethod` compilation fix (22 hours ago) <Nicolay Mitropolsky>
* 19c28c55c54 - (tag: build-1.3.70-dev-2092) Allow serialization plugin to work with inline types which are primitives (e.g. Char in JS IR) (22 hours ago) <Leonid Startsev>
* ed786c4daf0 - Enable compiler plugins in JS IR backend (and WASM too, since they use same loadIr function) (22 hours ago) <Leonid Startsev>
* 0441e484a6a - (tag: build-1.3.70-dev-2079) PSI2IR: For implicit function return, use expression's end offset as start offset of the IrReturn to generarate correct line number. (24 hours ago) <Jiaxiang Chen>
* e49431a12c5 - Debug information test: make stepping information more readable. (24 hours ago) <Jiaxiang Chen>
* 331b085b2f5 - JVM_IR: Fix line number for catch clause. (24 hours ago) <Jiaxiang Chen>
* 3ea878b1c65 - JVM_IR: Fix line number for varible initializer (24 hours ago) <Jiaxiang Chen>
* 8bb9c572ac7 - (tag: build-1.3.70-dev-2076) Move inProgress lock at the onFinish of background task (KT-34688) (25 hours ago) <Natalia Selezneva>
* ad09492eb08 - (tag: build-1.3.70-dev-2072) [Gradle, JS] Migrate on only name-version npm dependencies (26 hours ago) <Ilya Goncharov>
* 95b56e10b41 - [Gradle, JS] Activate root npm dependency declaration for multiplatform (26 hours ago) <Ilya Goncharov>
* 5397023f71d - [Gradle, JS] Add Groovy Closure support (26 hours ago) <Ilya Goncharov>
* 028c73d959e - [Gradle, JS] Add compatible operators for npm dependencies (26 hours ago) <Ilya Goncharov>
* 26cd392a9a8 - [Gradle, JS] First steps for npm dependencies in root (26 hours ago) <Ilya Goncharov>
* f73fc5199b9 - [Gradle, JS] Mute testWeb false positive test (26 hours ago) <Ilya Goncharov>
* be5b8c1bdb0 - [Gradle, JS] Mute false positive test for MPP JS-JVM (26 hours ago) <Ilya Goncharov>
* b40a888f1d9 - (tag: build-1.3.70-dev-2070) Formatter: fix line break between declarations with annotations #KT-35093 Fixed #KT-35106 Fixed (26 hours ago) <Dmitry Gridin>
* bfd539d5d1e - Formatter: fix line break between declarations with comment #KT-12490 Fixed #KT-35088 Fixed (26 hours ago) <Dmitry Gridin>
* b6b755506cc - Formatter: support `Chop down if long` for `Chained method calls` #KT-23929 Fixed #KT-33553 Fixed (26 hours ago) <Dmitry Gridin>
* 351fef56285 - DoubleBangToIfIntention: fix invalid psi tree (26 hours ago) <Dmitry Gridin>
* f48ad25626f - Advance bootstrap to 1.3.70-dev-1806 (26 hours ago) <Svyatoslav Kuzmich>
* 8185c452fe5 - Ignore jarRepositories.xml (26 hours ago) <Nikolay Krasko>
* 13b0054e0a8 - Fix compilation for service messages tests in 193 branch (26 hours ago) <Nikolay Krasko>
* 89f26cc89dd - Minor: Make diff function for AbstractKotlinFoldingTest (26 hours ago) <Nikolay Krasko>
* 5d6333f0f4d - 193: Better services registration for parser tests (26 hours ago) <Nikolay Krasko>
* 3d2800f99b7 - Move out symbols that do not depend on a BackendContext to a separate BuiltinSymbolsBase class. (26 hours ago) <Leonid Startsev>
* 3e18350a1f4 - Rewrite IR plugin infrastructure (and serialization plugin) so it won't emit LazyIR. (26 hours ago) <Leonid Startsev>
* e4d0d450ab8 - (tag: build-1.3.70-dev-2069) Uast: keeping annotations from sources in non-light-methods backed UMethods (KT-27806) (27 hours ago) <Nicolay Mitropolsky>
* 833571d8b25 - Uast: tests for suspend and `DeprecationLevel.HIDDEN` functions appears in Uast tree (KT-27806, KT-32031) (27 hours ago) <Nicolay Mitropolsky>
* 2772659ed22 - Uast: Uast produces reified methods on his own because light-classes doesn't (KT-34316) (27 hours ago) <Nicolay Mitropolsky>
* 9c18df61ca5 - Uast: `KotlinUMethod` and `KotlinUAnnotationMethod` are separated (KT-30489) (27 hours ago) <Nicolay Mitropolsky>
* 9fec2c78d1e - (tag: build-1.3.70-dev-2068) JS IR: apply forLoopsLowering (27 hours ago) <Anton Bannykh>
* 0ea407fef99 - (tag: build-1.3.70-dev-2067) debug information test: handle vm resume correctly. (27 hours ago) <Jiaxiang Chen>
* 251899c31af - (tag: build-1.3.70-dev-2062) Fix bad indentation when copy-paste to trimIndent() (28 hours ago) <Toshiaki Kameyama>
* 178dbd3c5d8 - (tag: build-1.3.70-dev-2057) Remove hacky re-initialization of PsiSubstitutor.KEY (branch 193) (29 hours ago) <Mikhail Glukhikh>
* 81699299f53 - (tag: build-1.3.70-dev-2053) JS_IR: DCE (29 hours ago) <Anton Bannykh>
* faf4c05fc8a - (tag: build-1.3.70-dev-2051) KT-34644 Give `return` keyword more priority in completion where appropriate (30 hours ago) <Roman Golyshev>
* de11b4cb640 - KT-34644 Refactor `CompletionUtils::returnExpressionItems` (30 hours ago) <Roman Golyshev>
* cf82efb49fd - (tag: build-1.3.70-dev-2047) [NI] Add missing diagnostic on callable references in fake calls (31 hours ago) <Pavel Kirpichenkov>
* eb736502091 - (tag: build-1.3.70-dev-2046) Fix race in IDE: inject proper storage manager for type parameters (31 hours ago) <Mikhail Zarechenskiy>
* 399667a4341 - (tag: build-1.3.70-dev-2037) JVM_IR: Implement data class array member intrinsics. (2 days ago) <Mads Ager>
* ea8ade0852b - (tag: build-1.3.70-dev-2036) [JS] Refactor and comment for typeOf fix (2 days ago) <Svyatoslav Kuzmich>
* dc336c3c8a2 - [JS] Add marker function getReifiedTypeParameterKType to runtime (2 days ago) <Svyatoslav Kuzmich>
* 600fb723f40 - [JS] Fix typeOf for some reified type parameters (2 days ago) <Svyatoslav Kuzmich>
* c4d993d14c5 - [KLIB] Fix top level property index. Include const properties as well. (2 days ago) <Roman Artemev>
* 1e4f8b2946f - [JS IR] Do not forbid typeOf inlining if it is not required (2 days ago) <Roman Artemev>
* 2e22ddba393 - [JS IR] Fix annotation constructor body generation (2 days ago) <Roman Artemev>
* c5e25a03828 - [JS IR] Make `PrivateMembersLowering` global to handle inlined private references correctly   - Fixes [KT-33334] (2 days ago) <Roman Artemev>
* 9946feb66ce - [JS IR] Fix name clash between class members defined on prototype  - Fixes [KT-33327] (2 days ago) <Roman Artemev>
* 987c6ab3ee7 - [JS IR] Roll making Char inline class back  - un/mute falling tests (2 days ago) <Roman Artemev>
* b9ac1341ff0 - (tag: build-1.3.70-dev-2035) Export generic serializer constructor from JS module (2 days ago) <Leonid Startsev>
* 73b9d2466a2 - Do not report 'Missing @Serializable on enum with @SerialInfo' if enum has custom serializer (2 days ago) <Leonid Startsev>
* 98ceee784a5 - (tag: build-1.3.70-dev-2026) JVM_IR: More special bridge rewriting. (2 days ago) <Mads Ager>
* f368d9761aa - (tag: build-1.3.70-dev-2021) Fix `for` loop conversion when multiple initializers are present (2 days ago) <Ilya Kirillov>
* b73625ad9e0 - (tag: build-1.3.70-dev-2019) Switch main-kts to the updated resolvers infrastructure (2 days ago) <Ilya Chernikov>
* baec10fb40a - Update apache ivy version to 2.5.0 (2 days ago) <Ilya Chernikov>
* 4234c5ec31a - Fix ivy resolver: deps config and maven repos: (2 days ago) <Ilya Chernikov>
* 5e5038416ef - (tag: build-1.3.70-dev-2018) Revert "tmp" (2 days ago) <Dmitriy Novozhilov>
* 3e336913b67 - (tag: build-1.3.70-dev-2011) tmp (2 days ago) <Dmitriy Novozhilov>
* 4fc554fa9ab - [FIR-TEST] Add test with unresolved SAM usage of `Comparator` (2 days ago) <Dmitriy Novozhilov>
* 98af866417f - [FIR] Fix stopping in AbstractFirUseSiteMemberScope (2 days ago) <Dmitriy Novozhilov>
* 52caa6a58d8 - [FIR] Don't recreate type resolver in `FirSpecificTypeResolverTransformer` (2 days ago) <Dmitriy Novozhilov>
* 841ba6ea114 - [FIR] Add generating of rawBuilder tests for light tree (2 days ago) <Dmitriy Novozhilov>
* 43e621530fa - [FIR] Add type parameters to FirQualifierExpression (2 days ago) <Dmitriy Novozhilov>
* 9330547f876 - (tag: build-1.3.70-dev-2004) Gradle 6.0.1 support. Fix Yarn loading progress logging (2 days ago) <Victor Turansky>
* 46220417061 - (tag: build-1.3.70-dev-2002) Update box test for unsigned to signed conversions (2 days ago) <Pavel Kirpichenkov>
* 076166c22f9 - (tag: build-1.3.70-dev-1999) Debugger: Generate line numbers for class initializers with a number on the 'init' keyword (KT-16277) (2 days ago) <Yan Zhulanow>
* bebc8974b2c - Report 5308947: check module validity before asking for library versions (2 days ago) <Yan Zhulanow>
* cf620cc60da - Debugger: Synchronize "Add field breakpoint" dialog with the platform code (2 days ago) <Yan Zhulanow>
* 75b366fc5e9 - EA-211653: Wrap field breakpoint dialog into a transaction guard (2 days ago) <Yan Zhulanow>
* ffeef6c18d9 - EA-210460: Use 'safeAllLineLocations()' instead of throwing 'allLineLocations()' (2 days ago) <Yan Zhulanow>
* aaa45425da8 - EA-210002: handle interruption in case of background inline callable searcher task (2 days ago) <Yan Zhulanow>
* 36073ef61ec - EA-209923: Add missing read action (2 days ago) <Yan Zhulanow>
* 69d5115b897 - EA-214241: Remove worthless error reporting (2 days ago) <Yan Zhulanow>
* 16c4b0e458a - EA-210823: Fix AIE in breakpoint applicability test (2 days ago) <Yan Zhulanow>
* ab06f772fc6 - EA-209419: Fix read action requirement in Light constant evaluator (2 days ago) <Yan Zhulanow>
* 2983c87212c - EA-215308: Fix unsafe check casts in template entry handling (2 days ago) <Yan Zhulanow>
* 3534d4af36b - EA-215324: Fix "Module already disposed" in Scratch combo-box (2 days ago) <Yan Zhulanow>
* 3d17af0ada9 - EA-215375: Check range, not rangeMarker with nullable 'range' inside (2 days ago) <Yan Zhulanow>
* 89bd3b8767b - EA-215872: Check text range validity before 'getText(range)' (2 days ago) <Yan Zhulanow>
* 49bcb103ef4 - EA-216005: Do not request KotlinFacetSettingsProvider for dead projects (2 days ago) <Yan Zhulanow>
* f91a84872a6 - EA-216299: fix SIOOBE in completion (2 days ago) <Yan Zhulanow>
* f75288b4805 - EA-216333: check PsiElement validity before light class generation (2 days ago) <Yan Zhulanow>
* 59296d6a6b5 - EA-217068: Add missing read action (2 days ago) <Yan Zhulanow>
* e12f17d5dc5 - EA-217069: Add missing read action (2 days ago) <Yan Zhulanow>
* 54203100bc6 - EA-217072: Add missing read action (2 days ago) <Yan Zhulanow>
* 6a4b658ad40 - EA-217153: Add line count check (2 days ago) <Yan Zhulanow>
* ab0f8416425 - Debugger: Provide fixed implementation of 'toString()' for lambdas (KT-32691) (2 days ago) <Yan Zhulanow>
* 82a1750d262 - Debugger: Forbid 'Nothing' constructor calls in evaluated code (KT-33093) (2 days ago) <Yan Zhulanow>
* 55b3637f032 - (tag: build-1.3.70-dev-1995) Fix case of inner object usage in missing supertypes checker (2 days ago) <Pavel Kirpichenkov>
* 5afab1ac2b6 - (tag: build-1.3.70-dev-1992) [FIR] FIR2IR: Populate calls with type arguments and function type parameters with bounds/supertypes. (2 days ago) <Mark Punzalan>
* 58dd9a60041 - (tag: build-1.3.70-dev-1991) Fix AWT freeze in KotlinNativeABICompatibilityChecker (part 2) (3 days ago) <Dmitriy Dolovov>
* 0747a4d9b7a - Fix AWT freeze in KotlinNativeABICompatibilityChecker (3 days ago) <Dmitriy Dolovov>
* e321c9e4e7b - (tag: build-1.3.70-dev-1986) Fix diagnostics calculations for incremental analysis (4 days ago) <Vladimir Dolzhenko>
*   c7c512d55e8 - (tag: build-1.3.70-dev-1984) Merge pull request #2815 from t-kameyama/KT-35022 (4 days ago) <Vladimir Dolzhenko>
|\  
| * f6059c3eb53 - "Change to var": remove `const` modifier (5 days ago) <Toshiaki Kameyama>
* | d599322503a - (tag: build-1.3.70-dev-1980) Calculate method parameter hint info in updateParameterInfo method (with a progress till 201) (4 days ago) <Vladimir Dolzhenko>
* | 84757964bb5 - (tag: build-1.3.70-dev-1979) Advance bootstrap to 1.3.70-dev-1806 (5 days ago) <Svyatoslav Kuzmich>
* | 73a152ccc75 - Re-mute inspection tests in AS34 (KT-32856) (5 days ago) <Nikolay Krasko>
* | e49d7c86ff9 - Re-mute move refactoring tests (KT-34106) (5 days ago) <Nikolay Krasko>
* | 0ae677e9453 - Re-mute checker tests (KT-34105) (5 days ago) <Nikolay Krasko>
* | 394a812329c - Re-mute completion tests (KT-32919) (5 days ago) <Nikolay Krasko>
* | 6797fb476c9 - Support auto-mute from file for database with mutes (5 days ago) <Nikolay Krasko>
* | 9356155f60b - Minor: add bunch directives for better discoverability banched code (5 days ago) <Nikolay Krasko>
* | 027bc671c13 - (tag: build-1.3.70-dev-1969) Build: Remove duplicated compiler.xml from idea module (5 days ago) <Vyacheslav Gerasimov>
|/  
* 8c103629a6f - (tag: build-1.3.70-dev-1968) Disable FIR box test for callable references to vararg function (5 days ago) <Pavel Kirpichenkov>
* 4267e9e3d0b - (tag: build-1.3.70-dev-1948) Revert "Advance bootstrap to 1.3.70-dev-1806" (5 days ago) <Nikolay Krasko>
* e506efb5b26 - (tag: build-1.3.70-dev-1942) Include Klib metadata utils into jps-plugin (5 days ago) <Alexey Tsvetkov>
* a0d4d0da587 - (tag: build-1.3.70-dev-1941) [coroutine][debug] rollback compilation failed exception as it breaks test scenarios (5 days ago) <Vladimir Ilmov>
* 9dc628bd72e - (tag: build-1.3.70-dev-1934) Fix FirJavaElementFinder.kt.183 compilation (5 days ago) <Denis Zharkov>
* d3f906a1a20 - Minor: extract method & reformat to improve readability (5 days ago) <Alexey Tsvetkov>
* ed6b90002e1 - conservatively generate code if descriptor unavailable, which happens for some suspend inline functions (5 days ago) <Kevin Bierhoff>
* 0285b26e400 - make FunctionCodegen skip method bodies we don't need, which avoids problems with inlining methods inside methods we don't need (5 days ago) <Kevin Bierhoff>
* b10f47b50e5 - (tag: build-1.3.70-dev-1927) Minor: merge util methods for scripting to one file in idea-gradle (5 days ago) <Natalia Selezneva>
* 23f95872ad1 - Minor: fix packages after moving classes to idea-gradle module (5 days ago) <Natalia Selezneva>
* 75a23b4bc46 - Minor: changes after review (5 days ago) <Sergey Rostov>
* fc100d13dd5 - Scripting: move gradle specific logic to idea-gradle (5 days ago) <Sergey Rostov>
* 0fb58ed94c2 - Scripting loading tests and extension points (5 days ago) <Sergey Rostov>
* ca71b2fe900 - Add script configuration dependencies to script classpath (5 days ago) <Natalia Selezneva>
* 29ef10a919b - Check gradle version for loading script configuration during import option (5 days ago) <Natalia Selezneva>
* 72ef43f4627 - Show filePattern in settings for new script definitions if present (5 days ago) <Natalia Selezneva>
* c40cd07cf0e - Do not show duplicated error gradle templates in settings (5 days ago) <Natalia Selezneva>
* d355a9f6869 - Minor: fix typo (5 days ago) <Natalia Selezneva>
* 229665d2fc5 - Remove unused environment properties from gradle configuration resolver (5 days ago) <Natalia Selezneva>
* 9710f1da770 - Minor: move class (5 days ago) <Natalia Selezneva>
* 6c4de96dcb7 - Minor: extract class to separate file (5 days ago) <Natalia Selezneva>
* 4b0844b21d1 - Minor: move classes in idea-gradle module related to scripting (5 days ago) <Natalia Selezneva>
* 28e2d2faf25 - (tag: build-1.3.70-dev-1926) KT-34740 Make `getImplicitReceiversWithInstanceToExpression` keep script implicit receivers (5 days ago) <Roman Golyshev>
* be2fe256ba1 - KT-34740 Refactor `implicitReceiversUtils.kt` (5 days ago) <Roman Golyshev>
* 34b8b96cdea - (tag: build-1.3.70-dev-1925) Generate forgotten FIR box test (5 days ago) <Pavel Kirpichenkov>
* d269c194c77 - (tag: build-1.3.70-dev-1923, kotlin/minamoto/misc/compiler-update/kotlin, kotlin/minamoto/misc/1.3.60/kotlin) Fix java version parsing in KAPT (5 days ago) <Ivan Gavrilovic>
* 508330e0bb5 - Remove deprecated method from CommandLineProcessor (5 days ago) <Jens Klingenberg>
* 3a7deffe2e9 - KT-33050: Pass source version to KAPT for JDK12+ (5 days ago) <Ivan Gavrilovic>
* f4c6f573540 - KT-34194: Pass error/NonExistentClass for incremental KAPT run (5 days ago) <Ivan Gavrilovic>
* 7bdda22cfa5 - (tag: build-1.3.70-dev-1921) [coroutine][debugger] broken testCompileOnly fix missing dependency aether-dependency-resolver in 192,193 versions (5 days ago) <Vladimir Ilmov>
* 3fa431e114e - (tag: build-1.3.70-dev-1916) [JS IR] Don't use full paths when generating comments with a path for file blocks (6 days ago) <Zalim Bashorov>
* c05c07f2435 - [JS IR] Generate special region comments at the start and the end of each file block (6 days ago) <Zalim Bashorov>
* fa76b9cf83c - [JS IR] Use single line comment instead of JsDoc comment for comments with path (6 days ago) <Zalim Bashorov>
* 83e85b3ec8e - [JS AST] Add single line comment node (6 days ago) <Zalim Bashorov>
* 5fe79f71ad7 - [JS IR] Don't generate comment with path for "empty" files (6 days ago) <Zalim Bashorov>
* 4e3a2a0b3ed - [JS AST] Don't generate a new line after try and if-then blocks (6 days ago) <Zalim Bashorov>
* 8f9895e64ee - (tag: build-1.3.70-dev-1912) Add external keyword support for UL (6 days ago) <Igor Yakovlev>
* f80a71517f1 - (tag: build-1.3.70-dev-1900) [NI] Handle vararg parameter in reflection type wrt array types (6 days ago) <Pavel Kirpichenkov>
* aba5ff0c1e9 - (tag: build-1.3.70-dev-1899) Fix copy refactoring for multiply kotlin files (6 days ago) <Igor Yakovlev>
* 7d944e2023c - (tag: build-1.3.70-dev-1892) FIR dispatch receiver: check nullability only (expected vs actual type) (6 days ago) <Mikhail Glukhikh>
* 0dc7c37b62f - Choose SDK consistently at least for non-COMPOSITE analysis (6 days ago) <Dmitry Savvinov>
* e4afbae954f - (tag: build-1.3.70-dev-1891) Minor, fix test data for kotlinx.serialization bytecode text test (6 days ago) <Alexander Udalov>
* 4e331d0fb9e - Update ReadMe.md (6 days ago) <Alexander Podkhalyuzin>
* 88dae8025e8 - (tag: build-1.3.70-dev-1887) Fix failure with Kotlin/Native distributions that have no stdlib (6 days ago) <sergey.igushkin>
* 6a28d1da82d - (tag: build-1.3.70-dev-1886) Resolve references in background thread in PlainTextPasteImportResolver (6 days ago) <Vladimir Dolzhenko>
* bdb1c2a27f1 - (tag: build-1.3.70-dev-1880) [Gradle, JS] Fix tasks naming (6 days ago) <Ilya Goncharov>
* d221c1f2424 - (tag: build-1.3.70-dev-1875) JVM_IR: refactor MoveCompanionObjectFieldsLowering (6 days ago) <pyos>
* afd59f0d468 - (tag: build-1.3.70-dev-1869) [NI] Fix 'only input type' check for intersection types (6 days ago) <Pavel Kirpichenkov>
* 57760e5873e - FIR: set anonymous initializers' parents (6 days ago) <pyos>
* b38153e402d - (tag: build-1.3.70-dev-1864) Minor, add runtime and comment to test on multi-file isInitialized (6 days ago) <Alexander Udalov>
* bf06d381b95 - Minor, move old Java nullability assertion tests under oldLanguageVersions/ (6 days ago) <Alexander Udalov>
* 16e76fb75a7 - Resolve imports in background thread in PlainTextPasteImportResolver (6 days ago) <Vladimir Dolzhenko>
* bffbe89f53b - (tag: build-1.3.70-dev-1861) Advance bootstrap to 1.3.70-dev-1806 (6 days ago) <Svyatoslav Kuzmich>
* 0f4f3f2429e - (tag: build-1.3.70-dev-1858) FIR: set correspondingPropertySymbol of backing fields (6 days ago) <pyos>
* 0dcce9f5840 - (tag: build-1.3.70-dev-1856) FIR: add forgotten annotation calls resolve at some points (6 days ago) <Mikhail Glukhikh>
* 1bc4642fc93 - Run CompileKotlinAgainstJava tests in both APT / non-APT modes (6 days ago) <Mikhail Glukhikh>
* 393047883e3 - JavacWrapper: add Kotlin classes to classpath only in APT mode (6 days ago) <Mikhail Glukhikh>
* 89a582b694b - JavacWrapper: perform makeOutputDirectoryClasses hack only in non-APT mode (6 days ago) <Mikhail Glukhikh>
* 64380670c54 - (tag: build-1.3.70-dev-1850) [Gradle, JS] Add more info for check exit code (6 days ago) <Ilya Goncharov>
* ac241852dea - [Gradle, JS] Add verbose option to yarn in debug mode (6 days ago) <Ilya Goncharov>
* 28f2a2a8640 - Fix: Kotlin/Native libs have non-user friendly representation in IDE (6 days ago) <Dmitriy Dolovov>
* d3a5dcb6011 - (tag: build-1.3.70-dev-1840) KT-35004: keep track of KotlinType for 'when' subject (6 days ago) <Dmitry Petrov>
* 338b4e2eab5 - (tag: build-1.3.70-dev-1837) Refactor AbstractCompileKotlinAgainstJavaTest (6 days ago) <Mikhail Glukhikh>
* 32aba31819b - Cleanup: AbstractCompileKotlinAgainstJavaTest (6 days ago) <Mikhail Glukhikh>
* 307c82e3a49 - (tag: build-1.3.70-dev-1835) JVM_IR: redirect to correct function in special brigdes (7 days ago) <Georgy Bronnikov>
* ef567c868eb - (tag: build-1.3.70-dev-1825) [NI] Add `checkCanceled` checks before resolving a candidate (7 days ago) <Mikhail Zarechenskiy>
* 63e62dcf429 - Add `checkCanceled` check on resolving imports path (7 days ago) <Mikhail Zarechenskiy>
* db24d4ac9ac - FIR: Drop ConeTypeAliasLookupTag (7 days ago) <Denis Zharkov>
* 38500d27e81 - FIR: Add cache for expanded types (7 days ago) <Denis Zharkov>
* 159aefd26de - FIR: Refactor Cone types (7 days ago) <Denis Zharkov>
* e03162f2dd5 - FIR: Rename ConeClassTypeImpl -> ConeClassLikeTypeImpl (7 days ago) <Denis Zharkov>
* f178cb6fb3c - FIR: Replace trivial usages of ConeClassType with ConeClassLikeType (7 days ago) <Denis Zharkov>
* a485a5ffd66 - (tag: build-1.3.70-dev-1824) JVM IR: load fields for JvmField properties from dependencies (7 days ago) <Alexander Udalov>
* 608449f41d8 - IR: introduce StubGeneratorExtensions for ExternalDependenciesGenerator (7 days ago) <Alexander Udalov>
* c3af2d5a10a - (tag: build-1.3.70-dev-1821) JVM_IR. Combine all inline function resolve logic in ResolveInlineCalls lower (7 days ago) <Mikhael Bogdanov>
* 939a9ff53e5 - (tag: build-1.3.70-dev-1820) JVM_IR: fix NPE in interface companion initializers (7 days ago) <pyos>
* 7c015564ce8 - (tag: build-1.3.70-dev-1818) JVM_IR: do not set ACC_VARARGS if vararg is not the last parameter (7 days ago) <pyos>
* 7adffe0007f - (tag: build-1.3.70-dev-1814) Handle `withIndex()` on Iterables (including progressions) and Sequences in ForLoopsLowering. (7 days ago) <Mark Punzalan>
* a54d9482dd1 - Handle `withIndex()` on arrays and CharSequences in ForLoopsLowering. (7 days ago) <Mark Punzalan>
* 735535dd5a9 - Extract HeaderInfo base class and add NumericHeaderInfo class, in preparation for handling withIndex(). (7 days ago) <Mark Punzalan>
* 2ab539c5ebb - Encapsulate variable construction and declaration order logic within ForLoopHeader instead of in HeaderProcessor. (7 days ago) <Mark Punzalan>
* 60c05362d27 - Refactor ForLoopHeader to clarify the purpose of its functions. (7 days ago) <Mark Punzalan>
* 7f803e60b65 - Fix typo in forInArrayWithIndex testdata filenames. (7 days ago) <Mark Punzalan>
* 9066614cb9d - (tag: build-1.3.70-dev-1813) Support inlining of implicitly casted lambda parameter (7 days ago) <Mikhael Bogdanov>
* d28ec1d449c - Add test for default lambda inlining in suspend inline (7 days ago) <Mikhael Bogdanov>
* a92afc5a89c - JVM_IR. Disable private default flag test (7 days ago) <Mikhael Bogdanov>
* 344c11af7f9 - JVM_IR. Support multifile facades in default function inlining (7 days ago) <Mikhael Bogdanov>
* 19ce0553222 - JVM_IR. Pass stub function reference in 'getSignature' (7 days ago) <Mikhael Bogdanov>
* a214d615677 - IR. Change visibility to lowered default function/constructors to public (7 days ago) <Mikhael Bogdanov>
* abef5daea96 - IR. Hack to distinguish default values (7 days ago) <Mikhael Bogdanov>
* ac31e0e8c7c - Support default lambda inlining in IR (7 days ago) <Mikhael Bogdanov>
* 8adac2d1ea0 - Don't add unused label if variables are absent (7 days ago) <Mikhael Bogdanov>
* be3eed5f1ff - Access to receiver thought reference class (7 days ago) <Mikhael Bogdanov>
* 7bab3a10481 - Set non-synthetic origin for generated members of PropertyReference (7 days ago) <Mikhael Bogdanov>
* 31968931662 - Don't write synthetic arguments to LVT (7 days ago) <Mikhael Bogdanov>
* f264942bf90 - Don't coerce intrisic value, it's already coerced (7 days ago) <Mikhael Bogdanov>
* e4093870786 - Don't generate jump for last when condition (7 days ago) <Mikhael Bogdanov>
* 9a07063d8b6 - Decrease number of 'invokeMethodDescriptor' usage in inliner (7 days ago) <Mikhael Bogdanov>
* 3eec67e5d3a - JVM_IR. Don't compare with 0 defaultFlag (7 days ago) <Mikhael Bogdanov>
* f5fb50b2242 - IR. Add separate origins for synthetic parameters in default functions. Keep information about types and default values in lowered funtion (7 days ago) <Mikhael Bogdanov>
* 764a25f6ae2 - [JS] Add deprecated typealias and extension properties for renamed in dukat update entities (7 days ago) <Alexey Trilis>
* 937cffd273b - (tag: build-1.3.70-dev-1809) Support Gradle 5.x in GradleInspectionTest (7 days ago) <Andrey Uskov>
* 21b9987a762 - Support Gradle 5.x in GradleMigrateTest (7 days ago) <Andrey Uskov>
* 5fe4baa4a5e - Fix GradleNativeLibrariesInIDENamingTest (7 days ago) <Andrey Uskov>
* 968ccf667a0 - Fix GradleNativeLibrariesPropagationTest (7 days ago) <Andrey Uskov>
* 8a3dfe93f26 - Fixed GradleFacetImportTests for gradle 5.x (7 days ago) <Andrey Uskov>
* 9e7eff7e72c - Enable ImportCompilerArgumentsWithInvalidDependencies test (7 days ago) <Andrey Uskov>
* 25acb1e1919 - (tag: build-1.3.70-dev-1806) [coroutine][debugger] removed and regenerated tests for not-ready-to-be-tested logic, kt* tests are failing due to KT-32691 (7 days ago) <Vladimir Ilmov>
* 09d2bd33f82 - (tag: build-1.3.70-dev-1801) [coroutine][debug] incorrect merge conflicting with 00a06ef9b998bc13d52bb13bdeb550b4c3d7804b (7 days ago) <Vladimir Ilmov>
* 137e54db056 - (tag: build-1.3.70-dev-1791) FIR Java (raw type bounds erasure): make better protection from recursion (8 days ago) <Mikhail Glukhikh>
* 95203e9310c - FIR: unmute passing black-box tests (nested constructor resolve) (8 days ago) <Mikhail Glukhikh>
* fa739f1aaeb - FIR: optimize classifier scope: don't search for nonexistent symbols (8 days ago) <Mikhail Glukhikh>
* d39a36ee25f - FIR declared member scope: remove constructors from callable index (8 days ago) <Mikhail Glukhikh>
* bd71d1dc3f4 - FIR resolve: use lazy nested classifier scopes for Java classes (8 days ago) <Mikhail Glukhikh>
* cc891c46b1f - (tag: build-1.3.70-dev-1787) Mute failing fir blackbox test (8 days ago) <Dmitriy Novozhilov>
* 15ed342282b - (tag: build-1.3.70-dev-1776) JVM_IR: Generate args check in existing methods for special bridge methods. (8 days ago) <Mads Ager>
* 369d9bfdabf - (tag: build-1.3.70-dev-1771) Dropped index from DeserializedSourceFile as it is no longer needed (8 days ago) <Alexander Gorshenev>
* e7ef453d226 - Got rid of klib file registry (8 days ago) <Alexander Gorshenev>
* f49bc0e96d1 - (tag: build-1.3.70-dev-1768, origin/rr/FIR/semoro/rawTypes) [FIR] Improve keyword colors (light-theme) in html dump (8 days ago) <Simon Ogorodnik>
* 36979e79379 - [FIR] Support ConeDefinitelyNotNullType in html dump (8 days ago) <Simon Ogorodnik>
* 9249d1b727e - [FIR] Support diagnostics in Html dump (8 days ago) <Simon Ogorodnik>
* 6e8f8f9a650 - [FIR] Partially support raw types (8 days ago) <Simon Ogorodnik>
* 119a3f13067 - (tag: build-1.3.70-dev-1762) JVM_IR: do not generate accessors to lateinit private properties (8 days ago) <Georgy Bronnikov>
* be0516348b2 - (tag: build-1.3.70-dev-1757) IDE formatting: add indention for new line in parameters list when there is a trailing comma (8 days ago) <victor.petukhov>
* d246d120938 - (tag: build-1.3.70-dev-1750) [Gradle, JS] Add intregration test on browser pipeline with transitive dependencies (8 days ago) <Ilya Goncharov>
* c87961dcad1 - [Gradle, JS] Dce should work with runtime classpath (8 days ago) <Ilya Goncharov>
* c2b53dfce74 - (tag: build-1.3.70-dev-1747) [Gradle, JS] Add debugger; only for debug mode (8 days ago) <Ilya Goncharov>
* 4d3698313d9 - [Debugger, JS] Configure timeouts for debugging (8 days ago) <Ilya Goncharov>
* 79ef361e1af - [Debugger, JS] Remove Mocha configuring in KotlinKarma (8 days ago) <Ilya Goncharov>
* 15a606c2b65 - [Debugger, JS] Rename karma-debug on karma-debug-runner (8 days ago) <Ilya Goncharov>
* 5f8a5d5fca7 - [Debugger, JS] Extract Debug's configurations (8 days ago) <Ilya Goncharov>
* d57127ed089 - [Debugger, JS] Fix for mocha timeout (8 days ago) <Ilya Goncharov>
* d7c2d098af7 - [Debugger, JS] Add configuring debuggable browser (8 days ago) <Ilya Goncharov>
* 550cc9d7750 - [Gradle, JS] Add karma debugger by timeout (8 days ago) <Ilya Goncharov>
* 821a4ea472a - [Debugger, JS] Use default js debug configuration with Karma (8 days ago) <Ilya Goncharov>
* 3d00212e343 - (tag: build-1.3.70-dev-1745) FIR Java: add minor comment (type parameter types) (8 days ago) <Mikhail Glukhikh>
* f60842efe11 - (tag: build-1.3.70-dev-1744) FIR resolve: add test with Java static class constructor access from Kotlin (8 days ago) <Mikhail Glukhikh>
* 19aff81b551 - FIR tower resolve: make static members accessible from derived classes (8 days ago) <Mikhail Glukhikh>
* 7dea06d2a75 - FIR tower resolve: make companion members accessible from derived classes (8 days ago) <Mikhail Glukhikh>
* 802ed9b502b - FIR: implement protected visibility checker #KT-34788 Fixed (8 days ago) <Mikhail Glukhikh>
* ad3659d1d91 - FIR deserializer: add forgotten type parameter bounds for FunctionX (8 days ago) <Mikhail Glukhikh>
* 1e548e3f21f - FIR substitution: use intersection of bounds for * projection (8 days ago) <Mikhail Glukhikh>
* 43a8c1282f5 - [FIR] Add `toString()` call to expressions in string templates (8 days ago) <Dmitriy Novozhilov>
* 8d9d6fd1817 - [TEST] Regenerate `FirBlackBoxCodegenTest` (8 days ago) <Dmitriy Novozhilov>
* 022a31398ae - (tag: build-1.3.70-dev-1741) [coroutine][debug] creation stack trace jump to line fixed (8 days ago) <Vladimir Ilmov>
* 25222b55e61 - [coroutine][debug] AsyncStackTraceProvider refactored (8 days ago) <Vladimir Ilmov>
* 310b3611ef8 - coroutine extention refactored to minimize brunch-related logic (8 days ago) <Vladimir Ilmov>
* c90cd8c4902 - [coroutine][debug] compilation error fixed (8 days ago) <Vladimir Ilmov>
* 3ca5d2d64fc - Debugger: Add 193 bunch for coroutines debugger (8 days ago) <Aleksandr Prokopyev>
* 1dc44b4000a - Debugger: Tests refactor (8 days ago) <Aleksandr Prokopyev>
* 12313fa5aa7 - Debugger: Fix for coroutine debugger after review (8 days ago) <Aleksandr Prokopyev>
* 5975251a326 - Debugger: Coroutines stack frames with variables & coroutine dumps (8 days ago) <Aleksandr Prokopyev>
* c459b2ca6e0 - (tag: build-1.3.70-dev-1737) [JS IR] Fix state machine control flow  - exception loop unwinding: make sure exception state is reset after try block is finished  - break/continue of suspended loops (8 days ago) <Roman Artemev>
* 18d0b477b60 - [JS IR] Fix `arrayOfNulls` API (8 days ago) <Roman Artemev>
* f2093a17639 - [JS IR] Fix boxing/unboxing of inline classes in coroutine scope  - don't box/unbox when value is known to be an inline class  - add unbox state when coroutine resumed  - correctly handle suspension in case of inline class  - add tests (8 days ago) <Roman Artemev>
* 52b24ead910 - [IR] Add `REINTERPRET_CAST` operator in IrTypeOperatorCall  - fix BE  - fix Serializer  - implement builder  - make Ir a bit more type-correct  - support developer mode (lowering [dynamic]implicit cast meterialized as general cast)  - fix autoboxing lowering (8 days ago) <Roman Artemev>
* 3795897fb7e - [JS IR] Add developer mode in configuration (8 days ago) <Roman Artemev>
* a2703b1534f - [IR] Unlink `isLocal` and `isAnonymousObject` from Descriptors API (8 days ago) <Roman Artemev>
* f633102b8ce - (tag: build-1.3.70-dev-1734) Unmute one of generated FIR black box codegen tests (8 days ago) <Mikhail Glukhikh>
* 9c9cf2086db - Unmute recently fixed FIR black box tests (8 days ago) <Mikhail Glukhikh>
* f3d0a976b23 - Disable recently added FIR black box tests (8 days ago) <Mikhail Glukhikh>
* 779b9e97d50 - Add IGNORE_BACKEND_FIR into generated black box tests (InRange, Ranges, ...) (8 days ago) <Mikhail Glukhikh>
* 7a7fc89c00f - Regenerate FIR black box codegen tests (8 days ago) <Mikhail Glukhikh>
* 2ab37699980 - Generation test utils: extract compileFilesUsing standard mode / FIR (8 days ago) <Mikhail Glukhikh>
* 9df2f69f091 - [FIR] Disable failing blackbox codegen tests for FIR. (8 days ago) <Mark Punzalan>
* fc9ccafb840 - [FIR] Generate and enable blackbox codegen tests. (8 days ago) <Mark Punzalan>
* ac590fa4c9a - (tag: build-1.3.70-dev-1733) [FIR] Fix deserializing nullability of type parameters (8 days ago) <Dmitriy Novozhilov>
* 950d1f4fe4d - [FIR] Fix enhancement of java array type (8 days ago) <Dmitriy Novozhilov>
* d56412e3976 - [FIR] Analyze lambda arguments in erroneously resolved calls (8 days ago) <Dmitriy Novozhilov>
* a85ece1d833 - [FIR-TEST] Add test with problem of invisible static members of supertype (8 days ago) <Dmitriy Novozhilov>
* 35dd1cf75a8 - [FIR] Fix binding return expression to function (8 days ago) <Dmitriy Novozhilov>
* 98378d89734 - [FIR] Infer type of lambda using all return statements (8 days ago) <Dmitriy Novozhilov>
* 99da7272f57 - [FIR] Change children order in FirConstructor (8 days ago) <Dmitriy Novozhilov>
* 01b47854c6d - [FIR] Fix implicit builtin types usages in body resolve (8 days ago) <Dmitriy Novozhilov>
* e4702bf4384 - (tag: build-1.3.70-dev-1729) [kotlinx-metadata] Add extensions for type aliases. (8 days ago) <Sergey Bogolepov>
* 85b36dcd88a - (tag: build-1.3.70-dev-1727) IR: Introduce IrClassifierSymbol.defaultType (9 days ago) <Steven Schäfer>
* 3d7d1022e4c - JVM IR: Add supertypes for PropertyReference classes in JvmSymbols (9 days ago) <Steven Schäfer>
* 2db8471dd79 - IR: Avoid "raw" IrTypes (9 days ago) <Steven Schäfer>
* 4d67803f04c - JVM IR: Fix IR types in default argument stubs (9 days ago) <Steven Schäfer>
* 9ef627ebec2 - JVM IR: Fix types in EnumClassLowering (9 days ago) <Steven Schäfer>
* 492a46206b7 - JVM IR: Fix return type of IrSetField in SharedVariablesManager (9 days ago) <Steven Schäfer>
* e8cb19fe229 - (tag: build-1.3.70-dev-1726) IR: minor, remove obsolete IrBasedDeclarationDescriptor (9 days ago) <Alexander Udalov>
* 0daab88f978 - JVM IR: make RemoveInlinedDeclarations a final module phase (9 days ago) <Alexander Udalov>
* cdb77039471 - JVM IR: fix VerifyError on annotated annotation properties (9 days ago) <Alexander Udalov>
* 994d4e081b9 - JVM IR: fix names of monitorenter/monitorexit intrinsics (9 days ago) <Alexander Udalov>
* f47b67781de - JVM IR: fix containing declaration for top level members in wrapped descriptors (9 days ago) <Alexander Udalov>
* 59af9672927 - JVM IR: support suspend inline functions in -Xmultifile-parts-inherit mode (9 days ago) <Alexander Udalov>
* 6f5aa583383 - JVM IR: support -Xmultifile-parts-inherit mode (9 days ago) <Alexander Udalov>
* 3b6b3c7e660 - JVM IR: minor, don't use symbols for maps of multifile members (9 days ago) <Alexander Udalov>
* 9182f2c7963 - (tag: build-1.3.70-dev-1724) IR: don't attempt to move defaults to `actual` in another module (9 days ago) <pyos>
* 1bc48c3df93 - (tag: build-1.3.70-dev-1723) IR: copy annotations when making lateinit fields nullable (9 days ago) <pyos>
* 4f56b1a9609 - (tag: build-1.3.70-dev-1717) Add support for Touch API in JS Stdlib #KT-34948 fixed #KT-21445 fixed (9 days ago) <Alexey Trilis>
* 2dfa6c360bb - (tag: build-1.3.70-dev-1713) Fix version range for Idea 191 plugin (9 days ago) <Vyacheslav Gerasimov>
* a46e970f47e - (tag: build-1.3.70-dev-1696) [JS] Remove kotlin-test-js build from JPS (9 days ago) <Svyatoslav Kuzmich>
* c8e5b2f2f87 - [KLIB] Add error message when failed to resolve library (9 days ago) <Svyatoslav Kuzmich>
* 3e8c15c62ac - (tag: build-1.3.70-dev-1685) Introduce component for caching missing supertypes (9 days ago) <Pavel Kirpichenkov>
* 4b405c6c0f0 - Supply kotlin mock JDK to relevant test runners (9 days ago) <Pavel Kirpichenkov>
* 8c52bb4212f - Add frontend checks for missing dependency supertypes (9 days ago) <Pavel Kirpichenkov>
* 388cd531053 - Add filtering during generation of mockJDK JAR (9 days ago) <Pavel Kirpichenkov>
* 27ff2d7816c - (tag: build-1.3.70-dev-1680) Prohibit using array based on non-reified type parameters as reified type arguments (9 days ago) <Ilya Chernikov>
* 8a1f8714e78 - (tag: build-1.3.70-dev-1679) Fix GradleConfiguratorTest (9 days ago) <Andrey Uskov>
* 43d916e92d2 - (tag: build-1.3.70-dev-1675) [NI] Add tests for obsolete issues (9 days ago) <Mikhail Zarechenskiy>
* cf161f82347 - (tag: build-1.3.70-dev-1672) Rework `notForIncompletionCall` test (10 days ago) <victor.petukhov>