### PR TITLE
[kotlin compiler][update] 1.3.70-dev-2743 

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -247,12 +247,12 @@ internal val copyDefaultValuesToActualPhase = konanUnitPhase(
 
 internal val serializerPhase = konanUnitPhase(
         op = {
-            val descriptorTable = DescriptorTable()
+            val descriptorTable = DescriptorTable.createDefault()
             serializedIr = KonanIrModuleSerializer(this, irModule!!.irBuiltins, descriptorTable).serializedIrModule(irModule!!)
             val serializer = KlibMetadataMonolithicSerializer(
                 this.config.configuration.languageVersionSettings,
                 config.configuration.get(CommonConfigurationKeys.METADATA_VERSION
-            )!!, descriptorTable, bindingContext)
+            )!!, descriptorTable)
             serializedMetadata = serializer.serializeModule(moduleDescriptor)
         },
         name = "Serializer",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -53,7 +53,6 @@ internal class KonanSymbols(
 
     val nothing = symbolTable.referenceClass(builtIns.nothing)
     val throwable = symbolTable.referenceClass(builtIns.throwable)
-    val string = symbolTable.referenceClass(builtIns.string)
     val enum = symbolTable.referenceClass(builtIns.enum)
     val nativePtr = symbolTable.referenceClass(context.nativePtr)
     val nativePointed = symbolTable.referenceClass(context.interopBuiltIns.nativePointed)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2665,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-dev-2665
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2743,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-dev-2743
 kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2522,branch:default:any,pinned:true/artifacts/content/maven
 kotlinStdlibVersion=1.3.70-dev-2522
 kotlinStdlibTestsVersion=1.3.70-dev-2522
-testKotlinCompilerVersion=1.3.70-dev-2665
+testKotlinCompilerVersion=1.3.70-dev-2743
 konanVersion=1.3.70
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* df2adb060c0 - (tag: build-1.3.70-dev-2743) Bumped K/N version (5 hours ago) <Igor Chevdar>
* a7b3f26cef7 - [native-gradle-plugin] Supported klib cache (building and using) (5 hours ago) <Igor Chevdar>
* 364d6a5afad - [Gradle, JS] Actualize NPM dependencies (5 hours ago) <Ilya Goncharov>
* f1f2e1830b0 - (tag: build-1.3.70-dev-2742) [FIR-TEST] Fix incorrect testdata (5 hours ago) <Dmitriy Novozhilov>
* 4faa2c0c2c2 - [FIR] Replace static cone types for integers with default classIds in ILT (5 hours ago) <Dmitriy Novozhilov>
* c6b95931570 - [FIR-TEST] Add identity checker of old frontend and fir testdata to old FE diagnostics tests (5 hours ago) <Dmitriy Novozhilov>
* 579cb5014a4 - [FIR-TEST] Add `!FIR_DUMP` directive to diagnostics tests from old frontend (5 hours ago) <Dmitriy Novozhilov>
* 2536fa0cd55 - [FIR-TEST] Add new testdata generated after changes in previous commit (5 hours ago) <Dmitriy Novozhilov>
* e9c02a1ccad - [FIR-TEST] Add fir diagnostics test based on diagnostics tests from old frontend (5 hours ago) <Dmitriy Novozhilov>
* e7f8c8e155f - [TEST] Regenerate tests after previous commit (5 hours ago) <Dmitriy Novozhilov>
* 5b1f96ba1be - [TEST] Add ability to exclude some testdata with pattern in test generator (5 hours ago) <Dmitriy Novozhilov>
* ae15fa7676d - [FIR] Fix outputs for logs of modularized test (5 hours ago) <Dmitriy Novozhilov>
* bb301f8aca2 - (tag: build-1.3.70-dev-2740) JVM_IR: fix wrong check in skipping captured vars (6 hours ago) <Georgy Bronnikov>
* 26032e4297f - (tag: build-1.3.70-dev-2739) Split exception table on finally insertion before non-local return (6 hours ago) <Mikhael Bogdanov>
* c335015c056 - Generate proper exception table (6 hours ago) <Mikhael Bogdanov>
* 078cfc02a52 - (tag: build-1.3.70-dev-2735) [IR] Removed wrong validation IrEnumConstructorCall behaves differently whether it is inside IrEnumEntry or not. Remove the validation for now. (6 hours ago) <Igor Chevdar>
* 62ef280c539 - Add compiler:ir.serialization.jvm to IDEA plugin (6 hours ago) <Alexander Udalov>
* 5f367278c17 - Psi2ir: support generic properties in class delegation (6 hours ago) <Alexander Udalov>
* 025360edc45 - (tag: build-1.3.70-dev-2733) JVM IR: lookup symbols by name in ProgressionHandlers in known classes only (7 hours ago) <Alexander Udalov>
* 359e49fa023 - (tag: build-1.3.70-dev-2732) [Commonizer] Blacklist conflicting K/N functions from commonization (7 hours ago) <Dmitriy Dolovov>
* c79fcb8cf36 - [Commonizer] Add compatible metadata version checks (7 hours ago) <Dmitriy Dolovov>
* 503fc4883cf - [Commonizer] Log duration of each CLI phase (7 hours ago) <Dmitriy Dolovov>
* 18117ed1f3c - [Commonizer] Serialize commonized metadata for KLIB writer (7 hours ago) <Dmitriy Dolovov>
* ce376f49fdc - [Commonizer] CLI for Kotlin/Native KLIBs (7 hours ago) <Dmitriy Dolovov>
* 5bc2a4e1e8b - [Commonizer] Fix: Don't commonize contents of stdlib (7 hours ago) <Dmitriy Dolovov>
* ee42e8c64c5 - [Commonizer] Fix: Correct resolution of nested classes (7 hours ago) <Dmitriy Dolovov>
* a74e364849b - [Commonizer] Support Kotlin/Native forward declarations (7 hours ago) <Dmitriy Dolovov>
* f4780206d98 - [Commonizer] Fix: Skip KNI bridge functions (7 hours ago) <Dmitriy Dolovov>
* 0a6c132241b - [Commonizer] Fix: Cache package fragments with module name (7 hours ago) <Dmitriy Dolovov>
* a3e3b43aed7 - [Commonizer] Fix: approximate signatures with type parameter upper bounds (7 hours ago) <Dmitriy Dolovov>
* 92656a53ae0 - [Commonizer] Fix: don't process same package fragments more than once (7 hours ago) <Dmitriy Dolovov>
* 8dc2784fc48 - (tag: build-1.3.70-dev-2727) Reapply "Drop deprecated displayName from descriptor visibility" (8 hours ago) <Pavel Kirpichenkov>
* 6e19004a4fa - (tag: build-1.3.70-dev-2717) [Gradle, JS] Add comment for test (9 hours ago) <Ilya Goncharov>
* 1bc47b3f6f2 - [Gradle, JS] Add test for package.json deserializing (9 hours ago) <Ilya Goncharov>
* b9a529d7d0a - [Gradle, JS] Hack for GSON to get non-null values (9 hours ago) <Ilya Goncharov>
* 7d98d33e3de - [Gradle, JS] Hack for GSON to get non-null values (9 hours ago) <Ilya Goncharov>
* 53480c22664 - (tag: build-1.3.70-dev-2704) [FIR] Fix fir2ir testdata broken in 4777dd6 (11 hours ago) <Dmitriy Novozhilov>
* 39e0c6d55b9 - (tag: build-1.3.70-dev-2681) Revert "Drop deprecated displayName from descriptor visibility" (27 hours ago) <Pavel Kirpichenkov>
* d9ef7d0c8ab - (tag: build-1.3.70-dev-2675) [NI] Update / mute diagnostics (28 hours ago) <Pavel Kirpichenkov>
* 6fa11d1573f - (tag: build-1.3.70-dev-2671) Drop deprecated displayName from descriptor visibility (28 hours ago) <Pavel Kirpichenkov>
* ebc1562b321 - (tag: build-1.3.70-dev-2669) Filter out non-xml model files in modularized test (28 hours ago) <Simon Ogorodnik>
* 48a05e36889 - Support prefixed modularized test-data installation (28 hours ago) <Simon Ogorodnik>
* 498b41b148d - (tag: build-1.3.70-dev-2667) JVM_IR: do not do invokeinterface on Object methods (28 hours ago) <pyos>