### PR TITLE
Remove obsolete enum comparisons of different types

### DIFF
--- a/backend.native/tests/codegen/enum/switchLowering.kt
+++ b/backend.native/tests/codegen/enum/switchLowering.kt
@@ -11,9 +11,6 @@ enum class EnumA {
     A, B, C
 }
 
-enum class EnumB {
-    A, B
-}
 
 enum class E {
     ONE, TWO, THREE
@@ -24,7 +21,6 @@ fun produceEntry() = EnumA.A
 // Check that we fail on comparison of different enum types.
 fun differentEnums() {
     println(when (produceEntry()) {
-        EnumB.A -> "EnumB.A"
         EnumA.A -> "EnumA.A"
         EnumA.B -> "EnumA.B"
         else    -> "nah"

--- a/backend.native/tests/runtime/basic/enum_equals.kt
+++ b/backend.native/tests/runtime/basic/enum_equals.kt
@@ -18,5 +18,4 @@ enum class EnumB {
 @Test fun run() {
     println(EnumA.A == EnumA.A)
     println(EnumA.A == EnumA.B)
-    println(EnumA.A == EnumB.B)
 }


### PR DESCRIPTION
Due to #KT-22043 this kind of comparison became a compiler error.