### PR TITLE
Forced ThrowTypeCastException to be exported

### DIFF
--- a/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt
@@ -29,6 +29,7 @@ fun ThrowClassCastException(instance: Any, typeInfo: NativePtr): Nothing {
     throw ClassCastException("${instance::class.qualifiedName} cannot be cast to ${clazz.qualifiedName}")
 }
 
+@ExportForCppRuntime
 fun ThrowTypeCastException(): Nothing {
     throw TypeCastException()
 }


### PR DESCRIPTION
It is used inside codegen after DCE phase