### PR TITLE
[kotlin compiler][update] 1.4.0-dev-2368

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
@@ -76,7 +76,7 @@ internal val Context.getBoxFunction: (IrClass) -> IrSimpleFunction by Context.la
             isFakeOverride = false,
             isOperator = false
     ).also { function ->
-        function.valueParameters.add(WrappedValueParameterDescriptor().let {
+        function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(
                     startOffset, endOffset,
                     IrDeclarationOrigin.DEFINED,
@@ -130,7 +130,7 @@ internal val Context.getUnboxFunction: (IrClass) -> IrSimpleFunction by Context.
             isFakeOverride = false,
             isOperator = false
     ).also { function ->
-        function.valueParameters.add(WrappedValueParameterDescriptor().let {
+        function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(
                     startOffset, endOffset,
                     IrDeclarationOrigin.DEFINED,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -126,7 +126,7 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
             builtClassesMap.getOrPut(descriptor) {
                 createClass(descriptor).apply {
                     val functionClass = this
-                    descriptor.declaredTypeParameters.mapTo(typeParameters) { typeParameterDescriptor ->
+                    typeParameters += descriptor.declaredTypeParameters.map { typeParameterDescriptor ->
                         createTypeParameter(typeParameterDescriptor).also {
                             it.parent = this
                             it.superTypes += irBuiltIns.anyNType
@@ -134,7 +134,7 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                     }
 
                     val descriptorToIrParametersMap = typeParameters.map { it.descriptor to it }.toMap()
-                    descriptor.typeConstructor.supertypes.mapTo(superTypes) { superType ->
+                    superTypes += descriptor.typeConstructor.supertypes.map { superType ->
                         val arguments = superType.arguments.map { argument ->
                             val argumentClassifierDescriptor = argument.type.constructor.declarationDescriptor
                             val argumentClassifierSymbol = argumentClassifierDescriptor?.let { descriptorToIrParametersMap[it] }
@@ -165,7 +165,7 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                             typeParameters.last().defaultType
                     ).apply {
                         parent = functionClass
-                        invokeFunctionDescriptor.valueParameters.mapTo(valueParameters) {
+                        valueParameters += invokeFunctionDescriptor.valueParameters.map {
                             IrValueParameterImpl(
                                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                                     invokeFunctionOrigin,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -170,9 +170,9 @@ internal class SpecialDeclarationsFactory(val context: Context) : KotlinMangler 
 
             dispatchReceiverParameter = dispatchReceiver?.copyTo(this)
             extensionReceiverParameter = extensionReceiver?.copyTo(this)
-            function.valueParameters.mapTo(valueParameters) { it.copyTo(this, type = valueParameterTypes[it.index]) }
+            valueParameters += function.valueParameters.map { it.copyTo(this, type = valueParameterTypes[it.index]) }
 
-            function.typeParameters.mapIndexedTo(typeParameters) { index, parameter ->
+            typeParameters += function.typeParameters.mapIndexed { index, parameter ->
                 WrappedTypeParameterDescriptor().let {
                     IrTypeParameterImpl(
                             startOffset, endOffset,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
@@ -44,7 +44,7 @@ internal fun makeEntryPoint(context: Context): IrFunction {
             isFakeOverride = false,
             isOperator = false
     ).also { function ->
-        function.valueParameters.add(WrappedValueParameterDescriptor().let {
+        function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(
                     actualMain.startOffset, actualMain.startOffset,
                     IrDeclarationOrigin.DEFINED,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.builtins.konan.KonanBuiltIns
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
+import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
@@ -63,6 +64,8 @@ internal abstract class KonanBackendContext(val config: KonanConfig) : CommonBac
     override val internalPackageFqn = KonanFqNames.internalPackageName
 
     override val mapping: Mapping = DefaultMapping()
+
+    override val extractedLocalClasses: MutableSet<IrClass> = mutableSetOf()
 }
 
 internal fun IrElement.getCompilerMessageLocation(containingFile: IrFile): CompilerMessageLocation? =

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
@@ -6,6 +6,8 @@
 package org.jetbrains.kotlin.backend.konan
 
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
+import org.jetbrains.kotlin.backend.common.DefaultMapping
+import org.jetbrains.kotlin.backend.common.Mapping
 import org.jetbrains.kotlin.backend.konan.descriptors.KonanSharedVariablesManager
 import org.jetbrains.kotlin.backend.konan.descriptors.findPackage
 import org.jetbrains.kotlin.backend.konan.descriptors.kotlinNativeInternal
@@ -60,6 +62,7 @@ internal abstract class KonanBackendContext(val config: KonanConfig) : CommonBac
 
     override val internalPackageFqn = KonanFqNames.internalPackageName
 
+    override val mapping: Mapping = DefaultMapping()
 }
 
 internal fun IrElement.getCompilerMessageLocation(containingFile: IrFile): CompilerMessageLocation? =

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -89,7 +89,11 @@ internal val arrayConstructorPhase = makeKonanModuleLoweringPhase(
 internal val inlinePhase = namedIrModulePhase(
         lower = object : SameTypeCompilerPhase<Context, IrModuleFragment> {
             override fun invoke(phaseConfig: PhaseConfig, phaserState: PhaserState<IrModuleFragment>, context: Context, input: IrModuleFragment): IrModuleFragment {
-                FunctionInlining(context).inline(input)
+                FunctionInlining(context).run {
+                    input.files.forEach {
+                        lower(it)
+                    }
+                }
                 return input
             }
         },

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -176,7 +176,8 @@ internal val tailrecPhase = makeKonanFileLoweringPhase(
 
 internal val defaultParameterExtentPhase = makeKonanFileOpPhase(
         { context, irFile ->
-            DefaultArgumentStubGenerator(context, skipInlineMethods = false).runOnFilePostfix(irFile)
+            DefaultArgumentStubGenerator(context, skipInlineMethods = false).lower(irFile)
+            DefaultParameterCleaner(context, replaceDefaultValuesWithStubs = true).lower(irFile)
             KonanDefaultParameterInjector(context).lower(irFile)
         },
         name = "DefaultParameterExtent",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -112,8 +112,12 @@ internal val lowerAfterInlinePhase = makeKonanModuleOpPhase(
 
 /* IrFile phases */
 
-internal val lateinitPhase = makeKonanFileLoweringPhase(
-        ::LateinitLowering,
+internal val lateinitPhase = makeKonanFileOpPhase(
+        { context, irFile ->
+            NullableFieldsForLateinitCreationLowering(context).lower(irFile)
+            NullableFieldsDeclarationLowering(context).lower(irFile)
+            LateinitUsageLowering(context).lower(irFile)
+        },
         name = "Lateinit",
         description = "Lateinit properties lowering",
         prerequisite = setOf(inlinePhase)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -275,8 +275,11 @@ internal val compileTimeEvaluatePhase = makeKonanFileLoweringPhase(
         prerequisite = setOf(varargPhase)
 )
 
-internal val coroutinesPhase = makeKonanFileLoweringPhase(
-        ::NativeSuspendFunctionsLowering,
+internal val coroutinesPhase = makeKonanFileOpPhase(
+        { context, irFile ->
+            NativeSuspendFunctionsLowering(context).lower(irFile)
+            RemoveSuspendLambdas().lower(irFile)
+        },
         name = "Coroutines",
         description = "Coroutines lowering",
         prerequisite = setOf(localFunctionsPhase, finallyBlocksPhase)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -1290,7 +1290,7 @@ private class ObjCBlockPointerValuePassing(
         irClass.addChild(invokeMethod)
         invokeMethod.createDispatchReceiverParameter()
 
-        (0 until parameterCount).mapTo(invokeMethod.valueParameters) { index ->
+        invokeMethod.valueParameters += (0 until parameterCount).map { index ->
             val parameterDescriptor = WrappedValueParameterDescriptor()
             val parameter = IrValueParameterImpl(
                     startOffset, endOffset,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/KonanIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/KonanIr.kt
@@ -97,8 +97,9 @@ class IrFileImpl(entry: SourceManager.FileEntry) : IrFile {
 
     override val metadata: MetadataSource.File?
         get() = TODO("not implemented")
-    override val annotations: MutableList<IrConstructorCall>
+    override var annotations: List<IrConstructorCall>
         get() = TODO("not implemented")
+        set(_) = TODO("not implemented")
     override val fqName: FqName
         get() = TODO("not implemented")
     override val symbol: IrFileSymbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
@@ -53,7 +53,7 @@ internal interface DescriptorToIrTranslationMixin {
                     descriptor = descriptor
             ).also { irClass ->
                 symbolTable.withScope(descriptor) {
-                    descriptor.typeConstructor.supertypes.mapTo(irClass.superTypes) {
+                    irClass.superTypes += descriptor.typeConstructor.supertypes.map {
                         it.toIrType()
                     }
                     irClass.generateAnnotations()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
@@ -82,7 +82,7 @@ internal interface DescriptorToIrTranslationMixin {
                 SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                 IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB, constructorDescriptor
         )
-        constructorDescriptor.valueParameters.mapTo(irConstructor.valueParameters) { valueParameterDescriptor ->
+        irConstructor.valueParameters += constructorDescriptor.valueParameters.map { valueParameterDescriptor ->
             symbolTable.declareValueParameter(
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrDeclarationOrigin.DEFINED,
                     valueParameterDescriptor,
@@ -123,7 +123,7 @@ internal interface DescriptorToIrTranslationMixin {
         val irFunction = symbolTable.declareSimpleFunctionWithOverrides(SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, origin, functionDescriptor)
         symbolTable.withScope(functionDescriptor) {
             irFunction.returnType = functionDescriptor.returnType!!.toIrType()
-            functionDescriptor.valueParameters.mapTo(irFunction.valueParameters) {
+            irFunction.valueParameters +=  functionDescriptor.valueParameters.map {
                 symbolTable.declareValueParameter(SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrDeclarationOrigin.DEFINED, it, it.type.toIrType())
             }
             irFunction.dispatchReceiverParameter = functionDescriptor.dispatchReceiverParameter?.let {
@@ -135,7 +135,7 @@ internal interface DescriptorToIrTranslationMixin {
     }
 
     private fun IrDeclaration.generateAnnotations() {
-        descriptor.annotations.mapTo(annotations) {
+        annotations += descriptor.annotations.map {
             typeTranslator.constantValueGenerator.generateAnnotationConstructorCall(it)!!
         }
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumClassGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumClassGenerator.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrEnumConstructorCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrExpressionBodyImpl
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -119,14 +120,14 @@ internal class CEnumClassGenerator(
                 SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                 IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB, entryDescriptor
         ).also { enumEntry ->
-            enumEntry.initializerExpression = IrEnumConstructorCallImpl(
+            enumEntry.initializerExpression = IrExpressionBodyImpl(IrEnumConstructorCallImpl(
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                     type = irBuiltIns.unitType,
                     symbol = symbolTable.referenceConstructor(enumDescriptor.unsubstitutedPrimaryConstructor!!),
                     typeArgumentsCount = 0 // enums can't be generic
             ).also {
                 it.putValueArgument(0, extractEnumEntryValue(entryDescriptor))
-            }
+            })
         }
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -509,6 +509,6 @@ private val Context.getLoweredInlineClassConstructor: (IrConstructor) -> IrSimpl
     ).apply {
         descriptor.bind(this)
         parent = irConstructor.parent
-        irConstructor.valueParameters.mapTo(valueParameters) { it.copyTo(this) }
+        valueParameters += irConstructor.valueParameters.map { it.copyTo(this) }
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
@@ -268,7 +268,7 @@ internal class CallableReferenceLowering(val context: Context): FileLoweringPass
                 parent = functionReferenceClass
                 functionReferenceClass.declarations += this
 
-                boundFunctionParameters.mapIndexedTo(valueParameters) { index, parameter ->
+                valueParameters += boundFunctionParameters.mapIndexed { index, parameter ->
                     parameter.copyTo(this, DECLARATION_ORIGIN_FUNCTION_REFERENCE_IMPL, index,
                             type = parameter.type.substitute(typeArgumentsMap))
                 }
@@ -328,7 +328,7 @@ internal class CallableReferenceLowering(val context: Context): FileLoweringPass
 
                 this.createDispatchReceiverParameter()
 
-                superFunction.valueParameters.mapIndexedTo(valueParameters) { index, parameter ->
+                valueParameters += superFunction.valueParameters.mapIndexed { index, parameter ->
                     parameter.copyTo(function, DECLARATION_ORIGIN_FUNCTION_REFERENCE_IMPL, index,
                             type = parameter.type.substitute(typeArgumentsMap))
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
@@ -222,7 +222,7 @@ internal class EnumClassLowering(val context: Context) : ClassLoweringPass {
                     enumEntries
                             .sortedBy { it.name }
                             .map {
-                                val initializer = it.initializerExpression
+                                val initializer = it.initializerExpression?.expression
                                 val entryConstructorCall = when {
                                     initializer is IrConstructorCall -> initializer
 
@@ -289,7 +289,7 @@ internal class EnumClassLowering(val context: Context) : ClassLoweringPass {
                                 dispatchReceiver = irGet(instances)
                                 putValueArgument(0, irInt(it.index))
                             }
-                            val initializer = it.value.initializerExpression!!
+                            val initializer = it.value.initializerExpression!!.expression
                             initializer.setDeclarationsParent(constructor)
                             when {
                                 initializer is IrConstructorCall -> +initInstanceCall(instance, initializer)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -153,7 +153,7 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
 
             loweredConstructor.valueParameters += createSynthesizedValueParameter(0, "name", context.irBuiltIns.stringType)
             loweredConstructor.valueParameters += createSynthesizedValueParameter(1, "ordinal", context.irBuiltIns.intType)
-            constructor.valueParameters.mapTo(loweredConstructor.valueParameters) {
+            loweredConstructor.valueParameters += constructor.valueParameters.map {
                 it.copyTo(loweredConstructor, index = it.loweredIndex).apply {
                     loweredEnumConstructorParameters[it] = this
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -262,9 +262,9 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
             resultDescriptor.bind(result)
             result.parent = irClass
             result.createDispatchReceiverParameter()
-            constructor.valueParameters.mapTo(result.valueParameters) { it.copyTo(result) }
+            result.valueParameters += constructor.valueParameters.map { it.copyTo(result) }
 
-            result.overriddenSymbols.add(initMethod.symbol)
+            result.overriddenSymbols += initMethod.symbol
 
             result.body = context.createIrBuilder(result.symbol).irBlockBody(result) {
                 +irReturn(
@@ -407,7 +407,7 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
             }
         }
 
-        parameterTypes.mapIndexedTo(newFunction.valueParameters) { index, type ->
+        newFunction.valueParameters += parameterTypes.mapIndexed { index, type ->
             WrappedValueParameterDescriptor().let {
                 IrValueParameterImpl(
                         function.startOffset, function.endOffset,

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2232,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-2232
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2232,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-2232
-kotlinStdlibTestsVersion=1.4.0-dev-2232
-testKotlinCompilerVersion=1.4.0-dev-2232
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2368,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-2368
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2368,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-2368
+kotlinStdlibTestsVersion=1.4.0-dev-2368
+testKotlinCompilerVersion=1.4.0-dev-2368
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* f7c784adebc - (tag: build-1.4.0-dev-2368) JVM_IR: minor code cleanup in JvmStaticAnnotationLowering (vor 25 Stunden) <Georgy Bronnikov>
* 182e1c1b3bb - JVM_IR: Remove buggy special case accessor code from JvmStaticAnnotationLowering (vor 25 Stunden) <Georgy Bronnikov>
* b451c25dba1 - (tag: build-1.4.0-dev-2366) Fixed MoveJavaInnerClassKotlinUsagesHandler after obsolete API drop off (vor 28 Stunden) <Vladimir Dolzhenko>
* 5b48f63bb9e - (tag: build-1.4.0-dev-2363) Added missed runReadAction to access psi on bg thread (vor 2 Tagen) <Vladimir Dolzhenko>
* ce2d32620a5 - (tag: build-1.4.0-dev-2359) Add JoinWithTrailingCommaHandler to plugin-common.xml 191, 192 (vor 3 Tagen) <Vladimir Dolzhenko>
* 304700cf7bc - (tag: build-1.4.0-dev-2351) JVM IR: Add all relevant overridden symbols to generated bridge methods (vor 3 Tagen) <Steven Schäfer>
* 951b2fa7706 - JVM IR: Optimize type checks to null checks if possible (vor 3 Tagen) <Steven Schäfer>
* 07737f8fc6d - JVM IR: Fix BridgeLowering (vor 3 Tagen) <Steven Schäfer>
* 461d8ef368b - Add renaming special bridges to SpecialBridgeMethods (vor 3 Tagen) <Steven Schäfer>
* 5f6af58aeb5 - JVM IR: (Un)mute tests and add more tests for bridge generation (vor 3 Tagen) <Steven Schäfer>
* 12e31a17603 - JVM IR: Use dispatchReceiver to calculate owner in MethodSignatureMapper (vor 3 Tagen) <Steven Schäfer>
* 0e243ca2959 - JVM IR: Fix receiver types in AddContinuationLowering (vor 3 Tagen) <Steven Schäfer>
* a4414829bc6 - JVM IR: Fix dispatch receiver type in ResolveInlineCalls (vor 3 Tagen) <Steven Schäfer>
* f46ad102664 - JVM IR: Fix dispatch receiver type in InheritedDefaultMethodsOnClassesLowering (vor 3 Tagen) <Steven Schäfer>
* edd0ac6c6f1 - JVM IR: Fix types of temporaries in AddContinuationLowering (vor 3 Tagen) <Steven Schäfer>
* 30166b20b74 - JVM IR: Fix dispatch receiver types in FunctionNVarargBridgeLowering and ReplaceKFunctionInvokeWithFunctionInvoke (vor 3 Tagen) <Steven Schäfer>
* 66cbe3b1a8e - JVM IR: Remove IrReplacementFunction (vor 3 Tagen) <Steven Schäfer>
* 73b4f897b6f - JVM IR: Fix modalities in JvmSymbols (vor 3 Tagen) <Steven Schäfer>
* cfcdf05c92e - (tag: build-1.4.0-dev-2347) Fix documentListener leakage in PluginStartupActivity (vor 3 Tagen) <Vladimir Dolzhenko>
* fee72839bf7 - (tag: build-1.4.0-dev-2337) Report error if IR is enabled with incorrect language version (vor 3 Tagen) <Pavel Kirpichenkov>
* feccf9cc1b5 - (tag: build-1.4.0-dev-2333) Remove dependency of fir.tree on ir.tree (vor 3 Tagen) <Alexander Udalov>
* 10d2eebe287 - (tag: build-1.4.0-dev-2331) Gradle, native: Fix running cinterop on Windows hosts (vor 3 Tagen) <Ilya Matveev>
* 8cdef13537f - (tag: build-1.4.0-dev-2330) [JVM IR] Add tests to verify correct parameter reflection metadata for suspend functions. (vor 3 Tagen) <Mark Punzalan>
* 06408011f0f - (tag: build-1.4.0-dev-2328) JVM_IR: prefer to move, not copy, suspend lambda bodies (vor 3 Tagen) <pyos>
* 5acb3e14fb8 - IR: mark parameters for captures of crossinline parameters (vor 3 Tagen) <pyos>
* 2bf50cc91aa - JVM_IR: correctly name $$forInline versions of @JvmName suspend funs (vor 3 Tagen) <pyos>
* 08074bb60e8 - JVM_IR: wrap inline suspend references in suspend lambdas (vor 3 Tagen) <pyos>
* c34d2f9daac - (tag: build-1.4.0-dev-2323) [FIR] Fix signature calculation in JvmMappedScope (vor 3 Tagen) <Mikhail Glukhikh>
* 0c195be513c - [FIR TEST] Add test with MutableMap.compute (vor 3 Tagen) <Mikhail Glukhikh>
* 2fb508aa1b6 - [FIR] Fix DFA behaviour for a case with == (!=) true / false (vor 3 Tagen) <Mikhail Glukhikh>
* 36ba8bf6a9f - [FIR] Add test imitating complex smart casts on descriptors (vor 3 Tagen) <Mikhail Glukhikh>
* a8e89a63900 - [FIR] Fix various corner cases in DFA (vor 3 Tagen) <Mikhail Glukhikh>
* 1344d6407c0 - [FIR] DFA fix: imply != null after x as? NotNullType for real variables (vor 3 Tagen) <Mikhail Glukhikh>
* 1bbcec4935d - [FIR] DFA fix after x?.syntheticProperty ?: return (vor 3 Tagen) <Mikhail Glukhikh>
* d23c03e9dca - [FIR] Add test about synthetic / non-synthetic smart casts (vor 3 Tagen) <Mikhail Glukhikh>
* 9f9d53cc5ac - [FIR] Fix handling of scope emptiness in case of synthetic properties (vor 3 Tagen) <Mikhail Glukhikh>
* c8c0ba480b0 - (tag: build-1.4.0-dev-2319) FIR: Add problem tests for smart cast within init-section (vor 3 Tagen) <Denis Zharkov>
* 3518fcf78ce - (tag: build-1.4.0-dev-2315) Fix psi2ir tests broken by 7249d2f889972c619c0adc19bde9cfc6bacd883e (vor 3 Tagen) <Dmitry Petrov>
* a1326d3ef52 - !RENDER_DIAGNOSTICS_FULL_TEXT directive (vor 3 Tagen) <Dmitry Petrov>
* 4e6c3b6b431 - Diagnostics tests with JVM backend (vor 3 Tagen) <Dmitry Petrov>
* a17027e3303 - (tag: build-1.4.0-dev-2310) Fixed incompatibility with 191 and 192 (vor 4 Tagen) <Vladimir Dolzhenko>
* 5605eb5a317 - (tag: build-1.4.0-dev-2299) Review fix: add TODO comments (vor 4 Tagen) <Anton Bannykh>
* 70a4c265de7 - Add tests extracted from regressions (vor 4 Tagen) <Anton Bannykh>
* 1e96c3d21ef - DCE-driven mode (vor 4 Tagen) <Anton Bannykh>
* 571bbba0e3a - Change DCE a bit to touch less declarations (vor 4 Tagen) <Anton Bannykh>
* f07fb91e9d2 - Simple stage layers + enforce model (vor 4 Tagen) <Anton Bannykh>
* f437da8ee5a - Persistent IR implementation (vor 4 Tagen) <Anton Bannykh>
* 4c4b0ef0130 - Suspend Functions (vor 4 Tagen) <Anton Bannykh>
* 94d2a79d2e8 - FoldConstantLowering (vor 4 Tagen) <Anton Bannykh>
* 0efe2ab00ae - PropertyAccessorInlineLowering (vor 4 Tagen) <Anton Bannykh>
* 6e501e5f9bc - AnnotationConstructorLowering (vor 4 Tagen) <Anton Bannykh>
* d76bfdf860c - Enums (vor 4 Tagen) <Anton Bannykh>
* 3165556c6b3 - PrivateMembersLowering (vor 4 Tagen) <Anton Bannykh>
* f6d4ea469c5 - PrimaryConstructorLowering (vor 4 Tagen) <Anton Bannykh>
* 76ff30b86ec - ObjectLowering (vor 4 Tagen) <Anton Bannykh>
* ce625075f68 - MoveBodilessDeclarationsToSeparatePlace (vor 4 Tagen) <Anton Bannykh>
* 09a2c145a90 - CallableReferenceLowering (vor 4 Tagen) <Anton Bannykh>
* 98122913647 - BlockDecomposerLowering (vor 4 Tagen) <Anton Bannykh>
* e2d16d50969 - FunctionInlining (vor 4 Tagen) <Anton Bannykh>
* 86a4e17dc45 - LocalDelegatedProperties (vor 4 Tagen) <Anton Bannykh>
* 81e599c18f2 - VarargLowering (vor 4 Tagen) <Anton Bannykh>
* 489ba508c3d - TypeOperatorLowering (vor 4 Tagen) <Anton Bannykh>
* 05ab17f1e16 - ThrowableLowering (vor 4 Tagen) <Anton Bannykh>
* 15b2312cec6 - StaticMembersLowering (vor 4 Tagen) <Anton Bannykh>
* d9fbe8b951a - SecondaryCtorLowering (vor 4 Tagen) <Anton Bannykh>
* fb36432cb51 - PrimitiveCompanionLowering (vor 4 Tagen) <Anton Bannykh>
* edf6dec63bf - MultipleCatchesLowering (vor 4 Tagen) <Anton Bannykh>
* f1442f5ae91 - ConstLowering (vor 4 Tagen) <Anton Bannykh>
* 21ef35bc25e - ClassReferenceLowering (vor 4 Tagen) <Anton Bannykh>
* d9646a53611 - BridgesConstruction (vor 4 Tagen) <Anton Bannykh>
* 4142031fe79 - AutoboxingTransformer (vor 4 Tagen) <Anton Bannykh>
* 38d409a4877 - Inline function removal + body copying (vor 4 Tagen) <Anton Bannykh>
* 76c7668162b - CallsLowering (vor 4 Tagen) <Anton Bannykh>
* 64a5039ebe3 - Refactor default arguments lowering (vor 4 Tagen) <Anton Bannykh>
* 9327776706a - Rewrite inner class lowerings (vor 4 Tagen) <Anton Bannykh>
* 908c23cb482 - Make ForLoopsLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* 0d1c6e08c31 - Refactor LateinitLowering into DeclarationTransformer's and a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* 6e96e271aeb - Make InitializersLowering a BodyLoweringPass and add a InitializersCleanupLowering (vor 4 Tagen) <Anton Bannykh>
* 600caaa636c - Make ExpectDeclarationsRemoveLowering a DeclarationTransformer (vor 4 Tagen) <Anton Bannykh>
* d0284d19ec8 - Make PropertiesLowering a DeclarationTransformer (vor 4 Tagen) <Anton Bannykh>
* 03398e60256 - Make StripTypeAliasDeclarationsLowering a DeclarationTransformer (vor 4 Tagen) <Anton Bannykh>
* 3d726fe5a25 - Make InlineClassDeclarationLowering a DeclarationTransformer (vor 4 Tagen) <Anton Bannykh>
* 0a5db9d222b - Make inlineClassUsageLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* fe236507a00 - Make LocalDeclarationsLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* 1eec2acf43b - Make LocalClassPopupLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* d228de90081 - Make ArrayConstructorLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* bf26b86cf2f - Make ProvisionalFunctionExpressionLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* 5aa2deb449c - Make ReturnableBlockLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* 2fa04afbf22 - Make SharedVariablesLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* 936e53d0445 - Make TailrecLowering a BodyLoweringPass (vor 4 Tagen) <Anton Bannykh>
* a42f8499816 - Change BodyLoweringPass API; add DeclarationTransformer + helper methods (vor 4 Tagen) <Anton Bannykh>
* b087d2d756d - IR impl: additional constructors for IrBody implementations (vor 4 Tagen) <Anton Bannykh>
* 20dc3ccdb8e - New mechanism for mappings between old and produced declarations (vor 4 Tagen) <Anton Bannykh>
* e8fba8bcb68 - IR API: change `val ... : MutableList` to `var ...: List` for most lists (vor 4 Tagen) <Anton Bannykh>
* 0bcde9dffcf - IR API: Make IrEnumEntry.initializerExpression IrExpressionBody (vor 4 Tagen) <Anton Bannykh>
* 3ec671d727a - (tag: build-1.4.0-dev-2292) Fix getMirror for kotlin decompiled file (vor 4 Tagen) <Igor Yakovlev>
* ab32f2efaca - (tag: build-1.4.0-dev-2282) Use legacy configuration names to make jps import happy (vor 4 Tagen) <Ilya Gorbunov>
* f428bbb7828 - (tag: build-1.4.0-dev-2281) TrailingComma: `Join Lines` should remove trailing comma (vor 4 Tagen) <Dmitry Gridin>
* cb66625688b - TrailingComma: fix case of `when` without expression or property (vor 4 Tagen) <Dmitry Gridin>
* 6739d038238 - TrailingCommaPostFormatProcessor: change recursive checker (vor 4 Tagen) <Dmitry Gridin>
* 5054bc65a53 - Introduce `TrailingCommaHelper` (vor 4 Tagen) <Dmitry Gridin>
* c08c3d4d9bb - (tag: build-1.4.0-dev-2275) Update JVM metadata version to 1.4.0 (vor 4 Tagen) <Alexander Udalov>
* 4d93b3d5ab4 - (tag: build-1.4.0-dev-2271) Dropped unused UsageDescriptor (vor 4 Tagen) <Vladimir Dolzhenko>
* a0c9b275aa6 - (tag: build-1.4.0-dev-2270) Removed deprecated usage of treeBuilder from currentProjectViewPane (vor 4 Tagen) <Vladimir Dolzhenko>
* 617807beeac - Removed deprecated usage of ScratchFileService.isInScratchRoot (vor 4 Tagen) <Vladimir Dolzhenko>
* 7c8f3b2b3b0 - Use LightJavaModule.getModule instead of deprecated getModule (vor 4 Tagen) <Vladimir Dolzhenko>
* dd8a120d450 - Use JList#getSelectedValuesList() instead of deprecated getSelectedValues() (vor 4 Tagen) <Vladimir Dolzhenko>
* 670e016d34b - PluginStartupComponent reworked into startup activity and service (vor 4 Tagen) <Vladimir Dolzhenko>
* df23274aa50 - Use Application.addListener(listener, disposable) (vor 4 Tagen) <Vladimir Dolzhenko>
* 45e288be49e - Drop deprecated file from @Storage (vor 4 Tagen) <Vladimir Dolzhenko>
* ff7221e1c4f - Cleaned up from deprecated CallerMethodsTreeStructure(PsiMethod) (vor 4 Tagen) <Vladimir Dolzhenko>
* 13d8603c4bc - Fixed incompatibility with 192 (vor 4 Tagen) <Alexander Podkhalyuzin>
* 2408977a688 - Fixed bunch file (vor 4 Tagen) <Alexander Podkhalyuzin>
* 46526ab53cf - Removed deprecated icons usages (vor 4 Tagen) <Alexander Podkhalyuzin>
* d880a507dd7 - Removed deprecated usage (vor 4 Tagen) <Alexander Podkhalyuzin>
* 35fa812a19d - Removed MethodNodeBase usage (vor 4 Tagen) <Alexander Podkhalyuzin>
* dd73629db15 - Obsolete API usages removed from 193 branch (vor 4 Tagen) <Alexander Podkhalyuzin>
* 312c7bc9bfd - Proper override in move (vor 4 Tagen) <Alexander Podkhalyuzin>
* e26dcdf10b9 - Removed unnecessary deprecated method overrides (vor 4 Tagen) <Alexander Podkhalyuzin>
* 4db89f073f0 - Remove outdated icon creation API usage (vor 4 Tagen) <Alexander Podkhalyuzin>
* 0890e6837bb - Proper check if plugin is disabled (vor 4 Tagen) <Alexander Podkhalyuzin>
* f3d66dcce8b - proper way to distinguish JetBrains annotations (vor 4 Tagen) <Alexander Podkhalyuzin>
* aee3887604e - removed deprecated usage for isAnnotated (vor 4 Tagen) <Alexander Podkhalyuzin>
* 08d5471f51d - isSearchForTextOccurencesAvailable usage replaced (vor 4 Tagen) <Alexander Podkhalyuzin>
* 23fa21d37e8 - getUsages -> getMetrics in FUSCollectors (vor 4 Tagen) <Alexander Podkhalyuzin>
* 8bb59e31e0c - (tag: build-1.4.0-dev-2254) Minor. Remove textifyMethodNode, since it duplicates nodeText (vor 4 Tagen) <Ilmir Usmanov>
* 7dfd7b6081c - Spill stack before analyzing it when looking for non-inline suspend lambda (vor 4 Tagen) <Ilmir Usmanov>
* b7a6fc271c5 - (tag: build-1.4.0-dev-2249) minor: remove unused import (vor 4 Tagen) <Pavel Kirpichenkov>
* e2a99f84a58 - [FIR] Fix test data (vor 4 Tagen) <Mikhail Glukhikh>
* 286622009d6 - (tag: build-1.4.0-dev-2245) FIR: Cleanup PostponedArguments.kt (vor 4 Tagen) <Denis Zharkov>
* 6f6281a3f31 - FIR: Support type aliases to function types in resolution (vor 4 Tagen) <Denis Zharkov>
* 7249d2f8899 - (tag: build-1.4.0-dev-2243) [FIR] Fix translation of invokes & add return expressions for lambdas (vor 4 Tagen) <Juan Chen>