### PR TITLE
Add Gradle task that makes LLVM dependency smaller

### DIFF
--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -5,13 +5,10 @@
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.FromString
 import org.jetbrains.kotlin.konan.target.*
-import org.jetbrains.kotlin.konan.util.DependencyProcessor
 import static org.jetbrains.kotlin.konan.target.KonanTarget.*
 import org.jetbrains.kotlin.konan.util.Named
 import org.jetbrains.kotlin.konan.properties.KonanPropertiesLoader
-import org.jetbrains.kotlin.konan.target.ConfigurablesImplKt
-import org.jetbrains.kotlin.konan.target.KonanTarget
-import org.jetbrains.kotlin.konan.target.TargetManager
+import org.jetbrains.kotlin.konan.util.ArchiveType
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
 
 import static org.jetbrains.kotlin.konan.util.VisibleNamedKt.getVisibleName
@@ -43,7 +40,7 @@ class NativeDep extends DefaultTask {
 
     @TaskAction
     void downloadAndExtract() {
-        def downloader = new DependencyProcessor(baseOutDir, konanPropertiesLoader, baseUrl, false)
+        def downloader = new DependencyProcessor(baseOutDir, konanPropertiesLoader, baseUrl, false, ArchiveType.systemDefault)
         downloader.showInfo = false
         downloader.run()
     }
@@ -94,7 +91,8 @@ platformManager.filteredOutEnabledButNotSupported.each { target ->
             loader.properties,
             loader.dependencies,
             NativeDep.baseUrl,
-            false
+            false,
+            ArchiveType.systemDefault
     )
 
     DependencyKind.values().each { kind ->

--- a/dependencyPacker/build.gradle.kts
+++ b/dependencyPacker/build.gradle.kts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+import org.jetbrains.kotlin.konan.properties.KonanPropertiesLoader
+import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.target.Distribution
+import org.jetbrains.kotlin.konan.target.presetName
+
+/**
+ * Creates an archive with LLVM distribution without files
+ * that are not required for Kotlin/Native.
+ *
+ * For example, it excludes binaries that are part of LLVM testing infrastructure.
+ */
+inline fun <reified T: AbstractArchiveTask> createLlvmPackingTask(
+        host: KonanTarget,
+        whitelist: File?,
+        blacklist: File?,
+        crossinline additionalConfiguration: T.() -> Unit
+) {
+    val distribution = Distribution(
+            konanHomeOverride = rootProject.projectDir.absolutePath
+    )
+    val reducedLlvmAppendix = distribution.properties
+            .getProperty("reducedLlvmAppendix")
+    val propertiesLoader = object : KonanPropertiesLoader(
+            host = host,
+            target = host,
+            properties = distribution.properties,
+            baseDir = DependencyProcessor.defaultDependenciesRoot.absolutePath
+    ) {}
+
+    val hostName = host.presetName.capitalize()
+    val downloadTaskName = "downloadLlvmFor$hostName"
+
+    tasks.create(downloadTaskName) {
+        doFirst {
+            propertiesLoader.downloadDependencies()
+        }
+    }
+    tasks.create<T>("packLlvmFor$hostName") {
+        dependsOn(downloadTaskName)
+        additionalConfiguration()
+
+        description = "Packs LLVM dependency for $hostName into archive"
+        group = "Distribution packing"
+
+        // > When both inclusion and exclusion are used,
+        // > only files/directories that match at least one of the include patterns
+        // > and don't match any of the exclude patterns are used.
+        //
+        // See: https://ant.apache.org/manual/dirtasks.html
+        whitelist?.let {
+            it.readLines()
+                    .filter { !it.startsWith("#") && it.isNotBlank() }
+                    .forEach(this::include)
+        }
+        blacklist?.let {
+            it.readLines()
+                    .filter { !it.startsWith("#") && it.isNotBlank() }
+                    .forEach(this::exclude)
+        }
+        from(propertiesLoader.absoluteLlvmHome)
+        destinationDirectory.set(buildDir.resolve("artifacts"))
+        archiveBaseName.set(propertiesLoader.llvmHome)
+        archiveAppendix.set(reducedLlvmAppendix)
+    }
+}
+
+createLlvmPackingTask<Tar>(
+        KonanTarget.MACOS_X64,
+        whitelist = file("macos_llvm_whitelist"),
+        blacklist = null
+) {
+    compression = Compression.GZIP
+}
+
+createLlvmPackingTask<Tar>(
+        KonanTarget.LINUX_X64,
+        whitelist = file("linux_llvm_whitelist"),
+        blacklist = file("linux_llvm_blacklist")
+) {
+    compression = Compression.GZIP
+}
+
+createLlvmPackingTask<Zip>(
+        KonanTarget.MINGW_X64,
+        whitelist = file("mingw_llvm_whitelist"),
+        blacklist = file("mingw_llvm_blacklist")
+) {}

--- a/dependencyPacker/linux_llvm_blacklist
+++ b/dependencyPacker/linux_llvm_blacklist
@@ -1,0 +1,6 @@
+# Unused large files
+lib/liblldb.so
+lib/liblldb.so.8
+lib/libLTO.so
+lib/libLTO.so.8
+lib/python2.7/site-packages/lldb/_lldb.so

--- a/dependencyPacker/linux_llvm_whitelist
+++ b/dependencyPacker/linux_llvm_whitelist
@@ -1,0 +1,28 @@
+# Compilation process
+bin/clang
+bin/clang++
+bin/clang-8
+
+# Linkage
+bin/dsymutil
+bin/lld
+bin/ld.lld
+bin/wasm-ld
+bin/llvm-ar
+
+# Useful utility
+bin/llvm-dis
+bin/c-index-test
+bin/llvm-config
+
+# Coverage support
+bin/llvm-cov
+bin/llvm-profdata
+
+# Used to link runtime files
+bin/llvm-link
+
+include/**
+lib/**
+libexec/**
+share/**

--- a/dependencyPacker/macos_llvm_whitelist
+++ b/dependencyPacker/macos_llvm_whitelist
@@ -1,0 +1,29 @@
+# Compilation process
+bin/clang
+bin/clang++
+bin/clang-8
+
+# Linkage
+bin/dsymutil
+bin/lld
+bin/ld.lld
+bin/wasm-ld
+bin/llvm-ar
+
+# Useful utility
+bin/llvm-dis
+bin/c-index-test
+bin/llvm-config
+
+# Coverage support
+bin/llvm-cov
+bin/llvm-profdata
+
+# Used to link runtime files
+bin/llvm-link
+
+include/**
+lib/**
+libexec/**
+local/**
+share/**

--- a/dependencyPacker/mingw_llvm_blacklist
+++ b/dependencyPacker/mingw_llvm_blacklist
@@ -1,0 +1,5 @@
+lib/gcc/x86_64-w64-mingw32/9.2.0/cc1plus.exe
+lib/gcc/x86_64-w64-mingw32/9.2.0/plugin/cc1.exe.a
+lib/gcc/x86_64-w64-mingw32/9.2.0/plugin/cc1plus.exe.a
+lib/gcc/x86_64-w64-mingw32/9.2.0/lto1.exe
+lib/gcc/x86_64-w64-mingw32/9.2.0/cc1.exe

--- a/dependencyPacker/mingw_llvm_whitelist
+++ b/dependencyPacker/mingw_llvm_whitelist
@@ -1,0 +1,39 @@
+# Compilation process
+bin/clang.exe
+bin/clang++.exe
+bin/clang-8.exe
+
+# Linkage
+bin/lld.exe
+bin/ld.lld.exe
+bin/wasm-ld.exe
+bin/llvm-ar.exe
+
+# Useful utility
+bin/llvm-dis.exe
+bin/llvm-config.exe
+
+# Coverage support
+bin/llvm-cov.exe
+bin/llvm-profdata.exe
+
+# Used to link runtime files
+bin/llvm-link.exe
+
+# Used for samples
+bin/windres.exe
+
+# Used by other binaries
+bin/zlib1.dll
+bin/libwinpthread-1.dll
+bin/libgcc_s_seh-1.dll
+bin/libstdc++-6.dll
+bin/libz3.dll
+
+include/**
+lib/**
+etc/**
+local/**
+share/**
+x86_64-w64-mingw32/**
+libclang.dll

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -32,6 +32,9 @@ downloadingAttempts = 10
 downloadingAttemptIntervalMs = 3000
 homeDependencyCache = .konan/cache
 
+# Appendix that is used for smaller version of LLVM distributions.
+reducedLlvmAppendix = compact
+
 clangDebugFlags = -O0
 llvmVersion.linux_x64 = 8.0.0
 llvmVersion.mingw_x64 = 8.0.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ include ':common'
 include ':backend.native:tests'
 include ':backend.native:debugger-tests'
 include ':utilities'
+include 'dependencyPacker'
 
 include ':performance'
 include ':performance:ring'
@@ -73,3 +74,4 @@ includeBuild 'build-tools'
 includeBuild 'extracted/konan.metadata'
 includeBuild 'extracted/konan.serializer'
 includeBuild 'tools/kotlin-native-gradle-plugin'
+

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/TargetProperties.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/TargetProperties.kt
@@ -18,11 +18,11 @@ package org.jetbrains.kotlin.konan.properties
 
 import org.jetbrains.kotlin.konan.target.*
 
-fun Properties.hostString(name: String): String?
-    = this.propertyString(name, HostManager.hostName)
+fun Properties.hostString(name: String, host: KonanTarget): String?
+    = this.propertyString(name, host.name)
 
-fun Properties.hostList(name: String): List<String>
-    = this.propertyList(name, HostManager.hostName)
+fun Properties.hostList(name: String, host: KonanTarget): List<String>
+    = this.propertyList(name, host.name)
 
 fun Properties.targetString(name: String, target: KonanTarget): String?
     = this.propertyString(name, target.name)
@@ -30,8 +30,8 @@ fun Properties.targetString(name: String, target: KonanTarget): String?
 fun Properties.targetList(name: String, target: KonanTarget): List<String>
     = this.propertyList(name, target.name)
 
-fun Properties.hostTargetString(name: String, target: KonanTarget): String?
-    = this.propertyString(name, hostTargetSuffix(HostManager.host, target))
+fun Properties.hostTargetString(name: String, target: KonanTarget, host: KonanTarget): String?
+    = this.propertyString(name, hostTargetSuffix(host, target))
 
-fun Properties.hostTargetList(name: String, target: KonanTarget): List<String>
-    = this.propertyList(name, hostTargetSuffix(HostManager.host, target))
+fun Properties.hostTargetList(name: String, target: KonanTarget, host: KonanTarget): List<String>
+    = this.propertyList(name, hostTargetSuffix(host, target))

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyExtractor.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyExtractor.kt
@@ -20,16 +20,22 @@ import org.jetbrains.kotlin.konan.file.unzipTo
 import java.io.File
 import java.util.concurrent.TimeUnit
 
+enum class ArchiveType(val fileExtension: String) {
+    ZIP("zip"),
+    TAR_GZ("tar.gz");
 
-class DependencyExtractor {
-    internal val useZip = System.getProperty("os.name").startsWith("Windows")
-
-    internal val archiveExtension = if (useZip) {
-        "zip"
-    } else {
-        "tar.gz"
+    companion object {
+        val systemDefault = if (System.getProperty("os.name").startsWith("Windows")) {
+            ZIP
+        } else {
+            TAR_GZ
+        }
     }
+}
 
+class DependencyExtractor(
+        private val archiveType: ArchiveType
+) {
     private fun extractTarGz(tarGz: File, targetDirectory: File) {
         val tarProcess = ProcessBuilder().apply {
             command("tar", "-xzf", tarGz.canonicalPath)
@@ -53,10 +59,9 @@ class DependencyExtractor {
     }
 
     fun extract(archive: File, targetDirectory: File) {
-        if (useZip) {
-            archive.toPath().unzipTo(targetDirectory.toPath())
-        } else {
-            extractTarGz(archive, targetDirectory)
+        when (archiveType) {
+            ArchiveType.ZIP -> archive.toPath().unzipTo(targetDirectory.toPath())
+            ArchiveType.TAR_GZ -> extractTarGz(archive, targetDirectory)
         }
     }
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
@@ -93,7 +93,8 @@ class DependencyProcessor(dependenciesRoot: File,
                           attemptIntervalMs: Long = DependencyDownloader.DEFAULT_ATTEMPT_INTERVAL_MS,
                           customProgressCallback: ProgressCallback? = null,
                           val keepUnstable: Boolean = true,
-                          val deleteArchives: Boolean = true) {
+                          val deleteArchives: Boolean = true,
+                          private val archiveType: ArchiveType = ArchiveType.systemDefault) {
 
     val dependenciesDirectory = dependenciesRoot.apply { mkdirs() }
     val cacheDirectory = homeDependencyCache.apply { mkdirs() }
@@ -104,32 +105,34 @@ class DependencyProcessor(dependenciesRoot: File,
     private var isInfoShown = false
 
     private val downloader = DependencyDownloader(maxAttempts, attemptIntervalMs, customProgressCallback)
-    private val extractor = DependencyExtractor()
-
-    private val archiveExtension get() = extractor.archiveExtension
+    private val extractor = DependencyExtractor(archiveType)
 
     constructor(dependenciesRoot: File,
                 properties: KonanPropertiesLoader,
                 dependenciesUrl: String = properties.dependenciesUrl,
-                keepUnstable:Boolean = true) : this(
+                keepUnstable:Boolean = true,
+                archiveType: ArchiveType = ArchiveType.systemDefault) : this(
             dependenciesRoot,
             properties.properties,
             properties.dependencies,
             dependenciesUrl,
-            keepUnstable = keepUnstable)
+            keepUnstable = keepUnstable,
+            archiveType = archiveType)
 
     constructor(dependenciesRoot: File,
                 properties: Properties,
                 dependencies: List<String>,
                 dependenciesUrl: String = properties.dependenciesUrl,
-                keepUnstable:Boolean = true) : this(
+                keepUnstable:Boolean = true,
+                archiveType: ArchiveType = ArchiveType.systemDefault) : this(
             dependenciesRoot,
             dependenciesUrl,
             dependencyToCandidates = properties.findCandidates(dependencies),
             airplaneMode = properties.airplaneMode,
             maxAttempts = properties.downloadingAttempts,
             attemptIntervalMs = properties.downloadingAttemptIntervalMs,
-            keepUnstable = keepUnstable)
+            keepUnstable = keepUnstable,
+            archiveType = archiveType)
 
 
     class DependencyFile(directory: File, fileName: String) {
@@ -165,7 +168,7 @@ class DependencyProcessor(dependenciesRoot: File,
         val depDir = File(dependenciesDirectory, dependency)
         val depName = depDir.name
 
-        val fileName = "$depName.$archiveExtension"
+        val fileName = "$depName.${archiveType.fileExtension}"
         val archive = cacheDirectory.resolve(fileName)
         val url = URL("$baseUrl/$fileName")
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt
@@ -85,21 +85,21 @@ sealed class DependencySource {
  * If [airplaneMode] is true will throw a RuntimeException instead of downloading.
  */
 class DependencyProcessor(dependenciesRoot: File,
-                          val dependenciesUrl: String,
+                          private val dependenciesUrl: String,
                           dependencyToCandidates: Map<String, List<DependencySource>>,
                           homeDependencyCache: File = defaultDependencyCacheDir,
-                          val airplaneMode: Boolean = false,
+                          private val airplaneMode: Boolean = false,
                           maxAttempts: Int = DependencyDownloader.DEFAULT_MAX_ATTEMPTS,
                           attemptIntervalMs: Long = DependencyDownloader.DEFAULT_ATTEMPT_INTERVAL_MS,
                           customProgressCallback: ProgressCallback? = null,
-                          val keepUnstable: Boolean = true,
-                          val deleteArchives: Boolean = true,
+                          private val keepUnstable: Boolean = true,
+                          private val deleteArchives: Boolean = true,
                           private val archiveType: ArchiveType = ArchiveType.systemDefault) {
 
-    val dependenciesDirectory = dependenciesRoot.apply { mkdirs() }
-    val cacheDirectory = homeDependencyCache.apply { mkdirs() }
+    private val dependenciesDirectory = dependenciesRoot.apply { mkdirs() }
+    private val cacheDirectory = homeDependencyCache.apply { mkdirs() }
 
-    val lockFile = File(cacheDirectory, ".lock").apply { if (!exists()) createNewFile() }
+    private val lockFile = File(cacheDirectory, ".lock").apply { if (!exists()) createNewFile() }
 
     var showInfo = true
     private var isInfoShown = false
@@ -283,15 +283,14 @@ class DependencyProcessor(dependenciesRoot: File,
 }
 
 internal object InternalServer {
-    private val host = "repo.labs.intellij.net"
-    val url = "https://$host/kotlin-native"
+    private const val host = "repo.labs.intellij.net"
+    const val url = "https://$host/kotlin-native"
 
-    private val internalDomain = "labs.intellij.net"
+    private const val internalDomain = "labs.intellij.net"
 
     val isAvailable: Boolean get() {
         val envKey = "KONAN_USE_INTERNAL_SERVER"
-        val envValue = System.getenv(envKey)
-        return when (envValue) {
+        return when (val envValue = System.getenv(envKey)) {
             null, "0" -> false
             "1" -> true
             "auto" -> isAccessible


### PR DESCRIPTION
Whitelists and blacklists are not tuned yet and (probably) will be updated in the next PR.
