### PR TITLE
Revert "Support suspend functions lowering changes"

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -275,11 +275,8 @@ internal val compileTimeEvaluatePhase = makeKonanFileLoweringPhase(
         prerequisite = setOf(varargPhase)
 )
 
-internal val coroutinesPhase = makeKonanFileOpPhase(
-        { context, irFile ->
-            NativeSuspendFunctionsLowering(context).lower(irFile)
-            RemoveSuspendLambdas().lower(irFile)
-        },
+internal val coroutinesPhase = makeKonanFileLoweringPhase(
+        ::NativeSuspendFunctionsLowering,
         name = "Coroutines",
         description = "Coroutines lowering",
         prerequisite = setOf(localFunctionsPhase, finallyBlocksPhase)


### PR DESCRIPTION
This reverts commit f4ac79e3

Rolled back due to issues with kotlinx.coroutines

Corresponding review in kotlin: https://upsource.jetbrains.com/kotlin/review/KOTLIN-CR-3833