### PR TITLE
[kotlin compiler][update] 1.4.0-dev-2107

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -132,6 +132,7 @@ configurations {
     kotlin_native_utils_jar
     trove4j_jar
     kotlinCommonSources
+    kotlin_coroutines_experimental_compat_jar
 
     cli_bcRuntime {
         extendsFrom compilerRuntime
@@ -150,8 +151,9 @@ dependencies {
     kotlin_reflect_jar "$kotlinReflectModule@jar"
     kotlin_script_runtime_jar "$kotlinScriptRuntimeModule@jar"
     kotlin_native_utils_jar "$kotlinNativeUtilsModule@jar"
-
-    [kotlinCommonStdlibModule, kotlinTestCommonModule, kotlinTestAnnotationsCommonModule].each {
+    kotlin_coroutines_experimental_compat_jar "$kotlinCoroutinesExperimentalCompatModule@jar"
+    [kotlinCommonStdlibModule, kotlinCoroutinesExperimentalCompatModule,
+     kotlinTestCommonModule, kotlinTestAnnotationsCommonModule].each {
         kotlinCommonSources(it) { transitive = false }
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -66,8 +66,6 @@ class KonanIrLinker(
 
     private val ModuleDescriptor.userName get() = konanLibrary!!.libraryFile.absolutePath
 
-    override fun checkAccessibility(declarationDescriptor: DeclarationDescriptor) = true
-
     override fun handleNoModuleDeserializerFound(key: UniqId): DeserializationState<*> {
         return globalDeserializationState
     }

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/CopyCommonSources.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/CopyCommonSources.kt
@@ -72,6 +72,12 @@ open class CopyCommonSources : DefaultTask() {
             it.include("generated/**/*.kt")
             it.include("kotlin/**/*.kt")
             it.include("kotlin.test/*.kt")
+            it.exclude("kotlin/**/experimental/jvm/**/*.kt")
+            it.exclude("kotlin/**/coroutines/experimental/**/*Jvm.kt")
+            it.exclude("kotlin/**/coroutines/experimental/intrinsics/*.kt")
+            it.exclude("kotlin/**/coroutines/experimental/SafeContinuation.kt")
+            it.exclude("kotlin/**/coroutines/experimental/CoroutinesLibrary.kt")
+            it.exclude("kotlin/**/coroutines/experimental/SequenceBuilder.kt")
             it.into(destinationDir)
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -291,6 +291,9 @@ task detectJarCollision(type: CollisionDetector) {
     resolvingRules["kotlin/reflect/reflect.kotlin_builtins"] = "kotlin-compiler"
     resolvingRules["META-INF/maven/com.google.protobuf/protobuf-java/pom.properties"] = "kotlin-compiler"
     resolvingRules["META-INF/maven/com.google.protobuf/protobuf-java/pom.xml"] = "kotlin-compiler"
+    resolvingRules["org/jetbrains/kotlin/builtins/konan/KonanBuiltIns.class"] = "kotlin-compiler"
+    resolvingRules["org/jetbrains/kotlin/resolve/konan/platform/NativeInliningRule.class"] = "kotlin-compiler"
+    resolvingRules["org/jetbrains/kotlin/resolve/konan/platform/NativePlatformAnalyzerServices.class"] = "kotlin-compiler"
     librariesWithIgnoredClassCollisions.addAll(["kotlin-util-klib", "kotlin-util-io", "kotlinx-metadata-klib"])
     if (project.hasProperty('kotlinProjectPath')) {
         resolvingRulesWithRegexes[new Regex("META-INF/.+\\.kotlin_module")] = "kotlin-compiler"

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ ext {
     kotlinScriptRuntimeModule="org.jetbrains.kotlin:kotlin-script-runtime:${kotlinVersion}"
     kotlinNativeUtilsModule="org.jetbrains.kotlin:kotlin-native-utils:${kotlinVersion}"
     kotlinUtilKliMetadatabModule="org.jetbrains.kotlin:kotlin-util-klib-metadata:${kotlinVersion}"
+    kotlinCoroutinesExperimentalCompatModule="org.jetbrains.kotlin:kotlin-coroutines-experimental-compat:${kotlinVersion}:sources"
 
     konanVersionFull = CompilerVersionGeneratedKt.getCurrentCompilerVersion()
     gradlePluginVersion = konanVersionFull

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/descriptors/konan/KonanModuleDescriptorUtils.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/descriptors/konan/KonanModuleDescriptorUtils.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.konan.library.KONAN_STDLIB_NAME
 import org.jetbrains.kotlin.name.Name
 
-private val STDLIB_MODULE_NAME = Name.special("<$KONAN_STDLIB_NAME>")
+//TODO: this is should be reverted!!!
+private val STDLIB_MODULE_NAME = Name.special("<stdlib>")
 
 fun ModuleDescriptor.isKonanStdlib() = name == STDLIB_MODULE_NAME

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1693,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-1693
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1693,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-1693
-kotlinStdlibTestsVersion=1.4.0-dev-1693
-testKotlinCompilerVersion=1.4.0-dev-1693
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2107,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-2107
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2107,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-2107
+kotlinStdlibTestsVersion=1.4.0-dev-2107
+testKotlinCompilerVersion=1.4.0-dev-2107
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/coroutines/experimental/Intrinsics.kt
+++ b/runtime/src/main/kotlin/kotlin/coroutines/experimental/Intrinsics.kt
@@ -71,7 +71,7 @@ public actual inline fun <R, T> (suspend R.() -> T).startCoroutineUninterceptedO
  * the execution was suspended and will not return any result immediately.
  */
 @SinceKotlin("1.1")
-public actual val COROUTINE_SUSPENDED: Any get() = CoroutineSingletons.COROUTINE_SUSPENDED
+public val COROUTINE_SUSPENDED: Any get() = CoroutineSingletons.COROUTINE_SUSPENDED
 
 // Using enum here ensures two important properties:
 //  1. It makes SafeContinuation serializable with all kinds of serialization frameworks (since all of them natively support enums)


### PR DESCRIPTION
* 8214a9383cd - (tag: build-1.4.0-dev-2107) Enabled some tests (7 часов назад) <Igor Chevdar>
* 562e8e357aa - [IR] SAM lowering: supported suspend functions (7 часов назад) <Igor Chevdar>
* d6f91333dc1 - [IR] SAM lowering: use block body instead of expr body (7 часов назад) <Igor Chevdar>
* 645488b3429 - [IR] SAM lowering: place wrappers into file if no enclosing class exists (7 часов назад) <Igor Chevdar>
* 6ecda9e8afd - [IR] [JVM_IR] Commonized SAM conversions lowering (7 часов назад) <Igor Chevdar>
* 4dbf60eb2ce - (tag: build-1.4.0-dev-2100) Fix: Load properties in konan Distribution in safe way (8 часов назад) <Dmitriy Dolovov>
* f69eef811bf - Minor: Remove unnecessary IO check (8 часов назад) <Dmitriy Dolovov>
* b1436804b3d - (tag: build-1.4.0-dev-2099) [FIR, by demiurg] Fix exception in DFA for a case with lambda empty body (9 часов назад) <Mikhail Glukhikh>
* 64c7ab13023 - [FIR] Fix lambda resolve in independent context (9 часов назад) <Mikhail Glukhikh>
* 4f8d0382f77 - Get rid of FirControlFlowGraphOwner (9 часов назад) <Mikhail Glukhikh>
* f28144ff9ca - Minor FirRenderer code cleanup (9 часов назад) <Mikhail Glukhikh>
* e977c1c076d - Get rid of name in FirConstructor (9 часов назад) <Mikhail Glukhikh>
* f20845ba403 - Get rid of FirMemberFunction (9 часов назад) <Mikhail Glukhikh>
* 677129ad207 - Get rid of FirNamedDeclaration (9 часов назад) <Mikhail Glukhikh>
* 7a52cf103a8 - (tag: build-1.4.0-dev-2097) Fix change signature refactoring (9 часов назад) <Ilya Kirillov>
* ed5156ee83b - Wizard: do not show disable/enable checkbox for new project wizard in AS (9 часов назад) <Ilya Kirillov>
* 451fa245b83 - (tag: build-1.4.0-dev-2094) JVM_IR: Change name for (dispatch|extension) receiver of inline class according to naming convention. (10 часов назад) <Jinseong Jeon>
* 19b516cbf4e - (tag: build-1.4.0-dev-2092) JVM IR: do not erase static fields in annotation classes (10 часов назад) <Alexander Udalov>
* 00de5dae326 - JVM IR: copy property instead of field in MoveOrCopyCompanionObjectFieldsLowering (10 часов назад) <Alexander Udalov>
* e42a4b2fac7 - IR: extract JvmPropertiesLowering out of PropertiesLowering (10 часов назад) <Alexander Udalov>
* 60da37404e7 - (tag: build-1.4.0-dev-2091, tag: build-1.4.0-dev-2089) [Gradle, JS] Distribution and distributeResources (11 часов назад) <Ilya Goncharov>
* e302818e26e - (tag: build-1.4.0-dev-2080) Refactor KotlinNativeToolRunner to make it extendable (12 часов назад) <Dmitriy Dolovov>
* cb07c9172fb - (tag: build-1.4.0-dev-2070) [NI] Record substituted generic signature for SAM arguments (13 часов назад) <Mikhail Zarechenskiy>
* 8ef79f932c8 - (tag: build-1.4.0-dev-2065) JVM_IR: Implement some BE diagnostics (24 часа назад) <Dmitry Petrov>
* c9df17f2f18 - (tag: build-1.4.0-dev-2054) Handle type arguments in IrType.eraseTypeParameters (28 часов назад) <Georgy Bronnikov>
* 22068dd6ad1 - (tag: build-1.4.0-dev-2037) [FIR TEST] Update test data due to hardened receiver check (NB: broken) (31 час назад) <Mikhail Glukhikh>
* 7dca4d2feec - [FIR TEST] Update test data for purely implements case (NB: broken) (31 час назад) <Mikhail Glukhikh>
* b25d99c1e50 - [FIR TEST] Add test with some problematic smart casts (31 час назад) <Mikhail Glukhikh>
* ca5fee77d4f - [FIR] Fix generation of raw FIR for delegate with receiver (31 час назад) <simon.ogorodnik>
* ef5aab374b1 - [FIR] Fix implicit this aliasing in DFA (31 час назад) <simon.ogorodnik>
* 645602b6755 - [FIR] Fix data-flow after while loops (31 час назад) <simon.ogorodnik>
* 91b432b4a12 - [FIR] Java super-type arguments are now handled as flexible (31 час назад) <Mikhail Glukhikh>
* aeb6f355715 - Support nullable callable references in FIR resolve (31 час назад) <Mikhail Glukhikh>
* a584589665b - Support nullable callable references in raw FIR (31 час назад) <Mikhail Glukhikh>
* 95122f1d0bc - Add two more FIR problematic tests (31 час назад) <Mikhail Glukhikh>
* 0b377c103ad - Add FIR problematic test (safe extension invoke) (31 час назад) <Mikhail Glukhikh>
* 34e6649d313 - [FIR] Harden check of argument type properly (31 час назад) <simon.ogorodnik>
* fe779bf7bd9 - (tag: build-1.4.0-dev-2029) KT-34795 Fix failing NewMultiplatformIT#testLibAndApp test (32 часа назад) <Roman Golyshev>
* c804190f367 - (tag: build-1.4.0-dev-2018, tag: build-1.4.0-dev-2015) [COROUTINE] NPE exception fix if no DebugMetadata in target jvm exists (2 дня назад) <Vladimir Ilmov>
* 7175e5a9278 - [COROUTINE] Extra logging removed, bug in method signature fix (2 дня назад) <Vladimir Ilmov>
* 21745565056 - (tag: build-1.4.0-dev-2014) [FIR-TEST] Update incorrect testdata (2 дня назад) <Dmitriy Novozhilov>
* cf9ceb4e992 - (tag: build-1.4.0-dev-2008) Add more diagnostic context to LightClassUtil#findClass (2 дня назад) <Vladimir Dolzhenko>
* 80eb1480924 - (tag: build-1.4.0-dev-1998) IDE: Fix ToolingSingleFileKlibResolveStrategy to recongnize klib archives (3 дня назад) <Dmitriy Dolovov>
* ef199f8e459 - Mark obsolete createKotlinLibrary() call as @Deprecated (3 дня назад) <Dmitriy Dolovov>
* acc3395ca50 - IDE: Don't analyze incompatible KLIBs with components (3 дня назад) <Dmitriy Dolovov>
* 623b554297a - IDE: Fix friendly displaying of K/N KLIBs with components (3 дня назад) <Dmitriy Dolovov>
* 43360967755 - Use "tooling" KLIB resolve strategy in IDE and commonizer (3 дня назад) <Dmitriy Dolovov>
* 1196044df76 - Introduce 2 KLIB resolve strategies: "compiler" & "tooling" (3 дня назад) <Dmitriy Dolovov>
* 1053428ee4d - Minor: Formatted (3 дня назад) <Dmitriy Dolovov>
* 8028a3f55be - Minor: Clean-up in konan File (3 дня назад) <Dmitriy Dolovov>
* 60a2d0f037c - (tag: build-1.4.0-dev-1982, tag: build-1.4.0-dev-1981) [NI] Approximate receivers for callable reference candidates (4 дня назад) <Mikhail Zarechenskiy>
* 517688e1638 - (tag: build-1.4.0-dev-1979) [NI] Revise variance calculation method for completion mode (4 дня назад) <Pavel Kirpichenkov>
* e27b2990e3e - Update message on KotlinReflectionInternalError to reflect that typealiases are also unsupported (4 дня назад) <Will Boyd>
* 3819b2ce59b - (tag: build-1.4.0-dev-1973) Change unsupported 1.0 version in maven plugin tests (4 дня назад) <Pavel Kirpichenkov>
* 188abc243a4 - (tag: build-1.4.0-dev-1970) [FIR] add vararg arguments support, improve vararg parameters support (4 дня назад) <Juan Chen>
* 069fbffaa31 - (tag: build-1.4.0-dev-1963) Regenerate tests: fix LightAnalysisModeTestGenerated (4 дня назад) <Mikhail Zarechenskiy>
* bda5b0d5a99 - (tag: build-1.4.0-dev-1961) JVM_IR: further refine synthetic accessor generation (4 дня назад) <pyos>
* 21d3adf084f - (tag: build-1.4.0-dev-1950) Minor. Fix android test compilation (4 дня назад) <Mikhael Bogdanov>
* 9e264916314 - Beatify names for enum name and ordinal local variables (4 дня назад) <Mikhael Bogdanov>
* cd0c45c8328 - JVM_IR. Generate proper suffix for companion backing field accessor and parameter name (4 дня назад) <Mikhael Bogdanov>
* 3ee344b836c - (tag: build-1.4.0-dev-1940) ForLoopsLowering: Fix issue with break/continue in loop over withIndex. (4 дня назад) <Mark Punzalan>
* 724eda8fdbf - (tag: build-1.4.0-dev-1937) Advance explicit Kotlin versions in gradle integration tests (5 дней назад) <Pavel Kirpichenkov>
* 9f25fdcedc2 - (tag: build-1.4.0-dev-1936) Minor, skip mustBeDocumented.kt for JDK 6 codegen tests (5 дней назад) <Alexander Udalov>
* e8a640851aa - (tag: build-1.4.0-dev-1934) FIR: Change the Fir2Ir handling of smart casts. (5 дней назад) <Mads Ager>
* d68a1898d01 - JVM_IR: Use direct field access instead of calling certain accessors. (5 дней назад) <Mads Ager>
* 09057c485b1 - (tag: build-1.4.0-dev-1929) Update to a newer idea to fix bad initialization of PsiSubstitutor (KT-36039) (5 дней назад) <Nikolay Krasko>
* 4490efab3e2 - (tag: build-1.4.0-dev-1925) [NI] Use original descriptor for functions imported from object during JS mangling (5 дней назад) <Victor Petukhov>
* fa924065ca3 - (tag: build-1.4.0-dev-1920) Enable `NonStrictOnlyInputTypesChecks` since 1.3 (5 дней назад) <Victor Petukhov>
* 06448b64696 - (tag: build-1.4.0-dev-1915) Revert "Set local build version to 1.4.255-SNAPSHOT" (5 дней назад) <Vyacheslav Gerasimov>
* 46b4620fdd9 - (tag: build-1.4.0-dev-1913) Use better wording in plugin advertiser (5 дней назад) <Kirill Shmakov>
* db6183644f6 - (tag: build-1.4.0-dev-1909) FIR: Add problem test (5 дней назад) <Denis Zharkov>
* e0dca923709 - FIR: Ignore whitespaces when comparing fir/non-fir diagnostic files (5 дней назад) <Denis Zharkov>
* 47ecaa5b06c - FIR: Fix scope intersection types (5 дней назад) <Denis Zharkov>
* d28e1f156a9 - FIR: Fix capturing of flexible types (5 дней назад) <Denis Zharkov>
* ac2b5beb4e3 - FIR: Optimize SupertypeComputationSession::breakLoops (5 дней назад) <Denis Zharkov>
* a44fa8db503 - (tag: build-1.4.0-dev-1905) Pack LLDB binaries into plugin (5 дней назад) <Kirill Shmakov>
* 06bab6ec48d - (tag: build-1.4.0-dev-1902) [FIR] Extract QualifierReceiver to a separate file (5 дней назад) <Mikhail Glukhikh>
* 2bb5740f470 - [FIR] Resolve ambiguities in Java static scopes (5 дней назад) <Mikhail Glukhikh>
* 4c8905b00fc - (tag: build-1.4.0-dev-1895) Add forgotten test file for FIR (5 дней назад) <Mikhail Zarechenskiy>
* 2f19ad7bdc8 - (tag: build-1.4.0-dev-1894) Redundant companion reference: fix false positive with overridden Java getter (#2935) (5 дней назад) <Toshiaki Kameyama>
* 9f7af4b58da - Fix testdata after ebe3619251c658080cc225ba4b0957be0a73ca8d (5 дней назад) <Ilya Kirillov>
* 736f5e365c4 - (tag: build-1.4.0-dev-1891, tag: build-1.4.0-dev-1887) [NI] Create error type for CST of error types (5 дней назад) <Pavel Kirpichenkov>
* ac69c287ecb - (tag: build-1.4.0-dev-1886) [NI] Don't treat last labeled return expression in lambda specially (5 дней назад) <Mikhail Zarechenskiy>
* 66a15d23d8b - Fix tests from `LiveTemplatesTest` (5 дней назад) <Dmitry Gridin>
* cf3e4608f3b - (tag: build-1.4.0-dev-1883) JVM IR: Support -Xno-call-assertions (5 дней назад) <Steven Schäfer>
* 61e6d346aa0 - (tag: build-1.4.0-dev-1879) [JVM IR] Interface Delegation by Property should use existing field (5 дней назад) <Kristoffer Andersen>
* d4170bca6e3 - Regenerate generated files after updating copyright year (5 дней назад) <Alexander Udalov>
* e33a81a9682 - (tag: build-1.4.0-dev-1876) Tests: fix gradle tests for script configuration loading (5 дней назад) <Natalia Selezneva>
* f9a4b8f9cb2 - [FIR] Split printer in tree generator to several files (5 дней назад) <Dmitriy Novozhilov>
* 075068155bb - [FIR] Delay configuration of nodes in tree generator (5 дней назад) <Dmitriy Novozhilov>
* 9f6cf5c8f4f - [FIR] Add forgotten replacing lambdas in arguments of try and when calls (5 дней назад) <Dmitriy Novozhilov>
* f8c8925fd67 - [FIR] Support DFA analysis of postponed lambdas. Add more kinds of edges of CFG (5 дней назад) <Dmitriy Novozhilov>
* c78da854f72 - [FIR] Make Stack an abstract class (5 дней назад) <Dmitriy Novozhilov>
* 5de37baf6e8 - [FIR] Rename `EnterNode` and `ExitNode` interface to markers (5 дней назад) <Dmitriy Novozhilov>
* ec0f8a9c771 - [FIR] Hide modifications of CFG from public API (5 дней назад) <Dmitriy Novozhilov>
* 6716cb0bf3c - [FIR] Add edge kinds to control flow graph (5 дней назад) <Dmitriy Novozhilov>
* 0c2157155d5 - [FIR-TEST] Remove outdated empty test class (5 дней назад) <Dmitriy Novozhilov>
* 237198758d2 - [FIR] Get rid of `alivePreviousNodes` in control flow graph (5 дней назад) <Dmitriy Novozhilov>
* 1180ec54ef4 - [FIR] Add unique id's for nodes of control flow graph (5 дней назад) <Dmitriy Novozhilov>
* 10900e0d907 - (tag: build-1.4.0-dev-1874) JVM_IR. Don't copy synthetic method for property annotations if @JvmStatic presented (5 дней назад) <Mikhael Bogdanov>
* 832064305f6 - (tag: build-1.4.0-dev-1871) [NI] Set correct applicability for unknown lambda parameter diagnostic (5 дней назад) <Pavel Kirpichenkov>
* eec039f5a26 - [NI] Report error about unknown parameter type of lambda argument (5 дней назад) <Pavel Kirpichenkov>
* 9fb85792528 - [minor] Refactor KotlinCallCompleter (5 дней назад) <Pavel Kirpichenkov>
* 96f49d8e3cb - (tag: build-1.4.0-dev-1858) Remove trailing comma from some tests (6 дней назад) <Dmitry Gridin>
* 53f66e95090 - (tag: build-1.4.0-dev-1853) PSI2IR: SAM conversion in varargs (6 дней назад) <Dmitry Petrov>
* 186a456e016 - (tag: build-1.4.0-dev-1845) JVM IR: fix condition in Documented annotation generation (6 дней назад) <Alexander Udalov>
* d71dec9b642 - (tag: build-1.4.0-dev-1844) Minor, fix typo in condition in AbstractWriteFlagsTest (6 дней назад) <Alexander Udalov>
* 5a04b7935e1 - (tag: build-1.4.0-dev-1842) Add workaround for obsolete inline suspend integration test (6 дней назад) <Pavel Kirpichenkov>
* 9902643a26e - Remove unsupported versions from kotlin compiler tab in settings (6 дней назад) <Pavel Kirpichenkov>
* 913ed71863e - Update error about unsupported language and API versions (6 дней назад) <Pavel Kirpichenkov>
* 715e7e1a3c1 - (tag: build-1.4.0-dev-1840) Downgrade Kotlin/Native version to 1.4-dev-14287 as latest published (6 дней назад) <Sergey Igushkin>
* 30a9f0a875a - (tag: build-1.4.0-dev-1839) Update versions.kotlin-native to 1.4-dev-14288 (6 дней назад) <Sergey Igushkin>
* a8650ccfd21 - (tag: build-1.4.0-dev-1835) Set local build version to 1.4.255-SNAPSHOT (6 дней назад) <Vyacheslav Gerasimov>
* f4912ed4335 - (tag: build-1.4.0-dev-1834) Minor, simplify JS-related build files a bit (6 дней назад) <Alexander Udalov>
* d27bb76fd02 - Remove dependency of serialization.js on cli (6 дней назад) <Alexander Udalov>
* dcf6a2199ac - (tag: build-1.4.0-dev-1829) Generate JvmOverloads methods as final (6 дней назад) <Alexander Udalov>
* 73aa36ca59c - JVM: Add D8 check that class files can be dexed with D8. (6 дней назад) <Mads Ager>
* 222ceb76987 - Uast: fix for Lambda in place call identifiers (KT-35432) (6 дней назад) <Nicolay Mitropolsky>
* ac3a8eb4948 - Uast: fixes for Enum identifiers (KT-35432) (6 дней назад) <Nicolay Mitropolsky>
* 953b461c53d - (tag: build-1.4.0-dev-1825) Add new compiler errors and flags when JVM compiles against JVM IR (6 дней назад) <Alexander Udalov>
* f262f610967 - (tag: build-1.4.0-dev-1824) [JVM + IR] Fix Generic Signature Test Expectations (6 дней назад) <Kristoffer Andersen>
* e226561150c - [JVM IR] Copy metadata in IrFieldBuilder. (6 дней назад) <Mark Punzalan>
* f5f25224b05 - (tag: build-1.4.0-dev-1822) JVM_IR. Add IrAsmLikeInstructionListingTestGenerated tests (6 дней назад) <Mikhael Bogdanov>
* 342ff50e31c - Minor. Update test (6 дней назад) <Mikhael Bogdanov>
* 1ecf9d407fd - JVM_IR. Align order of JvmOverload functions between backends (6 дней назад) <Mikhael Bogdanov>
* 504d79577df - JVM_IR. Align outer parameter name generation between backends (6 дней назад) <Mikhael Bogdanov>
* 17e89fbbdb9 - JVM_IR. Align synthetic parameter name generation across backends (6 дней назад) <Mikhael Bogdanov>
* c42984ca336 - Generate proper flags for <clinit> (6 дней назад) <Mikhael Bogdanov>
* 6c07dbf351c - JVM_IR. Support type annotations (6 дней назад) <Mikhael Bogdanov>
* e4258e528f5 - (tag: build-1.4.0-dev-1818) Introduce internal property sourceMapBaseDirs for Kotlin2JsCompile (6 дней назад) <Vyacheslav Gerasimov>
* b06645d1c0b - (tag: build-1.4.0-dev-1814) Update number of reachable nodes because of MutableList.removeFirst/Last (6 дней назад) <Abduqodiri Qurbonzoda>
* 9594b8db427 - (tag: build-1.4.0-dev-1805) Rename Kotlin/Native modules for uniformity (6 дней назад) <Dmitriy Dolovov>
* abd86107d1b - Include :native:frontend.native into kotlin-compiler.jar (6 дней назад) <Dmitriy Dolovov>
* 25ff33cc3cd - Update NativePlatformAnalyzerServices from Kotlin/Native repo (6 дней назад) <Dmitriy Dolovov>
* b49e6ac5811 - Rename :kotlin-native:kotlin-native-library-reader to :native:frontend.native (6 дней назад) <Dmitriy Dolovov>
* 53d50c935ae - (tag: build-1.4.0-dev-1801) [FIR] Do not use strict type equality in override checker (6 дней назад) <Mikhail Glukhikh>
* e43a57bdeed - [FIR] Do not process constructors in super-type scopes (6 дней назад) <Mikhail Glukhikh>
* b4267558d73 - [FIR] Fix constructors aliased importing (6 дней назад) <Mikhail Glukhikh>
* bf9673a0a27 - (tag: build-1.4.0-dev-1798) PSI2IR: SAM conversion should be performed once for index variables (6 дней назад) <Dmitry Petrov>
* e7505285516 - (tag: build-1.4.0-dev-1796) Fix project compilation against bootstrap compiler (6 дней назад) <Mikhail Zarechenskiy>
* 091e8495cd2 - [JS IR] Use util-klib tool to filter klib in JS IR gradle plugin (6 дней назад) <Svyatoslav Kuzmich>
* e3225469b5b - (tag: build-1.4.0-dev-1794) Fix typo in Copyright since year (6 дней назад) <Stanislav Erokhin>
* ebe3619251c - (tag: build-1.4.0-dev-1782) KT-33384 Intention to switch between single-line/multi-line lambda (#2790) (6 дней назад) <Toshiaki Kameyama>
* f94d026e641 - (tag: build-1.4.0-dev-1781) Retrieve outputFile from KotlinWebpack task (6 дней назад) <David Schreiber-Ranner>
* ae22dc352c3 - Fix file components order (6 дней назад) <David Schreiber-Ranner>
* a8edd081212 - (tag: build-1.4.0-dev-1777) [NI] Do not rely on a key that returns non-substituted types (7 дней назад) <Mikhail Zarechenskiy>
* e42f16c95c6 - [NI] Fix construction of common system for builder inference (7 дней назад) <Mikhail Zarechenskiy>
* e3b61044899 - [NI] Map vararg to Array if it's resolved against type variable (7 дней назад) <Mikhail Zarechenskiy>
* 35f6810b58f - [NI] Do not incorporate constraints that are needed only for nullability (7 дней назад) <Mikhail Zarechenskiy>
* ce690d8a1de - Add test for obsolete issue (7 дней назад) <Mikhail Zarechenskiy>
* e725f255f14 - (tag: build-1.4.0-dev-1775) FIR: Share the same ScopeSession instance between phases (7 дней назад) <Denis Zharkov>
* 280fb947749 - FIR: Cache file importing scopes (7 дней назад) <Denis Zharkov>
* 0b2b23189ab - FIR: Cache default importing scopes (7 дней назад) <Denis Zharkov>
* 95084a5312e - FIR: Minor. Inline unused parameter in FirDefaultStarImportingScope (7 дней назад) <Denis Zharkov>
* 3b33df6564d - Reduce external dependencies in :kotlin-native:kotlin-native-library-reader (7 дней назад) <Dmitriy Dolovov>
* 1b472b6b121 - Move KonanLibraryConstants out of :kotlin-native:kotlin-native-library-reader (7 дней назад) <Dmitriy Dolovov>
* cd71f250e55 - Move KonanFactories out of :kotlin-native:kotlin-native-library-reader (7 дней назад) <Dmitriy Dolovov>
* 3f95ac341c9 - (tag: build-1.4.0-dev-1773) [FIR] Implement SAM candidates discrimination (7 дней назад) <Mikhail Glukhikh>
* c37a2d3dc3c - (tag: build-1.4.0-dev-1769) Fix completion test: add coroutines-compat jar dependency (7 дней назад) <Ilya Gorbunov>
* 3bd3d614698 - Test experimental coroutines version requirement on JVM only (7 дней назад) <Ilya Gorbunov>
* 7792613f887 - Finishing touch: drop experimental coroutines sourcesets from stdlib (7 дней назад) <Ilya Gorbunov>
* c28710419a9 - Drop noStdLib coroutines tests (7 дней назад) <Ilya Gorbunov>
* 30bccc431bf - Migrate tests to release coroutines (7 дней назад) <Ilya Gorbunov>
* f465e7a9572 - Add coroutines-experimental-compat to idea plugin dist (7 дней назад) <Ilya Gorbunov>
* 9f8e3dad337 - Add coroutines-compat jar dependency to those tests that require it (7 дней назад) <Ilya Gorbunov>
* cef81e11b7d - Do not generate JS tests for experimental coroutines support (7 дней назад) <Ilya Gorbunov>
* b5a0daabc37 - Extract kotlin.coroutines.experimental API into compat artifact (7 дней назад) <Ilya Gorbunov>
* 075eea5a968 - (tag: build-1.4.0-dev-1760) Update year and fix inconsistency with LICENSE.txt (7 дней назад) <Stanislav Erokhin>
* 70ce63c8d4d - (tag: build-1.4.0-dev-1737) FIR: Support rewritten implicit types calculator in IDE (7 дней назад) <Denis Zharkov>
* c6c773f6f91 - FIR: Mark all dependencies' declarations as fully resolved (7 дней назад) <Denis Zharkov>
* dd51d5065a9 - FIR: Rename classes properly in FirImplicitBodyResolve.kt (7 дней назад) <Denis Zharkov>
* 1cb18a73db7 - FIR: Get rid of old FirImplicitTypeBodyResolveTransformerAdapter (7 дней назад) <Denis Zharkov>
* f2abb57021d - FIR: Introduce and use FirClass<*>::unsubstitutedScope (7 дней назад) <Denis Zharkov>
* 6e8d67b96f7 - FIR: Simplify contract in FirScopeProvider::getUseSiteMemberScope (7 дней назад) <Denis Zharkov>
* de4bfb39731 - FIR: Implement FirApplyInferredDeclarationTypesTransformer (7 дней назад) <Denis Zharkov>
* 8e672222bb1 - FIR: Do not resolve implicitly typed function twice (7 дней назад) <Denis Zharkov>
* c295f2dc25c - FIR: Reimplement implicit types calculator (7 дней назад) <Denis Zharkov>
* f256547cc86 - (tag: build-1.4.0-dev-1736) Revert "JVM_IR: Use direct field access instead of calling certain accessors." (7 дней назад) <max-kammerer>
* 6fdd4cb134b - (tag: build-1.4.0-dev-1731) Add scroll bar to compiler configuration tab (7 дней назад) <Igor Yakovlev>
* 056c3c95bb3 - (tag: build-1.4.0-dev-1722) [FIR-TEST] Remove unnecessary test (7 дней назад) <Dmitriy Novozhilov>
* ff3116f0ed0 - [FIR] Support intersection types in some type context methods (7 дней назад) <Dmitriy Novozhilov>
* 57a1342aac7 - [FIR] Fix creating DefinitelyNotNullTypes (7 дней назад) <Dmitriy Novozhilov>
* 4303cd2fc77 - [FIR] Put rendering of cone types in one place and change render for error types (7 дней назад) <Dmitriy Novozhilov>
* a882cd98ead - [FIR] Drop duplicate edges in fir tree graph (7 дней назад) <Dmitriy Novozhilov>
* 985b61f9253 - [FIR] Drop `ARRAY_CLASS_NAME` and use name from StandardClassIds instead (7 дней назад) <Dmitriy Novozhilov>
* 7d8363d6aaf - [FIR] Use `Function<R>` as super type for all `FunctionN`types (7 дней назад) <Dmitriy Novozhilov>
* 099d737e86d - (tag: build-1.4.0-dev-1717) [FIR] Fix compiler configuration for modularized test (7 дней назад) <simon.ogorodnik>
* f7dfbbbfbd6 - (tag: build-1.4.0-dev-1713) Remove const keyword requirement from UL final fields initializers (7 дней назад) <Igor Yakovlev>
* 00c71dd098f - (tag: build-1.4.0-dev-1711) Clear computable when value is calculated and CallOnceFunction is added (7 дней назад) <Vladimir Dolzhenko>
* 62f9e7a810f - (tag: build-1.4.0-dev-1710) JVM_IR: Use direct field access instead of calling certain accessors. (7 дней назад) <Mads Ager>
* e351d560d67 - (tag: build-1.4.0-dev-1708) IR: remove KotlinIrLinker.checkAccessibility (7 дней назад) <Georgy Bronnikov>
* 678c74b17f7 - [NI] Don't forget to update receivers for builder-inference (7 дней назад) <Mikhail Zarechenskiy>
* 97abc872b25 - IR: deal with corresponding classes for enum entries in JvmDescriptorUniqIdAware (7 дней назад) <Georgy Bronnikov>
* f75400cc1a9 - IR: avoid some calls of getUniqId() (7 дней назад) <Georgy Bronnikov>
* 8f4b4007fec - JVM_IR: Add test for compiling against cross-platform Klib (7 дней назад) <Georgy Bronnikov>
* f1b5198b860 - Avoid calling ExternalDependenciesGenerator twice (7 дней назад) <Georgy Bronnikov>
* 5ede65c5255 - JVM_IR: read Klib (7 дней назад) <Georgy Bronnikov>
* 47d6bdfd35a - IR: add isProvidedByDefault() to SearchPathResolver (7 дней назад) <Georgy Bronnikov>
* ed4be36484c - JVM_IR, minor: change package for JvmMangler (7 дней назад) <Georgy Bronnikov>
* 2d3a142786e - (tag: build-1.4.0-dev-1704) Commonize 'fun interface' handling as much as possible (8 дней назад) <Dmitry Petrov>
* edff099ab10 - (tag: build-1.4.0-dev-1702) [Commonizer] Don't use experimental Kotlin time in commonizer (8 дней назад) <Dmitriy Dolovov>
* 40b358b43c0 - [Commonizer] Process endorsed libraries in CLI (8 дней назад) <Dmitriy Dolovov>
* aa1c7bb5627 - [Commonizer] Fix classpath dependency for CLI (8 дней назад) <Dmitriy Dolovov>
* e4d157c126f - (tag: build-1.4.0-dev-1698) [coroutine] running coroutine stack frame merged with coroutine info (8 дней назад) <Vladimir Ilmov>
* f1669e22300 - (tag: build-1.4.0-dev-1697) IR: mark interface delegate fields as synthetic (8 дней назад) <pyos>
* ce1f746c5e2 - (tag: build-1.4.0-dev-1694) [FIR] Allow more than one function with some name in local scope (8 дней назад) <Mikhail Glukhikh>