### PR TITLE
Remove null terminator from Strings returned by toKStringFromUtf32

### DIFF
--- a/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Utils.kt
+++ b/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Utils.kt
@@ -532,8 +532,8 @@ public fun CPointer<IntVar>.toKStringFromUtf32(): String {
     var toIndex = 0
     while (true) {
         val value = nativeBytes[fromIndex++]
-        toIndex++
         if (value == 0) break
+        toIndex++
         if (value >= 0x10000 && value <= 0x10ffff) {
             toIndex++
         }


### PR DESCRIPTION
Remove the null terminator from `String`s returned by `toKStringFromUtf32`.

The loop should check for the null terminator *before* incrementing `toIndex`.
Found by @z3ntu in https://kotlinlang.slack.com/archives/C3SGXARS6/p1582582248013000 .
