### PR TITLE
Test platform libs dependencies

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3737,9 +3737,6 @@ task library_ir_provider_mismatch(type: KonanDriverTest) {
     goldValue = isWindows() ? messages.replaceAll('\\/', '\\\\') : messages
 }
 
-def target = ext.platformManager.targetByName(project.testTarget ?: 'host')
-def targetName = target.name
-
 if (isAppleTarget(project)) {
     task testValuesFramework(type: FrameworkTest) {
         final String frameworkName = 'Values'
@@ -3772,12 +3769,12 @@ if (isAppleTarget(project)) {
         }
 
         konanArtifacts {
-            framework(frameworkName, targets: [ targetName ]) {
+            framework(frameworkName, targets: [target.name]) {
                 srcDir 'framework/values'
                 baseDir dir
 
                 if (!useCustomDist) {
-                    dependsOn ":${targetName}CrossDistRuntime", ':commonDistRuntime', ':distCompiler'
+                    dependsOn ":${target.name}CrossDistRuntime", ':commonDistRuntime', ':distCompiler'
                 }
 
                 extraOpts "-Xembed-bitcode-marker"
@@ -3815,12 +3812,12 @@ if (isAppleTarget(project)) {
         frameworkNames = [frameworkName]
         if (cacheTesting == null) fullBitcode = true
         konanArtifacts {
-            framework(frameworkName, targets: [ targetName ]) {
+            framework(frameworkName, targets: [target.name]) {
                 srcDir 'framework/stdlib'
                 baseDir "$testOutputFramework/$testName"
 
                 if (!useCustomDist) {
-                    dependsOn ":${targetName}CrossDistRuntime", ':commonDistRuntime', ':distCompiler'
+                    dependsOn ":${target.name}CrossDistRuntime", ':commonDistRuntime', ':distCompiler'
                 }
 
                 extraOpts "-Xembed-bitcode"
@@ -3841,26 +3838,26 @@ if (isAppleTarget(project)) {
         final String dir = "$testOutputFramework/$testName"
 
         konanArtifacts {
-            framework(firstFrameworkName, targets: [ targetName ]) {
+            framework(firstFrameworkName, targets: [target.name]) {
                 srcDir 'framework/multiple/framework1'
                 srcDir 'framework/multiple/shared'
                 baseDir dir
 
                 if (!useCustomDist) {
-                    dependsOn ":${targetName}CrossDistRuntime", ':commonDistRuntime', ':distCompiler'
+                    dependsOn ":${target.name}CrossDistRuntime", ':commonDistRuntime', ':distCompiler'
                 }
 
                 extraOpts "-Xembed-bitcode"
                 extraOpts project.globalTestArgs
             }
 
-            framework(secondFrameworkName, targets: [ targetName ]) {
+            framework(secondFrameworkName, targets: [target.name]) {
                 srcDir 'framework/multiple/framework2'
                 srcDir 'framework/multiple/shared'
                 baseDir dir
 
                 if (!useCustomDist) {
-                    dependsOn ":${targetName}CrossDistRuntime", ':commonDistRuntime', ':distCompiler'
+                    dependsOn ":${target.name}CrossDistRuntime", ':commonDistRuntime', ':distCompiler'
                 }
 
                 extraOpts "-Xembed-bitcode"
@@ -3896,7 +3893,7 @@ KotlinNativeTestKt.createTest(project, 'harmonyRegexTest', KonanGTest) { task ->
     def sources = UtilsKt.getFilesToCompile(project, ["harmony_regex"], [])
 
     konanArtifacts {
-        program('harmonyRegexTest', targets: [targetName]) {
+        program('harmonyRegexTest', targets: [target.name]) {
             srcFiles sources
             baseDir "$testOutputStdlib/harmonyRegexTest"
             extraOpts '-tr'
@@ -3931,7 +3928,7 @@ if (UtilsKt.getTestTargetSupportsCodeCoverage(project)) {
         numberOfCoveredLines = 1
 
         konanArtifacts {
-            library("lib_to_cover", targets: [targetName]) {
+            library("lib_to_cover", targets: [target.name]) {
                 srcFiles 'coverage/basic/library/library.kt'
             }
             program(binaryName, targets: [ target ]) {
@@ -4003,7 +4000,7 @@ KotlinNativeTestKt.createTest(project, 'stdlibTest', KonanGTest) { task ->
             [ 'build/stdlib_external/stdlib/test/internalAnnotations.kt' ])
 
     konanArtifacts {
-        program('stdlibTest', targets: [ targetName ]) {
+        program('stdlibTest', targets: [target.name]) {
             srcFiles sources
             baseDir "$testOutputStdlib/stdlibTest"
             enableMultiplatform true
@@ -4041,7 +4038,7 @@ task buildKonanTests { t ->
     def sources = UtilsKt.getFilesToCompile(project, compileList, excludeList)
 
     konanArtifacts {
-        program('localTest', targets: [ targetName ]) {
+        program('localTest', targets: [target.name]) {
             srcFiles sources
             baseDir testOutputLocal
             extraOpts '-tr'
@@ -4051,7 +4048,7 @@ task buildKonanTests { t ->
 
     // Set build dependencies.
     dependsOn compileKonanLocalTest
-    UtilsKt.dependsOnDist(project, "compileKonanLocalTest${targetName.capitalize()}")
+    UtilsKt.dependsOnDist(project, "compileKonanLocalTest${target.name.capitalize()}")
 
     // Local tests build into a single binary should depend on this task
     project.tasks

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -317,8 +317,8 @@ def createTestTasks(File testRoot, Class<Task> taskType, Closure taskConfigurati
 
 void dependsOnPlatformLibs(Task t) {
     if (!useCustomDist) {
-        def testTarget = project.testTarget
-        if (testTarget != null && testTarget != project.hostName) {
+        def testTarget = project.target
+        if (testTarget != project.platformManager.Companion.host) {
             t.dependsOn(":${testTarget}PlatformLibs")
         } else {
             t.dependsOn(':distPlatformLibs')
@@ -3907,7 +3907,7 @@ KotlinNativeTestKt.createTest(project, 'harmonyRegexTest', KonanGTest) { task ->
     task.finalizedBy("resultsTask")
 }
 
-if (UtilsKt.testTargetSupportsCodeCoverage(project)) {
+if (UtilsKt.getTestTargetSupportsCodeCoverage(project)) {
     task coverage_basic_program(type: CoverageTest) {
 
         binaryName = "CoverageBasic"

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/CoverageTest.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/CoverageTest.kt
@@ -28,8 +28,8 @@ import org.gradle.api.tasks.TaskAction
  */
 open class CoverageTest : DefaultTask() {
 
-    private val target = project.testTarget()
-    private val platform = project.platformManager().platform(target)
+    private val target = project.testTarget
+    private val platform = project.platformManager.platform(target)
     private val llvmBin = "${platform.configurables.absoluteLlvmHome}/bin"
 
     @Input

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/PlatformInfo.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/PlatformInfo.kt
@@ -32,8 +32,8 @@ object PlatformInfo {
 
     @JvmStatic
     fun getTarget(project: Project): KonanTarget {
-        val platformManager = project.rootProject.platformManager()
-        val targetName = project.project.testTarget().name
+        val platformManager = project.rootProject.platformManager
+        val targetName = project.project.testTarget.name
         return platformManager.targetManager(targetName).target
     }
 

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/Utils.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/Utils.kt
@@ -52,14 +52,10 @@ val Project.globalTestArgs: List<String>
             else this as List<String>
     }
 
+val Project.testTargetSupportsCodeCoverage: Boolean
+    get() = this.testTarget.supportsCodeCoverage()
+
 //endregion
-
-
-fun Project.platformManager() = findProperty("platformManager") as PlatformManager
-fun Project.testTarget() = findProperty("target") as KonanTarget
-
-fun Project.testTargetSupportsCodeCoverage(): Boolean =
-        this.testTarget.supportsCodeCoverage()
 
 /**
  * Ad-hoc signing of the specified path.
@@ -214,7 +210,7 @@ fun getBuildProperty(buildJsonDescription: String, property: String) =
 @JvmOverloads
 fun compileSwift(project: Project, target: KonanTarget, sources: List<String>, options: List<String>,
                  output: Path, fullBitcode: Boolean = false) {
-    val platform = project.platformManager().platform(target)
+    val platform = project.platformManager.platform(target)
     assert(platform.configurables is AppleConfigurables)
     val configs = platform.configurables as AppleConfigurables
     val compiler = configs.absoluteTargetToolchain + "/usr/bin/swiftc"


### PR DESCRIPTION
Fix dependencies on platform libs. Running `-Ptest_target=raspberrypi` makes tests fail with:
`Task with path ':raspberrypiPlatformLibs' not found in project ':backend.native:tests'.``
Also cleanup targets usage