### PR TITLE
[kotlin compiler][1.3.60][update] 1.3.60-release-176

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,14 +16,14 @@
 
 # A version of the Kotlin "toolchain" (compiler, runtime, stdlib etc) used by the build script.
 buildKotlinVersion=1.3.60
-buildKotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1360_Compiler),number:1.3.60-release-155,branch:default:any/artifacts/content/maven
+buildKotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1360_Compiler),number:1.3.60-release-176,branch:default:true,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1360_Compiler),number:1.3.60-release-155,branch:default:any/artifacts/content/maven
+kotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1360_Compiler),number:1.3.60-release-176,branch:default:true,pinned:true/artifacts/content/maven
 kotlinVersion=1.3.60
-kotlinStdlibRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1360_Compiler),number:1.3.60-release-155,branch:default:any/artifacts/content/maven
+kotlinStdlibRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1360_Compiler),number:1.3.60-release-176,branch:default:true,pinned:true/artifacts/content/maven
 kotlinStdlibVersion=1.3.60
-kotlinStdlibTestsVersion=1.3.60-release-155
-testKotlinCompilerVersion=1.3.60-release-155
+kotlinStdlibTestsVersion=1.3.60-release-176
+testKotlinCompilerVersion=1.3.60-release-176
 konanVersion=1.3.60
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.workers.max=4


### PR DESCRIPTION
* 2da4cc27a9f - (tag: build-1.3.60-release-176) Fix AWT freeze in KotlinNativeABICompatibilityChecker (7 hours ago) <Dmitriy Dolovov>
* a5b177543d6 - (tag: build-1.3.60-release-175) Disable platform-specific checkers in common (9 hours ago) <Dmitry Savvinov>
* 42ac850dace - Add test on platform checks in project without that target (9 hours ago) <Dmitry Savvinov>
* 587fc691f0d - (tag: build-1.3.60-release-174) Add external keyword support for UL (3 days ago) <Igor Yakovlev>
* 89e0fc4657c - (tag: build-1.3.60-release-171) KT-35004: keep track of KotlinType for 'when' subject (3 days ago) <Dmitry Petrov>
* ee4a5cc22eb - (tag: build-1.3.60-release-168) Choose SDK consistently at least for non-COMPOSITE analysis (3 days ago) <Dmitry Savvinov>
* fea32f2e294 - (tag: build-1.3.60-release-167) Temporary comment out failing assert (3 days ago) <Ilmir Usmanov>
* 7e77ddb00ce - (tag: build-1.3.60-release-165, origin/rrr/1.3.60/ayalyshev/fus-completion) Turn off FUS data sending in 1.3.61+ as we as we sent enough in 1.3.60 (4 days ago) <Anton Yalyshev>
* d97b3a04318 - (tag: build-1.3.60-release-163) Add support for Touch API in JS Stdlib #KT-34948 fixed #KT-21445 fixed (5 days ago) <Alexey Trilis>
* 047a732c83f - [JS] Add deprecated typealias and extension properties for renamed in dukat update entities (5 days ago) <Alexey Trilis>
* 2c38847343a - (tag: build-1.3.60-release-162) Fix not converted jetbrains nullability annotations for types (5 days ago) <Ilya Kirillov>
* 590ef2d0bb5 - (tag: build-1.3.60-release-161) Add some changes to introduced extension points (5 days ago) <Stanislav Erokhin>
* 3ad00e82ed2 - Frontend plugins to upstream (5 days ago) <Jim>
* 19e95fdd1dd - (tag: build-1.3.60-release-159, tag: build-1.3.60-release-158) 193: Fix outdated gradle plugin id (6 days ago) <Florian Kistner>
* e3927092a15 - (tag: v1.3.60, tag: build-1.3.60-release-157) Add full changelog for 1.3.60 (7 days ago) <nikita.movshin>