### PR TITLE
[kotlin compiler][update] 1.4.0-dev-2894 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2781,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-2781
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2781,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-2781
-kotlinStdlibTestsVersion=1.4.0-dev-2781
-testKotlinCompilerVersion=1.4.0-dev-2781
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2894,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-2894
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-2894,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-2894
+kotlinStdlibTestsVersion=1.4.0-dev-2894
+testKotlinCompilerVersion=1.4.0-dev-2894
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/text/Strings.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Strings.kt
@@ -5,6 +5,8 @@
 
 package kotlin.text
 
+import kotlin.native.concurrent.SharedImmutable
+
 /**
  * Returns the index within this string of the first occurrence of the specified character, starting from the specified offset.
  */
@@ -336,6 +338,7 @@ public actual fun String.compareTo(other: String, ignoreCase: Boolean): Int {
     else compareToIgnoreCase(this, other)
 }
 
+@SharedImmutable
 private val STRING_CASE_INSENSITIVE_ORDER = Comparator<String> { a, b -> a.compareTo(b, ignoreCase = true) }
 
 public actual val String.Companion.CASE_INSENSITIVE_ORDER: Comparator<String>


### PR DESCRIPTION
* 6d1da6e6d58 - (tag: build-1.4.0-dev-2894) KT-36143 Fix type approximation for type arguments in PSI2IR (vor 28 Stunden) <Dmitry Petrov>
* 2340a86d8de - (tag: build-1.4.0-dev-2892) Update to 201.5259.13-EAP-SNAPSHOT (vor 28 Stunden) <Nikolay Krasko>
* 6c968859add - Access to test root disposable through accessor (vor 28 Stunden) <Nikolay Krasko>
* 272ccf64ae3 - Refactoring: extract resetApplicationToNull to separate file (vor 28 Stunden) <Nikolay Krasko>
* c748b6f3ee7 - (tag: build-1.4.0-dev-2888) JVM_IR. Minor. Update bytecode text test to JVM_IR or create issues when this (vor 28 Stunden) <Ilmir Usmanov>
* 4b954c347a1 - JVM IR: Avoid optimizing comparisons between boxed primitives and null (vor 29 Stunden) <Steven Schäfer>
* 32e1ec8e988 - (tag: build-1.4.0-dev-2882, tag: build-1.4.0-dev-2872) [minor] Update build output in test to fit NI (vor 31 Stunden) <Pavel Kirpichenkov>
* 64590cc56b0 - [JPS-TEST] Update test checking JPS build with NI in IDE (vor 31 Stunden) <Pavel Kirpichenkov>
* 2ead2fba084 - [IDEA-TESTS] Update quickfix test parameters for 1.4 (vor 31 Stunden) <Pavel Kirpichenkov>
* fdf4f477a6e - (tag: build-1.4.0-dev-2871) FIR2IR: fix problems with enum entry / anonymous object visibility (vor 31 Stunden) <Mikhail Glukhikh>
* 9f0ef775310 - [Gradle, JS] Provide js compilations parameters to link tasks (vor 33 Stunden) <Ilya Goncharov>
* ce8e511b791 - (tag: build-1.4.0-dev-2863) Add setOfNotNull function #KT-35851 (vor 2 Tagen) <Abduqodiri Qurbonzoda>
* 5a4ce2aa4cd - (tag: build-1.4.0-dev-2862) Mark shared global vals to fix K/N worker thread crash (vor 2 Tagen) <Abduqodiri Qurbonzoda>
* 94d20d9176f - (tag: build-1.4.0-dev-2856) Update bytecode text tests in JVM_IR (vor 2 Tagen) <Dmitry Petrov>
* 64141b8b38b - (tag: build-1.4.0-dev-2854) [JVM IR] Fix issue where fields are not being set to their default values within initializer blocks. (vor 2 Tagen) <Mark Punzalan>
* 56c819f06e5 - (tag: build-1.4.0-dev-2851) FIR2IR: add two-statements block with iterator + while for 'for' loops (vor 2 Tagen) <Mikhail Glukhikh>
* 2bfce4f127e - FIR2IR: provide correct origins for 'for' loops (vor 2 Tagen) <Mikhail Glukhikh>
* 83e68be2dcb - FIR2IR: add declarations to all library classes from kotlin.* package (vor 2 Tagen) <Mikhail Glukhikh>
* 4a4fb5a590a - Raw FIR: eliminate range variable declaration in 'for' loops (vor 2 Tagen) <Mikhail Glukhikh>
* 4abbcd1267e - Unmute two passing FIR black box tests (fixed by commits of demiurg) (vor 2 Tagen) <Mikhail Glukhikh>
* 91814364de9 - Mute two failing FIR black box tests (broken by commits of demiurg) (vor 2 Tagen) <Mikhail Glukhikh>
* baa2c56e2da - (tag: build-1.4.0-dev-2850) Force-set path to exact project for MPP run configurations (vor 2 Tagen) <Dmitry Savvinov>
* cc2884b8aec - Add test on multiplatform run configurations in multiproject build (vor 2 Tagen) <Dmitry Savvinov>
* 1ea3db90e18 - Add ability to render project of run configuration in tests (vor 2 Tagen) <Dmitry Savvinov>
* 51edf2b3511 - (tag: build-1.4.0-dev-2846) NI: introduce warning about implicitly inferred Nothing with existing non-Nothing expected type ^KT-35406 Fixed (vor 2 Tagen) <Victor Petukhov>
* e3184e407d4 - (tag: build-1.4.0-dev-2829) KT-20844 Re-enable stack spilling during inline. (vor 2 Tagen) <Jinseong Jeon>
*   c9ed27e6746 - (tag: build-1.4.0-dev-2822) KT-36685 "Convert to a range check" transform hex range to int if it is compared with "Less" or "Greater" (vor 2 Tagen) <Vladimir Dolzhenko>
|\  
| * 7f2cf571b00 - Convert to range check: do not transform binaries/hexadecimals to decimals (vor 3 Tagen) <Toshiaki Kameyama>
* 811ed1ade44 - (tag: build-1.4.0-dev-2809) [FIR] Don't update expression in receiver value with smartcast in candidate factory (vor 2 Tagen) <Dmitriy Novozhilov>
* e302e06c735 - [FIR-TEST] Add test with nullability annotation problem (vor 2 Tagen) <Dmitriy Novozhilov>
* 47d5bbc224f - [FIR-TEST] Move fixed tests out `problems` directory (vor 2 Tagen) <Dmitriy Novozhilov>
* e67c8a55bf5 - [FIR-TEST] Add test with callable reference to member of local class (vor 2 Tagen) <Dmitriy Novozhilov>
* d10e56c3589 - [FIR] Add mapping of primitive types to JVM signatures (vor 2 Tagen) <Dmitriy Novozhilov>
* 031952268ad - (tag: build-1.4.0-dev-2808) Minor. Disable test on Android (vor 2 Tagen) <Mikhael Bogdanov>
* ee2e40ce6b3 - (tag: build-1.4.0-dev-2802) Regenerate test (vor 2 Tagen) <Alexey Tsvetkov>
* 70d416cafd2 - (tag: build-1.4.0-eap-2, tag: build-1.4.0-eap-10, tag: build-1.4.0-dev-2800, tag: build-1.4-M1-eap-11) Remove test that become useless after enabling NI everywhere (vor 2 Tagen) <Mikhail Zarechenskiy>
* dfe23e770cd - Update test about lookups for SAMs after enabling NI (vor 2 Tagen) <Mikhail Zarechenskiy>
* 297d296b623 - (tag: build-1.4.0-dev-2798) [JS] Respect SKIP_DCE_DRIVEN in tests (vor 2 Tagen) <Igor Chevdar>
* 9bc7a439918 - [IR] [JS_IR] Supported fun interfaces in JS (vor 2 Tagen) <Igor Chevdar>
* 4a7b4d655cb - (tag: build-1.4.0-dev-2795) [NI] Fix completion for ILT when Nothing constraint is present (vor 2 Tagen) <Pavel Kirpichenkov>
* 208c06516b8 - (tag: build-1.4.0-dev-2794) [IR][Serialization] Allow backends to skip files (vor 2 Tagen) <Sergey Bogolepov>
* bcf6ee0c0b9 - (tag: build-1.4.0-dev-2792) KotlinDslScriptsModel: pass provider mode properly (vor 2 Tagen) <Natalia Selezneva>
* ed6f13cf568 - KotlinDslScriptsModel: do not add prepare task for each gradle task invocation (vor 2 Tagen) <Natalia Selezneva>
* e40dc37be87 - KotlinDslScriptsModel: pass correlationId during the request (vor 2 Tagen) <Natalia Selezneva>
* 55b836a0ac3 - (tag: build-1.4.0-dev-2790) Mute light class tests (vor 2 Tagen) <Pavel Kirpichenkov>
* fda8d7de8b3 - [IDEA-TESTS] Specify language version in feature-dependent tests (vor 2 Tagen) <Pavel Kirpichenkov>
* 85d7a0f6b16 - [IDEA-TESTS] Fix `ReplaceProtectedToPublishedApiCallFix` (vor 2 Tagen) <Pavel Kirpichenkov>
* 05b00a13023 - [JPS-TEST] Update deprecated language version in test (vor 2 Tagen) <Pavel Kirpichenkov>
* bd3b23b933f - Use LATEST_STABLE version during prerelease in VersionView (vor 2 Tagen) <Pavel Kirpichenkov>
* f9129332b7f - (tag: build-1.4.0-dev-2787) [NI] Minor optimisation: don't call extra `contains` checks (vor 2 Tagen) <Mikhail Zarechenskiy>
* 724bb1b1349 - [NI] Force variable substitution for properties with stub types (vor 2 Tagen) <Mikhail Zarechenskiy>
* 155b716e7e5 - Revert "Disable NewInference for stdlib tests" (vor 2 Tagen) <Mikhail Zarechenskiy>
* 18b218bfa82 - [NI] Use projected type for constraint like Cap(out A) <: out @Exact T (vor 2 Tagen) <Mikhail Zarechenskiy>
* 3cf77d29b59 - Unmute test for NI (vor 2 Tagen) <Mikhail Zarechenskiy>
* 4542f3b720f - [NI] Finish analysis for coerced last lambda expressions if needed (vor 2 Tagen) <Mikhail Zarechenskiy>