### PR TITLE
Prevent inlining of `Kotlin_ObjCExport_RethrowExceptionAsNSError`

### DIFF
--- a/runtime/src/main/cpp/ObjCExportErrors.mm
+++ b/runtime/src/main/cpp/ObjCExportErrors.mm
@@ -52,7 +52,7 @@ extern "C" RUNTIME_NORETURN void Kotlin_ObjCExport_trapOnUndeclaredException(KRe
 
 static char kotlinExceptionOriginChar;
 
-extern "C" void Kotlin_ObjCExport_RethrowExceptionAsNSError(KRef exception, id* outError) {
+extern "C" NO_INLINE void Kotlin_ObjCExport_RethrowExceptionAsNSError(KRef exception, id* outError) {
   if (Kotlin_ObjCExport_isUnchecked(exception)) {
     printlnMessage(uncheckedExceptionMessage);
     TerminateWithUnhandledException(exception);


### PR DESCRIPTION
Currently its callsites don't have debug information, but some of the containing functions do.
Inlining such a callsite invalidates debug information in the entire module.