### PR TITLE
Move KonanSymbols.string to common Kotlin

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -53,7 +53,6 @@ internal class KonanSymbols(
 
     val nothing = symbolTable.referenceClass(builtIns.nothing)
     val throwable = symbolTable.referenceClass(builtIns.throwable)
-    val string = symbolTable.referenceClass(builtIns.string)
     val enum = symbolTable.referenceClass(builtIns.enum)
     val nativePtr = symbolTable.referenceClass(context.nativePtr)
     val nativePointed = symbolTable.referenceClass(context.interopBuiltIns.nativePointed)


### PR DESCRIPTION
This is a companion change for https://github.com/JetBrains/kotlin/commit/025360edc45e8b1d34eb278588a04e1088e74425

(Please only merge after updating Kotlin to that revision or later.)