### PR TITLE
Rename Clock to TimeSource

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,15 +15,15 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.3.70-eap-82
-buildKotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-82,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.3.70-eap-104
+buildKotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-104,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-82,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-eap-82
-kotlinStdlibRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-82,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-eap-82
-kotlinStdlibTestsVersion=1.3.70-eap-82
-testKotlinCompilerVersion=1.3.70-eap-82
+kotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-104,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-eap-104
+kotlinStdlibRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-104,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.70-eap-104
+kotlinStdlibTestsVersion=1.3.70-eap-104
+testKotlinCompilerVersion=1.3.70-eap-104
 konanVersion=1.3.70
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/time/MonotonicTimeSource.kt
+++ b/runtime/src/main/kotlin/kotlin/time/MonotonicTimeSource.kt
@@ -9,7 +9,7 @@ import kotlin.system.*
 
 @SinceKotlin("1.3")
 @ExperimentalTime
-public actual object MonoClock : AbstractLongClock(unit = DurationUnit.NANOSECONDS), Clock { // TODO: interface should not be required here
+internal actual object MonotonicTimeSource : AbstractLongTimeSource(unit = DurationUnit.NANOSECONDS), TimeSource { // TODO: interface should not be required here
     override fun read(): Long = getTimeNanos()
-    override fun toString(): String = "Clock(nanoTime)"
+    override fun toString(): String = "TimeSource(nanoTime())"
 }


### PR DESCRIPTION
Not yet in master of native, but already in kotlin-mirror/master.

Please update kotlin-compiler dependency version to at least 1.3.70-eap-104 when it is ready.