### PR TITLE
[kotlin compiler][update] 1.3.70-dev-2158

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2113,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-dev-2113
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2113,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-dev-2113
-kotlinStdlibTestsVersion=1.3.70-dev-2113
-testKotlinCompilerVersion=1.3.70-dev-2113
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2158,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-dev-2158
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2158,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.70-dev-2158
+kotlinStdlibTestsVersion=1.3.70-dev-2158
+testKotlinCompilerVersion=1.3.70-dev-2158
 konanVersion=1.3.70
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 1ed23d7c54d - (tag: build-1.3.70-dev-2158) IR: reorganize IrProvider handling (18 hours ago) <Georgy Bronnikov>
* be04912f6fc - (tag: build-1.3.70-dev-2155) KT-19574 Code with inferred default parameters and parameter vs property name clashes (#2671) (19 hours ago) <Toshiaki Kameyama>
* 1bbd17c4d6a - Turn off FUS data sending in 1.3.61+ as we as we sent enough in 1.3.60 (20 hours ago) <Anton Yalyshev>
* e38fdae1bc9 - (tag: build-1.3.70-dev-2154) Regenerate `DiagnosticsTestWithJsStdLibGenerated` (20 hours ago) <Dmitriy Novozhilov>
* 5190ff97332 - [FIR-TEST] Add test with SAM conversion in constructor call (20 hours ago) <Dmitriy Novozhilov>
* 71acd427270 - [FIR-TEST] Add test with ambiguity produced by definitely not null types (20 hours ago) <Dmitriy Novozhilov>
* fa2ef816b17 - Support Gradle instant execution with Kotlin/JVM and Android tasks (20 hours ago) <Sergey Igushkin>
* d59a171b65b - (tag: build-1.3.70-dev-2150) [FIR] Fix isMyTypeVariable in ConeInferenceContext (21 hours ago) <Simon Ogorodnik>
* ffa08965926 - (tag: build-1.3.70-dev-2146) Minor correction of attributes naming (21 hours ago) <Anton Yalyshev>
* c57c9b2e63d - Prepare data for successful FUS Whitelist parsing (21 hours ago) <Anton Yalyshev>
* c72622c6d78 - (tag: build-1.3.70-dev-2142) KT-32551 New J2K: Non-canonical modifiers order inspection is not applied during convertion of inner super class (#2806) (22 hours ago) <Toshiaki Kameyama>
* dbacae94d0b - (tag: build-1.3.70-dev-2138) Fix common super type calculation for captured dynamic types ^KT-32499 Fixed (22 hours ago) <victor.petukhov>
* 1c4c5520a25 - Fix incremental analysis in case of property does not have initializer but could be initialized on a class level (23 hours ago) <Vladimir Dolzhenko>
* c67222c1761 - Add ERRORs check to AbstractOutOfBlockModificationTest (23 hours ago) <Vladimir Dolzhenko>
* 144f721a446 - Kotlinify AbstractOutOfBlockModificationTest, p2 (23 hours ago) <Vladimir Dolzhenko>
* 8f8ed4dbcf4 - Kotlinify AbstractOutOfBlockModificationTest, p1 (23 hours ago) <Vladimir Dolzhenko>
* 567248ebd76 - (tag: build-1.3.70-dev-2136) [FIR] Add default upper bounds to type parameter of synthetic when and try calls (23 hours ago) <Dmitriy Novozhilov>
* 5770d19d618 - [FIR] Fix calculating of completion mode (23 hours ago) <Dmitriy Novozhilov>
* 9c3117ba40a - [FIR] Git rid of creating new when and try fir nodes (23 hours ago) <Dmitriy Novozhilov>
* 8085ec8b0be - [FIR-TEST] Add test with ambiguity between java field and java accessor (23 hours ago) <Dmitriy Novozhilov>
* 3c661dd1422 - [FIR-TEST] Add test with unresolved invoke of lambda with receiver (23 hours ago) <Dmitriy Novozhilov>
* 96d3a061296 - [FIR-TEST] Add test with hiding local functions (23 hours ago) <Dmitriy Novozhilov>
* 5d14c76f70c - [FIR-TEST] Add test with unresolved `Array<T>.clone()` (23 hours ago) <Dmitriy Novozhilov>
* 4059fae1b78 - [FIR-TEST] Add test with type mismatch on receiver with captured type (23 hours ago) <Dmitriy Novozhilov>
* 572256e2ebe - [FIR-TEST] Add test with not-working bound smartcast (23 hours ago) <Dmitriy Novozhilov>
* 1a2e09e6a5c - (tag: build-1.3.70-dev-2121) ForLoopsLowering: Handle Iterable.withIndex() where the type is a bounded type parameter. (25 hours ago) <Mark Punzalan>
* e8252ea874e - (tag: build-1.3.70-dev-2118) handle kotlin shifts like bitwise binary ops (26 hours ago) <Kevin Bierhoff>
* a9baec47273 - Add headless mode for tests to avoid graphic card switch (26 hours ago) <Nikolay Krasko>
* 54338686d47 - Add test for lambda parameter type (26 hours ago) <Nikolay Krasko>
* eb71e686da1 - Stable order of generated annotation targets (26 hours ago) <Nikolay Krasko>
* 592df477e99 - Mute MultiModuleHighlightingTest tests (26 hours ago) <Nikolay Krasko>
* 00a70c51f0e - (tag: build-1.3.70-dev-2115) FIR: Generate fake overrides always if there are type parameters (27 hours ago) <Denis Zharkov>
* 8efd59403d3 - FIR: Avoid redundant substitution when type parameters don't change (27 hours ago) <Denis Zharkov>
* 07a4352809c - FIR: Add hack for Fir2IrVisitor (27 hours ago) <Denis Zharkov>
* 3b7ad066fc6 - FIR: Substitute type alias constructors properly (27 hours ago) <Denis Zharkov>
* f68929fe74d - FIR: Leave functions type parameters in subsituting scope (27 hours ago) <Denis Zharkov>
* b5ef063b0fe - FIR: Cache functions in use-site member scope (27 hours ago) <Denis Zharkov>
* f659dc0bea4 - FIR: Add synthetic values/valueOf methods to Java classes (27 hours ago) <Denis Zharkov>
* 256f5ca0a11 - FIR: Support inherited default parameters (27 hours ago) <Denis Zharkov>
* c9cb4dff523 - (tag: build-1.3.70-dev-2114) Scripting: introduce ide-specific comparision of script compilation configurations (KT-34626) (27 hours ago) <Natalia Selezneva>
* 07b6dadbf05 - Scripting: move additional classpath to the end of script classpath (KT-34626) (27 hours ago) <Natalia Selezneva>
* 72e99b58634 - Scripting: avoid just in case configuration requests to Gradle (KT-34442) (27 hours ago) <Natalia Selezneva>
* f27e13035a8 - Minor: introduce helper method to check registry option (27 hours ago) <Natalia Selezneva>
* 7ade2ec5763 - Scripting: configurations from gradle import should be always taken into account (KT-34442) (27 hours ago) <Natalia Selezneva>
* 2f1915d85e6 - Scripting: check that kotlin dsl models are provided during import as soon as possible (27 hours ago) <Natalia Selezneva>