### PR TITLE
[Interop][IrProvider] Simplify IrProviderForInteropStubs

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -215,7 +215,10 @@ internal val psiToIrPhase = konanUnitPhase(
             modulesWithoutDCE
                     .filter(ModuleDescriptor::isFromInteropLibrary)
                     .forEach(irProviderForCEnumsAndCStructs::buildAllEnumsAndStructsFrom)
-            val irProviderForInteropStubs = IrProviderForInteropStubs(irProviderForCEnumsAndCStructs::canHandleSymbol)
+            val irProviderForInteropStubs = IrProviderForInteropStubs(
+                    stubGenerator,
+                    irProviderForCEnumsAndCStructs::canHandleSymbol
+            )
             val irProviders = listOf(
                     irProviderForCEnumsAndCStructs,
                     irProviderForInteropStubs,


### PR DESCRIPTION
IrProviderForInteropStubs was doing the same thing as DeclarationStubGenerator. The only difference was support of backing fields, which is incorrect, since they should never be exported. 
Instead of replicating, we should delegate stub generation to DeclarationStubGenerator.