### PR TITLE
[kotlin compiler][update] 1.4.0-dev-3197 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3138,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-3138
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3138,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-3138
-kotlinStdlibTestsVersion=1.4.0-dev-3138
-testKotlinCompilerVersion=1.4.0-dev-3138
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3197,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-3197
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3197,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-3197
+kotlinStdlibTestsVersion=1.4.0-dev-3197
+testKotlinCompilerVersion=1.4.0-dev-3197
 konanVersion=1.4.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 62e335ac886 - (tag: build-1.4.0-dev-3197) Implement members: fix it works correctly for data class (vor 18 Stunden) <Toshiaki Kameyama>
* fe009ac695f - (tag: build-1.4.0-dev-3193) IR: restore reading common Klib from JVM (vor 27 Stunden) <Georgy Bronnikov>
* d54a35ef56f - (tag: build-1.4.0-dev-3191) Add "Remove argument" quick fix for TOO_MANY_ARGUMENTS (vor 29 Stunden) <Toshiaki Kameyama>
* 13afb2e45e6 - (tag: build-1.4.0-dev-3189) Make kotlin build version for buildSrc the same as for kotlin project (vor 33 Stunden) <nataliya.valtman>
* 699ea0aa2b8 - (tag: build-1.4.0-dev-3179) Replace 'if' with 'when': don't swallow comments if there is no synthetic else branch (vor 2 Tagen) <Toshiaki Kameyama>
* f487118be50 - (tag: build-1.4.0-dev-3176) Change signature: fix it works correctly when call site function has no value argument list (vor 2 Tagen) <Toshiaki Kameyama>
* 223ed1ad602 - (tag: build-1.4.0-dev-3175) KT-27601 review fixes (vor 2 Tagen) <kvirolainen>
* 90cfa80683e - KT-27601 keep imports for extension functions used in kdoc (vor 2 Tagen) <kvirolainen>
* 423aeb9a085 - (tag: build-1.4.0-dev-3172) Always check project.useCompositeAnalysis in findAnalyzerServices (vor 3 Tagen) <Dmitry Savvinov>
* e56abcbb854 - (tag: build-1.4.0-dev-3170) Inline variable: fix it works correctly for 'when' subject variable (vor 3 Tagen) <Toshiaki Kameyama>
* d8ab046136e - (tag: build-1.4.0-dev-3168) Convert property to function: remove annotation use-site target (vor 3 Tagen) <Toshiaki Kameyama>
* d5e71ebef12 - (tag: build-1.4.0-dev-3166) Invert if condition intention: 'isEmpty' <-> 'isNotEmpty' (vor 3 Tagen) <Toshiaki Kameyama>
* 79c15e49b69 - (tag: build-1.4.0-dev-3165) Convert function to property: suggest on fun keyword (vor 3 Tagen) <Toshiaki Kameyama>
* 820b8c3c548 - (tag: build-1.4.0-dev-3163) Introduce "Redundant '?: return null'" inspection (vor 3 Tagen) <Toshiaki Kameyama>
* 5f1cc3b1521 - Introduce "Redundant 'inner' modifier" inspection (vor 3 Tagen) <Toshiaki Kameyama>
* d76dc6f57e2 - (tag: build-1.4.0-dev-3160) [Commonizer] Call commonizer on Gradle configuration phase (vor 3 Tagen) <Dmitriy Dolovov>
* f2f95496e33 - (tag: build-1.4.0-dev-3159) [NI] Complete contradictory candidates inside builder-inference (vor 3 Tagen) <Mikhail Zarechenskiy>
* 33986830933 - (tag: build-1.4.0-dev-3149) Unused symbol: do not report for secondary constructor when class is used as typealias (vor 3 Tagen) <Toshiaki Kameyama>
* 81f1f441fc1 - (tag: build-1.4.0-dev-3145) [FIR] Add stub default values to kotlin.Enum constructor parameters (vor 3 Tagen) <Mikhail Glukhikh>
* 39bd97147f5 - [FIR] Don't create initializers for simple enum entries (vor 3 Tagen) <Mikhail Glukhikh>
* b1e9dbf994a - [FIR] Use super<Enum> as delegated calls in enum constructors (vor 3 Tagen) <Mikhail Glukhikh>
* f173af9238d - FIR2IR: use enum constructor call for enum entries (vor 3 Tagen) <Mikhail Glukhikh>
* 9e3f17c52a1 - (tag: build-1.4.0-dev-3144) [FIR TEST] Add test for unresolved reference in default argument (vor 3 Tagen) <Mikhail Glukhikh>
* a3252b9480b - Unused symbol: fix false positive in anonymous object in top level or companion object (vor 3 Tagen) <Toshiaki Kameyama>
* ef1e54eda97 - (tag: build-1.4.0-dev-3143) ReplaceToStringWithStringTemplateInspection: insert curly braces if needed (vor 3 Tagen) <Toshiaki Kameyama>
* c87bc2123cd - (tag: build-1.4.0-dev-3142) Add "Change to val" quick fix for MUST_BE_INITIALIZED (vor 3 Tagen) <Toshiaki Kameyama>
* a46c6ce5df3 - Revert global project settings to LATEST_STABLE in teardown (vor 3 Tagen) <Nikolay Krasko>
* f995192f21f - Always configure and restore api version settings in tests (vor 3 Tagen) <Nikolay Krasko>
* 6c83e9fb850 - Clean LANGUAGE_VERSION_SETTINGS after the test (vor 3 Tagen) <Nikolay Krasko>
* 19bc39d3aba - Clean facet if it wasn't set before test (fix tests on 201) (vor 3 Tagen) <Nikolay Krasko>
* af3b057ba20 - Always clean language and api versions after usage (vor 3 Tagen) <Nikolay Krasko>
* c0dac9bf32f - Refactoring: extract long function out of local context (vor 3 Tagen) <Nikolay Krasko>
* 3a5f42cc5ea - Refactoring: always use compiler settings with de-configuration in tests (vor 3 Tagen) <Nikolay Krasko>
* 018215f47d2 - De-bunch KotlinLightCodeInsightFixtureTestCase.kt (vor 3 Tagen) <Nikolay Krasko>
* 94be4d77ffb - Fix init order in inline fun (native test) (vor 3 Tagen) <Pavel Punegov>
* 19093e2e02b - (tag: build-1.4.0-dev-3140) Redundant companion reference: fix false positive when companion has same name member as companion name (vor 3 Tagen) <Toshiaki Kameyama>
* 98ce49ba73d - [build][native] version with milestone clause (vor 3 Tagen) <Vasily Levchenko>