### PR TITLE
[kotlin compiler][update] 1.3.70-dev-2416

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2332,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-dev-2332
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2332,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-dev-2332
-kotlinStdlibTestsVersion=1.3.70-dev-2332
-testKotlinCompilerVersion=1.3.70-dev-2332
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2416,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-dev-2416
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2416,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.70-dev-2416
+kotlinStdlibTestsVersion=1.3.70-dev-2416
+testKotlinCompilerVersion=1.3.70-dev-2416
 konanVersion=1.3.70
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* ca0bff75cd0 - [KLIB] Keep order of constant properties depending on backend  - Fix K/N performance regression (3 hours ago) <Roman Artemev>
* 6ef3831f14e - Build: Take parent directory as rootProject directory in case of buildSrc (3 hours ago) <Vyacheslav Gerasimov>
* 462d6ac5b6a - Build: Add remote build cache parameters for teamcity builds (3 hours ago) <Vyacheslav Gerasimov>
* d3c1ef9251a - Build: Use kotlin-build-gradle-plugin in buildSrc (3 hours ago) <Vyacheslav Gerasimov>
* ab8542bbdba - Build: Advance kotlin-build-gradle-plugin version to 0.0.2 (3 hours ago) <Vyacheslav Gerasimov>
* 46d77419a8e - Build: Add build cache properties to kotlin-build-gradle-plugin (3 hours ago) <Vyacheslav Gerasimov>
* ad79efeba37 - Build: Use kotlin version embedded to gradle (3 hours ago) <Vyacheslav Gerasimov>
* fa7bd3dd2e5 - FIR: Support SAM constructors for type aliases (3 hours ago) <Denis Zharkov>
* ae01d050c93 - FIR: Abstract parts for type alias constructors resolution (3 hours ago) <Denis Zharkov>
* fbe7db5471b - FIR: Move constructor processing parts to a separate file (3 hours ago) <Denis Zharkov>
* bf68e85a5c8 - FIR: Support SAM conversion for interfaces containing Object methods (3 hours ago) <Denis Zharkov>
* 7cd55c85e6a - (tag: build-1.3.70-dev-2416) JVM/JVM_IR: fix mapping of KClass in annotation classes (5 hours ago) <pyos>
* f869be6a714 - (tag: build-1.3.70-dev-2414) JVM IR: do not mangle synthetic methods with inline class parameters (5 hours ago) <Alexander Udalov>
* 66ffdf1b2d9 - (tag: build-1.3.70-dev-2412) KT-33979 KT-34150 Remove filtering overridden object members and nested objects (5 hours ago) <Roman Golyshev>
* 2552540f716 - (tag: build-1.3.70-dev-2411) IR: wrap exceptions and add file path in per-file lowerings (6 hours ago) <Alexander Udalov>
* fd627603a06 - Refactor CompilationErrorHandler (6 hours ago) <Alexander Udalov>
* 2435b8d9fac - (tag: build-1.3.70-dev-2407) Update testData for enum constructor result type in IR (7 hours ago) <Dmitry Petrov>
* 35c2573b336 - PSI2IR: generate IrEnumConstructorCalls with correct return type (7 hours ago) <pyos>
* 145ad1a6fa6 - (tag: build-1.3.70-dev-2406) FIR: Minor. Extract common parts in FirCallCompletionResultsWriterTransformer (7 hours ago) <Denis Zharkov>
* 71bf8a14e83 - (tag: build-1.3.70-dev-2405) [FIR] Make `ConeTypeCheckerContext` implements `ConeInferenceContext` (7 hours ago) <Dmitriy Novozhilov>
* 69033b7b152 - (tag: build-1.3.70-dev-2403) JVM_IR: handle @JvmName on annotation getters (8 hours ago) <pyos>
* ac7d9fa90d3 - (tag: build-1.3.70-dev-2402) JVM_IR: implement -Xpolymorphic-signature (8 hours ago) <pyos>
* fe6be0f4366 - (tag: build-1.3.70-dev-2401) Fix failed FIR multi-module test (forgotten test data update) (8 hours ago) <Mikhail Glukhikh>
* 0ff77bd3c56 - (tag: build-1.3.70-dev-2394) Add UL support for const fields initializers (22 hours ago) <Igor Yakovlev>
* 775eb672199 - (tag: build-1.3.70-dev-2386) NI: Add constraints which contain constraining type without projection ^KT-32243 Fixed ^KT-35172 Fixed (23 hours ago) <Victor Petukhov>
* 65cc0fa4636 - (tag: build-1.3.70-dev-2382) PSI2IR: have GeneratorExtensions implement StubGeneratorExtensions (24 hours ago) <pyos>
* a950df3c807 - PSI2IR: copy isPropertyWithPlatformField to GeneratorExtensions (24 hours ago) <pyos>
* 3cae90dd266 - (tag: build-1.3.70-dev-2379) [minor] fix source root creation from imported scripts: (24 hours ago) <Ilya Chernikov>
* f2a4a835e70 - Improve script cli diagnostics (24 hours ago) <Ilya Chernikov>
* 49de5e19fb3 - Implement repl, script and expressions evaluation support in kotlin runner (24 hours ago) <Ilya Chernikov>
* 531ff927912 - Implement support for expression evaluation in jvm cli compiler (24 hours ago) <Ilya Chernikov>
* 7bb9f97b113 - Allow to separate top-level script declarations and statements with semicolon (24 hours ago) <Ilya Chernikov>
* b8034567ef3 - Change script definition lookup key from File to ScriptSource (24 hours ago) <Ilya Chernikov>
* 615624802ce - Add kotlinx-html test (24 hours ago) <Ilya Chernikov>
* 4439582d232 - Remove unnecessary update of the source roots, simplify interface accordingly (24 hours ago) <Ilya Chernikov>
* 02a71d2cda6 - Save updated roots before a packagePartProvider is created (24 hours ago) <Ilya Chernikov>
* a190ab260ef - Load main-kts jar automatically from scripting plugin, if available (24 hours ago) <Ilya Chernikov>
* 22cb6fa8363 - (tag: build-1.3.70-dev-2373) [Gradle, JS] Fix case with null distribution (25 hours ago) <Ilya Goncharov>
* c2673575969 - [Gradle, JS] Add distribution DSL (25 hours ago) <Ilya Goncharov>
* fe9ddd9f228 - [Gradle, JS] Check if resourcesDir exists and resourceDir is input directory (25 hours ago) <Ilya Goncharov>
* 053469dcec4 - [Gradle, JS] Copy index.html from resources to dist (25 hours ago) <Ilya Goncharov>
* b9dee4e93ae - (tag: build-1.3.70-dev-2355) Remove assertion on sorted ranges: it could be empty if lambda doesn't contain any linenumber (29 hours ago) <Mikhael Bogdanov>
* ae4a1e3cca2 - [Gradle, JS] Fix check on Kotlin/JS modules from NPM in DCE (29 hours ago) <Ilya Goncharov>
* 0380380de48 - (tag: build-1.3.70-dev-2351) More cleanups after tests execution (29 hours ago) <Nikolay Krasko>
* 0cbb3a39569 - Remove unused ProjectRootModificationTrackerFixer.kt (29 hours ago) <Nikolay Krasko>
* c12599a045f - Fix test data for testParamTypeLambdaMismatch in >= 192 (29 hours ago) <Nikolay Krasko>
* 408f958273a - (tag: build-1.3.70-dev-2350) [Gradle, JS] Add idle run for debug node tests (29 hours ago) <Ilya Goncharov>
* 38de98429d3 - (tag: build-1.3.70-dev-2348) Fix importing tests in bunch 183 (30 hours ago) <Andrey Uskov>
* 9643d5d28e3 - Added import-resolve integration tests (30 hours ago) <Andrey Uskov>
* e9946b21b5b - (tag: build-1.3.70-dev-2344, tag: build-1.3.70-dev-2340) JVM IR: do not hide constructor with inline class types and defaults (31 hours ago) <Alexander Udalov>
* 4e1cd6bcd54 - (tag: build-1.3.70-dev-2338) Mute 2 black-box FIR test due to disallowed Kotlin synthetic properties problem (31 hours ago) <Mikhail Glukhikh>
* 18e8896c08c - (tag: build-1.3.70-dev-2334) [JVM IR] Leave private @JvmDefault methods on interface (33 hours ago) <Kristoffer Andersen>
* 6f8682c9500 - [JVM IR] Stabilize accesor names in IR Backend (33 hours ago) <Kristoffer Andersen>
* d1c2862e272 - IR: Align Interface Defaults with Old Backend (33 hours ago) <Kristoffer Andersen>
* b5de6253507 - Minor refactor: lifting common code (33 hours ago) <Kristoffer Andersen>
* 6a41700689c - [JVM_IR] Fix interface method resolution (33 hours ago) <Kristoffer Andersen>
* df96841c9d2 - (tag: build-1.3.70-dev-2333) Prohibit protected method calls from inline function (33 hours ago) <Mikhael Bogdanov>