### PR TITLE
[Coverage] Handle return inside nested loop

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/coverage/CoverageInformation.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/coverage/CoverageInformation.kt
@@ -20,26 +20,11 @@ import org.jetbrains.kotlin.ir.declarations.name
  * Besides the obvious [file] and line/column borders, it has [RegionKind] which is described later.
  */
 class Region(
-        startOffset: Int,
-        endOffset: Int,
+        val startOffset: Int,
+        val endOffset: Int,
         val file: IrFile,
         val kind: RegionKind
 ) {
-
-    var startOffset: Int = startOffset
-        set(value) {
-            if (value != UNDEFINED_OFFSET) {
-                field = value
-            }
-        }
-
-    var endOffset: Int = endOffset
-        set(value) {
-            if (value != UNDEFINED_OFFSET) {
-                field = value
-            }
-        }
-
     val startLine: Int
         get() = file.fileEntry.line(startOffset)
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3967,8 +3967,8 @@ if (UtilsKt.getTestTargetSupportsCodeCoverage(project)) {
 
     task coverage_jumps(type: CoverageTest) {
         binaryName = "CoverageJumps"
-        numberOfCoveredFunctions = 7
-        numberOfCoveredLines = 66
+        numberOfCoveredFunctions = 8
+        numberOfCoveredLines = 74
 
         konanArtifacts {
             program(binaryName, targets: [ target ]) {

--- a/backend.native/tests/coverage/basic/jumps/main.kt
+++ b/backend.native/tests/coverage/basic/jumps/main.kt
@@ -55,6 +55,21 @@ fun singleReturn() {
     return
 }
 
+fun nestedReturn() {
+    while (true) {
+        while (true) {
+            while (true) {
+                if (1 < 2) {
+                    return
+                }
+                println()
+            }
+            println()
+        }
+    }
+    println()
+}
+
 fun main() {
     simpleReturn(0)
     simpleReturn(1)
@@ -71,4 +86,5 @@ fun main() {
     breakFromWhile()
     continueFromDoWhile()
     singleReturn()
+    nestedReturn()
 }


### PR DESCRIPTION
The previous way of handling return expressions is incorrect and gives unexpected coverage results on samples with return inside a nested loop:
- Regions should not intersect with each other, correct mapping can contain only nested regions. Since changing offsets of an already recorded region can cause intersection, `Region.*offset` mutability is redundant 
- Return expression "cuts" not only enclosing function, but also all of the enclosing statements