### PR TITLE
[kotlin compiler][update] 1.4.0-dev-1693

### DIFF
--- a/Interop/StubGenerator/build.gradle
+++ b/Interop/StubGenerator/build.gradle
@@ -44,6 +44,6 @@ dependencies {
 
 compileKotlin {
     kotlinOptions {
-        freeCompilerArgs = ['-Xuse-experimental=kotlin.ExperimentalUnsignedTypes']
+        freeCompilerArgs = ['-Xuse-experimental=kotlin.ExperimentalUnsignedTypes', '-Xskip-metadata-version-check']
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -57,7 +57,8 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
                     isData = false,
                     isExternal = false,
                     isInline = false,
-                    isExpect = false
+                    isExpect = false,
+                    isFun = false
             ).apply {
                 it.bind(this)
                 parent = enumClass

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -1204,7 +1204,8 @@ private class ObjCBlockPointerValuePassing(
                 OBJC_BLOCK_FUNCTION_IMPL, IrClassSymbolImpl(classDescriptor),
                 Name.identifier(stubs.getUniqueKotlinFunctionReferenceClassName("BlockFunctionImpl")),
                 ClassKind.CLASS, Visibilities.PRIVATE, Modality.FINAL,
-                isCompanion = false, isInner = false, isData = false, isExternal = false, isInline = false, isExpect = false
+                isCompanion = false, isInner = false, isData = false, isExternal = false,
+                isInline = false, isExpect = false, isFun = false
         )
         classDescriptor.bind(irClass)
         irClass.createParameterDeclarations()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -535,7 +535,8 @@ internal fun KotlinStubs.generateCFunctionPointer(
             expression.endOffset,
             expression.type,
             fakeFunction.symbol,
-            0
+            typeArgumentsCount = 0,
+            reflectionTarget = null
     )
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -116,7 +116,8 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                         endOffset     = job.endOffset,
                         type          = job.type,
                         symbol        = bridge.symbol,
-                        typeArgumentsCount = 0)
+                        typeArgumentsCount = 0,
+                        reflectionTarget = null)
                 )
                 return expression
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
@@ -165,7 +165,8 @@ internal class CallableReferenceLowering(val context: Context): FileLoweringPass
                     isData = false,
                     isExternal = false,
                     isInline = false,
-                    isExpect = false
+                    isExpect = false,
+                    isFun = false
             ).apply {
                 it.bind(this)
                 parent = this@FunctionReferenceBuilder.parent

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
@@ -211,7 +211,8 @@ internal class PropertyDelegationLowering(val context: Context) : FileLoweringPa
                         type          = getterKFunctionType,
                         symbol        = expression.getter!!,
                         typeArgumentsCount = getter.typeParameters.size,
-                        valueArgumentsCount = getter.valueParameters.size
+                        valueArgumentsCount = getter.valueParameters.size,
+                        reflectionTarget = expression.getter!!
                 ).apply {
                     this.dispatchReceiver = dispatchReceiver?.let { irGet(it) }
                     this.extensionReceiver = extensionReceiver?.let { irGet(it) }
@@ -233,7 +234,8 @@ internal class PropertyDelegationLowering(val context: Context) : FileLoweringPa
                             type          = setterKFunctionType,
                             symbol        = expression.setter!!,
                             typeArgumentsCount = setter.typeParameters.size,
-                            valueArgumentsCount = setter.valueParameters.size
+                            valueArgumentsCount = setter.valueParameters.size,
+                            reflectionTarget = expression.setter!!
                     ).apply {
                         this.dispatchReceiver = dispatchReceiver?.let { irGet(it) }
                         this.extensionReceiver = extensionReceiver?.let { irGet(it) }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -1038,7 +1038,8 @@ private class InteropTransformer(val context: Context, override val irFile: IrFi
                             builder.startOffset, builder.endOffset,
                             symbols.executeImpl.owner.valueParameters[3].type,
                             targetSymbol,
-                            typeArgumentsCount = 0)
+                            typeArgumentsCount = 0,
+                            reflectionTarget = null)
 
                     builder.irCall(symbols.executeImpl).apply {
                         putValueArgument(0, expression.dispatchReceiver)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -107,7 +107,8 @@ internal class TestProcessor (val context: Context) {
                             registerTestCase.valueParameters[1].type,
                             it.function.symbol,
                             typeArgumentsCount = 0,
-                            valueArgumentsCount = 0))
+                            valueArgumentsCount = 0,
+                            reflectionTarget = null))
                     putValueArgument(2, irBoolean(it.ignored))
                 }
             } else {
@@ -127,7 +128,8 @@ internal class TestProcessor (val context: Context) {
                             registerFunction.valueParameters[1].type,
                             it.function.symbol,
                             typeArgumentsCount = 0,
-                            valueArgumentsCount = 0))
+                            valueArgumentsCount = 0,
+                            reflectionTarget = null))
                 }
             }
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -491,7 +491,8 @@ internal class TestProcessor (val context: Context) {
                 isData = false,
                 isExternal = false,
                 isInline = false,
-                isExpect = false
+                isExpect = false,
+                isFun = false
         ).apply {
             descriptor.bind(this)
             createParameterDeclarations()

--- a/build-tools/build.gradle.kts
+++ b/build-tools/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("com.ullink.slack:simpleslackapi:1.2.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.10.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0")
 
     implementation("io.ktor:ktor-client-auth:1.2.1")
     implementation("io.ktor:ktor-client-core:1.2.1")

--- a/build-tools/build.gradle.kts
+++ b/build-tools/build.gradle.kts
@@ -86,3 +86,11 @@ compileGroovy.apply {
     classpath += project.files(compileKotlin.destinationDir)
     dependsOn(compileKotlin)
 }
+
+val kotlinCompilerPluginClasspath by configurations.getting
+
+kotlinCompilerPluginClasspath.resolutionStrategy.eachDependency {
+    if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-serialization") {
+        useVersion(buildKotlinVersion)
+    }
+}

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecutorService.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecutorService.kt
@@ -17,8 +17,8 @@
 package org.jetbrains.kotlin
 
 import groovy.lang.Closure
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.process.ExecResult
@@ -420,11 +420,11 @@ private fun deviceLauncher(project: Project) = object : ExecutorService {
         }
         return out.toString().run {
             check(isNotEmpty())
-            @Serializable
+            @kotlinx.serialization.Serializable
             data class DeviceTarget(val name: String, val udid: String, val state: String, val type: String)
             split("\n")
                     .filter { it.isNotEmpty() }
-                    .map { Json(strictMode = false).parse(DeviceTarget.serializer(), it) }
+                    .map { Json(JsonConfiguration.Default).parse(DeviceTarget.serializer(), it) }
                     .first {
                         it.type == "device" && deviceName?.run { this == it.name } ?: true
                     }

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExternalReportUtils.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExternalReportUtils.kt
@@ -2,12 +2,12 @@ package org.jetbrains.kotlin
 
 import kotlinx.io.PrintWriter
 import kotlinx.serialization.*
-import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.*
 import java.io.File
 import java.io.FileReader
 
 
-@Serializable
+@kotlinx.serialization.Serializable
 data class ExternalTestReport(val statistics: Statistics, val groups: List<KonanTestGroupReport>)
 
 @ImplicitReflectionSerializer

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/KonanTestSuiteReport.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/KonanTestSuiteReport.kt
@@ -13,7 +13,7 @@ enum class TestStatus {
     SKIPPED
 }
 
-@Serializable
+@kotlinx.serialization.Serializable
 data class Statistics(
         var passed: Int = 0,
         var failed: Int = 0,
@@ -42,13 +42,13 @@ val Statistics.total: Int
 
 class TestFailedException(msg:String) : RuntimeException(msg)
 
-@Serializable
+@kotlinx.serialization.Serializable
 data class KonanTestGroupReport(val name:String, val suites:List<KonanTestSuiteReport>)
 
-@Serializable
+@kotlinx.serialization.Serializable
 data class KonanTestSuiteReport(val name: String, val tests: List<KonanTestCaseReport>)
 
-@Serializable
+@kotlinx.serialization.Serializable
 data class KonanTestCaseReport(val name:String, val status: TestStatus, @Optional val comment:String? = null)
 
 class KonanTestSuiteReportEnvironment(val name:String, val project: Project, val statistics: Statistics) {

--- a/build.gradle
+++ b/build.gradle
@@ -436,6 +436,10 @@ targetList.each { target ->
 
         destinationDir distDir
 
+        from(project(':runtime').file("build/${target}Stdlib")) {
+            include('**')
+            into(stdlib)
+        }
         from(project(':runtime').file("build/$target")) {
             include("runtime.bc")
             into("$stdlibDefaultComponent/targets/$target/native")
@@ -444,10 +448,6 @@ targetList.each { target ->
             include("*.bc")
             exclude("runtime.bc")
             into("konan/targets/$target/native")
-        }
-        from(project(':runtime').file("build/${target}Stdlib")) {
-            include('**')
-            into(stdlibDefaultComponent)
         }
         if (target == 'wasm32') {
             into("$stdlibDefaultComponent/targets/wasm32/included") {

--- a/build.gradle
+++ b/build.gradle
@@ -402,6 +402,7 @@ task distEndorsedLibraries {
 }
 
 def stdlib = 'klib/common/stdlib'
+def stdlibDefaultComponent = "$stdlib/default"
 def endorsedLibs = 'klib/common/endorsedLibraries'
 def endorsedLibsBase = 'klib/common'
 
@@ -437,7 +438,7 @@ targetList.each { target ->
 
         from(project(':runtime').file("build/$target")) {
             include("runtime.bc")
-            into("$stdlib/targets/$target/native")
+            into("$stdlibDefaultComponent/targets/$target/native")
         }
         from(project(':runtime').file("build/$target")) {
             include("*.bc")
@@ -446,10 +447,10 @@ targetList.each { target ->
         }
         from(project(':runtime').file("build/${target}Stdlib")) {
             include('**')
-            into(stdlib)
+            into(stdlibDefaultComponent)
         }
         if (target == 'wasm32') {
-            into("$stdlib/targets/wasm32/included") {
+            into("$stdlibDefaultComponent/targets/wasm32/included") {
                 from(project(':runtime').file('src/main/js'))
                 from(project(':runtime').file('src/launcher/js'))
                 from(project(':Interop:JsRuntime').file('src/main/js'))

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1161,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-1161
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1161,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-1161
-kotlinStdlibTestsVersion=1.4.0-dev-1161
-testKotlinCompilerVersion=1.4.0-dev-1161
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1693,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-1693
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1693,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-1693
+kotlinStdlibTestsVersion=1.4.0-dev-1693
+testKotlinCompilerVersion=1.4.0-dev-1693
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/collections/Maps.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Maps.kt
@@ -12,3 +12,21 @@ internal inline actual fun <K, V> Map<K, V>.toSingletonMapOrSelf(): Map<K, V> = 
 // creates a singleton copy of map
 internal actual fun <K, V> Map<out K, V>.toSingletonMap(): Map<K, V>
         = with(entries.iterator().next()) { mutableMapOf(key to value) }
+
+
+/**
+ * Native map and set implementations do not make use of capacities or load factors.
+ */
+@PublishedApi
+internal actual fun mapCapacity(expectedSize: Int) = expectedSize
+
+/**
+ * Checks a collection builder function capacity argument.
+ * Does nothing, capacity is validated in List/Set/Map constructor
+ */
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+@PublishedApi
+internal actual fun checkBuilderCapacity(capacity: Int) {
+    require(capacity >= 0) { "capacity must be non-negative." }
+}

--- a/runtime/src/main/kotlin/kotlin/time/MonoClock.kt
+++ b/runtime/src/main/kotlin/kotlin/time/MonoClock.kt
@@ -9,7 +9,7 @@ import kotlin.system.*
 
 @SinceKotlin("1.3")
 @ExperimentalTime
-public actual object MonoClock : AbstractLongClock(unit = DurationUnit.NANOSECONDS), Clock { // TODO: interface should not be required here
+internal actual object MonotonicTimeSource : AbstractLongTimeSource(unit = DurationUnit.NANOSECONDS), TimeSource { // TODO: interface should not be required here
     override fun read(): Long = getTimeNanos()
-    override fun toString(): String = "Clock(nanoTime)"
+    override fun toString(): String = "TimeSource(nanoTime)"
 }

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/KonanLibraryLayout.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/KonanLibraryLayout.kt
@@ -22,13 +22,12 @@ import org.jetbrains.kotlin.library.IrKotlinLibraryLayout
 import org.jetbrains.kotlin.library.KotlinLibraryLayout
 import org.jetbrains.kotlin.library.MetadataKotlinLibraryLayout
 
-
 interface TargetedKotlinLibraryLayout : KotlinLibraryLayout {
     val target: KonanTarget?
         // This is a default implementation. Can't make it an assignment.
         get() = null
     val targetsDir
-        get() = File(libDir, "targets")
+        get() = File(componentDir, "targets")
     val targetDir
         get() = File(targetsDir, target!!.visibleName)
     val includedDir

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/SearchPathResolver.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/SearchPathResolver.kt
@@ -3,7 +3,7 @@ package org.jetbrains.kotlin.konan.library
 import org.jetbrains.kotlin.konan.CompilerVersion
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.library.impl.KonanLibraryImpl
-import org.jetbrains.kotlin.konan.library.impl.createKonanLibrary
+import org.jetbrains.kotlin.konan.library.impl.createKonanLibraryComponents
 import org.jetbrains.kotlin.konan.target.Distribution
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.library.*
@@ -60,7 +60,7 @@ fun resolverByName(
         skipCurrentDir,
         logger
     ) {
-        override fun libraryBuilder(file: File, isDefault: Boolean) = createKonanLibrary(file, null, isDefault)
+        override fun libraryComponentBuilder(file: File, isDefault: Boolean) = createKonanLibraryComponents(file, null, isDefault)
     }
 
 internal class KonanLibraryProperResolver(
@@ -84,7 +84,7 @@ internal class KonanLibraryProperResolver(
     listOf(KLIB_INTEROP_IR_PROVIDER_IDENTIFIER)
 ),  SearchPathResolverWithTarget<KonanLibrary>
 {
-    override fun libraryBuilder(file: File, isDefault: Boolean) = createKonanLibrary(file, target, isDefault)
+    override fun libraryComponentBuilder(file: File, isDefault: Boolean) = createKonanLibraryComponents(file, target, isDefault)
 
     override val distPlatformHead: File?
         get() = distributionKlib?.File()?.child("platform")?.child(target.visibleName)

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryImpl.kt
@@ -89,14 +89,15 @@ class KonanLibraryImpl(
 
 fun createKonanLibrary(
     libraryFile: File,
+    component: String,
     target: KonanTarget? = null,
     isDefault: Boolean = false
 ): KonanLibrary {
-    val baseAccess = BaseLibraryAccess<KotlinLibraryLayout>(libraryFile)
-    val targetedAccess = TargetedLibraryAccess<TargetedKotlinLibraryLayout>(libraryFile, target)
-    val metadataAccess = MetadataLibraryAccess<MetadataKotlinLibraryLayout>(libraryFile)
-    val irAccess = IrLibraryAccess<IrKotlinLibraryLayout>(libraryFile)
-    val bitcodeAccess = BitcodeLibraryAccess<BitcodeKotlinLibraryLayout>(libraryFile, target)
+    val baseAccess = BaseLibraryAccess<KotlinLibraryLayout>(libraryFile, component)
+    val targetedAccess = TargetedLibraryAccess<TargetedKotlinLibraryLayout>(libraryFile, component, target)
+    val metadataAccess = MetadataLibraryAccess<MetadataKotlinLibraryLayout>(libraryFile, component)
+    val irAccess = IrLibraryAccess<IrKotlinLibraryLayout>(libraryFile, component)
+    val bitcodeAccess = BitcodeLibraryAccess<BitcodeKotlinLibraryLayout>(libraryFile, component, target)
 
     val base = BaseKotlinLibraryImpl(baseAccess, isDefault)
     val targeted = TargetedLibraryImpl(targetedAccess, base)
@@ -105,4 +106,16 @@ fun createKonanLibrary(
     val bitcode = BitcodeLibraryImpl(bitcodeAccess, targeted)
 
     return KonanLibraryImpl(targeted, metadata, ir, bitcode)
+}
+
+fun createKonanLibraryComponents(
+    libraryFile: File,
+    target: KonanTarget? = null,
+    isDefault: Boolean = true
+) : List<KonanLibrary> {
+    val baseAccess = BaseLibraryAccess<KotlinLibraryLayout>(libraryFile, null)
+    val base = BaseKotlinLibraryImpl(baseAccess, isDefault)
+    return base.componentList.map {
+        createKonanLibrary(libraryFile, it, target, isDefault)
+    }
 }

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryLayoutImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryLayoutImpl.kt
@@ -7,8 +7,8 @@ import org.jetbrains.kotlin.library.*
 import org.jetbrains.kotlin.library.impl.*
 import java.nio.file.FileSystem
 
-open class TargetedLibraryLayoutImpl(klib: File, override val target: KonanTarget?) :
-    KotlinLibraryLayoutImpl(klib), TargetedKotlinLibraryLayout {
+open class TargetedLibraryLayoutImpl(klib: File, component: String, override val target: KonanTarget?) :
+    KotlinLibraryLayoutImpl(klib, component), TargetedKotlinLibraryLayout {
 
     override val extractingToTemp: TargetedKotlinLibraryLayout by lazy {
         ExtractingTargetedLibraryImpl(this)
@@ -19,8 +19,8 @@ open class TargetedLibraryLayoutImpl(klib: File, override val target: KonanTarge
 
 }
 
-class BitcodeLibraryLayoutImpl(klib: File, target: KonanTarget?) : TargetedLibraryLayoutImpl(klib, target),
-    BitcodeKotlinLibraryLayout {
+class BitcodeLibraryLayoutImpl(klib: File, component: String, target: KonanTarget?) :
+    TargetedLibraryLayoutImpl(klib, component, target), BitcodeKotlinLibraryLayout {
     override val extractingToTemp: BitcodeKotlinLibraryLayout by lazy {
         ExtractingBitcodeLibraryImpl(this)
     }
@@ -30,14 +30,14 @@ class BitcodeLibraryLayoutImpl(klib: File, target: KonanTarget?) : TargetedLibra
 
 }
 
-open class TargetedLibraryAccess<L : KotlinLibraryLayout>(klib: File, val target: KonanTarget?) :
-    BaseLibraryAccess<L>(klib) {
-    override val layout = TargetedLibraryLayoutImpl(klib, target)
+open class TargetedLibraryAccess<L : KotlinLibraryLayout>(klib: File, component: String, val target: KonanTarget?) :
+    BaseLibraryAccess<L>(klib, component) {
+    override val layout = TargetedLibraryLayoutImpl(klib, component, target)
 }
 
-open class BitcodeLibraryAccess<L : KotlinLibraryLayout>(klib: File, target: KonanTarget?) :
-    TargetedLibraryAccess<L>(klib, target) {
-    override val layout = BitcodeLibraryLayoutImpl(klib, target)
+open class BitcodeLibraryAccess<L : KotlinLibraryLayout>(klib: File, component: String, target: KonanTarget?) :
+    TargetedLibraryAccess<L>(klib, component, target) {
+    override val layout = BitcodeLibraryLayoutImpl(klib, component, target)
 }
 
 private open class FromZipTargetedLibraryImpl(zipped: TargetedLibraryLayoutImpl, zipFileSystem: FileSystem) :

--- a/utilities/build.gradle
+++ b/utilities/build.gradle
@@ -14,6 +14,13 @@ repositories {
     }
 }
 
+compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs = ['-Xskip-metadata-version-check']
+    }
+}
+
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     compile project(':backend.native')


### PR DESCRIPTION
* 71d8b41beff - (tag: build-1.4.0-dev-1598) [FIR] Remove unused utilities (15 часов назад) <Mikhail Glukhikh>
* dc4f332c087 - [FIR] Implement early calculation of "not SAM" flag for classes (15 часов назад) <Mikhail Glukhikh>
* 279adae3e47 - [FIR] Implement primitive tower for type resolving (15 часов назад) <Mikhail Glukhikh>
* 7721eaab231 - [FIR] Transform qualified access / callable refs type arguments properly (15 часов назад) <Mikhail Glukhikh>
* 483ce8bf043 - [FIR TEST] Stabilize top-level extension vs outer member behavior (15 часов назад) <Mikhail Glukhikh>
* ef8485a2326 - FIR2IR: change receiver handling in case it's an outer object (15 часов назад) <Mikhail Glukhikh>
* 14204a842a2 - Refactoring & clarification: implement new FIR tower resolver (15 часов назад) <Mikhail Glukhikh>
* a3ab763f0b9 - [FIR] Get rid of processors in FirScope (15 часов назад) <simon.ogorodnik>
* 224b2acdcc4 - (tag: build-1.4.0-dev-1587) K/N: Get rid of remaining parts of "lite" KLIB API (22 часа назад) <Dmitriy Dolovov>
* a7da605816f - (tag: build-1.4.0-dev-1581) K/N: Drop unused part of "lite" KLIB API (29 часов назад) <Dmitriy Dolovov>
* 345863a1d2b - (tag: build-1.4.0-dev-1578) Fix: KotlinNativeABICompatibilityChecker.dispose() leads to dead lock (33 часа назад) <Dmitriy Dolovov>
* d1e14598a67 - (tag: build-1.4.0-dev-1575) Add IDE support for common klibs (2 дня назад) <Dmitry Savvinov>
* 6d45b048cb4 - Check for presence of ir-folder in klibs additionally for Kotlin/Native (2 дня назад) <Dmitry Savvinov>
* 5665261e5b8 - Minor: extract name of ir-folder in klib into const property (2 дня назад) <Dmitry Savvinov>
* 7ecab7f0aa2 - Pass proper metadata_version in K2MetadataKlibSerializer (2 дня назад) <Dmitry Savvinov>
* 823d3cc4125 - (tag: build-1.4.0-dev-1573) (minor) Fix accessing a shared-native compilation's konanTarget (3 дня назад) <Sergey Igushkin>
* 1f42951152c - (tag: build-1.4.0-dev-1566) Fix KlibBasedMppIT test compilation error (missing import) (3 дня назад) <Sergey Igushkin>
* 1f3755248c5 - (tag: build-1.4.0-dev-1557) Build: Make task inputs relative to improve caching (3 дня назад) <Vyacheslav Gerasimov>
* 8e0dd604afc - Build: Annotate KotlinModuleShadowTransformer with @CacheableTransformer (3 дня назад) <Vyacheslav Gerasimov>
* 131765537a5 - Build: Implement preserveFileTimestamps for stripMetadata task (3 дня назад) <Vyacheslav Gerasimov>
* 82182893ad0 - Build: Set preserveFileTimestamps & isReproducibleFileOrder properties (3 дня назад) <Vyacheslav Gerasimov>
* 317972db2ae - Build: Make :kotlin-reflect:stripMetadata cacheable (3 дня назад) <Vyacheslav Gerasimov>
* 760e34aeec3 - Build: Fix type of builtinsJar task (3 дня назад) <Vyacheslav Gerasimov>
* 526f29cc1a4 - Build: Upgrade com.github.jengelman.gradle.plugins:shadow to 5.2.0 (3 дня назад) <Vyacheslav Gerasimov>
* 3f10329347e - Build: Fix publication of stdlib-js to avoid publishing all artifacts (3 дня назад) <Vyacheslav Gerasimov>
* 7dcdc506d89 - Build: Fix outputs for :kotlin-stdlib-js:compileJs (3 дня назад) <Vyacheslav Gerasimov>
* 770344770db - Build: Make :kotlin-stdlib-js:compileJs task cacheable (3 дня назад) <Vyacheslav Gerasimov>
* 392e5a6edd9 - Build: Make :kotlin-compiler:proguard task cacheable (3 дня назад) <Vyacheslav Gerasimov>
* 8dd6a34e172 - Build: Make :core:builtins:serialize task cacheable (3 дня назад) <Vyacheslav Gerasimov>
* d1826374a6b - (tag: build-1.4.0-dev-1555) Fix the K/N stdlib leaking into other common source sets (3 дня назад) <Sergey Igushkin>
* 970ee4539ba - Common klib support in the Kotlin Gradle plugin (KT-32677) (3 дня назад) <Sergey Igushkin>
* dd9ac39b658 - (tag: build-1.4.0-dev-1552) Build: Add :compiler:ir.serialization.common to kotlin-plugin.jar (3 дня назад) <Vyacheslav Gerasimov>
*   e4d82a6dbb3 - (tag: build-1.4.0-dev-1546) Merge remote-tracking branch 'origin/master' (3 дня назад) <Vsevolod Tolstopyatov>
|\
| * b647d2c645b - (tag: build-1.4.0-dev-1541) Prolong deprecation cycle for several restrictions until 1.5 (3 дня назад) <Mikhail Zarechenskiy>
| * 5c6e7100139 - (tag: build-1.4.0-dev-1538) Revert "Workaround an inliner problem upon which the compiler code itself stumbled ^KT-35856 Fixed" (3 дня назад) <Victor Petukhov>
| * 90b250d2410 - (tag: build-1.4.0-dev-1536) PSI2IR: Fix bound inner class constructor callable reference generation (3 дня назад) <Dmitry Petrov>
| * f7321b497b1 - Set KotlinCompilerVersion.IS_PRE_RELEASE = true (3 дня назад) <Alexander Udalov>
* | a00e98bad9e - (origin/rr/stdlib/coroutine-context-key) KT-36118 Introduce AbstractCoroutineContextKey and corresponding extensions required by its implementors (3 дня назад) <Vsevolod Tolstopyatov>
|/
* 90fe1bb1ab1 - (tag: build-1.4.0-dev-1532) Enable FUS for Code Completion in 1.3.70 (3 дня назад) <Anton Yalyshev>
* 7bb504321ce - (tag: build-1.4.0-dev-1529) KT-15363 Rename expectedSize to capacity and edit docs (3 дня назад) <Ilya Gorbunov>
* 14351446d75 - KT-15363 Fix failing test: missing capacity parameter check in JS (3 дня назад) <Ilya Gorbunov>
* 4aa7d45a5ae - KT-15363 Collection builders: improve tests and samples (3 дня назад) <Ilya Gorbunov>
* bf9d3d87a62 - KT-15363 Collection Builders (3 дня назад) <Fleshgrinder>
* fa811c731f3 - (tag: build-1.4.0-dev-1528) [IDEA] Use withType instead of isAssignableFrom (3 дня назад) <Ilya Goncharov>
* 6dc91097360 - [IDEA] Check assignable from task to KotlinTest class (3 дня назад) <Ilya Goncharov>
* 6b860206bd4 - [IDEA] Use GradleVersion fqn to use it in case when there is no import (3 дня назад) <Ilya Goncharov>
* c3951d394b6 - [IDEA] Preload KotlinTest class instead of loop finding (3 дня назад) <Ilya Goncharov>
* 2c4cfd2fb8a - [IDEA] Add check on gradle version not to broke Gradle older 4.0 (3 дня назад) <Ilya Goncharov>
* 20ac606df4b - (tag: build-1.4.0-dev-1522) Add js runtime to failing blackbox test (3 дня назад) <Dmitriy Novozhilov>
* de07d3387b3 - (tag: build-1.4.0-dev-1520) Update dukat dependency to 0.0.26 (3 дня назад) <Shagen Ogandzhanian>
* 2fca7f1a544 - (tag: build-1.4.0-dev-1519) Add codegen tests for old behavior of null checks (3 дня назад) <Alexander Udalov>
* 632fe18db6b - (tag: build-1.4.0-dev-1511) Revert "Remove deprecated method from CommandLineProcessor" (3 дня назад) <Yan Zhulanow>
* 9bf63f5399b - Kapt, minor: Add extra case for property initializers (3 дня назад) <Yan Zhulanow>
* ca3c1d04c59 - Add an IR version of Android Extensions blackbox tests (3 дня назад) <pyos>
* 4094841dc6d - Add a basic IR extension to the Android plugin (3 дня назад) <pyos>
* 6d32b3256b8 - suppress duplicate @override annotations (3 дня назад) <Kevin Bierhoff>
* a55a0d94dee - (tag: build-1.4.0-dev-1508) Scripts: clear manual configuration loading state after project import (3 дня назад) <Natalia Selezneva>
* bbdad452012 - (tag: build-1.4.0-dev-1505) Added project size and metrics collectors in gradle plugin (3 дня назад) <Andrey Uskov>
* c540116b712 - IR: additional callable reference adapter stuff in IR (3 дня назад) <Dmitry Petrov>
* 57bbfbbfccb - PSI2IR: capture adapted reference receiver to a local val if required (3 дня назад) <Dmitry Petrov>
* 38b90b7fbd8 - Minor: move callable reference IR tests to a separate directory (3 дня назад) <Dmitry Petrov>
* c5f14a29a47 - PSI2IR: Generate adapted callable references (3 дня назад) <Dmitry Petrov>
* 89c832b5a01 - FE: provide argument mapping info for adapted callable reference (3 дня назад) <Dmitry Petrov>
* da7d594d0f5 - Wizard: change new wizard title (3 дня назад) <Ilya Kirillov>
* 90108e146a8 - Wizard: make new wizard to be second in the Kotlin group (3 дня назад) <Ilya Kirillov>
* 35076eb559f - Wizard: add FUS statistic collection (3 дня назад) <Ilya Kirillov>
* 69151933379 - Wizard: allow simple js template to be used with JsSingleplatformModuleConfigurator (3 дня назад) <Ilya Kirillov>
* 4854294bb51 - Wizard: fix removing template in UI (3 дня назад) <Ilya Kirillov>
* 3d6aa79f459 - Wizard: allow enabling new wizard in UI (3 дня назад) <Ilya Kirillov>
* fa4cba341b7 - Wizard: fix tests (3 дня назад) <Ilya Kirillov>
* 217cf3edd11 - Wizard: fix adding dependencies to targets (3 дня назад) <Ilya Kirillov>
* 3d5007c1a50 - Wizard: temporary hide sourcesets editing for users (3 дня назад) <Ilya Kirillov>
* c87ece8ae53 - Wizard: fix incorrectly added classpath dependency for Android with Groovy dsl (3 дня назад) <Ilya Kirillov>
* d5618cadc80 - Wizard: put pluginManagement section in the beginning of settings.gradle file (3 дня назад) <Ilya Kirillov>
* 0a4d45b3470 - Wizard: add support of creating run configurations (3 дня назад) <Ilya Kirillov>
* d330652eee5 - Wizard: add support of react js to the js template (3 дня назад) <Ilya Kirillov>
* 351a037bcd5 - Wizard: fix not added dependencies for MPP modules (3 дня назад) <Ilya Kirillov>
* 0f86a7e158e - Wizard: fix text of module configurators which is shown in module editor (3 дня назад) <Ilya Kirillov>
* dc26138da30 - Wizard: add support of JS singleplatform projects (3 дня назад) <Ilya Kirillov>
* b9226ce54f0 - Wizard: automatically determine Kotlin version based on Kotlin plugin version (3 дня назад) <Ilya Kirillov>
* 40d6fe7a005 - Wizard: remove empty border from module settings (3 дня назад) <Ilya Kirillov>
* 129ee55fe06 - Wizard: remove unused function (3 дня назад) <Ilya Kirillov>
* 18090c0e0a7 - Wizard: fix incorrectly added modules to the tree (3 дня назад) <Ilya Kirillov>
* 5392ff128f1 - Wizard: move "validation error" string from message to title (3 дня назад) <Ilya Kirillov>
* 5f8930e1094 - Wizard: add validation for project name (3 дня назад) <Ilya Kirillov>
* 09b50a209bb - Wizard: do not suggest invalid groupId (3 дня назад) <Ilya Kirillov>
* 1b4e2825404 - Wizard: do not show expert panel form wizard (3 дня назад) <Ilya Kirillov>
* 7527e4b02d2 - Wizard: remove duplicated string validator (3 дня назад) <Ilya Kirillov>
* b33ae61508f - Wizard: add validators for POM data (3 дня назад) <Ilya Kirillov>
* 7df1b54c821 - Wizard: Show message when module has no configurable settings (3 дня назад) <Ilya Kirillov>
* 923f646b3d7 - Wizard: Move test framework settings to module configurators (3 дня назад) <Ilya Kirillov>
* ba62ba39f13 - Wizard: Move module templates to modules: separate SourcetModuleIR to MultiplatformModuleIR & SourcesetIR (3 дня назад) <Ilya Kirillov>
* 0ebcf482ca0 - Wizard: move module templates to modules (3 дня назад) <Ilya Kirillov>
* 56738047073 - Wizard: add module dependencies for JPS (3 дня назад) <Ilya Kirillov>
* 479f6a44028 - Wizard: add kotlin native console application template (3 дня назад) <Ilya Kirillov>
* 9e96cd4507c - Wizard: do not print binaries specification for all native targets (3 дня назад) <Ilya Kirillov>
* bf93d767b39 - Wizard: sort & distinct imports in Gradle build files (3 дня назад) <Ilya Kirillov>
* dd882c2717a - Wizard: move fqName to import in NativeTargetConfigurator (3 дня назад) <Ilya Kirillov>
* 97416e651e4 - Wizard: add irs for build files from targets (3 дня назад) <Ilya Kirillov>
* 2a83111fa3d - Wizard: do not add empty gradle project to settings.gradle (3 дня назад) <Ilya Kirillov>
* afc320ac8d6 - Wizard: use settings.gradle instead of .kts for Groovy DSL Gradle projects (3 дня назад) <Ilya Kirillov>
* 4f4106a17e2 - Wizard: print repositories for Maven (3 дня назад) <Ilya Kirillov>
* bced2655e87 - Wizard: retrieve repositories from artifacts (3 дня назад) <Ilya Kirillov>
* baedd2a253e - Wizard: correctly add Kotlin dependencies to singleplatform modules with gradle dsl build system (3 дня назад) <Ilya Kirillov>
* 796848b5a9c - Wizard: fix adding invalid dependencies for maven build files (3 дня назад) <Ilya Kirillov>
* 029dad4d9ee - Wizard: allow dashes for module names (3 дня назад) <Ilya Kirillov>
* 6acf279a34a - Wizard: Use default Java source roots for JPS projects (3 дня назад) <Ilya Kirillov>
* 206284d33c5 - Wizard: rework UI components for settings (3 дня назад) <Ilya Kirillov>
* 89199e5cc0f - Wizard: fix incorrect ktor repository (3 дня назад) <Ilya Kirillov>
* 2df499b12d0 - Wizard: remove redundant return in native target configuration (3 дня назад) <Ilya Kirillov>
* bfe3b58264a - Wizard: fix swapped artifactId and groupId fields titles (3 дня назад) <Ilya Kirillov>
* 49e85139283 - Wizard: do not overwrite existing artifactId & groupId settings (3 дня назад) <Ilya Kirillov>
* 37c7212a306 - (tag: build-1.4.0-dev-1504, tag: build-1.4.0-dev-1502) Normalize line separators in GradleImportingTestCase (3 дня назад) <Dmitry Savvinov>
* 56286cd4dcf - Fix overly restrictive cast to allow running multiplatform tests for objects (3 дня назад) <Dmitry Savvinov>
* 77a7ceaa554 - Add test on object with tests in common module (3 дня назад) <Dmitry Savvinov>
* f78ea754318 - Fix running tests from expect class by using FakeLightClasses (3 дня назад) <Dmitry Savvinov>
* cea612cba40 - Add test on expect class with test methods inside (3 дня назад) <Dmitry Savvinov>
* 36aa14ead4d - Add testing support for MPP projects (3 дня назад) <Dmitry Savvinov>
* b34f091fa4e - Introduce tests runner for run configurations + highlighting + Gradle (3 дня назад) <Dmitry Savvinov>
* 4f5c3d13877 - Allow rendering extra tags for lineMarkers in tests (3 дня назад) <Dmitry Savvinov>
* 5800160ee15 - Rewrite GradleDaemonAnalyzerTest (3 дня назад) <Dmitry Savvinov>
* a02e5d452f4 - Minor: remove unnecessary callback from checkFiles (3 дня назад) <Dmitry Savvinov>
* 3dfad4f0c3e - [FIR] Fix generating properties for varargs in primary constructors (3 дня назад) <Dmitriy Novozhilov>
* 69927409fca - [FIR] Fix exhaustiveness check when subject has flexible type (3 дня назад) <Dmitriy Novozhilov>
* 0f049fd5365 - (tag: build-1.4.0-dev-1499) Properly handle a case when Code Style settings = null (3 дня назад) <Anton Yalyshev>
* e89893b6fd8 - (tag: build-1.4.0-dev-1494) Optimize ArrayDeque tests run time (3 дня назад) <Abduqodiri Qurbonzoda>
* 8733d5f9ed3 - (tag: build-1.4.0-dev-1493) ArrayDeque: avoid triggering JDK 1.6 bug in tests (4 дня назад) <Ilya Gorbunov>
* 6352cded1b8 - (tag: build-1.4.0-dev-1487) Add modCounter to invalidate  synthetic file cache (4 дня назад) <Vladimir Dolzhenko>
* 7329a1641a2 - (tag: build-1.4.0-dev-1486) [JVM IR] Fix `lambdaInLocalFunction.kt` by adding helper methods that return the target backend under test. (4 дня назад) <Mark Punzalan>
* beb3165839f - (tag: build-1.4.0-dev-1484) Added FUS extensions and new metrics for reporting statistics from gradle (4 дня назад) <Andrey Uskov>
* bac0309a9b5 - Added tests to gradle statistics reporter (4 дня назад) <Andrey Uskov>
* 33d89e15b51 - Metric description and anonymization rules added (4 дня назад) <Andrey Uskov>
* 763e02b3e82 - Collecting performance information in Gradle plugin supported (4 дня назад) <Andrey Uskov>
* e1d03e1f3ad - Open files leak on incremental compilation fixed (4 дня назад) <Andrey Uskov>
* 44edfc37179 - Do not show warnings when some projects are not generated before import (4 дня назад) <Andrey Uskov>
* 76759d3a5f8 - (tag: build-1.4.0-dev-1481) Drop compatibility stub for experimental unsigned API from 1.3.0 (4 дня назад) <Ilya Gorbunov>
* 39078342ee2 - (tag: build-1.4.0-dev-1479) Remove mod function deprecation tests (4 дня назад) <Ilya Gorbunov>
* b1766b167f4 - Remove mod function usage from tests (4 дня назад) <Ilya Gorbunov>
* 9fffa615967 - Update builtin serialization tests (4 дня назад) <Ilya Gorbunov>
* 8f37ace9ee6 - Finally drop deprecated mod functions from numeric types (4 дня назад) <Ilya Gorbunov>
* 06550a6d317 - (tag: build-1.4.0-dev-1477) [NI] Actualize spec tests, affected by KT-35668 (4 дня назад) <Pavel Kirpichenkov>
* 78c9bbcc0de - [NI] Soften restictions on using `Nothing` as proper constraint for full call completion (4 дня назад) <Pavel Kirpichenkov>
* f1d9177112a - (tag: build-1.4.0-dev-1475) [NI] Fix issue with returning non-deparenthesized lambdas from labmdas (4 дня назад) <Mikhail Zarechenskiy>
* 6b07ef42dda - [NI] Update testdata for NI after switching language versions (4 дня назад) <Mikhail Zarechenskiy>
* 7bd7db839d3 - [NI] Fix adapting arguments for callable references with receivers (4 дня назад) <Mikhail Zarechenskiy>
* 43858e81693 - (tag: build-1.4.0-dev-1469) Do not include annotations and KDoc into NO_EXPLICIT_VISIBILITY_IN_API_MODE report range (4 дня назад) <Leonid Startsev>
* 4285c6045a5 - Fix unavailable 'Specify visibility explicitly' quickfix (4 дня назад) <Leonid Startsev>
* f44fa67a517 - (tag: build-1.4.0-dev-1457) Fix compilation for 192 (4 дня назад) <Dmitry Gridin>
* 194d5a61dc9 - [FIR-TEST] Add tests with problems of fir resolve (4 дня назад) <Dmitriy Novozhilov>
* f68542e6511 - [FIR] Add FirEnumEntry to HTML dump (4 дня назад) <Dmitriy Novozhilov>
* 14cf7a3d163 - (tag: build-1.4.0-dev-1454) [NI] Add collecting forgotten type variables from callable references (4 дня назад) <Dmitriy Novozhilov>
* be74e92c272 - [NI] Add missing type variables to common system in builder inference (4 дня назад) <Dmitriy Novozhilov>
* 6d49f36cd68 - (tag: build-1.4.0-dev-1450) Add bunches for unsupported versions (4 дня назад) <Anton Yalyshev>
* 1d7dcf36337 - Add Formatter settings tracking to FUS (4 дня назад) <Anton Yalyshev>
* 7c0d8ad6c7b - Add languageVersion tracking to FUS (4 дня назад) <Anton Yalyshev>
* 556814e9b62 - TrailingCommaVisitor: add `checkCanceled` for the recursive case (4 дня назад) <Dmitry Gridin>
* 522ae4945e2 - TrailingCommaPostFormatProcessor: convert `mapNotNull` to `filter` (4 дня назад) <Dmitry Gridin>
* a2b2c47b514 - (tag: build-1.4.0-dev-1448) KT-34795 Use `maven(...)` instead of `maven { setUrl(...) }` for gradle scripts generation (4 дня назад) <Roman Golyshev>
* 3dbc058db9e - KT-34795 Remove obsolete Gradle 3.5 test data (4 дня назад) <Roman Golyshev>
* 7627834dd0c - (tag: build-1.4.0-dev-1446) TrailingCommaInspection: report `Missing trailing comma` on argument (4 дня назад) <Dmitry Gridin>
* 5aa413014bb - FormatterUtil: cleanup code (4 дня назад) <Dmitry Gridin>
* 80194dd5365 - Trailing comma: cleanup code after review (4 дня назад) <Dmitry Gridin>
* ac8a8ecab43 - ktPsiUtil: cleanup code (4 дня назад) <Dmitry Gridin>
* b0455136420 - KotlinCommonBlock: cleanup code (4 дня назад) <Dmitry Gridin>
* 63ee7239288 - TrailingCommaPostFormatProcessor: improve `findInvalidCommas` (4 дня назад) <Dmitry Gridin>
* ca1aa6ed4e9 - TrailingCommaInspection: should report `Missing line break` (4 дня назад) <Dmitry Gridin>
* 3e722887ab6 - RedundantSemicolonInspection: move `isLineBreak` to utils (4 дня назад) <Dmitry Gridin>
* 9b64a1d18ad - TrailingCommaInspection: should report `Missing trailing comma` on symbol after argument (4 дня назад) <Dmitry Gridin>
* 66fa54d8056 - TrailingCommaInspection: introduce enum `TrailingCommaAction` (4 дня назад) <Dmitry Gridin>
* c5893913f33 - (tag: build-1.4.0-dev-1444) [NI] Remove lambda coersion to Unit in case of error return type(s) (4 дня назад) <Pavel Kirpichenkov>
* 3a98c84105f - [NI] Make behaviour of anonymous functions consistent with lambdas (4 дня назад) <Pavel Kirpichenkov>
* 4554f91aff5 - (tag: build-1.4.0-dev-1442) Add cocoa binary dependencies (4 дня назад) <Kirill Shmakov>
* 9e8f21cc207 - (tag: build-1.4.0-dev-1437, origin/selezneva/KT-36090) Search for standard serializers in both internal and root packages (4 дня назад) <Leonid Startsev>
* db4273d677f - Pass actual serializable properties count in the generated code (4 дня назад) <Leonid Startsev>
* 9558538d152 - Refactor plugin-generated call to EnumSerializer(): (4 дня назад) <Leonid Startsev>
* 94ec22762a0 - (tag: build-1.4.0-dev-1435) Rename: FirLibrarySymbolProviderImpl -> FirBuiltinSymbolProvider (4 дня назад) <Mikhail Glukhikh>
* 2086c34cb99 - [FIR] Fix callable references to fields / parameters / etc. (4 дня назад) <Mikhail Glukhikh>
* c37394ec834 - [FIR] Count alias reference with type arguments as qualifier w/out value (4 дня назад) <Mikhail Glukhikh>
* e39df5bb915 - [FIR] Support type aliases in double colon expression resolver (4 дня назад) <Mikhail Glukhikh>
* 84c8697720c - [FIR] Do not build synthetics for static or Unit returning get (4 дня назад) <Mikhail Glukhikh>
* 69ecbd93a95 - [FIR] Fix type alias handling in qualifier position (4 дня назад) <Mikhail Glukhikh>
* e644edfe84a - [FIR] Handle unresolved callable references more correctly (4 дня назад) <Mikhail Glukhikh>
* 97d8f3fa4b9 - [FIR TEST] Add test for erroneous callable reference resolve (4 дня назад) <Mikhail Glukhikh>
* c1207dd5af9 - [FIR] QualifierReceiver minor cleanup (4 дня назад) <Mikhail Glukhikh>
* 858698cf9a2 - (tag: build-1.4.0-dev-1434, origin/selezneva/notification) Provide a notification for gradle script that aren't related to any gradle project (KT-35268) (4 дня назад) <Natalia Selezneva>
* a373ab96d45 - (tag: build-1.4.0-dev-1420) Implement persistent storage for script class path roots (KT-35886) (4 дня назад) <Natalia Selezneva>
* c59e794ab4d - K/N KLIBs detection in Gradle plugin: drop useless code (4 дня назад) <Dmitriy Dolovov>
* 72b7023529e - Minor: Rename NativePlatformConfigurator for consistency (4 дня назад) <Dmitriy Dolovov>
* 6a24d8432cb - Properly retrieve compiler version from K/N distribution (4 дня назад) <Dmitriy Dolovov>
* 5eb0c83965e - (tag: build-1.4.0-dev-1418) [FIR] Fix failing tests (4 дня назад) <Mikhail Glukhikh>
* 1203df7405a - (tag: build-1.4.0-dev-1416, origin/rr/stdlib/deprecate-floating-to-integral-lesser-than-int) Deprecate floating point to integral types lesser than Int #KT-30360 (5 дней назад) <Abduqodiri Qurbonzoda>
* e459542e6f5 - (tag: build-1.4.0-dev-1414) Add removeFirst(OrNull) and removeLast(OrNull) methods to MutableList (5 дней назад) <Abduqodiri Qurbonzoda>
* b6849efd47e - Common ArrayDeque (5 дней назад) <Abduqodiri Qurbonzoda>
* db8b0a65936 - (tag: build-1.4.0-dev-1396) Show Review Added Imports on paste action Fixed multi-caret selection in kotlin-to-kotlin copy-paste processor (5 дней назад) <Vladimir Dolzhenko>
* 84fd5b35eb8 - (tag: build-1.4.0-dev-1389) Revert "[coroutine] For RUNNING coroutines -1 is the correct number" (5 дней назад) <Vladimir Ilmov>
* ed09c673f83 - AsyncStackTraceContext extra logging removed (5 дней назад) <Vladimir Ilmov>
* aea5e3ffbcb - (tag: build-1.4.0-dev-1384) JVM IR: Remove type substitutions from ExpressionCodegen (5 дней назад) <Steven Schäfer>
* 2f0f4e570f1 - (tag: build-1.4.0-dev-1380) JVM_IR: do not remap locals in contexts nested inside lambdas (5 дней назад) <pyos>
* 8e79d9b90e8 - (tag: build-1.4.0-dev-1375) Add changelog for 1.3.60 (5 дней назад) <nikita.movshin>
* 3ca0f8a5698 - (tag: build-1.4.0-dev-1371) Fix incorrect message for new nullability assertion exception in 1.4 (5 дней назад) <Alexander Udalov>
* cc317d7548e - [coroutine] For RUNNING coroutines -1 is the correct number (5 дней назад) <Vladimir Ilmov>
* aa48f2e3638 - (tag: build-1.4.0-dev-1360) Unmute test about fun interfaces for JVM IR (5 дней назад) <Mikhail Zarechenskiy>
* e6074e87597 - (tag: build-1.4.0-dev-1356) [JS BE] Unmute test (5 дней назад) <Zalim Bashorov>
* f92376fbbdb - [BE test] Extract and mute cases which don't work on JS from eqNullableDoubles.kt and eqNullableDoubles.kt (5 дней назад) <Zalim Bashorov>
* 79fa3c2c30a - (tag: build-1.4.0-dev-1354) [Gradle, JS] Fix check on klib (5 дней назад) <Ilya Goncharov>
* 72cb0de7058 - [FIR-TEST] Update testdata (5 дней назад) <Dmitriy Novozhilov>
* 93906bad1d5 - [FIR] Add workaround about incorrect safe call invoke desugaring (5 дней назад) <Dmitriy Novozhilov>
* 62e01a8aa4b - [FIR] Update smartcast info for receiivers when enter to when condition (5 дней назад) <Dmitriy Novozhilov>
* 9684ff70712 - [FIR] Don't create smartcasts to error types (5 дней назад) <Dmitriy Novozhilov>
* 384a0941939 - [FIR] Unbound aliased variables in DFA more carefully (5 дней назад) <Dmitriy Novozhilov>
* 2a23e14e2b7 - [FIR-TEST] Fix problem test without proper smartcast (5 дней назад) <Dmitriy Novozhilov>
* d7c85406fbd - [FIR-TEST] Mute some failing tests according to changes in DFA (5 дней назад) <Dmitriy Novozhilov>
* 9bc62fc34d4 - [FIR-TEST] Mute test due to incorrect invoke desugaring (5 дней назад) <Dmitriy Novozhilov>
* 5f639dd2aee - [FIR-TEST] Update testdata of old frontend tests (5 дней назад) <Dmitriy Novozhilov>
* 19e0b8039b7 - [FIR] Cleanup DFA code and rename some classes for better understanding (5 дней назад) <Dmitriy Novozhilov>
* 16a9ca5912d - [FIR] Remove old DFA (5 дней назад) <Dmitriy Novozhilov>
* 5d3b75ebc3e - [FIR] Implement new data flow analysis (5 дней назад) <Dmitriy Novozhilov>
* 2c66c3b0b64 - (tag: build-1.4.0-dev-1346) Gradle, native: Allow setting destination directory for binaries (5 дней назад) <Ilya Matveev>
* df46dfc63de - Gradle, native: Don't pass to compiler missing klib files (5 дней назад) <Ilya Matveev>
* ce45df2c968 - Gradle, tests: Skip building in native binaries test for Groovy DSL (5 дней назад) <Ilya Matveev>
* 01622f069e3 - Gradle, native: Support exporting dependencies for static and shared libs (5 дней назад) <Ilya Matveev>
* c7e3df506d5 - (tag: build-1.4.0-dev-1336, origin/rr/snrostov/gradle-kts-import-fix) gradle.kts importing: proper check for root project (5 дней назад) <Sergey Rostov>
* b38836c4884 - (tag: build-1.4.0-dev-1328) Fix script configurations for gradle project without source roots in 193 and as40 (5 дней назад) <Natalia Selezneva>
* 7ec04a1bf94 - (tag: build-1.4.0-dev-1325) generators: extract OperationsMap generator to a separate source set (5 дней назад) <Ilya Gorbunov>
* 2251c271671 - J2K GeneratorsFileUtil (5 дней назад) <Ilya Gorbunov>
* d64ec712052 - J2K GeneratorsFileUtil: Rename .java to .kt (5 дней назад) <Ilya Gorbunov>
* 64a405e7a0d - (tag: build-1.4.0-dev-1316) IR: 'fun interface' support (6 дней назад) <Dmitry Petrov>
* a55989a2a52 - (tag: build-1.4.0-dev-1314) JVM_IR: Support interface delegation of suspend functions (6 дней назад) <Ilmir Usmanov>
* e34a2077255 - (tag: build-1.4.0-dev-1313) Implement KTypeProjection.toString (6 дней назад) <Alexander Udalov>
* 3a90e2dd75b - (tag: build-1.4.0-dev-1306) Store addUnambiguousImportsOnTheFly in kotlin code insight settings store optimizeImportsOnTheFly in kotlin code insight workspace settings (6 дней назад) <Vladimir Dolzhenko>
* 70ed03ac4b7 - Now using Kotlin setting instead of Java one in 191 as well (6 дней назад) <Alexander Podkhalyuzin>
* dca0a71d9b2 - (tag: build-1.4.0-dev-1304) Add only non-jdk classpath entries from the compiler to script (6 дней назад) <Ilya Chernikov>
* 75441386e36 - Use scripting cache earlier in the pipeline: (6 дней назад) <Ilya Chernikov>
* c7d9eaed409 - Speed up REPL package member declaration provider (6 дней назад) <Ilya Chernikov>
* cb7cc8ac6b6 - [minor] fix typo in function name (6 дней назад) <Ilya Chernikov>
* 1b65ec75ad2 - Immplement default cache in main-kts (6 дней назад) <Ilya Chernikov>
* a4752087db7 - Get rid of kotlinx.coroutines usage in saved script runner (6 дней назад) <Ilya Chernikov>
* 891914167a1 - Switch cli expression evaluation argument syntax to -expression/-e (6 дней назад) <Ilya Chernikov>
* 5f15cacb1b7 - Fix ivy mapping to the maven repos in main-kts (6 дней назад) <Ilya Chernikov>
* b5ac35dec10 - Implement automatic loading of .main.kts scripts support (6 дней назад) <Ilya Chernikov>
* d15d62a3381 - Check REPL snippet syntax before calling analysis (6 дней назад) <Ilya Chernikov>
* 8e074828625 - (tag: build-1.4.0-dev-1296) JVM IR: Fix generation of parameterless default constructor (6 дней назад) <Steven Schäfer>
* 5321a6af330 - (tag: build-1.4.0-dev-1290) Forbid spread operator in signature-polymorphic calls (6 дней назад) <Alexander Udalov>
* b6feec41152 - Add language version 1.5 (6 дней назад) <Alexander Udalov>
* 8e2b76698a6 - (tag: build-1.4.0-dev-1281) Remove -Xno-use-ir from modules where JVM IR problems are fixed (6 дней назад) <Alexander Udalov>
* d3a93b20150 - (tag: build-1.4.0-dev-1277) Remove unneeded IncrementalCompilerRunner#postCompilationHook (6 дней назад) <Alexey Tsvetkov>
* ba0ce92159b - Report messages only after IC scope expansion converged (6 дней назад) <Alexey Tsvetkov>
* c912f76d6f7 - Add IC scope expansion tests (6 дней назад) <Alexey Tsvetkov>
* b979be701ed - Remove some unneeded gradle specific IC logs (6 дней назад) <Alexey Tsvetkov>
* ef83431618b - Recompile all dirty files in case of error (6 дней назад) <Alexey Tsvetkov>
* 2d598d50d7b - Expand compilation scope for IC before backend is run (6 дней назад) <Alexey Tsvetkov>
* 4f3418dc89b - Minor: use CompilerConfiguration#putIfNotNull for IC services (6 дней назад) <Alexey Tsvetkov>
* a950226602f - Format and cleanup incremental-compilation-impl (6 дней назад) <Alexey Tsvetkov>
* 5816722a646 - Minor: remove unused property (6 дней назад) <Alexey Tsvetkov>
* db252f60cda - (tag: build-1.4.0-dev-1274) Rename task generateTests in android-tests project (6 дней назад) <Ilya Gorbunov>
* f0cb51a5bcf - KotlinDslScriptModel request shouldn't fail the gradle build (6 дней назад) <Natalia Selezneva>
* 606279b4627 - as36: Update to AS 3.6 RC (192.7142.36.36.6071332) (6 дней назад) <Natalia Selezneva>
* 4699ba758e9 - Remove unnecessary bunch file for AS4.0 (6 дней назад) <Natalia Selezneva>
* 61b3f447b14 - Remove jsIrDist (kotlin.stdlib.js.ir.dist) flag and the logic it enables (6 дней назад) <Ilya Gorbunov>
* 5f0e3018db0 - (tag: build-1.4.0-dev-1269) KT-27856 Add contracts to Timing.kt lambdas (#1987) (6 дней назад) <Tsvetan>
* 7dc29a18407 - (tag: build-1.4.0-dev-1256) Coroutine debugger starting even if registry key set to false - fixed (6 дней назад) <Vladimir Ilmov>
* 9f720e576db - [coroutine] ComboBox disabled as in progress (6 дней назад) <Vladimir Ilmov>
* c33546f6781 - [coroutine] Exception fixed for SUSPEND coroutines. (6 дней назад) <Vladimir Ilmov>
* 99294cfdae9 - (tag: build-1.4.0-dev-1255) Minor, fix test data (6 дней назад) <Alexander Udalov>
* 79840a05b23 - Fix test expectations. (6 дней назад) <Mads Ager>
* 1c527fc1591 - (tag: build-1.4.0-dev-1253) IR: avoid name clashes between raised local functions. (6 дней назад) <Georgy Bronnikov>
* 4e0b54e1a69 - (tag: build-1.4.0-dev-1251, tag: build-1.4.0-dev-1249) [FIR] Add equality to ConeTypeVariableType (6 дней назад) <Dmitriy Novozhilov>
* 2daedc98b5c - (tag: build-1.4.0-dev-1246) KT-35648 RemoveArgumentNameIntention: Support MixedNamedArgumentsInTheirOwnPosition (6 дней назад) <Toshiaki Kameyama>
* 401baa35ab1 - (tag: build-1.4.0-dev-1242) [Gradle, Native] Implement custom name for generated framework for XCode (6 дней назад) <Yaroslav Chernyshev>
* a24e62eaf7a - (tag: build-1.4.0-dev-1241) Scripting: do not call getConfiguration inside ScriptClassRootsCache (6 дней назад) <Natalia Selezneva>
* 1336da84530 - (tag: build-1.4.0-dev-1234) Rename Clock to TimeSource, ClockMark to TimeMark (7 дней назад) <Ilya Gorbunov>
* a11a25087a8 - Rename Clock to TimeSource, ClockMark to TimeMark (7 дней назад) <Ilya Gorbunov>
* ac9c106a77f - (tag: build-1.4.0-dev-1231) Fix of UL classes muted tests (7 дней назад) <Igor Yakovlev>
* 15a441141f4 - (tag: build-1.4.0-dev-1220) Update public API dump after KT-11567 codegen changes came into effect (7 дней назад) <Ilya Gorbunov>
* c0600e6873d - (tag: build-1.4.0-dev-1217) JVM IR: minor, mute and adapt noCallAssertions.kt to 1.4 (7 дней назад) <Alexander Udalov>
* 078b9345808 - Mute/unmute JVM backend tests for language version 1.4 (7 дней назад) <Alexander Udalov>
* f48bdc1fcb6 - Fix codegen box tests for language version 1.4 (7 дней назад) <Alexander Udalov>
* 6a90dc2efe9 - Fix bytecode text tests for language version 1.4 (7 дней назад) <Alexander Udalov>
* 1ef5e25c608 - (tag: build-1.4.0-dev-1216) JVM_IR: Minor. Update test data (7 дней назад) <Ilmir Usmanov>
* 51c5fcc8b82 - (tag: build-1.4.0-dev-1207) Drop experimental stdlib sourceset (7 дней назад) <Ilya Gorbunov>
* 6ede10c1ca1 - (tag: build-1.4.0-dev-1202) JVM_IR: Minor. Add test for SMAP of inner object/lambda of inline suspend function (7 дней назад) <Ilmir Usmanov>
* 877509306de - JVM_IR: Minor. Unmute tests. (7 дней назад) <Ilmir Usmanov>
* 891a55d79ad - JVM_IR: Fix visibility of inner suspend lambda inside inline function (7 дней назад) <Ilmir Usmanov>
* 56c8fdc6c4c - JVM_IR: Perform tail-call optimization on IR (7 дней назад) <Ilmir Usmanov>
* 9f5b51ed43e - JVM_IR: Do not generate fake continuation markers inside inline suspend lambdas (7 дней назад) <Ilmir Usmanov>
* 16d63cd1d09 - JVM_IR: Use attributes to find $$forInline version of crossroutine (7 дней назад) <Ilmir Usmanov>
* 4d9d62ad128 - JVM_IR: Also check attributes for suspendImpls when generating continuation (7 дней назад) <Ilmir Usmanov>
* d17afddaa99 - JVM_IR: Fix bridges generation for suspend functions (7 дней назад) <Ilmir Usmanov>
* 2507e2b526f - JVM_IR: Fix parents of $$forInline companions (7 дней назад) <Ilmir Usmanov>
* 7167d5f75c0 - JVM_IR: Generate $$forInline companion for transformed crossroutines (7 дней назад) <Ilmir Usmanov>
* 33c0bfb4c2c - JVM_IR: Generate $$forInline companion for transformed crossroutines (7 дней назад) <Ilmir Usmanov>
* 64c1446fbe7 - JVM_IR: Generate $$forInline companion for suspend inline functions (7 дней назад) <Ilmir Usmanov>
* 4ef2ecf9a9b - JVM_IR: Add returns unit marker if suspend call returns unit (7 дней назад) <Ilmir Usmanov>
* 1911cbb0776 - (tag: build-1.4.0-dev-1196) Fixed ProgressIndicatorUtils.kt for 201 (7 дней назад) <Vladimir Dolzhenko>
* 5cb7cf040a9 - (tag: build-1.4.0-dev-1194) Update some testdata according switching compiler to 1.4 (7 дней назад) <Dmitriy Novozhilov>
* 796d4da9f5f - (tag: build-1.4.0-dev-1192) Fix testLanguageSettingsConsistency with default language version 1.4 (7 дней назад) <Sergey Igushkin>
* 5c5635ce20a - Fix codegen & bytecode tests after unifying exceptions in JVM backend (7 дней назад) <Mikhail Zarechenskiy>
* 1ed7e33f420 - (tag: build-1.4.0-dev-1186) JVM_IR: Fix default argument bit mask for methods made static. (7 дней назад) <Mads Ager>
* 137c500e3ad - (tag: build-1.4.0-dev-1177) Support SerializerFactory in Native (7 дней назад) <Leonid Startsev>
* 976db65911a - (tag: build-1.4.0-dev-1175) TrailingCommaInspection: replace "Redundant trailing comma" message with "Useless trailing comma" (7 дней назад) <Dmitry Gridin>
* abb82f791e4 - TrailingCommaInspection: add option for missing comma (7 дней назад) <Dmitry Gridin>
* 33a24bfd278 - (tag: build-1.4.0-dev-1174) JVM_IR: Avoid using parent name in name of captures. (7 дней назад) <Mads Ager>
* 9782f6808d4 - (tag: build-1.4.0-dev-1168) Minor: Fix deprecation notice in KotlinIndicesHelperExtension (7 дней назад) <Yan Zhulanow>
* 520f9a6da5a - Kapt: Support all kinds of constant types (KT-35536) (7 дней назад) <Yan Zhulanow>
* 532e879d5c7 - Pill: Fix gradle-api artifacts attaching after migration to compileClasspath/runtimeClasspath (7 дней назад) <Yan Zhulanow>
* ea957872ebb - Pill: Support Kotlin JUnit configurations (7 дней назад) <Yan Zhulanow>
* 66cd78fbc05 - Pill: Remove robolectric classpath passing (7 дней назад) <Yan Zhulanow>
* cb0b44273db - (tag: build-1.4.0-dev-1165) [NI] Check stub types in result type (7 дней назад) <Pavel Kirpichenkov>
* 581db19544d - (tag: build-1.4.0-dev-1164) Fix test after advancing bootstrap compiler to 1.4 (7 дней назад) <Mikhail Zarechenskiy>
* 0725a336fcc - (tag: build-1.4.0-dev-1693) Fix data race in zip FileSystem reference counting (7 часов назад) <Ilya Matveev>
* 4eb38721a5f - (tag: build-1.4.0-dev-1682) Minor. Fix BuildSessionLoggerTest (18 часов назад) <Andrey Uskov>
* e7057cf2b33 - Fix classpath of IDEA plugin tests (18 часов назад) <Andrey Uskov>
* 9ae3b2cf430 - Fixed locking statistics files when multiple gradle daemons started (18 часов назад) <Andrey Uskov>
* a68a6b77dfa - (tag: build-1.4.0-dev-1681) Move top level declaration refactoring (18 часов назад) <Igor Yakovlev>
* f58a6e054c5 - (tag: build-1.4.0-dev-1677) Provide the same createKotlinLibrary even in multi-component situation (20 часов назад) <Alexander Gorshenev>
* 8b036ace26e - Moved several more components to resolveSingleFileKlib (20 часов назад) <Alexander Gorshenev>
* 19cbdb096f2 - Fine tuned the single file klib resolver (20 часов назад) <Alexander Gorshenev>
* fcce35c06f8 - Move tools to resolveSingleFileKlib (20 часов назад) <Alexander Gorshenev>
* 7390e74bbda - Initial implementation of klib components (20 часов назад) <Alexander Gorshenev>
* f7626d6474b - (tag: build-1.4.0-dev-1657) Exclude reporting `IMPLICIT_NOTHING_AS_TYPE_PARAMETER` warning for suspend lambdas (22 часа назад) <Victor Petukhov>
* 901bb904e08 - (tag: build-1.4.0-dev-1648) Fix GradleNativeLibrariesInIDENamingTest (23 часа назад) <Dmitriy Dolovov>
* 97f134eab16 - (tag: build-1.4.0-dev-1646) Remove outdated fir-view module (23 часа назад) <simon.ogorodnik>
* c939fb7b057 - (tag: build-1.4.0-dev-1642) PSI2IR: Fix argument adaptation for unbound references (23 часа назад) <Dmitry Petrov>
* 0152f19d5f3 - PSI2IR: Use substituted value parameter in function reference adaptation (23 часа назад) <Dmitry Petrov>
* 6e94eddb71f - (tag: build-1.4.0-dev-1640) JVM_IR. Fix bridge generation (24 часа назад) <Mikhael Bogdanov>
* dfa509ec5b3 - (tag: build-1.4.0-dev-1631) This reverts commits     afb2e9f38def4de8d58feaf5341e125eeae06012.     8c4fa6446d2bd16d721806bac716beb089bf48f4.     f3bc533073c3488cc4219d00ef0c0ac3df232bc1.     ccf084b1a55cf383feb6dbba12c1c982cfac5762. (25 часов назад) <Alexander Gorshenev>
* e327b174a22 - IR: Use name \$\$delegate_n for the field for interface delegation. (25 часов назад) <Mads Ager>
* a37ec5a0628 - [minor] "fix" fir testdata for KT-32792 & KT-34857 (25 часов назад) <Ilya Chernikov>
* dc4d453879e - PsiErrorBuilder - error reporting abstraction for JVM_IR (25 часов назад) <Dmitry Petrov>
* afb2e9f38de - (tag: build-1.4.0-dev-1622) Fine tuned the single file klib resolver (26 часов назад) <Alexander Gorshenev>
* 8c4fa6446d2 - Moved several more components to resolveSingleFileKlib (26 часов назад) <Alexander Gorshenev>
* f3bc533073c - Move tools to resolveSingleFileKlib (26 часов назад) <Alexander Gorshenev>
* ccf084b1a55 - Initial implementation of klib components (26 часов назад) <Alexander Gorshenev>
* f949b48b4ab - (tag: build-1.4.0-dev-1616) [FIR] Swap priority of kotlin libraries / built-ins #KT-35948 Fixed (27 часов назад) <Mikhail Glukhikh>
* c9b1c384e69 - (tag: build-1.4.0-dev-1615) Clean-up: Split nativeLibrariesUtil.kt into separate files in idea-gradle (27 часов назад) <Dmitriy Dolovov>
* ba1415d7d11 - (tag: build-1.4.0-dev-1609) Minor: remove assertion in getCallableReferenceAdaptation (28 часов назад) <Dmitry Petrov>
* 9623b0eedba - (tag: build-1.4.0-dev-1608) Report error instead of assertion when property is used as operator (28 часов назад) <Ilya Chernikov>
* a1acb4afaf6 - Return correct PSI expression for EmptyLabeledReturn (28 часов назад) <Ilya Chernikov>
* ca150005a8e - (tag: build-1.4.0-dev-1607) [Gradle, JS] Fix Task Configuration Avoidance (29 часов назад) <Ilya Goncharov>
* a2b774b1867 - [Gradle, JS] Distribution task depends on processResources (29 часов назад) <Ilya Goncharov>
* 1ba8b528567 - (tag: build-1.4.0-dev-1604) Constructor parameter is never used as a property: do not report if parameter is used as a reference (29 часов назад) <Toshiaki Kameyama>
* 59f70a912a7 - Convert to lambda reference: don't suggest when lambda is argument for 'suspend' function parameter (29 часов назад) <Toshiaki Kameyama>
* b75ab5c8327 - (tag: build-1.4.0-dev-1602) Refactoring: SingleAbstractMethodUtils -> JavaSingleAbstractMethodUtils (29 часов назад) <Mikhail Zarechenskiy>
* 0530f9ed1c9 - Refactoring: generify and remove duplicated code (29 часов назад) <Mikhail Zarechenskiy>
* 4e3c27c4ecc - Refactoring: move SamConversionOracle to core (29 часов назад) <Mikhail Zarechenskiy>
* 6c4f5ea9c9a - Minor: generify check for sam conversions (29 часов назад) <Mikhail Zarechenskiy>
* 02387e77dde - Refactoring: rename SamConversionTransformer -> SamConversionOracle (29 часов назад) <Mikhail Zarechenskiy>
* 08f80ba15a8 - Refactoring: remove useless method (29 часов назад) <Mikhail Zarechenskiy>
* 00469712d14 - [NI] Don't use only platform specific checks for FIC in inference (29 часов назад) <Mikhail Zarechenskiy>
* 7e85674c61e - (tag: build-1.4.0-dev-1601) Minor. Allow IR compilation of FIR and IR.TREE module (30 часов назад) <Mikhael Bogdanov>