### PR TITLE
[kotlin compiler][update] 1.4.0-dev-216 

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -57,7 +57,7 @@ import org.jetbrains.kotlin.library.SerializedIrModule
  * Offset for synthetic elements created by lowerings and not attributable to other places in the source code.
  */
 
-internal class SpecialDeclarationsFactory(val context: Context) : KotlinMangler by KonanMangler {
+internal class SpecialDeclarationsFactory(val context: Context) : KotlinMangler by KonanManglerForBE {
     private val enumSpecialDeclarationsFactory by lazy { EnumSpecialDeclarationsFactory(context) }
     private val outerThisFields = mutableMapOf<ClassDescriptor, IrField>()
     private val bridgesDescriptors = mutableMapOf<Pair<IrSimpleFunction, BridgeDirections>, IrSimpleFunction>()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -48,6 +48,7 @@ import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExport
 import org.jetbrains.kotlin.backend.konan.llvm.coverage.CoverageManager
 import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.descriptors.WrappedTypeParameterDescriptor
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrTypeParameterSymbolImpl
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.konan.library.KonanLibraryLayout
@@ -205,6 +206,8 @@ internal class Context(config: KonanConfig) : KonanBackendContext(config) {
     lateinit var objCExport: ObjCExport
 
     lateinit var cAdapterGenerator: CAdapterGenerator
+
+    lateinit var expectDescriptorToSymbol: MutableMap<DeclarationDescriptor, IrSymbol>
 
     override val builtIns: KonanBuiltIns by lazy(PUBLICATION) {
         moduleDescriptor.builtIns as KonanBuiltIns

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
@@ -4,15 +4,19 @@ import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.serialization.DeclarationTable
 import org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer
 import org.jetbrains.kotlin.backend.konan.RuntimeNames
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 
 class KonanIrFileSerializer(
-        logger: LoggingContext,
-        declarationTable: DeclarationTable,
-        bodiesOnlyForInlines: Boolean = false
-): IrFileSerializer(logger, declarationTable, bodiesOnlyForInlines) {
+    logger: LoggingContext,
+    declarationTable: DeclarationTable,
+    expectDescriptorToSymbol: MutableMap<DeclarationDescriptor, IrSymbol>,
+    skipExpects: Boolean,
+    bodiesOnlyForInlines: Boolean = false
+): IrFileSerializer(logger, declarationTable, expectDescriptorToSymbol, skipExpects = skipExpects, bodiesOnlyForInlines = bodiesOnlyForInlines) {
 
     override fun backendSpecificExplicitRoot(declaration: IrFunction) =
             declaration.annotations.hasAnnotation(RuntimeNames.exportForCppRuntime)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
@@ -4,9 +4,11 @@ import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.descriptors.propertyIfAccessor
 import org.jetbrains.kotlin.backend.common.serialization.*
 import org.jetbrains.kotlin.backend.konan.descriptors.isFromInteropLibrary
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.UniqId
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
@@ -34,13 +36,14 @@ private class KonanDeclarationTable(
 class KonanIrModuleSerializer(
     logger: LoggingContext,
     irBuiltIns: IrBuiltIns,
-    private val descriptorTable: DescriptorTable
+    private val descriptorTable: DescriptorTable,
+    private val expectDescriptorToSymbol: MutableMap<DeclarationDescriptor, IrSymbol>,
+    val skipExpects: Boolean
 ) : IrModuleSerializer<KonanIrFileSerializer>(logger) {
 
 
     private val globalDeclarationTable = KonanGlobalDeclarationTable(irBuiltIns)
 
     override fun createSerializerForFile(file: IrFile): KonanIrFileSerializer =
-            KonanIrFileSerializer(logger, KonanDeclarationTable(descriptorTable, globalDeclarationTable, 0))
-
+            KonanIrFileSerializer(logger, KonanDeclarationTable(descriptorTable, globalDeclarationTable, 0), expectDescriptorToSymbol, skipExpects = skipExpects)
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -31,12 +31,12 @@ import org.jetbrains.kotlin.ir.util.UniqId
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
 class KonanIrLinker(
-        currentModule: ModuleDescriptor,
-        logger: LoggingContext,
-        builtIns: IrBuiltIns,
-        symbolTable: SymbolTable,
-        forwardModuleDescriptor: ModuleDescriptor?,
-        exportedDependencies: List<ModuleDescriptor>
+    currentModule: ModuleDescriptor,
+    logger: LoggingContext,
+    builtIns: IrBuiltIns,
+    symbolTable: SymbolTable,
+    forwardModuleDescriptor: ModuleDescriptor?,
+    exportedDependencies: List<ModuleDescriptor>
 ) : KotlinIrLinker(logger, builtIns, symbolTable, exportedDependencies, forwardModuleDescriptor, KonanMangler),
     DescriptorUniqIdAware by DeserializedDescriptorUniqIdAware {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2841,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-dev-2841
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-216,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-216
 kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-2841,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-dev-2841
-kotlinStdlibTestsVersion=1.3.70-dev-2841
-testKotlinCompilerVersion=1.3.70-dev-2841
+kotlinStdlibVersion=1.4.0-dev-216
+kotlinStdlibTestsVersion=1.4.0-dev-216
+testKotlinCompilerVersion=1.4.0-dev-216
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,4 +34,3 @@ org.gradle.workers.max=4
 
 # Uncomment to enable composite build
 #kotlinProjectPath=<insert the path to Kotlin project root here>
-

--- a/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
+++ b/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
@@ -17,7 +17,9 @@ import org.jetbrains.kotlin.konan.target.Distribution
 import org.jetbrains.kotlin.konan.target.PlatformManager
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
 import org.jetbrains.kotlin.library.unpackZippedKonanLibraryTo
-import org.jetbrains.kotlin.konan.utils.KonanFactories.DefaultDeserializedDescriptorFactory
+import org.jetbrains.kotlin.konan.util.KlibMetadataFactories
+import org.jetbrains.kotlin.konan.utils.createKonanBuiltIns
+import org.jetbrains.kotlin.backend.common.serialization.metadata.DynamicTypeDeserializer
 import org.jetbrains.kotlin.util.Logger
 import org.jetbrains.kotlin.library.metadata.KlibMetadataProtoBuf
 import org.jetbrains.kotlin.konan.library.KonanLibrary
@@ -26,6 +28,8 @@ import org.jetbrains.kotlin.library.metadata.parseModuleHeader
 import org.jetbrains.kotlin.storage.LockBasedStorageManager
 import java.lang.System.out
 import kotlin.system.exitProcess
+
+object KlibFactories : KlibMetadataFactories(::createKonanBuiltIns, DynamicTypeDeserializer)
 
 fun printUsage() {
     println("Usage: klib <command> <library> <options>")
@@ -159,7 +163,7 @@ class Library(val name: String, val requestedRepository: String?, val target: St
         val storageManager = LockBasedStorageManager("klib")
         val library = libraryInRepoOrCurrentDir(repository, name)
         val versionSpec = LanguageVersionSettingsImpl(currentLanguageVersion, currentApiVersion)
-        val module = DefaultDeserializedDescriptorFactory.createDescriptorAndNewBuiltIns(library, versionSpec, storageManager, null)
+        val module = KlibFactories.DefaultDeserializedDescriptorFactory.createDescriptorAndNewBuiltIns(library, versionSpec, storageManager, null)
 
         val defaultModules = mutableListOf<ModuleDescriptorImpl>()
         if (!module.isKonanStdlib()) {
@@ -170,7 +174,7 @@ class Library(val name: String, val requestedRepository: String?, val target: St
                     logger = KlibToolLogger)
             resolver.defaultLinks(false, true, true)
                     .mapTo(defaultModules) {
-                        DefaultDeserializedDescriptorFactory.createDescriptor(
+                        KlibFactories.DefaultDeserializedDescriptorFactory.createDescriptor(
                                 it, versionSpec, storageManager, module.builtIns, null)
                     }
         }

--- a/runtime/src/main/kotlin/kotlin/text/Appendable.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Appendable.kt
@@ -10,28 +10,28 @@ package kotlin.text
  */
 public actual interface Appendable {
     /**
-     * Appends the specified character [c] to this Appendable and returns this instance.
+     * Appends the specified character [value] to this Appendable and returns this instance.
      *
-     * @param c the character to append.
+     * @param value the character to append.
      */
-    actual fun append(c: Char): Appendable
+    actual fun append(value: Char): Appendable
 
     /**
-     * Appends the specified character sequence [csq] to this Appendable and returns this instance.
+     * Appends the specified character sequence [value] to this Appendable and returns this instance.
      *
-     * @param csq the character sequence to append. If [csq] is `null`, then the four characters `"null"` are appended to this Appendable.
+     * @param value the character sequence to append. If [value] is `null`, then the four characters `"null"` are appended to this Appendable.
      */
-    actual fun append(csq: CharSequence?): Appendable
+    actual fun append(value: CharSequence?): Appendable
 
     /**
-     * Appends a subsequence of the specified character sequence [csq] to this Appendable and returns this instance.
+     * Appends a subsequence of the specified character sequence [value] to this Appendable and returns this instance.
      *
-     * @param csq the character sequence from which a subsequence is appended. If [csq] is `null`,
-     *  then characters are appended as if [csq] contained the four characters `"null"`.
-     * @param start the beginning (inclusive) of the subsequence to append.
-     * @param end the end (exclusive) of the subsequence to append.
+     * @param value the character sequence from which a subsequence is appended. If [value] is `null`,
+     *  then characters are appended as if [value] contained the four characters `"null"`.
+     * @param startIndex the beginning (inclusive) of the subsequence to append.
+     * @param endIndex the end (exclusive) of the subsequence to append.
      *
-     * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [start] or [end] is out of range of the [csq] character sequence indices or when `start > end`.
+     * @throws IndexOutOfBoundsException or [IllegalArgumentException] when [startIndex] or [endIndex] is out of range of the [value] character sequence indices or when `startIndex > endIndex`.
      */
-    actual fun append(csq: CharSequence?, start: Int, end: Int): Appendable
+    actual fun append(value: CharSequence?, startIndex: Int, endIndex: Int): Appendable
 }

--- a/runtime/src/main/kotlin/kotlin/text/StringBuilder.kt
+++ b/runtime/src/main/kotlin/kotlin/text/StringBuilder.kt
@@ -46,20 +46,20 @@ actual class StringBuilder private constructor (
     actual override fun subSequence(startIndex: Int, endIndex: Int): CharSequence = substring(startIndex, endIndex)
 
     // Of Appenable.
-    actual override fun append(c: Char) : StringBuilder {
+    actual override fun append(value: Char) : StringBuilder {
         ensureExtraCapacity(1)
-        array[_length++] = c
+        array[_length++] = value
         return this
     }
 
-    actual override fun append(csq: CharSequence?): StringBuilder {
+    actual override fun append(value: CharSequence?): StringBuilder {
         // Kotlin/JVM processes null as if the argument was "null" char sequence.
-        val toAppend = csq ?: "null"
+        val toAppend = value ?: "null"
         return append(toAppend, 0, toAppend.length)
     }
 
     @UseExperimental(ExperimentalStdlibApi::class)
-    actual override fun append(csq: CharSequence?, start: Int, end: Int): StringBuilder = this.appendRange(csq, start, end)
+    actual override fun append(value: CharSequence?, startIndex: Int, endIndex: Int): StringBuilder = this.appendRange(value, startIndex, endIndex)
 
     /**
      * Reverses the contents of this string builder and returns this instance.

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
@@ -36,9 +36,14 @@ open class TargetedLibraryImpl(
 
     override val targetList by lazy {
         access.inPlace { it: TargetedKotlinLibraryLayout ->
-            it.targetsDir.listFiles.map {
-                it.name
-            }
+            if (!it.targetsDir.exists)
+                // TODO: We have a choice: either assume it is the CURRENT TARGET
+                //  or a list of ALL KNOWN targets.
+                access.target ?. let { listOf(it.visibleName) } ?: emptyList()
+            else
+                it.targetsDir.listFiles.map {
+                    it.name
+                }
         }
     }
 


### PR DESCRIPTION
* 4efab517513 - (tag: build-1.4.0-dev-216) Fix allopen call from UL methods (3 days ago) <Igor Yakovlev>
* 8d02d00f227 - (tag: build-1.4.0-dev-214) [IR Serialization] Removed native-specific hack in mangler (3 days ago) <Igor Chevdar>
* 1f55b59fa35 - (tag: build-1.4.0-dev-210) Unmute a fixed Fir2IrText test (3 days ago) <pyos>
* 26822a0cdea - Minor: IGNORE_BACKEND: ANY_FIR -> IGNORE_BACKEND_FIR: ANY (3 days ago) <pyos>
* 38a37973253 - (tag: build-1.4.0-dev-206) Unmute FIR2IR test (due to fixed bug in FIR) (3 days ago) <Mikhail Glukhikh>
* 69e9ae94c6a - (tag: build-1.4.0-dev-203) Use snakeyaml from maven instead of from intellij (3 days ago) <Ilya Kirillov>
* 2adcb5dec47 - (tag: build-1.4.0-dev-200) Add the ANY_FIR target for muting Fir2IrText tests (3 days ago) <pyos>
* a4b005fd5d2 - PSI2IR: generate field writes for all val property assignments (3 days ago) <pyos>
* 92f8432b1ef - New J2K: Fix not converted jetbrains nullability annotations for types (3 days ago) <Ilya Kirillov>
* 3840294f442 - (tag: build-1.4.0-dev-199) Add tests for obsolete issues (3 days ago) <Mikhail Zarechenskiy>
* c3ffef18400 - Fix incorrect use of language feature (3 days ago) <Mikhail Zarechenskiy>
* c94dd2939ef - (tag: build-1.4.0-dev-196) [NI] Add test for KT-32429 (3 days ago) <Dmitriy Novozhilov>
* e730965bc50 - [NI] Approximate intersection type in type argument to star if it's necessary (3 days ago) <Dmitriy Novozhilov>
* 26f7bf1c219 - Regenerate tests (3 days ago) <Dmitriy Novozhilov>
* e466fd5196c - [NI] Infer type variable to Nothing if all upper constraints are from upper bounds (3 days ago) <Dmitriy Novozhilov>
* 7fed7a840ba - [NI] Update some testdata broken in NI (3 days ago) <Dmitriy Novozhilov>
* c311a66e5e8 - (tag: build-1.4.0-dev-195) Fix 191 & as35 compilation (3 days ago) <Ilya Kirillov>
* d6daaf14f8f - Fix "Protected function call from public-API inline function is prohibited" error (3 days ago) <Ilya Kirillov>
* 2dcc6177748 - (tag: build-1.4.0-dev-192) Minor: reformat (4 days ago) <Nikolay Krasko>
* e99dc0f87fc - Show only unique diagnostics in psi checker (KT-35578) (4 days ago) <Nikolay Krasko>
* 75beaa861f8 - Use abstract class to prevent GradleDaemonAnalyzerTestCase running as test (4 days ago) <Nikolay Krasko>
* 3e484948378 - Proper ignore new daemon tests without warning about tests absence (4 days ago) <Nikolay Krasko>
* 19422b12b47 - (tag: build-1.4.0-dev-189) Build: Add buildScanUserData script gradle-build-scan-snippets (4 days ago) <Vyacheslav Gerasimov>
* c89def9e061 - (tag: build-1.4.0-dev-188) [minor] Update test data for 1.4 (4 days ago) <Victor Petukhov>
* 254dc8f71c7 - (tag: build-1.4.0-dev-183) Build: Drop IntelliJ 2018.3 and Android Studio 3.4 support (4 days ago) <Michael Kuzmin>
* ae0efa77e39 - [minor] updating fir testdata (4 days ago) <Ilya Chernikov>
* 75c94f3b0f3 - (tag: build-1.4.0-dev-180) Build: Upgrade kotlin-build-gradle-plugin to 0.0.8 (4 days ago) <Vyacheslav Gerasimov>
* 20faa9e3e48 - Build: Make use of user & password properties in build cache configuration (4 days ago) <Vyacheslav Gerasimov>
* e43ea7e1830 - Build: Add build cache user and password properties to BuildProperties (4 days ago) <Vyacheslav Gerasimov>
* 1ee54d74d0b - (tag: build-1.4.0-dev-178) [FIR] Use FIR resolution API in explorer window (4 days ago) <Simon Ogorodnik>
* 87c698f8437 - [FIR] Remove obsolete total kotlin resolve test (4 days ago) <Simon Ogorodnik>
* a3d531e8b49 - [FIR] Extract jvm-only call conflict resolver (4 days ago) <Simon Ogorodnik>
* 05308a36527 - [FIR] Introduce module for all jvm extensions (4 days ago) <Simon Ogorodnik>
* 99489321f19 - (tag: build-1.4.0-dev-177) [FIR] Add forgotten test data for old FE test (4 days ago) <Mikhail Glukhikh>
* fe8d68ecc71 - Use different transformers per module in FIR diagnostics tests (4 days ago) <Mikhail Glukhikh>
* c4e6f8a6403 - Cache FirPackageMemberScope in ScopeSession instead of member scope provider (4 days ago) <Mikhail Glukhikh>
* cb93b25fcae - FIR: make possible to use differently typed IDs in ScopeSession (4 days ago) <Mikhail Glukhikh>
* 4d1b032c1f6 - Rename: FirSelfImportingScope -> FirPackageMemberScope (4 days ago) <Mikhail Glukhikh>
* 4e14d04926f - (tag: build-1.4.0-dev-173) [minor] fix testdata for compiler 1.4 (4 days ago) <Ilya Chernikov>
* 6e6d9ae7951 - (tag: build-1.4.0-dev-170) FIR body resolve: start analyzing files with independent context (4 days ago) <Mikhail Glukhikh>
* ada7f3da6ca - FIR: resolve anonymous initializer in context independent mode (4 days ago) <Mikhail Glukhikh>
* 99643e1b2d4 - FIR: do not run full tower resolve on integer literal type (4 days ago) <Mikhail Glukhikh>
* cb3f02d015d - FIR modularized test: do not print unnecessary stuff to the console (4 days ago) <Mikhail Glukhikh>
* 48c74fd1ba4 - FIR black box codegen tests: do not print bytecode to the console (4 days ago) <Mikhail Glukhikh>
* ad6f4fa92ee - FirResolveBench: do not print unnecessary stuff to the console #KT-35030 Fixed (4 days ago) <Mikhail Glukhikh>
* f38bb19fc67 - [minor] Fix testdata for compiler 1.4 (4 days ago) <Ilya Chernikov>
* 06dc2caf41b - (tag: build-1.4.0-dev-169) Fix compilation for AS (4 days ago) <Ilya Kirillov>
* ac47c0cf3c5 - (tag: build-1.4.0-dev-168) [minor] Update test data for 1.4 (4 days ago) <Pavel Kirpichenkov>
* ba640be81de - (tag: build-1.4.0-dev-164) KT-32178 Keyword completion: don't add 'fun' after 'suspend' in type position (4 days ago) <Toshiaki Kameyama>
* 1f878049eb4 - (tag: build-1.4.0-dev-163) Allow @author usage in `...projectWizard.settings.version.maven` package (4 days ago) <Nikolay Krasko>
* 280cb5b60b2 - Exclude kotlin-test-nodejs-runner generated folders from code conformance test (4 days ago) <Nikolay Krasko>
* 2c684c56a3a - Mute testVersionsAreConsistent test (KT-35567) (4 days ago) <Nikolay Krasko>
* 650cfeaaed7 - (tag: build-1.4.0-dev-161) Update inline tests to void PROTECTED_CALL_FROM_PUBLIC_INLINE_ERROR (4 days ago) <Mikhael Bogdanov>
* 8322398133a - (tag: build-1.4.0-dev-160) [minor] Fix testdata for compiler 1.4 (4 days ago) <Ilya Chernikov>
* 45e881f03f6 - (tag: build-1.4.0-dev-155) [NI] Fix inference if inner system has only by "uninteresting" constraint (4 days ago) <Ilya Chernikov>
* 3e537cfcb48 - [minor] [NI] Additional test for loosing type annotations on extension functions (4 days ago) <Ilya Chernikov>
* 1c6da8b9b44 - (tag: build-1.4.0-dev-149) [FIR] Add separate diagnostic tests working in light tree mode (4 days ago) <Mikhail Glukhikh>
* 9efb1fc527e - Change FIR modularized test to be able to work in light tree mode (4 days ago) <Mikhail Glukhikh>
* 3f76408c6ff - Protect FirResolveBench from light tree (this prevents cast to KtFile exception) (4 days ago) <Mikhail Glukhikh>
* 09c3279cc76 - (tag: build-1.4.0-dev-148) PSI2IR: Infer smart cast on dispatch receiver of FAKE_OVERRIDE calls (4 days ago) <Dmitry Petrov>
* feda832eb73 - (tag: build-1.4.0-dev-146) Tests: switch off script configuration update in MutlifileRefactoringTests (4 days ago) <Natalia Selezneva>
* 233d400e931 - Scripting: remove unexpected cache clear (4 days ago) <Natalia Selezneva>
* 7ba0a11f432 - (tag: build-1.4.0-dev-144) FIR light tree: add forgotten default bound for type parameters (4 days ago) <Mikhail Glukhikh>
* ebb1ca7cd9c - Fix 'fir:lightTree' build script to be able to run light tree tests (4 days ago) <Mikhail Glukhikh>
* 7abb3fc9876 - Protect FirJavaElementFinder from light tree (4 days ago) <Mikhail Glukhikh>
* 774eb621180 - FIR resolve bench: make possible building FIR files via light tree (4 days ago) <Mikhail Glukhikh>
* d702dc862a3 - FIR light tree: eliminate unused 'project' argument (4 days ago) <Mikhail Glukhikh>
* e8131d6e30a - (tag: build-1.4.0-dev-142) Choose Java field during overload resolution with a pure Kotlin property (4 days ago) <Denis Zharkov>
* aa8578b6756 - (tag: build-1.4.0-dev-141) Allow null operators for result and using Result as return type with enabled InlineClasses (4 days ago) <Dmitriy Novozhilov>
* eed5b3f1d1d - Add quickfix for removing redundant spread operator (4 days ago) <Dmitriy Novozhilov>
* ee36fb903f0 - Allow use expression of array type as named argument for vararg (4 days ago) <Dmitriy Novozhilov>
* 0cb48999ff6 - (tag: build-1.4.0-dev-135) JVM IR: retain optional annotations as package private classes (5 days ago) <Alexander Udalov>
* 5d3ef4c632d - (tag: build-1.4.0-dev-132) JVM IR: Fix names of fake local variables for inline arguments (5 days ago) <Steven Schäfer>
* c486fa61894 - (tag: build-1.4.0-dev-129) NI: Report incompatible receiver of callable reference (5 days ago) <Denis Zharkov>
* dd56c3d9182 - NI: Fix property references overload ambiguity (5 days ago) <Denis Zharkov>
* ab79c3e0a06 - Properly mute (and unmute) tests for unrelated backends (5 days ago) <Alexander Gorshenev>
* ffa368e0a71 - Reconciled -Xklib-mpp with commonizer (5 days ago) <Alexander Gorshenev>
* dc8240c24eb - Expect/actual support in klibs under -Xklib-mpp (5 days ago) <Alexander Gorshenev>
* 218d7c31ed5 - (tag: build-1.4.0-dev-127) Remove muted tests on automatic experimental->release coroutine migration (5 days ago) <Alexander Udalov>
* 3ac5cb9a6e7 - Minor, fix typos in exception message (5 days ago) <Alexander Udalov>
* ebb9f096563 - (tag: build-1.4.0-dev-117, minamoto/ir/inliner/inliner-no-local-object-copier-1/kotlin) [NI] Fix issues with star projection uncapturing (5 days ago) <Pavel Kirpichenkov>
* 86dc0925b10 - [NI] Preserve constraint position for OnlyInputType during incorporation (5 days ago) <Pavel Kirpichenkov>
* 2fc79856a24 - [NI] Fix OnlyInputTypes for captured types (5 days ago) <Pavel Kirpichenkov>
* 16db3a8b5f9 - (tag: build-1.4.0-dev-115) Fix compiler and IDE tests on Experimental/RequiresOptIn (5 days ago) <Alexander Udalov>
* 830f0c6137b - (tag: build-1.4.0-dev-113) Fix class not found exception in gradle wizard tests (5 days ago) <Ilya Kirillov>
* 1ab405a86c6 - Wizard: introduce unit test mode (5 days ago) <Ilya Kirillov>
* 1c305728449 - Wizard: fix android tests (5 days ago) <Ilya Kirillov>
* b2166dc40df - Wizard: fix wrong checking for project kind in UI (5 days ago) <Ilya Kirillov>
* c1ce215b5d2 - Wizard: disable abbility to switch between targets in existing module (5 days ago) <Ilya Kirillov>
* 7204ab091af - Wizard: add suggested module names for js targets (5 days ago) <Ilya Kirillov>
* fc9f63d49f7 - Wizard: do not allow to create more than one target of each type (5 days ago) <Ilya Kirillov>
* aa2992e84a7 - Wizard: add additional applicability checker for template (5 days ago) <Ilya Kirillov>
* 40367635cc8 - Wizard: remove unused android service (5 days ago) <Ilya Kirillov>
* af174b4f74c - Wizard: format templates code (5 days ago) <Ilya Kirillov>
* b29e6d0c696 - Wizard: add simple js template (5 days ago) <Ilya Kirillov>
* 5d56f3d28b8 - Wizard: do not print duplicated repositories (5 days ago) <Ilya Kirillov>
* 32a151f561d - Wizard: introduce interceptors for module templates (5 days ago) <Ilya Kirillov>
* 8bf9c31880f - Wizard: add simple JS client template (5 days ago) <Ilya Kirillov>
* 56fccce305c - Wizard: add basic ktor server template (5 days ago) <Ilya Kirillov>
* f927fb3471e - Wizard: introduce ServicesManager & correctly handle disabled gradle & maven Idea plugins (5 days ago) <Ilya Kirillov>
* 9011eecfdfc - Wizard: change wizard title to experimental (5 days ago) <Ilya Kirillov>
* b10e157147d - Wizard: Create parent group for current and experimental project wizard (5 days ago) <Ilya Kirillov>
* 8684b0d6c10 - Wizard: show experimental new project wizard only by registry flag (5 days ago) <Ilya Kirillov>
* aca193ddd2f - Wizard: Add initial version of the new project wizard (5 days ago) <Ilya Kirillov>
* 4916f166fe4 - (tag: build-1.4.0-dev-111) Move `android.test.dependencies` under `dependencies` folder (5 days ago) <Mikhael Bogdanov>
* 0d8036bb140 - (tag: build-1.4.0-dev-109) JVM_IR: do not generate main() when extension main is present (5 days ago) <Georgy Bronnikov>
* 9d0c736f0ef - (tag: build-1.4.0-dev-108) Use `assertAllTestsPresentByMetadataWithExcluded` for `addSpreadOperatorForArrayAsVarargAfterSam` IDE quick fix test (5 days ago) <Victor Petukhov>
* 220ea72d65e - (tag: build-1.4.0-dev-87) JVM_IR: add coercion for index in ArrayGet intrinsic (5 days ago) <Georgy Bronnikov>
* cca3f13e481 - (tag: build-1.4.0-dev-85) Added multi-module test on inline functions (5 days ago) <Igor Chevdar>
* bd805d71b13 - (tag: build-1.4.0-dev-84) KT-35463 EA-214439 Pass adjusted files to `KotlinAwareMoveFilesOrDirectoriesDialog` instead of originals (5 days ago) <Roman Golyshev>
* dd8396efbc8 - (tag: build-1.4.0-dev-72) Convert lambda to reference: support nested class constructor call (#2877) (6 days ago) <Toshiaki Kameyama>
* 646c7ad0af4 - (tag: build-1.4.0-dev-66) [IDE, klib] Support in IDE klibs with dynamic type (6 days ago) <Zalim Bashorov>
* 34eb6645041 - (tag: build-1.4.0-dev-61) Build: Remove teamcity tag setup from settings.gradle (tag via gradle arguments instead) (6 days ago) <Vyacheslav Gerasimov>
* 7eda60d57eb - (tag: build-1.4.0-dev-59) Minor, add more tests on signature-polymorphic calls (6 days ago) <Alexander Udalov>
* 64d40b47436 - Support JVM polymorphic signature calls to methods with void return type (6 days ago) <Alexander Udalov>
* e009c7064eb - (tag: build-1.4.0-dev-58, tag: build-1.4.0-dev-57) Add -Xopt-in command line argument (6 days ago) <Alexander Udalov>
* cdbabf224f3 - Introduce RequiresOptIn and OptIn annotations (6 days ago) <Alexander Udalov>
* 33bc3db1449 - Deprecate -Xexperimental compiler argument (6 days ago) <Alexander Udalov>
* 571bba7c045 - (tag: build-1.4.0-dev-55) Build: Add teamcity tag to build scans (6 days ago) <Vyacheslav Gerasimov>
* b868e6f8da4 - (tag: build-1.4.0-dev-50) Rename Appendable methods parameters (6 days ago) <Abduqodiri Qurbonzoda>
* d1c0dfe8acf - (tag: build-1.4.0-dev-45) [FIR] Run System.gc() before each pass in modularized tests (6 days ago) <Simon Ogorodnik>
* 0f71460833b - (tag: build-1.4.0-dev-39) Add missed comment (6 days ago) <Roman Artemev>
* dbb282e60f5 - Arg postfix postfix completion: fix typo in description (6 days ago) <Toshiaki Kameyama>
* cad3cb1bbe8 - [KLIB] Fix references to type made from TypeParameter in KotlinMangler  - promote ABI version (6 days ago) <Roman Artemev>
* 3544bf17f4e - (tag: build-1.4.0-dev-38) ConeIntegerLiteralType: extract COMPARABLE_TAG (6 days ago) <Mikhail Glukhikh>
* 3d961ffe8fe - ConeTypeContext: use built-in nullable any type (6 days ago) <Mikhail Glukhikh>
* 4d0b1212238 - FIR SAM resolution: use built-in nullable any type (6 days ago) <Mikhail Glukhikh>
* c6db5abb14a - FIR call resolve: make earlier qualifier resolver reset (6 days ago) <Mikhail Glukhikh>
* 684bdc44bb3 - FIR: add implementation of reified type parameter references (6 days ago) <Mikhail Glukhikh>
* cccb95465e1 - FIR status resolve: update type alias phase (6 days ago) <Mikhail Glukhikh>
* a6b6c9ba181 - Minor: remove when unreachable branches (6 days ago) <Mikhail Glukhikh>
* af3ab9178a0 - Minor: remove unused imports (6 days ago) <Mikhail Glukhikh>
* 8e53ccb8521 - (tag: build-1.4.0-dev-31) Add ML completion jar to the resulting plugin jar (6 days ago) <Roman Golyshev>
* e92985458bf - (tag: build-1.4.0-dev-25) JVM_IR: skip private declarations in imported classes (6 days ago) <Georgy Bronnikov>
* 776736a25ab - (tag: build-1.4.0-dev-22) [IR] Remapped some forgotten types during IR copying (6 days ago) <Igor Chevdar>
* f0992772109 - [JS IR] Unmute tests and add KJS_WITH_FULL_RUNTIME (6 days ago) <Svyatoslav Kuzmich>
* e32ec2a7892 - [JS IR BE] Support typeOf (6 days ago) <Svyatoslav Kuzmich>
* 3df8393edec - [JS IR] Properly report compiler errors (6 days ago) <Svyatoslav Kuzmich>
* ea8fa55f12d - (tag: build-1.4.0-dev-17) Rename kotlinJUnitSettings test data folder to fix tests (6 days ago) <Nikolay Krasko>
* 2aa1c40de45 - Avoid checking trivial incorporated constraints (6 days ago) <Denis Zharkov>
* 02f3cedcf4b - FIR: Optimize ConeInferenceContext::typeDepth (6 days ago) <Denis Zharkov>
* b53c00cf698 - FIR: Optimize simple things in inference (6 days ago) <Denis Zharkov>
* 03c2350e799 - (tag: build-1.4.0-dev-14) Keep original casts during reification to avoid VerifyError (6 days ago) <Mikhael Bogdanov>
* 6f16d029205 - (tag: build-1.4.0-dev-13) [gradle-native-plugin] Build static caches instead of dynamic (6 days ago) <Igor Chevdar>
* b6de3c2fcc9 - (tag: build-1.4.0-dev-9) Disable tail-call optimization for suspend functions with Unit return type (6 days ago) <Ilmir Usmanov>
* 09acdb655d5 - (tag: build-1.4.0-dev-6) KtScratchExecutionSession: fix compilation for 191 (6 days ago) <Dmitry Gridin>
* 898308c7ba9 - (tag: build-1.4.0-dev-4) KotlinDebuggerCaches: fix INRE #EA-219472 Fixed (6 days ago) <Dmitry Gridin>
* 3f500c6e924 - KotlinConsoleRunner: fix INRE #EA-219478 Fixed (6 days ago) <Dmitry Gridin>
* 02beb72ab12 - IDEKotlinAsJavaSupport: fix INRE #EA-213321 Fixed (6 days ago) <Dmitry Gridin>
* 4d7fe78a515 - KotlinFunctionBreakpoint: fix INRE #KT-35316 Fixed #EA-219418 Fixed (6 days ago) <Dmitry Gridin>
* 09bcfab047c - KotlinNativeModuleConfigurator: fix INRE #EA-219416 Fixed (6 days ago) <Dmitry Gridin>
* 86f9253fa05 - KtScratchExecutionSession: fix INRE #EA-218701 Fixed (6 days ago) <Dmitry Gridin>
* 78f7ed2c276 - KotlinVariableInplaceIntroducer: fix PIEAE #EA-209820 Fixed (6 days ago) <Dmitry Gridin>
* 580885245d4 - JavaToKotlinAction: fix KNPE #EA-215300 Fixed (6 days ago) <Dmitry Gridin>
* 34dcc72e7f7 - idea: fix some `ControlFlowException` #EA-219412 Fixed (6 days ago) <Dmitry Gridin>
* cdabff19417 - KotlinImportOptimizer: should use with `isIndeterminate=false` #KT-34928 Fixed (6 days ago) <Dmitry Gridin>
* 7c9826b60b0 - PerModulePackageCacheService: fix NPE for code injection #KT-35208 Fixed (6 days ago) <Dmitry Gridin>
* ebf3bfc0489 - KotlinIntroduceImportAliasHandler: remove unnecessary transformations (6 days ago) <Dmitry Gridin>
* 9f1f743d55c - (tag: build-1.4.0-dev-2923) FIR: fix test data after Make 'statics visible from nested classes' (6 days ago) <Mikhail Glukhikh>
* 7b1771d4322 - (tag: build-1.3.70-dev-2917) Remove braces from 'when' entry: do not suggest when statement is lambda that has no arrow (6 days ago) <Toshiaki Kameyama>
* afc680d5c94 - (tag: build-1.3.70-dev-2915) JavaMapForEachInspection: do not report when lambda parameter is destructuring declaration (6 days ago) <Toshiaki Kameyama>
* 8857827dce2 - "Add not-null asserted (!!) call": do not add `this` when implicit receiver is not extension receiver (6 days ago) <Toshiaki Kameyama>
* f1c605d0f72 - (tag: build-1.3.70-dev-2914) AddFunctionParametersFix: improve parameter name for 'it' argument (6 days ago) <Toshiaki Kameyama>
* f8f50b2131e - (tag: build-1.3.70-dev-2913) DeprecatedCallableAddReplaceWithInspection: add argument name if needed (6 days ago) <Toshiaki Kameyama>
* 23749bdde7f - Add constructor parameter: add generic types correctly (6 days ago) <Toshiaki Kameyama>
* 76a65af14b4 - (tag: build-1.3.70-dev-2912) Fix #KT-31967 Typo in inspection name: "+= create new list under the hood" (6 days ago) <tommykw>
* ae827bfd800 - (tag: build-1.3.70-dev-2911) Use declaration-site session in phased FIR instead of use-site session (6 days ago) <Mikhail Glukhikh>
* 37839a181c9 - Introduce FirIdeModuleDependenciesSymbolProvider #KT-35424 In Progress (6 days ago) <Mikhail Glukhikh>
* befcfad8984 - Rename: IdeFirProvider -> FirIdeProvider (6 days ago) <Mikhail Glukhikh>
* 8703da5a254 - Rename: FirResolveState -> FirModuleResolveState to reflect per-module status (6 days ago) <Mikhail Glukhikh>
* 8dbbd64beb0 - (tag: build-1.3.70-dev-2910) idea: cleanup code (6 days ago) <Dmitry Gridin>
* e77d8657f4d - (tag: build-1.3.70-dev-2904) Fix configuration for AS 3.5 (7 days ago) <Natalia Selezneva>
* 54d707b3b63 - (tag: build-1.3.70-dev-2903) JVM_IR: make constructors of named local classes public (7 days ago) <pyos>
* 82f48cdd11e - JVM_IR: Backwards compatible handling of default tailrec params. (7 days ago) <Mads Ager>
* 90a1b15b773 - (tag: build-1.3.70-dev-2899) [FIR] Make statics visible from nested companion/classes (7 days ago) <Simon Ogorodnik>
* 02cbe990c03 - [FIR] Use fast firSymbolProvider access (7 days ago) <Simon Ogorodnik>
* 2e27862d38f - [FIR] Cache lookupTag lookup on creation from symbol (partially) (7 days ago) <Simon Ogorodnik>
* 0fb883ef628 - [FIR] Use builtinTypes instead of creating new ones (7 days ago) <Simon Ogorodnik>
* 5de69471b04 - [FIR] Use yieldIfNeed instead of yield (7 days ago) <Simon Ogorodnik>
* 81759e8c553 - [FIR] Use proper sourceScope for modularized tests (7 days ago) <Simon Ogorodnik>
* 0a2c457f54e - [FIR] Properly check typealias fqn matching (7 days ago) <Simon Ogorodnik>
* d0c58be4e9a - [FIR] Pass proper use-site session in deserialized provider (7 days ago) <Simon Ogorodnik>
* 85ff834fdb0 - [FIR] Do not create Kotlin scopes for handledByJava classes (7 days ago) <Simon Ogorodnik>
* dd803cb6507 - [FIR] Fix moduleInfo module names (7 days ago) <Simon Ogorodnik>
* 7f51be9cd34 - (tag: build-1.3.70-dev-2889) Minor, change parameter name of FrameMap.enter/leave (7 days ago) <Alexander Udalov>
* f51a0048f66 - Minor, rename test and avoid commented directive (7 days ago) <Alexander Udalov>
* 561cde9d069 - JVM IR: minor, add exception message to IrFrameMap.typeOf (7 days ago) <Alexander Udalov>
* 0b7c11c96e8 - (tag: build-1.3.70-dev-2883) [JS IR] Fix external fields naming (7 days ago) <Roman Artemev>
* 02db5ea0eb5 - [JS IR] Fix state machine builder (7 days ago) <Roman Artemev>
* ccb9a4e0a90 - (tag: build-1.3.70-dev-2881, tag: build-1.3.70-dev-2876) [FIR TEST]: add problematic test for T::class.java case (7 days ago) <Mikhail Glukhikh>
* 38b0de4ab6f - (tag: build-1.3.70-eap-3, tag: build-1.3.70-dev-2873) Scripting: do not start multiple request when related file was changed (7 days ago) <Natalia Selezneva>
* fba17d5b9a4 - Minor, tests: clear memory cache in tests that check scripting file attributes (7 days ago) <Natalia Selezneva>
* 780c61dc164 - Fix line separators in tests (7 days ago) <Natalia Selezneva>
* 31887d2fd19 - Scripting: check if affected scripts are changed using file modification stamp instead of mark them out of date in cache (7 days ago) <Natalia Selezneva>
* ec04f0059c6 - Scripting: do not threat comments and spaces as modifications inside essential block (7 days ago) <Natalia Selezneva>
* 2f35d6d8683 - Scripting: save inputs stamp and diagnostics to file attributes (7 days ago) <Natalia Selezneva>
* 13b4e8716c8 - Changes inside initscript and pluginManagement blocks should invalidate script configuration (7 days ago) <Natalia Selezneva>
* d68c3584f27 - Scripting: add test for loading configuration for gradle scripts (7 days ago) <Natalia Selezneva>
* 424a2c72b26 - Implement KotlinWordsScanner (7 days ago) <Natalia Selezneva>
* 886e9613b8a - Move script related extensions to separate xml-s (7 days ago) <Natalia Selezneva>
* 2e933507c6e - Fix duplicated “Kotlin Script” definition for Gradle/Kotlin projects (KT-35096) (7 days ago) <Natalia Selezneva>
* 153d894afb4 - (tag: build-1.3.70-eap-2, tag: build-1.3.70-dev-2870, minamoto/compler-update/kotlin) FIR: Optimize ConeTypeContext::asSimpleType (7 days ago) <Denis Zharkov>
* 1790dcf80c5 - FIR: Reorder when entries in ConeTypeContext::typeConstructor (7 days ago) <Denis Zharkov>
* a14852a6ec5 - Minor. Make ConeClassLikeTypeImpl final (7 days ago) <Denis Zharkov>
* ac81f046fd2 - (tag: build-1.3.70-dev-2867) gradle.kts importing test: don't run on 191 (including as34) (7 days ago) <Sergey Rostov>
* a2d8e2435fb - (tag: build-1.3.70-dev-2863) Reorder steps in psi2ir so postprocessing goes before unbound symbols stub generating (7 days ago) <Leonid Startsev>
* 737eaebee6c - (tag: build-1.3.70-dev-2857) FIR resolve: fold flexible types whenever possible #KT-31528 Fixed (7 days ago) <Mikhail Glukhikh>
* 9f5a02dc7ad - (tag: build-1.3.70-dev-2853) gradle.kts importing: fix as36 (7 days ago) <Sergey Rostov>
* 637e6f5acc5 - (tag: build-1.3.70-dev-2852) FIR: add forgotten test data for old FE test (7 days ago) <Mikhail Glukhikh>
* acf48a1af78 - (tag: build-1.3.70-dev-2850) Return NONE from FirSuperTypeScope if nothing is found (7 days ago) <Mikhail Glukhikh>
* 001af684957 - FIR: distinguish lazy/non-lazy nested scopes more clear (7 days ago) <Mikhail Glukhikh>
* fea224749bb - FIR: introduce symbolProvider.getNestedClassifierScope to choose lazy/non-lazy (7 days ago) <Mikhail Glukhikh>
* 663d545d79b - FIR: get rid of symbolProvider.getClassDeclaredMemberScope at all (7 days ago) <Mikhail Glukhikh>
* af87a183c2b - FIR: get rid of symbolProvider.getClassDeclaredMemberScope usages in compiler (7 days ago) <Mikhail Glukhikh>
* f497231acda - FIR: try to use JavaSymbolProvider directly in lazy nested classifier scope (7 days ago) <Mikhail Glukhikh>
* 48d60ed4eaa - (tag: build-1.3.70-dev-2849) revert accidentally changed vcs.xml (7 days ago) <Sergey Rostov>
* 039090d2bf0 - (tag: build-1.3.70-dev-2848) gradle.kts importing tests: run gradle 6.0.1 only for that test (7 days ago) <Sergey Rostov>
* 1930ab7c388 - gradle.kts importing: reduce bunch files (7 days ago) <Sergey Rostov>
* c0690ff5f6f - gradle.kts importing: move code to dedicated package (7 days ago) <Sergey Rostov>
* 6e3e65c490e - gradle.kts importing: add support for included builds and fix sub projects (7 days ago) <Sergey Rostov>
* fef193be637 - gradle.kts: add tests for importing scripts configuration (7 days ago) <Sergey Rostov>
* dcd67d79f45 - gradle.kts: script models should be imported in ProjectData key, not in GradleSourceSetData (7 days ago) <Sergey Rostov>
* fd16078a348 - gradle.kts: add clearCaches method for testing (7 days ago) <Sergey Rostov>
* 559b067f913 - gradle.kts: move areSimilar to utils.kt to use in tests (7 days ago) <Sergey Rostov>
* 249f72585d6 - (tag: build-1.3.70-dev-2847) Fix test data in FIR old FE diagnostics test (7 days ago) <Mikhail Glukhikh>