### PR TITLE
[kotlin compiler][update] 1.4.0-dev-783

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-588,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-588
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-588,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-588
-kotlinStdlibTestsVersion=1.4.0-dev-588
-testKotlinCompilerVersion=1.4.0-dev-588
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-783,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-783
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-783,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-783
+kotlinStdlibTestsVersion=1.4.0-dev-783
+testKotlinCompilerVersion=1.4.0-dev-783
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 272ca002d7f - (tag: build-1.4.0-dev-783) Drop UNREACHABLE_CODE eager text range calculation (18 hours ago) <Vladimir Dolzhenko>
* 9e4d7df86e8 - (tag: build-1.4.0-dev-775) Revert "[JS IR] stdlib: switch between artifacts rather than artifact content" (2 days ago) <Ilya Gorbunov>
* e2bb6022718 - (tag: build-1.4.0-dev-772) Fix invalid test data file names (3 days ago) <Igor Yakovlev>
* 0c4134470df - (tag: build-1.4.0-dev-770) Fix exception of rename readonly overridden methods (3 days ago) <Igor Yakovlev>
* 3a2704d9565 - (tag: build-1.4.0-dev-769) Remove usage of deprecated method (3 days ago) <Igor Yakovlev>
* df2a0e10871 - Add MPP warning message for move refactoring (3 days ago) <Igor Yakovlev>
* 2b4dc1199ab - (tag: build-1.4.0-dev-765) JVM IR: fix monitorEnterMonitorExit.kt (3 days ago) <Alexander Udalov>
* b2f8a4e82a9 - (tag: build-1.4.0-dev-761) JVM_IR: Put continuation parameter before default mask and handler. (3 days ago) <Mads Ager>
* c948459ed53 - (tag: build-1.4.0-dev-746) Minor, add comment to synthetic accessor generation for super calls (3 days ago) <Alexander Udalov>
* b48d7f4ba72 - JVM IR: fix InterfaceLowering for $default methods from base interfaces (3 days ago) <Alexander Udalov>
* 3848ac9cac6 - JVM IR: never produce "$s<hash>" suffix for accessors in interfaces (3 days ago) <Alexander Udalov>
* 3193689086e - JVM IR: do not add suffix for accessors to top level functions (3 days ago) <Alexander Udalov>
* d6ed93b2b87 - (tag: build-1.4.0-dev-742) JVM IR: fail when SyntheticAccessorLowering adds accessor to other files (3 days ago) <Alexander Udalov>
* 957b100cd1f - JVM IR: do not generate hidden constructor for inline classes more than once (3 days ago) <Alexander Udalov>
* a339e7af198 - (tag: build-1.4.0-dev-738) build.gradle.kts: tests and docs for LastModifiedFiles collection (3 days ago) <Sergey Rostov>
* 4cf8203ce72 - (tag: build-1.4.0-dev-735) PSI2IR: Unify behavior for lambda return values with old back-end (3 days ago) <Dmitry Petrov>
* c47e04ac8d3 - (tag: build-1.4.0-dev-727) JVM_IR: handle suspend functions for signatures in callable references. (3 days ago) <Mads Ager>
* 32539073170 - (tag: build-1.4.0-dev-725) [Spec tests] Hotfix for not-null-assertion-expression test (3 days ago) <anastasiia.spaseeva>
* 2a4e235e341 - (tag: build-1.4.0-dev-724) [NI] Decrease only input types check diagnostic level to warning (3 days ago) <Pavel Kirpichenkov>
* 23c2a5c830b - (tag: build-1.4.0-dev-721) Uast: fake light method for uast is created only when containing class exists (KT-35310, EA-219604) (3 days ago) <Nicolay Mitropolsky>
* 59175912054 - (tag: build-1.4.0-dev-720) Workaround an inliner problem upon which the compiler code itself stumbled ^KT-35856 Fixed (3 days ago) <Victor Petukhov>
* 5b8ab766131 - (tag: build-1.4.0-dev-719) [FIR] Move JvmMappedScope to fir:jvm module (3 days ago) <simon.ogorodnik>
* 16c82030a34 - (tag: build-1.4.0-dev-718) KT-20120 fixing bug for Java 9 Deprecated Unconditionally changing it to @Deprecated("") in kotlin (3 days ago) <Alex Chmyr>
* ba4163ba02e - (tag: build-1.4.0-dev-715, origin/rr/kishmakov/KT-33113) [FIR] Improve synthetic functional interfaces support (3 days ago) <simon.ogorodnik>
* 573188bdc4a - (tag: build-1.4.0-dev-713) [FIR2IR]: fix translation of this references in instance methods (3 days ago) <Juan Chen>
* 6b4e5bc2f0d - [FIR] Cleanup code and fix type check in SAM resolution (3 days ago) <Mikhail Glukhikh>
* c464322b3a5 - [FIR2IR] Fix translation of library func parameters with default values (3 days ago) <Juan Chen>
* 7eaac0bf2ae - [FIR]: allow char comparison in Fir2Ir (3 days ago) <Juan Chen>
* d4076637345 - Add another binding for wrapped parameter descriptors. (3 days ago) <Juan Chen>
* d3b21aed8a4 - [FIR]: add missed bindings for WrappedReceiverParameterDescriptor. (3 days ago) <Juan Chen>
* ea267d9ef4f - [FIR IDE]: support enum entry search properly (3 days ago) <Mikhail Glukhikh>
* 2f6a48f70c1 - Handle phase for FirEnumEntry correctly (3 days ago) <Mikhail Glukhikh>
* 05ee6fdd77a - Add problematic enum test (3 days ago) <Mikhail Glukhikh>
* 7e946c6f5b9 - Forbid manual phase updates during FIR compilation (non-IDE mode) (3 days ago) <Mikhail Glukhikh>
* 961037506ac - FIR2IR: support FirEnumEntry (3 days ago) <simon.ogorodnik>
* 3671c8489ff - FirEnumEntry: set correct child class name (3 days ago) <Mikhail Glukhikh>
* 97670e5036f - [Raw FIR] Fix PSI consistency test (enum entry) + some cleanup (3 days ago) <Mikhail Glukhikh>
* 2b05320ae96 - [Raw FIR] Synchronize enum entry building in PSI / light AST modes (3 days ago) <Mikhail Glukhikh>
* 65a44e2e207 - Migrate to FirEnumEntry (3 days ago) <simon.ogorodnik>
* 5b5a5292b79 - Support FirEnumEntry in FirRenderer (3 days ago) <simon.ogorodnik>
* c6e28537ff4 - Create node for FirEnumEntry (3 days ago) <simon.ogorodnik>
* 13132e69a31 - [FIR] Start enum entries reworking (3 days ago) <Simon Ogorodnik>
* 68d64f1b5cd - (tag: build-1.4.0-dev-709) IDEA plugin: Don't create iOS test in the share lib project template (3 days ago) <Ilya Matveev>
* c084dfa1d71 - (tag: build-1.4.0-dev-705) [JS IR] stdlib: use 'base' plugin instead of kotlin("jvm") (4 days ago) <Ilya Gorbunov>
* a9fec21178b - [JS IR] stdlib: switch between artifacts rather than artifact content (4 days ago) <Ilya Gorbunov>
* 372a4009bd2 - Fix coreLibsInstall composite task again (4 days ago) <Ilya Gorbunov>
* 8d0ffa14442 - (tag: build-1.4.0-dev-703) IR:  copy type parameters for local functions in LocalDeclarationLowering (4 days ago) <Georgy Bronnikov>
* 01da7f289b0 - JVM_IR: rework type parameters in AddContinuationLowering (4 days ago) <Georgy Bronnikov>
* d81231fdf70 - JVM_IR: fix type arguments in inline callable references (4 days ago) <Georgy Bronnikov>
* a67df82b1e3 - IR: modify IrTypeParametersContainer.copyTypeParameters() (4 days ago) <Georgy Bronnikov>
* 96c1b96f3aa - (tag: build-1.4.0-dev-700) [NI] Report "not enough information" on callable references in lambdas (4 days ago) <Pavel Kirpichenkov>
* 4e4e57f60a7 - (tag: build-1.4.0-dev-697) JVM_IR: deal with inline class default values in AddContinuationLowering. (4 days ago) <Mads Ager>
* 31ba2d64db8 - (tag: build-1.4.0-dev-695) [JVM IR] Mangle variable names for anonymous parameters in lambdas. (4 days ago) <Mark Punzalan>
* 88cac53d88b - (tag: build-1.4.0-dev-683) JVM_IR: skip synthetic enum parameters in signatures (4 days ago) <pyos>
* 94c008872e8 - (tag: build-1.4.0-dev-678, origin/rr/ilmir/review/ager/inline-class-default-values) [Spec tests] Fix tests (4 days ago) <anastasiia.spaseeva>
* 7dc469b32da - [Spec tests] Minor changes of TestInfoParser and Generated files (4 days ago) <anastasiia.spaseeva>
* e0743f22688 - [Spec tests] Add fixed tests for expressions section, fix linkage for reference-equality-expressions section (4 days ago) <anastasiia.spaseeva>
* 9e3ecbd9026 - [Spec tests] Add codegen tests for indexing-expression (paragraph 3) (4 days ago) <anastasiia.spaseeva>
* 0a1b8a928c3 - [Spec tests] Add  tests for not-null-assertion-expression (4 days ago) <anastasiia.spaseeva>
* e4d12593be9 - [Spec tests] Add  tests for  postfix-expressions, postfix-decrement-expression && postfix-increment (4 days ago) <anastasiia.spaseeva>
* 7980db8613f - [Spec tests] Add  tests for  prefix-expressions, logical-not--expression (4 days ago) <anastasiia.spaseeva>
* e5a9a58d65b - [Spec tests] Add  tests for  prefix-expressions,  unary-minus-expression and unary-minus-expression (4 days ago) <anastasiia.spaseeva>
* a8af3dc3c93 - [Spec tests] Add  tests for  prefix-decrement-expression (4 days ago) <anastasiia.spaseeva>
* 01a4562076f - [Spec tests] Add  tests for  additive-expression and Multiplicative expression (4 days ago) <anastasiia.spaseeva>
* 72358aa52a2 - [Spec tests] Add  tests for  range-expression (4 days ago) <anastasiia.spaseeva>
* 84cf4c5049a - [Spec tests] Add  tests for  elvis-expression (4 days ago) <anastasiia.spaseeva>
* 479fa0e7b8c - [Spec tests] Add  tests for  containment-checking-expression (4 days ago) <anastasiia.spaseeva>
* 4a94ffa5ddb - [Spec tests] Add  tests for type-checking-expression (4 days ago) <anastasiia.spaseeva>
* 2a1e084f03a - [Spec tests] Add  tests for comparison-expression (4 days ago) <anastasiia.spaseeva>
* 5e42a205753 - [Spec tests] Add  tests for value-equality-expressions (paragraph 2-3) (4 days ago) <anastasiia.spaseeva>
* 3bb5ddb2244 - [Spec tests] Add  tests for reference-equality-expressions (paragraph 3) (4 days ago) <anastasiia.spaseeva>
* 15b561195f4 - [Spec tests] Add  tests for logical-conjunction-expression (4 days ago) <anastasiia.spaseeva>
* 6da8ccb9eba - [Spec tests] Add  tests for logical-disjunction-expression (paragraph 2) (4 days ago) <anastasiia.spaseeva>
* d4a83d535ca - [Spec tests] Add  tests for KT_35565 (local-property-declaration) (4 days ago) <anastasiia.spaseeva>
* 31df799103b - [Spec tests] Add codegen tests for logical-disjunction-expression (paragraph 1) (4 days ago) <anastasiia.spaseeva>
* 1ea5eb68500 - [Spec tests] Add test for return expression (4 days ago) <anastasiia.spaseeva>
* dcfcc9c7b6a - [Spec tests] Add tests for when-expression (p-3, 4) (4 days ago) <anastasiia.spaseeva>
* bd979a12de2 - [Spec tests] Review fix tests for try-expression and if-expression (4 days ago) <anastasiia.spaseeva>
* e8653273862 - [Spec tests] Add tests for try-expression (paragraphs 1, 2, 5-9) (4 days ago) <anastasiia.spaseeva>
* 3aa3f0c50c2 - [Spec tests] Add tests for character-literals (4 days ago) <anastasiia.spaseeva>
* 8187405dbd0 - [Spec tests] fix test parser exceptions handler (4 days ago) <anastasiia.spaseeva>
* fdef51e8b7b - [Spec tests] Add tests for boolean-literals (p-1 sentence 2) (4 days ago) <anastasiia.spaseeva>
* 744cc54dffb - [Spec tests] Add tests for if-expression (4 days ago) <anastasiia.spaseeva>
* a41c4c84a63 - [Spec-tests] Add tests for prefix increment expression (4 days ago) <anastasiia.spaseeva>
* f95a03cba36 - [Spec-tests] Add tests for abstract classes (4 days ago) <anastasiia.spaseeva>
* 6c644448c2b - [Spec tests] Add tests for abstract classes (4 days ago) <anastasiia.spaseeva>
* 20ed66cd82c - [Spec tests] Add remove link to the issue KT-27825 from all tests which are not related to the issue (4 days ago) <anastasiia.spaseeva>
* 6accbf62841 - [Spec tests] Add prefix increment expression codegen tests (4 days ago) <anastasiia.spaseeva>
* 86d072e3aa0 - [Spec tests] Add diag tests for abstract classes and prefix increment (4 days ago) <anastasiia.spaseeva>
* 44d0a998750 - [Spec tests] Add spec tests for kotlin.Nothing, kotlin.Unit, reference equality and cast expressions (4 days ago) <anastasiia.spaseeva>
* bf50edee17d - [Spec tests] Add tests for kotlin.Nothing and kotlin.Unit built-in types (4 days ago) <anastasiia.spaseeva>
* 52ac8d788d8 - (tag: build-1.4.0-dev-665) Minor. Convert test (4 days ago) <Mikhael Bogdanov>
* 70d71f0f070 - Don't generate type annotations on synthetic accessors (4 days ago) <Mikhael Bogdanov>
* 1032e3a17ca - Support field type annotations (4 days ago) <Mikhael Bogdanov>
* 2ed0cb2a89b - Support type annotations (4 days ago) <Mikhael Bogdanov>
* fde9b21a406 - (tag: build-1.4.0-dev-655) Fix syntheticMethodForProperty.kt for JDK 9+ and Android tests (4 days ago) <Alexander Udalov>
* 5803fcdeb41 - (tag: build-1.4.0-dev-651) Bugfix: KotlinIdeaResolutionException on absent/corrupted KLIB artifact (4 days ago) <Dmitriy Dolovov>
* 995c6a32b82 - (tag: build-1.4.0-dev-650) Allow only single expression eval in cli compiler and kotlin runner (4 days ago) <Ilya Chernikov>
* 7ffb64ec578 - (tag: build-1.4.0-dev-648, origin/rr/ddol/commonizer-prototype) Minor: formatted code (4 days ago) <Dmitriy Dolovov>
* e0d90ccf4b9 - [Commonizer] Log commonization stats into a single file (4 days ago) <Dmitriy Dolovov>
* f18aa3e0be8 - [Commonizer] Re-organize commonizer CLI (4 days ago) <Dmitriy Dolovov>
* 805ac2d307a - [Commonizer] Re-organize utilities (4 days ago) <Dmitriy Dolovov>
* ed4e73c8e93 - Uast: the `returnType` support for light methods for reified functions (KT-35610) (4 days ago) <Nicolay Mitropolsky>
* c04ba009e6c - Uast: properly handling annotations on destructured variables (KT-35673, EA-220128) (4 days ago) <Nicolay Mitropolsky>
* 9da536c202d - (tag: build-1.4.0-dev-640) [minor] "fix" fir testdata for KT-30245 test, todo: fix problems in fir accordingly (4 days ago) <Ilya Chernikov>
* caa677e6d21 - [NI] Convert extension lambda to the non-extension one, if needed (4 days ago) <Ilya Chernikov>
* ef5fe0675a7 - (tag: build-1.4.0-dev-636) JVM_IR: refactor suspendFunctionView (5 days ago) <pyos>
* 137ef267237 - [JVM IR] Fix issue with destructuring declaration in parameter for suspend lambda. (5 days ago) <Mark Punzalan>
* 36c4df6d990 - (tag: build-1.4.0-dev-634) [JVM IR] Use names of local functions in names of local classes. (5 days ago) <Mark Punzalan>
* 70b304e6e4d - [JVM IR] Support target templates in AbstractCheckLocalVariablesTableTest and fix `checkLocalVariablesTable/localFun.kt` for JVM IR. (5 days ago) <Mark Punzalan>
* 152d88e7479 - (tag: build-1.4.0-dev-630) Mute generated FIR tests after 929fb5c8 (5 days ago) <Alexander Udalov>
* 929fb5c82b7 - (tag: build-1.4.0-dev-612) Mute FIR tests containing broken function calls (5 days ago) <Steven Schäfer>
* 5309e774ac7 - JVM IR: Remove FAKE_OWNER from MethodSignatureMapper (5 days ago) <Steven Schäfer>
* 5ffbf9264a6 - JVM IR: Implement the enumValues and enumValueOf intrinsics (5 days ago) <Steven Schäfer>
* bd74e976c99 - JVM IR: Lower calls to the emptyArray intrinsic in VarargLowering (5 days ago) <Steven Schäfer>
* 1b1dff9191a - JVM_IR: fix default argument stub visibility. (5 days ago) <Mads Ager>
* 7f319c18de4 - JVM IR: Mark Enum.$VALUES field as synthetic (#2957) (5 days ago) <Steven Schäfer>
* 6b5d92a6935 - (tag: build-1.4.0-dev-589) IR: work around a bug in interface delegation descriptors (10 days ago) <pyos>