### PR TITLE
Fix link conflicts between multiple non-debug static frameworks

### DIFF
--- a/runtime/src/main/cpp/Runtime.cpp
+++ b/runtime/src/main/cpp/Runtime.cpp
@@ -183,7 +183,7 @@ void Kotlin_resumeRuntime(RuntimeState* state) {
     WorkerResume(state->worker);
 }
 
-RuntimeState* RUNTIME_USED Kotlin_getRuntime() {
+RuntimeState* Kotlin_getRuntime() {
   RuntimeCheck(isValidRuntime(), "Runtime must be active on the current thread");
   return ::runtimeState;
 }

--- a/runtime/src/main/cpp/Runtime.h
+++ b/runtime/src/main/cpp/Runtime.h
@@ -26,24 +26,24 @@ struct InitNode;
 extern "C" {
 #endif
 
-void RUNTIME_USED Kotlin_initRuntimeIfNeeded();
-void RUNTIME_USED Kotlin_deinitRuntimeIfNeeded();
+void Kotlin_initRuntimeIfNeeded();
+void Kotlin_deinitRuntimeIfNeeded();
 
 // Operations below allow flexible runtime scheduling on different threads.
 // Created runtime is in SUSPENDED state, and need to be resumed for actual execution.
-RuntimeState* RUNTIME_USED Kotlin_createRuntime();
+RuntimeState* Kotlin_createRuntime();
 // Runtime must be in SUSPENDED state, before it could be destroyed.
-void RUNTIME_USED Kotlin_destroyRuntime(RuntimeState*);
+void Kotlin_destroyRuntime(RuntimeState*);
 
 // Transition current runtime from RUNNING to SUSPENDED state, and clearing thread local variable caching
 // the runtime. After suspension, runtime could be rescheduled to a different thread.
-RuntimeState* RUNTIME_USED Kotlin_suspendRuntime();
+RuntimeState* Kotlin_suspendRuntime();
 // Transition runtime from SUSPENDED to RUNNING state, and sets thread local variable caching
 // the runtime. After resume, current thread could be used for executing Kotlin code.
-void RUNTIME_USED Kotlin_resumeRuntime(RuntimeState*);
+void Kotlin_resumeRuntime(RuntimeState*);
 
 // Gets currently active runtime, fails if no runtime is currently available.
-RuntimeState* RUNTIME_USED Kotlin_getRuntime();
+RuntimeState* Kotlin_getRuntime();
 
 bool Kotlin_hasRuntime();
 

--- a/runtime/src/main/cpp/StdCppStubs.cpp
+++ b/runtime/src/main/cpp/StdCppStubs.cpp
@@ -18,6 +18,7 @@
 #include "Porting.h"
 #include "Common.h"
 
+#if KONAN_LINUX || KONAN_WINDOWS
 // This function replaces `__cxa_demangle` defined in GNU libstdc++
 // by adding `--defsym` flag in `konan.properties`.
 // This allows to avoid linking `__cxa_demangle` and its dependencies, thus reducing binary size.
@@ -34,3 +35,5 @@ namespace std {
     RuntimeAssert(false, __s);
   }
 }
+
+#endif // KONAN_LINUX || KONAN_WINDOWS


### PR DESCRIPTION
Avoid exporting symbols that aren't required externally.