### PR TITLE
[kotlin compiler][update] 1.4.0-dev-2632 

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -275,11 +275,8 @@ internal val compileTimeEvaluatePhase = makeKonanFileLoweringPhase(
         prerequisite = setOf(varargPhase)
 )
 
-internal val coroutinesPhase = makeKonanFileOpPhase(
-        { context, irFile ->
-            NativeSuspendFunctionsLowering(context).lower(irFile)
-            RemoveSuspendLambdas().lower(irFile)
-        },
+internal val coroutinesPhase = makeKonanFileLoweringPhase(
+        ::NativeSuspendFunctionsLowering,
         name = "Coroutines",
         description = "Coroutines lowering",
         prerequisite = setOf(localFunctionsPhase, finallyBlocksPhase)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2368,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-2368
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2368,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-2368
-kotlinStdlibTestsVersion=1.4.0-dev-2368
-testKotlinCompilerVersion=1.4.0-dev-2368
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2632,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-2632
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2632,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-2632
+kotlinStdlibTestsVersion=1.4.0-dev-2632
+testKotlinCompilerVersion=1.4.0-dev-2632
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/text/Regex.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Regex.kt
@@ -155,10 +155,11 @@ public actual class Regex internal constructor(internal val nativePattern: Patte
      *
      * @param startIndex An index to start search with, by default 0. Must be not less than zero and not greater than `input.length()`
      * @return An instance of [MatchResult] if match was found or `null` otherwise.
+     * @throws IndexOutOfBoundsException if [startIndex] is less than zero or greater than the length of the [input] char sequence.
      */
     actual fun find(input: CharSequence, startIndex: Int): MatchResult? {
         if (startIndex < 0 || startIndex > input.length) {
-            throw IndexOutOfBoundsException("Start index out of bounds: $startIndex")
+            throw IndexOutOfBoundsException("Start index is out of bounds: $startIndex, input length: ${input.length}")
         }
         val matchResult = MatchResultImpl(input, this)
         matchResult.mode = Mode.FIND
@@ -174,9 +175,15 @@ public actual class Regex internal constructor(internal val nativePattern: Patte
 
     /**
      * Returns a sequence of all occurrences of a regular expression within the [input] string, beginning at the specified [startIndex].
+     *
+     * @throws IndexOutOfBoundsException if [startIndex] is less than zero or greater than the length of the [input] char sequence.
      */
-    actual fun findAll(input: CharSequence, startIndex: Int): Sequence<MatchResult>
-            = generateSequence({ find(input, startIndex) }, MatchResult::next)
+    actual fun findAll(input: CharSequence, startIndex: Int): Sequence<MatchResult> {
+        if (startIndex < 0 || startIndex > input.length) {
+            throw IndexOutOfBoundsException("Start index is out of bounds: $startIndex, input length: ${input.length}")
+        }
+        return generateSequence({ find(input, startIndex) }, MatchResult::next)
+    }
 
     /**
      * Attempts to match the entire [input] CharSequence against the pattern.


### PR DESCRIPTION
* ed7b8e9b857 - (tag: build-1.4.0-dev-2632) Scan functions for Sequences and Iterable #KT-7657 (vor 10 Stunden) <Abduqodiri Qurbonzoda>
* 0d7e6417366 - (tag: build-1.4.0-dev-2627) Extra dependencies after performance tests modularization (vor 14 Stunden) <Vladimir Dolzhenko>
* 89cf32eccc8 - (tag: build-1.4.0-dev-2624) Clarify comments about KT-36625 that it is pending design decision. (vor 15 Stunden) <Mark Punzalan>
* ba606147c95 - (tag: build-1.4.0-dev-2622) [JVM IR] Maintain KT-36625 bug compatibility between non-IR and IR backends by removing IMPLICIT_NOTNULL casts from IrStringConcatenation arguments. (vor 15 Stunden) <Mark Punzalan>
* 18a3d7ee08f - (tag: build-1.4.0-dev-2621) Moved extra files after performance tests modularization (vor 15 Stunden) <Vladimir Dolzhenko>
* 60f17c3adf8 - (tag: build-1.4.0-dev-2619) Modularization of performance tests (vor 16 Stunden) <Vladimir Dolzhenko>
* 572dee68357 - (tag: build-1.4.0-dev-2617) Revert "Only create descriptors for candidates with lambda args" (vor 17 Stunden) <Pavel Kirpichenkov>
* 52ae63f191f - IR: decommonize AbstractSuspendFunctionsLowering.kt (vor 18 Stunden) <Anton Bannykh>
* d5987fd7f39 - (tag: build-1.4.0-dev-2609) Minor, move wrongAnnotationArgumentInCtor.kt to CLI tests (vor 19 Stunden) <Alexander Udalov>
* 9c9e13d93e7 - Minor, move obsolete test to oldLanguageVersions (vor 19 Stunden) <Alexander Udalov>
* 0df455cb52f - Minor, remove duplicate test (vor 19 Stunden) <Alexander Udalov>
* c28d8c6575b - (tag: build-1.4.0-dev-2606) Don't iterate over all tasks in KotlinProjectNpmResolver (KT-36472) (vor 19 Stunden) <Sergey Igushkin>
* 9e05c702abd - (tag: build-1.4.0-dev-2605) Fix KtDotQualifiedExpressionElementType stub building for complex qualified elements (vor 19 Stunden) <Igor Yakovlev>
* ddcc3b39f7f - (tag: build-1.4.0-dev-2591) JS Regex.find does not throw on invalid start index #KT-36082 (vor 20 Stunden) <Abduqodiri Qurbonzoda>
* c592201a437 - Fail fast in Regex.findAll on an invalid startIndex #KT-28356 (vor 20 Stunden) <Abduqodiri Qurbonzoda>
* 95a80609463 - (tag: build-1.4.0-dev-2584) [NI] Don't report uninferred type parameter error on special functions (vor 21 Stunden) <Pavel Kirpichenkov>
* fd0c644b6f9 - [Gradle, JS] Fix order of free compiler args assigning (vor 21 Stunden) <Ilya Goncharov>
* cd8af5d3ec8 - [Gradle, JS] Configure build for nodejs in ir (vor 21 Stunden) <Ilya Goncharov>
* a1497682ed5 - [Gradle, JS] Remove depending of link tasks on assemble (vor 21 Stunden) <Ilya Goncharov>
* db86076864f - [Gradle, JS] Remove redundant dependsOn (vor 21 Stunden) <Ilya Goncharov>
* 752d6765231 - [Gradle, JS] Fix tests for VariantAwareDependenciesIT.kt (vor 21 Stunden) <Ilya Goncharov>
* 589cea557bb - [Gradle, JS] Fix tests after changing default on legacy instead of ir (vor 21 Stunden) <Ilya Goncharov>
* fc872d5a539 - [Gradle, JS] Fix clean output test (vor 21 Stunden) <Ilya Goncharov>
* e53fd1b5828 - [Gradle, JS] Distribution and distribute task for KotlinBrowserJsIr.kt (vor 21 Stunden) <Ilya Goncharov>
* bbb98f9168d - [Gradle, JS] Change default on legacy instead of ir (vor 21 Stunden) <Ilya Goncharov>
* a33affc3254 - [Gradle, JS] Fix android tests (vor 21 Stunden) <Ilya Goncharov>
* 016dd91e373 - [Gradle, JS] Fix destination dir for link tasks (vor 21 Stunden) <Ilya Goncharov>
* 24d229e5a02 - [Gradle, JS] Make entryModule internally (vor 21 Stunden) <Ilya Goncharov>
* 5aed541d9e6 - [Gradle, JS] Remove redundant (vor 21 Stunden) <Ilya Goncharov>
* 333bb4da50d - [Gradle, JS] Remove redundant delegation (vor 21 Stunden) <Ilya Goncharov>
* 196907b2ef1 - [Gradle, JS] Compatibility with lower than 4.9 (vor 21 Stunden) <Ilya Goncharov>
* 0129b71cfe6 - [Gradle, JS] Link task is part of assemble (vor 21 Stunden) <Ilya Goncharov>
* 347f52ae102 - [Gradle, JS] Fix tests for both mode (vor 21 Stunden) <Ilya Goncharov>
* c8be2876bc6 - [Gradle, JS] Remove redundant compiler flags and make them internal (vor 21 Stunden) <Ilya Goncharov>
* bdf76f92641 - fixup! [Gradle, JS] Fix review remarks (vor 21 Stunden) <Ilya Goncharov>
* 29a55fc47e3 - [Gradle, JS] Remove redundant testTasks (vor 21 Stunden) <Ilya Goncharov>
* 300fd9bd077 - [Gradle, JS] Extract archiveType property on Configurator level (vor 21 Stunden) <Ilya Goncharov>
* cedfb71a1ef - [Gradle, JS] Task configuration avoidance with providers (vor 21 Stunden) <Ilya Goncharov>
* 05b48bbf857 - [Gradle, JS] Fix names for js compiler property (vor 21 Stunden) <Ilya Goncharov>
* d44aef3f3d2 - [Gradle, JS] Check existence of input file before run and test (vor 21 Stunden) <Ilya Goncharov>
* bcd2707fe66 - [Gradle, JS] Fix naming from jsMode to jsCompilerType (vor 21 Stunden) <Ilya Goncharov>
* b30328a7661 - [Gradle, JS] Fix capilatiozation for gradle attributes (vor 21 Stunden) <Ilya Goncharov>
* 54e068dee25 - [Gradle, JS] Attribute and compiler type is on one enum (vor 21 Stunden) <Ilya Goncharov>
* d86384225ea - [Gradle, JS] Rename of property for control compiler type (vor 21 Stunden) <Ilya Goncharov>
* 8de4966e536 - [Gradle, JS] Fix name of workers file (vor 21 Stunden) <Ilya Goncharov>
* f342508a6e0 - [Gradle, JS] Fix ambiguity with target name (vor 21 Stunden) <Ilya Goncharov>
* 6793fb285e6 - [Gradle, JS] Prepare for review (vor 21 Stunden) <Ilya Goncharov>
* 85919ed0fc0 - [Gradle, JS] Fix manifest destination (vor 21 Stunden) <Ilya Goncharov>
* 433053e4794 - [Gradle, JS] Fix manifest destination (vor 21 Stunden) <Ilya Goncharov>
* a4ed71075d6 - [Gradle, JS] Fix test for lib and app (vor 21 Stunden) <Ilya Goncharov>
* 43903e5d195 - [Gradle, JS] Fix test incremental compilation (only for legacy) (vor 21 Stunden) <Ilya Goncharov>
* c6935a57a40 - [Gradle, JS] Fix test for old kotlin2js plugin (vor 21 Stunden) <Ilya Goncharov>
* d69266de507 - [Gradle, JS] Fix parallel tasks test (vor 21 Stunden) <Ilya Goncharov>
* 5ff07baf532 - [Gradle, JS] Fix parallel tasks test (vor 21 Stunden) <Ilya Goncharov>
* 40f5663a572 - [Gradle, JS] Fix associated compilations test and adopt to js ir (vor 21 Stunden) <Ilya Goncharov>
* 6698dc75976 - [Gradle, JS] new-mpp-with-dce is actual only for legacy (vor 21 Stunden) <Ilya Goncharov>
* 57d2939cf90 - [Gradle, JS] Fix lower case of target (vor 21 Stunden) <Ilya Goncharov>
* d50f5206396 - [Gradle, JS] Fix WorkersIT tests (vor 21 Stunden) <Ilya Goncharov>
* 8646f6a0983 - [Gradle, JS] Commonization setting of js mode (vor 21 Stunden) <Ilya Goncharov>
* e7b981c467e - [Gradle, JS] Fix testBrowserDistribution (vor 21 Stunden) <Ilya Goncharov>
* 99d0fa0d292 - [Gradle, JS] Fix newFileProperty for gradle <5.0 (vor 21 Stunden) <Ilya Goncharov>
* d2261f54915 - [Gradle, JS] Fix legacy test (vor 21 Stunden) <Ilya Goncharov>
* 26c27f55b3d - [Gradle, JS] Fix test for resolving (vor 21 Stunden) <Ilya Goncharov>
* fff5d9a6845 - [Gradle, JS] Remove redundant disambiguation for ir preset (vor 21 Stunden) <Ilya Goncharov>
* c208f038ad4 - [Gradle, JS] Fix gradle <5.1 incompatibility with fileProperty (vor 21 Stunden) <Ilya Goncharov>
* 24451f62ac8 - [Gradle, JS] Fix gradle <5.1 incompatibility #2 (vor 21 Stunden) <Ilya Goncharov>
* cd5ed54cd66 - [Gradle, JS] Fix gradle <5.1 incompatibility (vor 21 Stunden) <Ilya Goncharov>
* df5b86c2896 - [Gradle, JS] Use include instead of sources for link stage of compiler (vor 21 Stunden) <Ilya Goncharov>
* da9080055cb - [Gradle, JS] Remove sources for link tasks (vor 21 Stunden) <Ilya Goncharov>
* 247da4984ed - [Gradle, JS] Fix naming (vor 21 Stunden) <Ilya Goncharov>
* ded996aedfa - [Gradle, JS] Delegates all calls from js target to ir target (vor 21 Stunden) <Ilya Goncharov>
* 62aa6d01e90 - [Gradle, JS] Remove redundant (vor 21 Stunden) <Ilya Goncharov>
* 406c249d99b - [Gradle, JS] Fix mpp generator (vor 21 Stunden) <Ilya Goncharov>
* 0b06f0a05b4 - [Gradle, JS] Remove redundant classes (vor 21 Stunden) <Ilya Goncharov>
* 59045916761 - [Gradle, JS] Commonize targets with interfaces (vor 21 Stunden) <Ilya Goncharov>
* d33521052f0 - [Gradle, JS] In Ir target should configure Ir subtarget (vor 21 Stunden) <Ilya Goncharov>
* 831757018cc - [Gradle, JS] Check only once set producing type (vor 21 Stunden) <Ilya Goncharov>
* 9f3601412b8 - [Gradle, JS] Commonize producing for js targets (vor 21 Stunden) <Ilya Goncharov>
* 8322d7b0078 - [Gradle, JS] Move producing dsl from subtarget to target in IR (vor 21 Stunden) <Ilya Goncharov>
* 7a3b6e2d71f - [Gradle, JS] Move producing dsl from subtarget to target (vor 21 Stunden) <Ilya Goncharov>
* 2680ea6bdd4 - [Gradle, JS] Fix after rebase on master (vor 21 Stunden) <Ilya Goncharov>
* a2930b45f67 - [Gradle, JS] Fix compilation after rebase (vor 21 Stunden) <Ilya Goncharov>
* 35c681685b6 - [Gradle, JS] Set only one attribute for ir target (vor 21 Stunden) <Ilya Goncharov>
* 31f8fe04613 - [Gradle, JS] Api and runtime variants for legacy and ir (vor 21 Stunden) <Ilya Goncharov>
* 15a33a85031 - [Gradle, JS] Fix naming (vor 21 Stunden) <Ilya Goncharov>
* 8f8eaa28d5a - [Gradle, JS] Add attribute for IR target (vor 21 Stunden) <Ilya Goncharov>
* 9833e2202e3 - [Gradle, JS] Hack for npm resolving of js mixed mode (vor 21 Stunden) <Ilya Goncharov>
* a1e6f566f6b - [Gradle, JS] Add disambiguation classifier for MPP (vor 21 Stunden) <Ilya Goncharov>
* 246fb317869 - [Gradle, JS] Add hack for process ir compilations in NPM resolver in mixed (vor 21 Stunden) <Ilya Goncharov>
* 18fa5266b79 - [Gradle, JS] Producing for ir target through legacy target (vor 21 Stunden) <Ilya Goncharov>
* 21a1e2e89fa - [Gradle, JS] Add additinal DSL (with KotlinLibrary or Executable) for mixed and legacy (vor 21 Stunden) <Ilya Goncharov>
* 00572395daf - [Gradle, JS] Fix naming of produce Js (vor 21 Stunden) <Ilya Goncharov>
* 808a776efbf - [Gradle, JS] Default source-set name w/o legacy disambiguation in mixed (vor 21 Stunden) <Ilya Goncharov>
* 27b9c6ff290 - [Gradle, JS] Fix compilation after cherry-pick (vor 21 Stunden) <Ilya Goncharov>
* 619b9222152 - [Gradle, JS] Difference through gradle attribute (vor 21 Stunden) <Ilya Goncharov>
* 4d323d35673 - [Gradle, JS] Fix attribute type on type of zip (vor 21 Stunden) <Ilya Goncharov>
* b3067d655e9 - [Gradle, JS] Rebase on master (vor 21 Stunden) <Ilya Goncharov>
* 3731d4b89af - [Gradle, JS] Publish with 2 variants (vor 21 Stunden) <Ilya Goncharov>
* f15d1ef23e4 - [Gradle, JS] Create not Jar tasks, but Zip tasks, because we can create klibs (vor 21 Stunden) <Ilya Goncharov>
* 3467230242a - [Gradle, JS] Add appendix for archive in case of mixed mode (vor 21 Stunden) <Ilya Goncharov>
* f169c8ea24b - [Gradle, JS] Flags with producing unzipped klib is by default (vor 21 Stunden) <Ilya Goncharov>
* b37c2a05fd3 - [Gradle, JS] Configure ir target in legacy plugin #2 (vor 21 Stunden) <Ilya Goncharov>
* 43ab4ad8e8b - [Gradle, JS] Configure ir target in legacy plugin (vor 21 Stunden) <Ilya Goncharov>
* 04c0b8c07d9 - [Gradle, JS] Inject ir's classes into legacy for mixed mode #2 (vor 21 Stunden) <Ilya Goncharov>
* fd93654c4fc - [Gradle, JS] Inject ir's classes into legacy for mixed mode (vor 21 Stunden) <Ilya Goncharov>
* e6be134f2af - [Gradle, JS] Activate legacy plugin and new plugin via gradle property (vor 21 Stunden) <Ilya Goncharov>
* 29c2d62e436 - [Gradle, JS] Compile fix after rebase (vor 21 Stunden) <Ilya Goncharov>
* 0c7284de014 - [Gradle, JS] Link test task with property of compile task (vor 21 Stunden) <Ilya Goncharov>
* dd577e10082 - [Gradle, JS] Migrate in KotlinJsIrTest (vor 21 Stunden) <Ilya Goncharov>
* bf415704b60 - [Gradle, JS] Generalization of Js test frameworks to work with ir (vor 21 Stunden) <Ilya Goncharov>
* 599215e74a8 - [Gradle, JS] Migrate on properties to link output of compile with consumer (vor 21 Stunden) <Ilya Goncharov>
* 4bd744f1634 - [Gradle, JS] Fix run for nodejs with IR backend (vor 21 Stunden) <Ilya Goncharov>
* 14387332d5f - [Gradle, JS] Distribution task depends on processed resources (vor 21 Stunden) <Ilya Goncharov>
* 9c89859c672 - [Gradle, JS] Webpack catch files from js compilations (vor 21 Stunden) <Ilya Goncharov>
* d827f9b0400 - [Gradle, JS] JS compile tasks nit in archives now (vor 21 Stunden) <Ilya Goncharov>
* 4861b47f9c7 - [Gradle, JS] Enable IR backend for prod and dev tasks (vor 21 Stunden) <Ilya Goncharov>
* 2e22b8eb9a6 - [Gradle, JS] Register link tasks (vor 21 Stunden) <Ilya Goncharov>
* 60da60757de - [Gradle, JS] Extract KotlinJsLinkTask (vor 21 Stunden) <Ilya Goncharov>
* c043fc2272d - [Gradle, JS] Prod and dev compile tasks depends on klib compile task (vor 21 Stunden) <Ilya Goncharov>
* 3ee7e9272b9 - [Gradle, JS] Depends on prod and dev compile tasks (vor 21 Stunden) <Ilya Goncharov>
* 222c663fac4 - [Gradle, JS] Configure prod and dev compilations (vor 21 Stunden) <Ilya Goncharov>
* abf2a9e073c - [Gradle, JS] Extract ir compiler flags (vor 21 Stunden) <Ilya Goncharov>
* ad321e45dc2 - [Gradle, JS] Create KotlinJsIrCompilationFactory (vor 21 Stunden) <Ilya Goncharov>
* 5bdf9f6e399 - [Gradle, JS] Fix codegen and avoid deprecate (vor 21 Stunden) <Ilya Goncharov>
* 544a6bf15eb - [Gradle, JS] Add production and development compilations (vor 21 Stunden) <Ilya Goncharov>
* 2f4f4dbbd8c - [Gradle, JS] Fix deprecation replace with on register task (vor 21 Stunden) <Ilya Goncharov>
* d0e2a653f74 - [Gradle, JS] Reformat code (vor 21 Stunden) <Ilya Goncharov>
* 64def2e1735 - [Gradle, JS] Continue to migrate on ir compiler (vor 21 Stunden) <Ilya Goncharov>
* 8b641bf6135 - [Gradle, JS] Add mpp presets for jsIr (vor 21 Stunden) <Ilya Goncharov>
* a20e9ae0ede - [Gradle, JS] Extract hack for Native and JS IR compiler (vor 21 Stunden) <Ilya Goncharov>
* f936a0fc9b6 - [Gradle, JS] NodeJs and browser producing handlers (vor 21 Stunden) <Ilya Goncharov>
* 2de70511655 - [Gradle, JS] Add produceJs (vor 21 Stunden) <Ilya Goncharov>
* 64c2b4b076b - [Gradle, JS] Add callbacks on configuring producing target for JS IR (vor 21 Stunden) <Ilya Goncharov>
* e7c66531820 - [Gradle, JS] Remove DCE from ir tooling (vor 21 Stunden) <Ilya Goncharov>
* 6be8a83ff90 - [Gradle, JS] Configure compiler args for produceKotlinLibrary in IR (vor 21 Stunden) <Ilya Goncharov>
* 0ff84eaa63c - [Gradle, JS] Copy JS subtargets dsl for IR (vor 21 Stunden) <Ilya Goncharov>
* 3ac2bae4ced - [Gradle, JS] Copy JS plugin for IR (vor 21 Stunden) <Ilya Goncharov>
* ba770f7b614 - (tag: build-1.4.0-dev-2579) FIR2IR: fix type parameter indexes & fix some black-box & FIR2IR tests (vor 21 Stunden) <Mikhail Glukhikh>
* 3ebad2acecf - (tag: build-1.4.0-dev-2574) "Constructor has non-null self reference parameter": don't report for vararg parameter (vor 22 Stunden) <Toshiaki Kameyama>
* f3f88cae7a7 - FIR: unmute accidentally muted black-box test (vor 22 Stunden) <Mikhail Glukhikh>
* 6c932175398 - (tag: build-1.4.0-dev-2573) Lift assignment out: don't report when expression is used as expression (vor 22 Stunden) <Toshiaki Kameyama>
* 8baba380999 - (tag: build-1.4.0-dev-2568) "To raw string literal" intention: fix false negative with string content starts with newline symbol \n (vor 22 Stunden) <Toshiaki Kameyama>
* 61d02d9ecbf - FIR: Unbound FirJavaElementFinder from Kotlin PSI (vor 22 Stunden) <Denis Zharkov>
* 9c1577092b6 - FIR: Fix SAM conversion for constructor calls (vor 22 Stunden) <Denis Zharkov>
* 51db272e0ed - FIR: Clean environment in AbstractFirTypeEnhancementTest (vor 22 Stunden) <Denis Zharkov>
* 95b4fa4b316 - FIR: Support flexible types in getErasedVersionOfFirstUpperBound (vor 22 Stunden) <Denis Zharkov>
* 42e8017bde4 - FIR: Minor. Refactor calculation of erased upper bound (vor 22 Stunden) <Denis Zharkov>
* bc34bc3f967 - FIR: Use flexible type for generic parameters bounds (vor 22 Stunden) <Denis Zharkov>
* 5a2cdfcab43 - FIR: Run callable references resolution for synthetic-select calls (vor 22 Stunden) <Denis Zharkov>
* 003aea2e68a - FIR: Consider abbreviation's nullability when expanding types (vor 22 Stunden) <Denis Zharkov>
* 2bb6e4fd97f - Minor, add package to typeOfCapturedStar.kt test (vor 22 Stunden) <Alexander Udalov>
* eca562a0062 - (tag: build-1.4.0-dev-2566) Add possibility to depend on nightly repository (vor 23 Stunden) <Nikolay Krasko>
* 95b2a583ae7 - (tag: build-1.4.0-dev-2563) build.gradle.kts: change notification text (vor 24 Stunden) <Natalia Selezneva>
* c02dd720dc9 - (tag: build-1.4.0-dev-2558, tag: build-1.4.0-dev-2556, tag: build-1.4.0-dev-12) [NI] Restore missing call checker errors in coroutine inference (vor 26 Stunden) <Pavel Kirpichenkov>
* 6af8f320f76 - Add JS runtime to the failing test (vor 26 Stunden) <Mikhail Zarechenskiy>
* 9408bb84e91 - (tag: build-1.4.0-eap-1, tag: build-1.4.0-dev-7, tag: build-1.4.0-dev-2550, origin/1.4.0) [FIR-TEST] Update testname in testdata (vor 27 Stunden) <Dmitriy Novozhilov>
* a7de4a8b4bb - (tag: build-1.4.0-dev-5, tag: build-1.4.0-dev-2549) [FIR-TEST] Update testname in testdata (vor 27 Stunden) <Dmitriy Novozhilov>
* 759127df9a5 - (tag: build-1.4.0-dev-2546, tag: build-1.4.0-dev-2) Add NI diagnostics for spec tests (vor 28 Stunden) <Mikhail Zarechenskiy>
* c58e819a6a2 - Regenerate tests (vor 28 Stunden) <Mikhail Zarechenskiy>
* 0d310c0fa45 - [NI] Support signed-unsigned conversions for K/Native (vor 28 Stunden) <Mikhail Zarechenskiy>
* e14e58c1214 - Update test about conversions, remove irrelevant case (vor 28 Stunden) <Mikhail Zarechenskiy>
* 1acce46133b - [NI] Fix recording info about captured local variables (vor 28 Stunden) <Mikhail Zarechenskiy>
* 7f6c03c926b - [NI] Fix search of effects for substituted descriptors (vor 28 Stunden) <Mikhail Zarechenskiy>
* 7df92cd00bd - Set `isOperator` property for dynamic calls by convention (vor 28 Stunden) <Mikhail Zarechenskiy>
* a736551c2a8 - Add test checking that `fun` isn't inherited from base interface (vor 28 Stunden) <Mikhail Zarechenskiy>
* 45bbdaf73f2 - Add base declaration checker for `fun` interfaces (vor 28 Stunden) <Mikhail Zarechenskiy>
* 6735cc89374 - (tag: build-1.4.0-dev-2545, tag: build-1.4.0-dev-1) [FIR] Implement new bound smartcast algorithm (vor 28 Stunden) <Dmitriy Novozhilov>
* 40f907ec2fa - (tag: build-1.4.0-dev-2538) Fix compilation for 191 & as35 (vor 2 Tagen) <Ilya Kirillov>
* 67668d798b8 - (tag: build-1.4.0-dev-2537) FIR2IR: update test data (vor 2 Tagen) <Mikhail Glukhikh>
* 12c001f4911 - FIR: unmute two additional black-box tests (vor 2 Tagen) <Mikhail Glukhikh>
* 76f78d3fde0 - FIR2IR: don't mutate basic FIR for invoke / next calls (vor 2 Tagen) <Mikhail Glukhikh>
* 37abdb17321 - [FIR2IR] Fix NoSuchMethod for Iterator::next (same issue with invoke) (vor 2 Tagen) <Juan Chen>
* 8e35545e10d - FIR2IR: provide type arguments for class 'this' receiver (vor 2 Tagen) <Juan Chen>
* df07b77271e - FIR2IR: get rid of "creates list under the hood" warnings (vor 2 Tagen) <Mikhail Glukhikh>
* fe5dd4dba1b - FIR2IR: extract 'declareThisReceiverParameter', rename 'setThisReceiver' (vor 2 Tagen) <Mikhail Glukhikh>
* b75d0eb1a1e - (tag: build-1.4.0-dev-2532) 201: Restrict 193 and own plugin for 201 (vor 2 Tagen) <Nikolay Krasko>
* a983b0bf74c - 201: Additional method getOwnReferences is introduced (bunched) (vor 2 Tagen) <Nikolay Krasko>
* c9d97ae5559 - 201: Notification group was rewritten to Kotlin (no sam conversion) (vor 2 Tagen) <Nikolay Krasko>
* 034243b5e78 - 201: ExecutionManager.contentManager was rewritten to Kotlin (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 1cb56ee946f - 201: Processor<in PsiMethod> used in PsiShortNamesCache (vor 2 Tagen) <Nikolay Krasko>
* 9f6f8088e34 - 201: Processors changed for UsageInfo and SliceUsage (vor 2 Tagen) <Nikolay Krasko>
* e23f3b54c60 - 201: New DynamicBundle.LanguageBundleEP.EP_NAME needed for Java (vor 2 Tagen) <Nikolay Krasko>
* 51244d7b1d2 - 201: Return JavaCoreApplicationEnvironment subclassing (bunched) (vor 2 Tagen) <Nikolay Krasko>
* cfd92f252a2 - 201: Update version to 201.4515.24-EAP-SNAPSHOT (vor 2 Tagen) <Nikolay Krasko>
* 314474c33ba - 201: uast-tests.jar new dependency (depend on whole idea in tests) (vor 2 Tagen) <Nikolay Krasko>
* 7a89bd9c905 - 201: Change of ProblemDescriptorBase.getFixes() return type (vor 2 Tagen) <Nikolay Krasko>
* 8cb4a8f5c68 - 201: Raw Class -> Class<?> (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 890109beb8d - 201: PsiElementVisitor.visitElement nullability (vor 2 Tagen) <Nikolay Krasko>
* 98c6efaed9d - 201: BinaryFileStubBuilders.EP_NAME dropped (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 2cc4d878a8e - 201: ProjectManagerEx.forceCloseProject(project, true) - no second parameter (vor 2 Tagen) <Nikolay Krasko>
* 41ca51cb9e3 - 201: MadTestingUtil.enableAllInspections second parameter was removed (vor 2 Tagen) <Nikolay Krasko>
* ae1cfff5d23 - 201: IdeaTestApplication -> TestApplicationManager in tests (vor 2 Tagen) <Nikolay Krasko>
* 3eb4d46c3d5 - 201: ExternalProjectsManagerImpl.disableProjectWatcherAutoUpdate removed (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 10ce3c58e11 - 201: No PlatformTestCase.myProjectManager anymore (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 75f05d83292 - 201: TemplateManagerImpl.setTemplateTesting() parameter removed (vor 2 Tagen) <Nikolay Krasko>
* b17a28381b1 - 201: Can't instantiate subclass of Task anymore (vor 2 Tagen) <Nikolay Krasko>
* 54b1c512c52 - 201: LookupImpl.focusedDegree renamed (vor 2 Tagen) <Nikolay Krasko>
* 56d960c65b7 - 201: "testFramework" and "testFramework.core" libs introduced (vor 2 Tagen) <Nikolay Krasko>
* 641fa1f17c9 - 201: TextEditorWithPreview.java update - no ApiStatus (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 10aef794343 - 201: AbstractProjectResolverExtension.createModule returns nullable (vor 2 Tagen) <Nikolay Krasko>
* 066d77f3962 - 201: Tool windows - source incompatible change with Kotlin (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 4afd7c553b8 - 201: AbstractTreeNode generified in ide.projectView package (bunched) (vor 2 Tagen) <Nikolay Krasko>
* b425bf9a1bc - 201: TreeStructureProvider api changed: AbstractTreeNode<Any -> *> (vor 2 Tagen) <Nikolay Krasko>
* 9261f69dc8c - 201: MoveDestination.analyzeModuleConflicts variance in parameter changed (vor 2 Tagen) <Nikolay Krasko>
* 7ea52ebb45d - 201: Print type explicitly as RefactoringBundle.message() not null (vor 2 Tagen) <Nikolay Krasko>
* 4bc10f4c4fe - 201: MoveMultipleElementsViewDescriptor constructor nullability (vor 2 Tagen) <Nikolay Krasko>
* 2c72f539370 - 201: AbstractNavBarModelExtension.adjustElement nullability (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 78385d5f63d - 201: Update hierarchy to new API (fix bugs introduced by the platform) (vor 2 Tagen) <Nikolay Krasko>
* 5e58a66c586 - 201: Convert KotlinHierarchyViewTestBase.java because of typealiases (vor 2 Tagen) <Nikolay Krasko>
* 6bd91ec5b0f - 201: Rename .java to .kt (vor 2 Tagen) <Nikolay Krasko>
* 27467e4db7c - 201: Convert AbstractHierarchyTest.java because of typealiases (vor 2 Tagen) <Nikolay Krasko>
* 9f6f6838b8c - 201: Rename .java to .kt (vor 2 Tagen) <Nikolay Krasko>
* 579dd8f8feb - 201: J2K manual (vor 2 Tagen) <Nikolay Krasko>
* b92a228fb3a - 201: Convert KotlinCallHierarchyBrowser and KotlinCallHierarchyBrowser (vor 2 Tagen) <Nikolay Krasko>
* b795b387942 - 201: Rename .java to .kt (vor 2 Tagen) <Nikolay Krasko>
* 866c33fbdee - 201: RefactoringHelper.prepareOperation nullability (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 5440a5e2282 - 201: No BinaryFileStubBuilders.EP_NAME anymore (bunched) (vor 2 Tagen) <Nikolay Krasko>
* beb70526a21 - 201: CoreApplicationEnvironment.registerExtensionPointAndExtensions accepts Path (vor 2 Tagen) <Nikolay Krasko>
* cf78058cc2f - 201: PsiShortNamesCache.getAllClassNames(HashSet<String>) removed (vor 2 Tagen) <Nikolay Krasko>
* 4668518b2f1 - 201: ContainerUtil.newTroveSet<T>() removed (vor 2 Tagen) <Nikolay Krasko>
* 9d3d59fccb0 - 201: Remove JpsPersistentHashMap (bunched) (vor 2 Tagen) <Nikolay Krasko>
* 1ecd1a293d3 - 201: Processor<String> -> Processor<in String> in PsiShortNamesCache (vor 2 Tagen) <Nikolay Krasko>
* 2a71fe97cf9 - 201: picocontainer.jar is removed (vor 2 Tagen) <Nikolay Krasko>
* 354d7306ddb - 201: versions.jar.streamex and versions.jar.gson versions (vor 2 Tagen) <Nikolay Krasko>
* 162c2f3dc92 - 201: openapi.jar is removed (vor 2 Tagen) <Nikolay Krasko>
* c26e1e9c1ac - 201: Introduce 201 platform (vor 2 Tagen) <Nikolay Krasko>
* 0f4fadf104b - 201: Create bunch (vor 2 Tagen) <Nikolay Krasko>
* 4a1451ab631 - (tag: build-1.4.0-dev-2526) [FIR] Optimize TowerGroup (vor 2 Tagen) <simon.ogorodnik>
* d775852781f - [FIR] Refactor tower resolver to coroutines (vor 2 Tagen) <simon.ogorodnik>
* 695558465d8 - (tag: build-1.4.0-dev-2523) Build: Fix idea sources jar ivy for -EAP-SNAPSHOT versions (vor 2 Tagen) <Vyacheslav Gerasimov>
* 6d23e50142d - JVM IR: Create non-synthetic multifile parts for -Xmultifile-parts-inherit (vor 2 Tagen) <Steven Schäfer>
* 9db82bfcc81 - JVM IR: Create package private synthetic multi file part classes (vor 2 Tagen) <Steven Schäfer>
* 6584df3e01e - JVM IR: Fix references to const properties in facade classes (vor 2 Tagen) <Steven Schäfer>
* d9883067e6b - (tag: build-1.4.0-dev-2520) [FIR] Hide primary constructor parameters from accessors (vor 2 Tagen) <simon.ogorodnik>
* a0ed2c86404 - Enforce analysis inside top-level property initializer (vor 2 Tagen) <Vladimir Dolzhenko>
* bf9e7ad09a2 - (tag: build-1.4.0-dev-2517) Update 193 platform version to `193.6494.35` (vor 2 Tagen) <Vyacheslav Gerasimov>
* 058b2295440 - (tag: build-1.4.0-dev-2511) JVM IR: Handle external static declarations in companion objects (vor 2 Tagen) <Steven Schäfer>
* 48db96b66de - (tag: build-1.4.0-dev-2509) Improved kotlin decompiler range indexes (vor 2 Tagen) <Igor Yakovlev>
* cb1c0344b85 - (tag: build-1.4.0-dev-2506) Rename: add test for overridden method renaming in generic class (vor 2 Tagen) <Toshiaki Kameyama>
* ff76ba52d80 - (tag: build-1.4.0-dev-2500) Inline Function: fix false positive with inner function with 'return' (vor 2 Tagen) <Toshiaki Kameyama>
* 04e8cba8570 - (tag: build-1.4.0-dev-2499) [FIR] fixed overridden symbols of "invoke" in KFunction (vor 2 Tagen) <Juan Chen>
* e3721ed4063 - [FIR] Implement bare type modification with known type arguments (vor 2 Tagen) <Mikhail Glukhikh>
* 28332933ce3 - [FIR TEST] Add test case about values() priority (static over companion) (vor 2 Tagen) <Mikhail Glukhikh>
* dc7621a1125 - [FIR] Fix Java override ambiguity (Kotlin type parameter VS Java Object) (vor 2 Tagen) <Mikhail Glukhikh>
* 4b5f3b7a944 - (tag: build-1.4.0-dev-2495) Extract property: do not add unnecessary extension receiver (vor 2 Tagen) <Toshiaki Kameyama>
* 0fe5694cb76 - (tag: build-1.4.0-dev-2493, tag: build-1.4.0-dev-2491, tag: build-1.4.0-dev-2488) Do not render redundant Nullable annotations when generating declarations (vor 2 Tagen) <Ilya Kirillov>
* 4df8744b34b - Rename by-name parameter usage in function calls when renaming function's parameter (vor 2 Tagen) <Ilya Kirillov>
* 349d07ad432 - (tag: build-1.4.0-dev-2483) [minor] Fix testdata after commit "Only create descriptors for candidate"... (vor 2 Tagen) <Ilya Chernikov>
* a5e9e097558 - (tag: build-1.4.0-dev-2481) [Commonizer] Properly detect commonized KLIBs in IDE (vor 2 Tagen) <Dmitriy Dolovov>
* 51af1c13b1a - [Commonizer] Don't use base64 with padding in paths to libraries (vor 2 Tagen) <Dmitriy Dolovov>
* f46fc19fdf5 - (tag: build-1.4.0-dev-2467) ProhibitRepeatedUseSiteTargetAnnotationsMigration: improve name and description (vor 2 Tagen) <Dmitry Gridin>
* bcfd0894739 - (tag: build-1.4.0-dev-2466) AbstractDiagnosticBasedMigrationInspection: fix case with nullable custom factory (vor 2 Tagen) <Dmitry Gridin>
* b9911d0e0c3 - (tag: build-1.4.0-dev-2465) [Commonizer] Use only if kotlin.native.enableDependencyPropagation=false (vor 2 Tagen) <Dmitriy Dolovov>
* f98a4e67154 - Minor. Text formatted in commonizer CLI (vor 2 Tagen) <Dmitriy Dolovov>
* 63b03d29dc7 - [Commonizer] Prevent from running commonizer from Gradle more then once (vor 2 Tagen) <Dmitriy Dolovov>
* 7cf4395ccda - [Commonizer] Integrate commonizer to the Gradle plugin, p.2 (vor 2 Tagen) <Dmitriy Dolovov>
* d7e82bf899d - [Commonizer] Integrate commonizer to the Gradle plugin, p.1 (vor 2 Tagen) <Dmitriy Dolovov>
* 4ccff3f1b13 - [Commonizer] Add extendable uniform multi-task CLI (vor 2 Tagen) <Dmitriy Dolovov>
* 91fce721b35 - [Commonizer] Publish artifact for Kotlin embeddable compiler (vor 2 Tagen) <Dmitriy Dolovov>
* 4027079b41e - [Commonizer] Fix dependencies visible in POM file (vor 2 Tagen) <Dmitriy Dolovov>
* b711c6d3988 - Rename :native:kotlin-native-commonizer to :native:kotlin-klib-commonizer (vor 2 Tagen) <Dmitriy Dolovov>
* 07863b61d85 - (tag: build-1.4.0-dev-2463) Fix UL classes failing tests (vor 3 Tagen) <Igor Yakovlev>
* dc7b1fbff94 - (tag: build-1.4.0-dev-2448) JVM IR: report warning instead of error for language/API version 1.2 (vor 3 Tagen) <Alexander Udalov>
* b8aacf07863 - (tag: build-1.4.0-dev-2446) Fix test data around flexibility after ae39d748e4d4215148ce2c46a62579464131824f (vor 3 Tagen) <victor.petukhov>
* dc2a9cdc816 - (tag: build-1.4.0-dev-2445) Add missing inspections for 191, 192 (vor 3 Tagen) <Dmitry Gridin>
* 2c918d27879 - (tag: build-1.4.0-dev-2443) [FIR TEST] Add example with invoke priority inconsistent with old FE (vor 3 Tagen) <Mikhail Glukhikh>
* 232efa63038 - [FIR] Fix situation with synthetic property in implicit body (vor 3 Tagen) <Mikhail Glukhikh>
* d19d52292e0 - [FIR] Use builder to create synthetic properties (vor 3 Tagen) <Mikhail Glukhikh>
* 9a80850700e - [FIR] Fix Kotlin-Java supertype recursion problem (vor 3 Tagen) <Mikhail Glukhikh>
* cc0e39ebca9 - [FIR] Support synthetic property setters (vor 3 Tagen) <Mikhail Glukhikh>
* a9ba94cf0ee - [FIR] Use only variable symbol inheritors in processPropertiesByName (vor 3 Tagen) <Mikhail Glukhikh>
* a569e290918 - [FIR] Make SyntheticPropertySymbol derived from FirAccessorSymbol (vor 3 Tagen) <Mikhail Glukhikh>
* a7f9e3ab093 - [FIR] Accessor symbol is now a property symbol, not a function symbol (vor 3 Tagen) <Mikhail Glukhikh>
* 69809fef944 - [FIR] Synthetic property symbol is now a property symbol, not a function (vor 3 Tagen) <Mikhail Glukhikh>
* 17e1f081c75 - (tag: build-1.4.0-dev-2441) JVM_IR: handle nested function references in InlineCallableReferenceToLambda (vor 3 Tagen) <Georgy Bronnikov>
* 15ff74209cc - (tag: build-1.4.0-dev-2437) JVM IR: do not resolve fake override in InterfaceSuperCallsLowering (vor 3 Tagen) <Alexander Udalov>
* d9cbc459d05 - (tag: build-1.4.0-dev-2435) Use PluginManagerCore instead of PluginManager (vor 3 Tagen) <Vladimir Dolzhenko>
* 44cf0a9f725 - (tag: build-1.4.0-dev-2430) Don't insert import if deprecation replacement contains stdlib typealias (vor 3 Tagen) <Vladimir Dolzhenko>
* 2249c223fee - (tag: build-1.4.0-dev-2423) Only create descriptors for candidates with lambda args (vor 3 Tagen) <Ilya Chernikov>
* 6ed42293592 - (tag: build-1.4.0-dev-2420) [FIR] Fix smartcasts on member vals in `init` blocks (vor 3 Tagen) <Dmitriy Novozhilov>
* 36a6eedd9cb - (tag: build-1.4.0-dev-2418) Minor: Update generated tests for KT-34569 (vor 3 Tagen) <Yan Zhulanow>
* 052710db16b - (tag: build-1.4.0-dev-2403) Added idea-plugin-performance-tests task (vor 3 Tagen) <Vladimir Dolzhenko>
* becc9c21f02 - (tag: build-1.4.0-dev-2401) FIR: Map raw types properly (vor 3 Tagen) <Denis Zharkov>
* b3f9fa22b4d - FIR: Fix inference when bound comes from type alias (vor 3 Tagen) <Denis Zharkov>
* 733e596eed2 - (tag: build-1.4.0-dev-2395) Create `WarningOnMainUnusedParameterMigrationInspection` (vor 3 Tagen) <Dmitry Gridin>
* 8d48d899d0d - Create `ProhibitRepeatedUseSiteTargetAnnotationsMigrationInspection` (vor 3 Tagen) <Dmitry Gridin>
* 266a7a67f0e - Create `ProhibitUseSiteTargetAnnotationsOnSuperTypesMigrationInspection` (vor 3 Tagen) <Dmitry Gridin>
* 181dd432ca1 - RestrictReturnStatementTargetMigrationInspection: add quickfix (vor 3 Tagen) <Dmitry Gridin>
* f1bad0c9ae1 - Convert `RemoveReturnLabelFix` from `LocalQuickFix` to `KotlinQuickFixAction` (vor 3 Tagen) <Dmitry Gridin>
* e9dc1e07b91 - Extract `RemoveReturnLabelFix` (vor 3 Tagen) <Dmitry Gridin>
* 311860699ea - Create `RedundantLabelMigrationInspection` (vor 3 Tagen) <Dmitry Gridin>
* 2441ee80e49 - Create `RestrictReturnStatementTargetMigrationInspection` (vor 3 Tagen) <Dmitry Gridin>
* 2f3e3b9c9ed - Create `ProhibitJvmOverloadsOnConstructorsOfAnnotationClassesMigrationInspection` (vor 3 Tagen) <Dmitry Gridin>
* cbcc76c3ffb - Create `ProhibitTypeParametersForLocalVariablesMigrationInspection` (vor 3 Tagen) <Dmitry Gridin>
* 8c455d9e087 - Create `AbstractDiagnosticBasedInspection` (vor 3 Tagen) <Dmitry Gridin>
* ae39d748e4d - (tag: build-1.4.0-dev-2394) NI: Try to solve constraint system with another flexibility from a type variable if couldn't solve ^KT-36254 Fixed (vor 3 Tagen) <Victor Petukhov>
* b5dd16784a5 - (tag: build-1.4.0-dev-2389) [FIR] Add .gitattributes for correct line endings on windows (vor 3 Tagen) <Dmitriy Novozhilov>
* b9357b54864 - (tag: build-1.4.0-dev-2387) Fix project build, part 2 (vor 3 Tagen) <Dmitry Petrov>
* 5aa6d1d64b3 - (tag: build-1.4.0-dev-2384) Fix project build (vor 3 Tagen) <Dmitry Petrov>
* 031a79528a1 - (tag: build-1.4.0-dev-2383) [FIR] Fix compiler error in build.gradle.kts (vor 3 Tagen) <Dmitriy Novozhilov>
* 55215ba1875 - [FIR] Fix generation root for FIR tree (vor 3 Tagen) <Dmitriy Novozhilov>
* abfd87411d4 - (tag: build-1.4.0-dev-2380) [FIR-TEST] Mute failing tests with java kotlin supertypes cycle (vor 3 Tagen) <Dmitriy Novozhilov>
* 779ab632da5 - [FIR] Remove modifiable intermediate implementations from tree (vor 3 Tagen) <Dmitriy Novozhilov>
* 3d671cbbad1 - Fix compiler error in test generator (vor 3 Tagen) <Dmitriy Novozhilov>
* 5ceb68f19f6 - [FIR-TEST] Update some testdata (vor 3 Tagen) <Dmitriy Novozhilov>
* 4b6c2f7a651 - [FIR] Remove equality by fir from symbols (vor 3 Tagen) <Dmitriy Novozhilov>
* c79fd61dbae - [FIR] Fix usage of typeParameterStack from parent class in java loading (vor 3 Tagen) <Dmitriy Novozhilov>
* dd67568cf65 - [FIR] Fix recursive annotation deserialization (vor 3 Tagen) <Dmitriy Novozhilov>
* d57fa859c83 - [FIR] Implement builders for leaf nodes of FIR tree (vor 3 Tagen) <Dmitriy Novozhilov>
* b0c13872799 - [FIR] Remove legacy annotation `@VisitedSupertype` (vor 4 Tagen) <Dmitriy Novozhilov>
* fcd9ef043c7 - [FIR] Reorganize some utility code of tree generator (vor 4 Tagen) <Dmitriy Novozhilov>