### PR TITLE
Collection builder helpers for 1.3.70

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,15 +15,15 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.3.70-eap-147
-buildKotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-147,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.3.70-eap-158
+buildKotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-158,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-147,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.3.70-eap-147
-kotlinStdlibRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-147,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.3.70-eap-147
-kotlinStdlibTestsVersion=1.3.70-eap-147
-testKotlinCompilerVersion=1.3.70-eap-147
+kotlinCompilerRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-158,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.3.70-eap-158
+kotlinStdlibRepo=https://buildserver.labs.intellij.net/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinRelease_1370_Compiler),number:1.3.70-eap-158,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.3.70-eap-158
+kotlinStdlibTestsVersion=1.3.70-eap-158
+testKotlinCompilerVersion=1.3.70-eap-158
 konanVersion=1.3.70
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/collections/Maps.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Maps.kt
@@ -12,3 +12,21 @@ internal inline actual fun <K, V> Map<K, V>.toSingletonMapOrSelf(): Map<K, V> = 
 // creates a singleton copy of map
 internal actual fun <K, V> Map<out K, V>.toSingletonMap(): Map<K, V>
         = with(entries.iterator().next()) { mutableMapOf(key to value) }
+
+
+/**
+ * Native map and set implementations do not make use of capacities or load factors.
+ */
+@PublishedApi
+internal actual fun mapCapacity(expectedSize: Int) = expectedSize
+
+/**
+ * Checks a collection builder function capacity argument.
+ * Does nothing, capacity is validated in List/Set/Map constructor
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+@PublishedApi
+internal actual fun checkBuilderCapacity(capacity: Int) {
+    require(capacity >= 0) { "capacity must be non-negative." }
+}


### PR DESCRIPTION
Cherry-picked from kotlin-mirror/master. The corresponding common part is already in Kotlin 1.3.70 branch.