### PR TITLE
Support compiling a common-Native source set into a descriptor-only library

### DIFF
--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -140,6 +140,8 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                 val outputKind = CompilerOutputKind.valueOf(
                     (arguments.produce ?: "program").toUpperCase())
                 put(PRODUCE, outputKind)
+                put(METADATA_KLIB, arguments.metadataKlib)
+
                 arguments.libraryVersion ?. let { put(LIBRARY_VERSION, it) }
 
                 arguments.mainPackage ?.let{ put(ENTRY, it) }

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -245,6 +245,9 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     @Argument(value="-Xallocator", valueDescription = "std | mimalloc", description = "Allocator used in runtime")
     var allocator: String = "std"
 
+    @Argument(value = "-Xmetadata-klib", description = "Produce a klib that only contains the declarations metadata")
+    var metadataKlib: Boolean = false
+
     override fun configureAnalysisFlags(collector: MessageCollector): MutableMap<AnalysisFlag<*>, Any> =
             super.configureAnalysisFlags(collector).also {
                 val useExperimental = it[AnalysisFlags.useExperimental] as List<*>

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
@@ -153,7 +153,7 @@ internal fun produceOutput(context: Context) {
                     context.config.includeBinaries,
                     neededLibraries,
                     context.serializedMetadata!!,
-                    context.serializedIr!!,
+                    context.serializedIr,
                     versions,
                     target,
                     output,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -64,6 +64,8 @@ class KonanConfig(val project: Project, val configuration: CompilerConfiguration
 
     internal val produce get() = configuration.get(KonanConfigKeys.PRODUCE)!!
 
+    internal val metadataKlib get() = configuration.get(KonanConfigKeys.METADATA_KLIB)!!
+
     internal val produceStaticFramework get() = configuration.getBoolean(KonanConfigKeys.STATIC_FRAMEWORK)
 
     internal val purgeUserLibs: Boolean

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -66,6 +66,8 @@ class KonanConfigKeys {
                 = CompilerConfigurationKey.create("memory model")
         val META_INFO: CompilerConfigurationKey<List<String>> 
                 = CompilerConfigurationKey.create("generate metadata")
+        val METADATA_KLIB: CompilerConfigurationKey<Boolean>
+                = CompilerConfigurationKey.create("metadata klib")
         val MODULE_KIND: CompilerConfigurationKey<ModuleKind> 
                 = CompilerConfigurationKey.create("module kind")
         val MODULE_NAME: CompilerConfigurationKey<String?> 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BitcodePhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BitcodePhases.kt
@@ -6,6 +6,10 @@
 package org.jetbrains.kotlin.backend.konan.llvm
 
 import llvm.*
+import org.jetbrains.kotlin.backend.common.phaser.CompilerPhase
+import org.jetbrains.kotlin.backend.common.phaser.PhaseConfig
+import org.jetbrains.kotlin.backend.common.phaser.PhaserState
+import org.jetbrains.kotlin.backend.common.phaser.namedUnitPhase
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.descriptors.GlobalHierarchyAnalysis
 import org.jetbrains.kotlin.backend.konan.optimizations.*
@@ -44,10 +48,14 @@ internal val createLLVMDeclarationsPhase = makeKonanModuleOpPhase(
         }
 )
 
-internal val disposeLLVMPhase = makeKonanModuleOpPhase(
+internal val disposeLLVMPhase = namedUnitPhase(
         name = "DisposeLLVM",
         description = "Dispose LLVM",
-        op = { context, _ -> context.disposeLlvm() }
+        lower = object : CompilerPhase<Context, Unit, Unit> {
+            override fun invoke(phaseConfig: PhaseConfig, phaserState: PhaserState<Unit>, context: Context, input: Unit) {
+                context.disposeLlvm()
+            }
+        }
 )
 
 internal val RTTIPhase = makeKonanModuleOpPhase(
@@ -265,10 +273,14 @@ internal val bitcodeOptimizationPhase = makeKonanModuleOpPhase(
         op = { context, _ -> runLlvmOptimizationPipeline(context) }
 )
 
-internal val produceOutputPhase = makeKonanModuleOpPhase(
+internal val produceOutputPhase = namedUnitPhase(
         name = "ProduceOutput",
         description = "Produce output",
-        op = { context, _ -> produceOutput(context) }
+        lower = object : CompilerPhase<Context, Unit, Unit> {
+            override fun invoke(phaseConfig: PhaseConfig, phaserState: PhaserState<Unit>, context: Context, input: Unit) {
+                produceOutput(context)
+            }
+        }
 )
 
 internal val verifyBitcodePhase = makeKonanModuleOpPhase(

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryWriterImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryWriterImpl.kt
@@ -44,7 +44,7 @@ fun buildLibrary(
     included: List<String>,
     linkDependencies: List<KonanLibrary>,
     metadata: SerializedMetadata,
-    ir: SerializedIrModule,
+    ir: SerializedIrModule?,
     versions: KotlinLibraryVersioning,
     target: KonanTarget,
     output: String,
@@ -57,7 +57,9 @@ fun buildLibrary(
     val library = KonanLibraryWriterImpl(File(output), moduleName, versions, target, nopack)
 
     library.addMetadata(metadata)
-    library.addIr(ir)
+    if (ir != null) {
+        library.addIr(ir)
+    }
 
     natives.forEach {
         library.addNativeBitcode(it)


### PR DESCRIPTION
🔺 This change should only be merged after the branch in the Kotlin repo is merged!