### PR TITLE
[kotlin compiler][update] 1.4.0-dev-508

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-445,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-445
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-445,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-445
-kotlinStdlibTestsVersion=1.4.0-dev-445
-testKotlinCompilerVersion=1.4.0-dev-445
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-508,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-508
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-508,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-508
+kotlinStdlibTestsVersion=1.4.0-dev-508
+testKotlinCompilerVersion=1.4.0-dev-508
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 42deb7db48f - (tag: build-1.4.0-dev-508) KT-34582 Exclude `kotlin.coroutines.experimental` package from completion and auto-import (21 hours ago) <Roman Golyshev>
* 8399614de83 - (tag: build-1.4.0-dev-504) Move muted test failing on all platforms to mute-common (2 days ago) <Pavel Kirpichenkov>
* a98f36bce4f - (tag: build-1.4.0-dev-499) Reorganize existing Closeable/AutoCloseable.use tests (2 days ago) <Ilya Gorbunov>
* 941de655c46 - Add contract for 'use' (2 days ago) <Toshiaki Kameyama>
* 043eddb432d - (tag: build-1.4.0-dev-498) Cleanup: use effects introduced by contracts of assert* functions (2 days ago) <Ilya Gorbunov>
* 04fe0dc795e - (tag: build-1.4.0-dev-491) Minor: enable commit message inspections in IDEA (3 days ago) <Zalim Bashorov>
* 9cf1a2b4047 - [Build] Remove the property to skip JS IR BE tests (3 days ago) <Zalim Bashorov>
* 9557034cf7d - [Build] Mark tmp dir in the root of project as excluded (3 days ago) <Zalim Bashorov>
* 40812cd1160 - (tag: build-1.4.0-dev-488) Mute quickfix test (KT-35728) (3 days ago) <Pavel Kirpichenkov>
* 2d21b825016 - [NI] Remove hack for special functions (3 days ago) <Pavel Kirpichenkov>
* 9a12641fde2 - (tag: build-1.4.0-dev-483) Allow parallel access to klib zip filesystem (3 days ago) <Alexander Gorshenev>
* ddda93ad965 - (tag: build-1.4.0-dev-472) Mute flaky JavaAgainstKotlin.testUsingMutableInterfaces (3 days ago) <Nikolay Krasko>
* e20c66011ad - Enable mute tests feature for BuiltInDecompilerTest (3 days ago) <Nikolay Krasko>
* 28e23f0aa83 - Mute flaky step over tests on Android Studio (3 days ago) <Nikolay Krasko>
* 11e4b710b5d - Mute GradleMigrateTest.testMigrateStdlib in AS (3 days ago) <Nikolay Krasko>
* 77edfed7649 - Mute tests for preferring JDK classes in completion and auto-import in 191 and 192 (KT-35709) (3 days ago) <Nikolay Krasko>
* 74e2c984268 - Fix test data for QuickFixTestGenerated.SupertypeInitialization in 191 (3 days ago) <Nikolay Krasko>
* 0d488553336 - Mute JavaToKotlinConverterSingleFileTestGenerated in 191 (3 days ago) <Nikolay Krasko>
* 28eb6a223df - Fix UpdateConfigurationQuickFixTest.testEnableCoroutinesFacet test (3 days ago) <Nikolay Krasko>
* 4c28e0dec32 - Split tests to common and platform parts (3 days ago) <Nikolay Krasko>
* 570b522e8e4 - Minor: sort tests in mute database (3 days ago) <Nikolay Krasko>
* 6da3c2fa4ec - (tag: build-1.4.0-dev-469) FIR2IR: set parent correctly (~) for anonymous functions (3 days ago) <Mikhail Glukhikh>
* a653feb2dc2 - (tag: build-1.4.0-dev-467) Scripting: use VFS events instead of document changes to track changes outside of IDE (KT-35557) (3 days ago) <Natalia Selezneva>
* 6bf0e4b1a9e - Simplify check for that gradle script configurations is up to date (3 days ago) <Natalia Selezneva>
* 3dfbd824e48 - Implement persistent storage for time stamps of files that affect build script configuration (KT-3556) (3 days ago) <Natalia Selezneva>
* ecb05ace919 - Scripting: extract API to check if script is related to any gradle project (3 days ago) <Natalia Selezneva>
* 716036a0005 - (tag: build-1.4.0-dev-465) RemoveModifierFix: fix message for 'companion object' (3 days ago) <Toshiaki Kameyama>
* 3dc58bc9951 - (tag: build-1.4.0-dev-464) [FIR2IR] Fix translating primitive array types (3 days ago) <Juan Chen>
* 1cf582e9edf - FIR2IR: set extension receiver for anonymous functions (3 days ago) <Mikhail Glukhikh>
* aa796e962a3 - FIR2IR (minor): remove duplicate of generateErrorCallExpression (3 days ago) <Mikhail Glukhikh>
* 95dd322bf0e - (tag: build-1.4.0-dev-461) Update FIR diagnostics test (3 days ago) <Mikhail Zarechenskiy>
* e4b2c238c72 - (tag: build-1.4.0-dev-458, minamoto/ir/inliner/inliner-no-local-object-copier-1/kotlin) FIR2IR: temporarily allow null receivers & use findIr*Receiver also for fields (3 days ago) <Mikhail Glukhikh>
* 338281e05fe - [FIR TEST]: add test for KT-35730 (3 days ago) <Mikhail Glukhikh>
* 15f373a8648 - FIR2IR: support object receiver case (this fixes 24 black box tests) (3 days ago) <Mikhail Glukhikh>
* f3b5ee4cba0 - FIR2IR: fix assertion in getIrFunctionSymbol (anonymous function case) (3 days ago) <Mikhail Glukhikh>
* 5e426fdc714 - [FIR] Optimization & checking fix: remove usage of dispatchReceiverValue (3 days ago) <simon.ogorodnik>
* 686965c0d37 - [FIR] Code cleanup: get rid of typeProvider hack (3 days ago) <simon.ogorodnik>
* caf02806d59 - (tag: build-1.4.0-dev-456, tag: build-1.4.0-dev-447) NI: Fix resolution ambiguity for references returned from lambda (3 days ago) <Denis Zharkov>
* 534718794c4 - Minor. Extract PSICallResolver::createCallableReferenceKotlinCallArgument (3 days ago) <Denis Zharkov>
* 840acbac684 - Minor. Make properties in KotlinResolutionCallbacksImpl private (3 days ago) <Denis Zharkov>