### PR TITLE
klib expect actual

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -46,8 +46,10 @@ import kotlin.reflect.KProperty
 import org.jetbrains.kotlin.backend.common.ir.copyTo
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExport
 import org.jetbrains.kotlin.backend.konan.llvm.coverage.CoverageManager
+import org.jetbrains.kotlin.ir.backend.js.lower.serialization.ir.IrKlibProtoBuf
 import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.descriptors.WrappedTypeParameterDescriptor
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrTypeParameterSymbolImpl
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.konan.library.KonanLibraryLayout
@@ -205,6 +207,8 @@ internal class Context(config: KonanConfig) : KonanBackendContext(config) {
     lateinit var objCExport: ObjCExport
 
     lateinit var cAdapterGenerator: CAdapterGenerator
+
+    lateinit var expectDescriptorToSymbol: MutableMap<DeclarationDescriptor, IrSymbol>
 
     override val builtIns: KonanBuiltIns by lazy(PUBLICATION) {
         moduleDescriptor.builtIns as KonanBuiltIns

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -17,10 +17,12 @@ import org.jetbrains.kotlin.backend.konan.serialization.*
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.languageVersionSettings
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.konan.isKonanStdlib
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.DeclarationStubGenerator
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.ir.util.addChild
@@ -165,7 +167,6 @@ internal val psiToIrPhase = konanUnitPhase(
             // Note: using [llvmModuleSpecification] since this phase produces IR for generating single LLVM module.
 
             val exportedDependencies = (getExportedDependencies() + modulesWithoutDCE).distinct()
-
             val deserializer = KonanIrLinker(
                     moduleDescriptor,
                     this as LoggingContext,
@@ -195,6 +196,9 @@ internal val psiToIrPhase = konanUnitPhase(
                 dependenciesCount = dependencies.size
             }
 
+
+            deserializer.initializeExpectActualLinker()
+
             val functionIrClassFactory = BuiltInFictitiousFunctionIrClassFactory(
                     symbolTable, generatorContext.irBuiltIns, reflectionTypes)
             val irProviderForInteropStubs = IrProviderForInteropStubs()
@@ -205,7 +209,9 @@ internal val psiToIrPhase = konanUnitPhase(
             )
             val irProviders = listOf(irProviderForInteropStubs, functionIrClassFactory, deserializer, stubGenerator)
             stubGenerator.setIrProviders(irProviders)
-            val module = translator.generateModuleFragment(generatorContext, environment.getSourceFiles(), irProviders)
+
+            expectDescriptorToSymbol = mutableMapOf<DeclarationDescriptor, IrSymbol>()
+            val module = translator.generateModuleFragment(generatorContext, environment.getSourceFiles(), irProviders, expectDescriptorToSymbol)
 
             if (this.stdlibModule in modulesWithoutDCE) {
                 functionIrClassFactory.buildAllClasses()
@@ -247,11 +253,13 @@ internal val copyDefaultValuesToActualPhase = konanUnitPhase(
 
 internal val serializerPhase = konanUnitPhase(
         op = {
-            val mppKlibs = config.configuration.get(CommonConfigurationKeys.MPP_KLIBS)?:false
+            val mppKlibs = config.configuration.get(CommonConfigurationKeys.KLIB_MPP)?:false
             val descriptorTable = DescriptorTable()
+
             serializedIr = KonanIrModuleSerializer(
-                this, irModule!!.irBuiltins, descriptorTable, !mppKlibs
+                this, irModule!!.irBuiltins, descriptorTable, expectDescriptorToSymbol, skipExpects = !mppKlibs
             ).serializedIrModule(irModule!!)
+
             val serializer = KlibMetadataMonolithicSerializer(
                 this.config.configuration.languageVersionSettings,
                 config.configuration.get(CommonConfigurationKeys.METADATA_VERSION)!!,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -251,8 +251,8 @@ internal val serializerPhase = konanUnitPhase(
             serializedIr = KonanIrModuleSerializer(this, irModule!!.irBuiltins, descriptorTable).serializedIrModule(irModule!!)
             val serializer = KlibMetadataMonolithicSerializer(
                 this.config.configuration.languageVersionSettings,
-                config.configuration.get(CommonConfigurationKeys.METADATA_VERSION
-            )!!, descriptorTable, bindingContext)
+                config.configuration.get(CommonConfigurationKeys.METADATA_VERSION)!!,
+                moduleDescriptor, descriptorTable, bindingContext)
             serializedMetadata = serializer.serializeModule(moduleDescriptor)
         },
         name = "Serializer",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -173,7 +173,8 @@ internal val psiToIrPhase = konanUnitPhase(
                     generatorContext.irBuiltIns,
                     symbolTable,
                     forwardDeclarationsModuleDescriptor,
-                    exportedDependencies
+                    exportedDependencies,
+                    config.configuration.get(CommonConfigurationKeys.KLIB_MPP)?:false
             )
 
             var dependenciesCount = 0

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -247,12 +247,16 @@ internal val copyDefaultValuesToActualPhase = konanUnitPhase(
 
 internal val serializerPhase = konanUnitPhase(
         op = {
+            val mppKlibs = config.configuration.get(CommonConfigurationKeys.MPP_KLIBS)?:false
             val descriptorTable = DescriptorTable()
-            serializedIr = KonanIrModuleSerializer(this, irModule!!.irBuiltins, descriptorTable).serializedIrModule(irModule!!)
+            serializedIr = KonanIrModuleSerializer(
+                this, irModule!!.irBuiltins, descriptorTable, !mppKlibs
+            ).serializedIrModule(irModule!!)
             val serializer = KlibMetadataMonolithicSerializer(
                 this.config.configuration.languageVersionSettings,
                 config.configuration.get(CommonConfigurationKeys.METADATA_VERSION)!!,
-                moduleDescriptor, descriptorTable, bindingContext)
+                moduleDescriptor, descriptorTable, bindingContext, !mppKlibs
+            )
             serializedMetadata = serializer.serializeModule(moduleDescriptor)
         },
         name = "Serializer",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -173,8 +173,7 @@ internal val psiToIrPhase = konanUnitPhase(
                     generatorContext.irBuiltIns,
                     symbolTable,
                     forwardDeclarationsModuleDescriptor,
-                    exportedDependencies,
-                    config.configuration.get(CommonConfigurationKeys.KLIB_MPP)?:false
+                    exportedDependencies
             )
 
             var dependenciesCount = 0
@@ -197,7 +196,6 @@ internal val psiToIrPhase = konanUnitPhase(
                 dependenciesCount = dependencies.size
             }
 
-
             deserializer.initializeExpectActualLinker()
 
             val functionIrClassFactory = BuiltInFictitiousFunctionIrClassFactory(
@@ -213,6 +211,8 @@ internal val psiToIrPhase = konanUnitPhase(
 
             expectDescriptorToSymbol = mutableMapOf<DeclarationDescriptor, IrSymbol>()
             val module = translator.generateModuleFragment(generatorContext, environment.getSourceFiles(), irProviders, expectDescriptorToSymbol)
+
+            deserializer.finalizeExpectActualLinker()
 
             if (this.stdlibModule in modulesWithoutDCE) {
                 functionIrClassFactory.buildAllClasses()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
@@ -11,8 +11,9 @@ import org.jetbrains.kotlin.ir.util.hasAnnotation
 class KonanIrFileSerializer(
         logger: LoggingContext,
         declarationTable: DeclarationTable,
+        skipExpects: Boolean,
         bodiesOnlyForInlines: Boolean = false
-): IrFileSerializer(logger, declarationTable, bodiesOnlyForInlines) {
+): IrFileSerializer(logger, declarationTable, skipExpects = skipExpects, bodiesOnlyForInlines = bodiesOnlyForInlines) {
 
     override fun backendSpecificExplicitRoot(declaration: IrFunction) =
             declaration.annotations.hasAnnotation(RuntimeNames.exportForCppRuntime)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
@@ -4,16 +4,19 @@ import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.serialization.DeclarationTable
 import org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer
 import org.jetbrains.kotlin.backend.konan.RuntimeNames
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 
 class KonanIrFileSerializer(
-        logger: LoggingContext,
-        declarationTable: DeclarationTable,
-        skipExpects: Boolean,
-        bodiesOnlyForInlines: Boolean = false
-): IrFileSerializer(logger, declarationTable, skipExpects = skipExpects, bodiesOnlyForInlines = bodiesOnlyForInlines) {
+    logger: LoggingContext,
+    declarationTable: DeclarationTable,
+    expectDescriptorToSymbol: MutableMap<DeclarationDescriptor, IrSymbol>,
+    skipExpects: Boolean,
+    bodiesOnlyForInlines: Boolean = false
+): IrFileSerializer(logger, declarationTable, expectDescriptorToSymbol, skipExpects = skipExpects, bodiesOnlyForInlines = bodiesOnlyForInlines) {
 
     override fun backendSpecificExplicitRoot(declaration: IrFunction) =
             declaration.annotations.hasAnnotation(RuntimeNames.exportForCppRuntime)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
@@ -3,9 +3,11 @@ package org.jetbrains.kotlin.backend.konan.serialization
 import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.serialization.*
 import org.jetbrains.kotlin.backend.konan.descriptors.isFromInteropLibrary
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.UniqId
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
@@ -33,6 +35,7 @@ class KonanIrModuleSerializer(
     logger: LoggingContext,
     irBuiltIns: IrBuiltIns,
     private val descriptorTable: DescriptorTable,
+    private val expectDescriptorToSymbol: MutableMap<DeclarationDescriptor, IrSymbol>,
     val skipExpects: Boolean
 ) : IrModuleSerializer<KonanIrFileSerializer>(logger) {
 
@@ -40,5 +43,5 @@ class KonanIrModuleSerializer(
     private val globalDeclarationTable = KonanGlobalDeclarationTable(irBuiltIns)
 
     override fun createSerializerForFile(file: IrFile): KonanIrFileSerializer =
-            KonanIrFileSerializer(logger, KonanDeclarationTable(descriptorTable, globalDeclarationTable, 0), skipExpects = skipExpects)
+            KonanIrFileSerializer(logger, KonanDeclarationTable(descriptorTable, globalDeclarationTable, 0), expectDescriptorToSymbol, skipExpects = skipExpects)
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
@@ -32,13 +32,13 @@ private class KonanDeclarationTable(
 class KonanIrModuleSerializer(
     logger: LoggingContext,
     irBuiltIns: IrBuiltIns,
-    private val descriptorTable: DescriptorTable
+    private val descriptorTable: DescriptorTable,
+    val skipExpects: Boolean
 ) : IrModuleSerializer<KonanIrFileSerializer>(logger) {
 
 
     private val globalDeclarationTable = KonanGlobalDeclarationTable(irBuiltIns)
 
     override fun createSerializerForFile(file: IrFile): KonanIrFileSerializer =
-            KonanIrFileSerializer(logger, KonanDeclarationTable(descriptorTable, globalDeclarationTable, 0))
-
+            KonanIrFileSerializer(logger, KonanDeclarationTable(descriptorTable, globalDeclarationTable, 0), skipExpects = skipExpects)
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -25,20 +25,20 @@ import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
-import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.ir.util.UniqId
 
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
 class KonanIrLinker(
-        currentModule: ModuleDescriptor,
-        logger: LoggingContext,
-        builtIns: IrBuiltIns,
-        symbolTable: SymbolTable,
-        forwardModuleDescriptor: ModuleDescriptor?,
-        exportedDependencies: List<ModuleDescriptor>
-) : KotlinIrLinker(logger, builtIns, symbolTable, exportedDependencies, forwardModuleDescriptor, KonanMangler),
+    currentModule: ModuleDescriptor,
+    logger: LoggingContext,
+    builtIns: IrBuiltIns,
+    symbolTable: SymbolTable,
+    forwardModuleDescriptor: ModuleDescriptor?,
+    exportedDependencies: List<ModuleDescriptor>,
+    klibMpp: Boolean
+) : KotlinIrLinker(logger, builtIns, symbolTable, exportedDependencies, forwardModuleDescriptor, KonanMangler, klibMpp),
     DescriptorUniqIdAware by DeserializedDescriptorUniqIdAware {
 
     override val descriptorReferenceDeserializer =

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -36,9 +36,8 @@ class KonanIrLinker(
     builtIns: IrBuiltIns,
     symbolTable: SymbolTable,
     forwardModuleDescriptor: ModuleDescriptor?,
-    exportedDependencies: List<ModuleDescriptor>,
-    klibMpp: Boolean
-) : KotlinIrLinker(logger, builtIns, symbolTable, exportedDependencies, forwardModuleDescriptor, KonanMangler, klibMpp),
+    exportedDependencies: List<ModuleDescriptor>
+) : KotlinIrLinker(logger, builtIns, symbolTable, exportedDependencies, forwardModuleDescriptor, KonanMangler),
     DescriptorUniqIdAware by DeserializedDescriptorUniqIdAware {
 
     override val descriptorReferenceDeserializer =

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.ir.util.UniqId
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3897,6 +3897,27 @@ KotlinNativeTestKt.createTest(project, 'harmonyRegexTest', KonanGTest) { task ->
     task.finalizedBy("resultsTask")
 }
 
+task expect_actual_link {
+    konanArtifacts {
+        library("expects", targets: [targetName]) {
+            srcFiles 'link/expect/expects.kt'
+            extraOpts "-Xmulti-platform", "-Xmpp-klibs"
+        }
+        library("actuals", targets: [targetName]) {
+            srcFiles 'link/expect/actuals.kt'
+            extraOpts "-Xmulti-platform", "-Xmpp-klibs"
+        }
+        program("expect_actual_link", targets: [targetName]) {
+            srcFiles 'link/expect/main.kt'
+            libraries {
+                artifact konanArtifacts.expects
+                artifact konanArtifacts.actuals
+            }
+            extraOpts "-Xmulti-platform", "-Xmpp-klibs"
+        }
+    }
+}
+
 if (UtilsKt.testTargetSupportsCodeCoverage(project)) {
     task coverage_basic_program(type: CoverageTest) {
 

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/resolve/konan/platform/KonanPlatformConfigurator.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/resolve/konan/platform/KonanPlatformConfigurator.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.resolve.inline.ReasonableInlineRule
 import org.jetbrains.kotlin.resolve.jvm.checkers.SuperCallWithDefaultArgumentsChecker
 
 object KonanPlatformConfigurator : PlatformConfiguratorBase(
-    additionalDeclarationCheckers = listOf(ExpectedActualDeclarationChecker(ModuleStructureOracle.SingleModule, emptyList())),
+    //additionalDeclarationCheckers = listOf(ExpectedActualDeclarationChecker(ModuleStructureOracle.SingleModule, emptyList())),
     additionalCallCheckers = listOf(SuperCallWithDefaultArgumentsChecker())
 ) {
     override fun configureModuleComponents(container: StorageComponentContainer) {

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/resolve/konan/platform/KonanPlatformConfigurator.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/resolve/konan/platform/KonanPlatformConfigurator.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.resolve.inline.ReasonableInlineRule
 import org.jetbrains.kotlin.resolve.jvm.checkers.SuperCallWithDefaultArgumentsChecker
 
 object KonanPlatformConfigurator : PlatformConfiguratorBase(
-    //additionalDeclarationCheckers = listOf(ExpectedActualDeclarationChecker(ModuleStructureOracle.SingleModule, emptyList())),
+    additionalDeclarationCheckers = listOf(ExpectedActualDeclarationChecker(ModuleStructureOracle.SingleModule, emptyList())),
     additionalCallCheckers = listOf(SuperCallWithDefaultArgumentsChecker())
 ) {
     override fun configureModuleComponents(container: StorageComponentContainer) {

--- a/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
+++ b/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
@@ -17,7 +17,10 @@ import org.jetbrains.kotlin.konan.target.Distribution
 import org.jetbrains.kotlin.konan.target.PlatformManager
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
 import org.jetbrains.kotlin.library.unpackZippedKonanLibraryTo
-import org.jetbrains.kotlin.konan.utils.KonanFactories.DefaultDeserializedDescriptorFactory
+//import org.jetbrains.kotlin.konan.utils.KonanFactories.DefaultDeserializedDescriptorFactory
+import org.jetbrains.kotlin.konan.util.KlibMetadataFactories
+import org.jetbrains.kotlin.konan.utils.createKonanBuiltIns
+import org.jetbrains.kotlin.backend.common.serialization.metadata.DynamicTypeDeserializer
 import org.jetbrains.kotlin.util.Logger
 import org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf
 import org.jetbrains.kotlin.konan.library.KonanLibrary
@@ -26,6 +29,8 @@ import org.jetbrains.kotlin.library.metadata.parseModuleHeader
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 import java.lang.System.out
 import kotlin.system.exitProcess
+
+object KlibFactories : KlibMetadataFactories(::createKonanBuiltIns, DynamicTypeDeserializer)
 
 fun printUsage() {
     println("Usage: klib <command> <library> <options>")
@@ -159,7 +164,7 @@ class Library(val name: String, val requestedRepository: String?, val target: St
         val storageManager = LockBasedStorageManager("klib")
         val library = libraryInRepoOrCurrentDir(repository, name)
         val versionSpec = LanguageVersionSettingsImpl(currentLanguageVersion, currentApiVersion)
-        val module = DefaultDeserializedDescriptorFactory.createDescriptorAndNewBuiltIns(library, versionSpec, storageManager, null)
+        val module = KlibFactories.DefaultDeserializedDescriptorFactory.createDescriptorAndNewBuiltIns(library, versionSpec, storageManager, null)
 
         val defaultModules = mutableListOf<ModuleDescriptorImpl>()
         if (!module.isKonanStdlib()) {
@@ -170,7 +175,7 @@ class Library(val name: String, val requestedRepository: String?, val target: St
                     logger = KlibToolLogger)
             resolver.defaultLinks(false, true, true)
                     .mapTo(defaultModules) {
-                        DefaultDeserializedDescriptorFactory.createDescriptor(
+                        KlibFactories.DefaultDeserializedDescriptorFactory.createDescriptor(
                                 it, versionSpec, storageManager, module.builtIns, null)
                     }
         }

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
@@ -36,9 +36,14 @@ open class TargetedLibraryImpl(
 
     override val targetList by lazy {
         access.inPlace { it: TargetedKotlinLibraryLayout ->
-            it.targetsDir.listFiles.map {
-                it.name
-            }
+            if (!it.targetsDir.exists)
+                // TODO: We have a choice: either assume it is the CURRENT TARGET
+                //  or a list of ALL KNOWN targets.
+                access.target ?. let { listOf(it.visibleName) } ?: emptyList()
+            else
+                it.targetsDir.listFiles.map {
+                    it.name
+                }
         }
     }
 


### PR DESCRIPTION
This is a basic expect and actual support in klibs.
It is needed to be able to reliably write and read expect and actual declaration to klib metadata and klib ir.
Use -Xklib-mpp to turn it on.
The IR part is rather limited for now.