### PR TITLE
[kotlin compiler][update] 1.4.0-dev-3327

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -98,7 +98,7 @@ class KonanIrLinker(
         val fwdModule = forwardModuleDescriptor ?: error("Forward declaration module should not be null")
 
         return with(idSig as IdSignature.PublicSignature) {
-            val classId = ClassId(packageFqn, classFqn, false)
+            val classId = ClassId(packageFqn, declarationFqn, false)
             fwdModule.findClassAcrossModuleDependencies(classId)
         }
     }

--- a/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/utils/KonanFactories.kt
+++ b/extracted/konan.serializer/src/org/jetbrains/kotlin/konan/utils/KonanFactories.kt
@@ -2,7 +2,7 @@ package org.jetbrains.kotlin.konan.utils
 
 import org.jetbrains.kotlin.builtins.konan.KonanBuiltIns
 import org.jetbrains.kotlin.konan.util.KlibMetadataFactories
-import org.jetbrains.kotlin.serialization.konan.NullFlexibleTypeDeserializer
+import org.jetbrains.kotlin.library.metadata.NullFlexibleTypeDeserializer
 import org.jetbrains.kotlin.storage.StorageManager
 
 fun createKonanBuiltIns(storageManager: StorageManager) = KonanBuiltIns(storageManager)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3251,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-3251
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3251,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-3251
-kotlinStdlibTestsVersion=1.4.0-dev-3251
-testKotlinCompilerVersion=1.4.0-dev-3251
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3327,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-3327
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3327,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-3327
+kotlinStdlibTestsVersion=1.4.0-dev-3327
+testKotlinCompilerVersion=1.4.0-dev-3327
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/runtime/src/main/kotlin/generated/_CollectionsNative.kt
+++ b/runtime/src/main/kotlin/generated/_CollectionsNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/runtime/src/main/kotlin/generated/_ComparisonsNative.kt
+++ b/runtime/src/main/kotlin/generated/_ComparisonsNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 
@@ -137,6 +137,76 @@ public actual inline fun maxOf(a: Double, b: Double, c: Double): Double {
 }
 
 /**
+ * Returns the greater of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun <T : Comparable<T>> maxOf(a: T, vararg other: T): T {
+    var max = a
+    for (e in other) max = maxOf(max, e)
+    return max
+}
+
+/**
+ * Returns the greater of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun maxOf(a: Byte, vararg other: Byte): Byte {
+    var max = a
+    for (e in other) max = maxOf(max, e)
+    return max
+}
+
+/**
+ * Returns the greater of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun maxOf(a: Short, vararg other: Short): Short {
+    var max = a
+    for (e in other) max = maxOf(max, e)
+    return max
+}
+
+/**
+ * Returns the greater of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun maxOf(a: Int, vararg other: Int): Int {
+    var max = a
+    for (e in other) max = maxOf(max, e)
+    return max
+}
+
+/**
+ * Returns the greater of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun maxOf(a: Long, vararg other: Long): Long {
+    var max = a
+    for (e in other) max = maxOf(max, e)
+    return max
+}
+
+/**
+ * Returns the greater of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun maxOf(a: Float, vararg other: Float): Float {
+    var max = a
+    for (e in other) max = maxOf(max, e)
+    return max
+}
+
+/**
+ * Returns the greater of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun maxOf(a: Double, vararg other: Double): Double {
+    var max = a
+    for (e in other) max = maxOf(max, e)
+    return max
+}
+
+/**
  * Returns the smaller of two values.
  * If values are equal, returns the first one.
  */
@@ -267,5 +337,75 @@ public actual inline fun minOf(a: Float, b: Float, c: Float): Float {
 @kotlin.internal.InlineOnly
 public actual inline fun minOf(a: Double, b: Double, c: Double): Double {
     return minOf(a, minOf(b, c))
+}
+
+/**
+ * Returns the smaller of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun <T : Comparable<T>> minOf(a: T, vararg other: T): T {
+    var min = a
+    for (e in other) min = minOf(min, e)
+    return min
+}
+
+/**
+ * Returns the smaller of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun minOf(a: Byte, vararg other: Byte): Byte {
+    var min = a
+    for (e in other) min = minOf(min, e)
+    return min
+}
+
+/**
+ * Returns the smaller of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun minOf(a: Short, vararg other: Short): Short {
+    var min = a
+    for (e in other) min = minOf(min, e)
+    return min
+}
+
+/**
+ * Returns the smaller of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun minOf(a: Int, vararg other: Int): Int {
+    var min = a
+    for (e in other) min = minOf(min, e)
+    return min
+}
+
+/**
+ * Returns the smaller of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun minOf(a: Long, vararg other: Long): Long {
+    var min = a
+    for (e in other) min = minOf(min, e)
+    return min
+}
+
+/**
+ * Returns the smaller of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun minOf(a: Float, vararg other: Float): Float {
+    var min = a
+    for (e in other) min = minOf(min, e)
+    return min
+}
+
+/**
+ * Returns the smaller of given values.
+ */
+@SinceKotlin("1.4")
+public actual fun minOf(a: Double, vararg other: Double): Double {
+    var min = a
+    for (e in other) min = minOf(min, e)
+    return min
 }
 

--- a/runtime/src/main/kotlin/generated/_StringsNative.kt
+++ b/runtime/src/main/kotlin/generated/_StringsNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/runtime/src/main/kotlin/generated/_UArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_UArraysNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
  */
 

--- a/runtime/src/main/kotlin/kotlin/reflect/KProperty.kt
+++ b/runtime/src/main/kotlin/kotlin/reflect/KProperty.kt
@@ -14,42 +14,42 @@ import kotlin.native.internal.FixmeReflection
  * See the [Kotlin language documentation](https://kotlinlang.org/docs/reference/reflection.html)
  * for more information.
  *
- * @param R the type of the property.
+ * @param V the type of the property value.
  */
-public actual interface KProperty<out R> : KCallable<R>
+public actual interface KProperty<out V> : KCallable<V>
 
-public actual interface KProperty0<out R> : kotlin.reflect.KProperty<R>, () -> R {
+public actual interface KProperty0<out V> : kotlin.reflect.KProperty<V>, () -> V {
 
-    public actual fun get(): R
+    public actual fun get(): V
 
-    public override abstract operator fun invoke(): R
+    public override abstract operator fun invoke(): V
 }
 
-public actual interface KProperty1<T, out R> : kotlin.reflect.KProperty<R>, (T) -> R {
-    public actual fun get(receiver: T): R
+public actual interface KProperty1<T, out V> : kotlin.reflect.KProperty<V>, (T) -> V {
+    public actual fun get(receiver: T): V
 
-    public override operator fun invoke(p1: T): R
+    public override operator fun invoke(p1: T): V
 }
 
-public actual interface KProperty2<T1, T2, out R> : kotlin.reflect.KProperty<R>, (T1, T2) -> R {
-    public actual fun get(receiver1: T1, receiver2: T2): R
+public actual interface KProperty2<T1, T2, out V> : kotlin.reflect.KProperty<V>, (T1, T2) -> V {
+    public actual fun get(receiver1: T1, receiver2: T2): V
 
-    public override operator fun invoke(p1: T1, p2: T2): R
+    public override operator fun invoke(p1: T1, p2: T2): V
 }
 
 /**
  * Represents a property declared as a `var`.
  */
-public actual interface KMutableProperty<R> : KProperty<R>
+public actual interface KMutableProperty<V> : KProperty<V>
 
-public actual interface KMutableProperty0<R> : KProperty0<R>, KMutableProperty<R> {
-    public actual fun set(value: R)
+public actual interface KMutableProperty0<V> : KProperty0<V>, KMutableProperty<V> {
+    public actual fun set(value: V)
 }
 
-public actual interface KMutableProperty1<T, R> : KProperty1<T, R>, KMutableProperty<R> {
-    public actual fun set(receiver: T, value: R)
+public actual interface KMutableProperty1<T, V> : KProperty1<T, V>, KMutableProperty<V> {
+    public actual fun set(receiver: T, value: V)
 }
 
-public actual interface KMutableProperty2<T1, T2, R> : KProperty2<T1, T2, R>, KMutableProperty<R> {
-    public actual fun set(receiver1: T1, receiver2: T2, value: R)
+public actual interface KMutableProperty2<T1, T2, V> : KProperty2<T1, T2, V>, KMutableProperty<V> {
+    public actual fun set(receiver1: T1, receiver2: T2, value: V)
 }


### PR DESCRIPTION
* 5ed28b38be2 - (tag: build-1.4.0-dev-3327) [NI] Fix coroutine inference for qualified chained call with stub type (vor 21 Stunden) <Mikhail Zarechenskiy>
* a47c818a3c2 - (tag: build-1.4.0-dev-3324) Minor: update testData in box tests with signature check (vor 23 Stunden) <Dmitry Petrov>
* af5a381c2b8 - (tag: build-1.4.0-dev-3322) Minor. Use java 6 construct in test (vor 23 Stunden) <Ilmir Usmanov>
* bb43a667161 - (tag: build-1.4.0-dev-3319) [Metadata] Add platform dependent type transformer (vor 24 Stunden) <Roman Artemev>
* 25a91a217e2 - [KLIB] Fix package for NullFlexibleTypeDeserializer (vor 24 Stunden) <Roman Artemev>
* b744ee0aa43 - (tag: build-1.4.0-dev-3316) JS IR: Remove nested blocks from bodies (vor 24 Stunden) <Anton Bannykh>
* 71521566596 - JS IR: Don't yield methods with no body (vor 24 Stunden) <Anton Bannykh>
* 71cc288a149 - (tag: build-1.4.0-dev-3312) [Linker][IdSignature] Rename classFqn property (vor 25 Stunden) <Sergey Bogolepov>
* 221d24c5973 - [Linker] Do not generate wrapped descriptor if descriptor is provided (vor 25 Stunden) <Sergey Bogolepov>
* 6eec8c28adc - (tag: build-1.4.0-dev-3310) Add `JvmDefault` to recently added method for compiler extensions (vor 25 Stunden) <Mikhail Zarechenskiy>
* 74348d5ffbf - (tag: build-1.4.0-dev-3307) Fix compile configuration for maven compiler plugins (vor 26 Stunden) <Stanislav Erokhin>
* 453008e488a - Deprecated reportFromPlugin way to report diagnostics from plugin (vor 26 Stunden) <Stanislav Erokhin>
* 84baa0b4c29 - (tag: build-1.4.0-dev-3306) Check more flags in bytecode listing tests (vor 27 Stunden) <Dmitry Petrov>
* ee9be61c20a - (tag: build-1.4.0-dev-3304) [Gradle, JS] Fix propogation useCommonJs to irTarget (vor 27 Stunden) <Ilya Goncharov>
* 7719dfca4a0 - (tag: build-1.4.0-dev-3303) [Gradle, JS] Fix timeout for debug (vor 27 Stunden) <Ilya Goncharov>
* 870b7d234fa - (tag: build-1.4.0-dev-3301) Wizard: refactoring do not use context directly in UI (vor 27 Stunden) <Ilya Kirillov>
* ad39d0520a3 - Wizard: use first enum entry as default value for enumSetting (vor 27 Stunden) <Ilya Kirillov>
* 3967522c082 - Wizard: fix Android minifyEnabled call for groovy (vor 27 Stunden) <Ilya Kirillov>
* 7e225723244 - Wizard: add configuration for Android MPP target (vor 27 Stunden) <Ilya Kirillov>
* 3eca687611e - Wizard: move module configurator settings to companion objects (vor 27 Stunden) <Ilya Kirillov>
* 4c62f643963 - Wizard: minor, not to use reading context directly in some places (vor 27 Stunden) <Ilya Kirillov>
* 8259bf749d6 - Wizard: always use all plugin set in tests (vor 27 Stunden) <Ilya Kirillov>
* 7a3d730aec5 - Wizard: refactoring: rename contexts (vor 27 Stunden) <Ilya Kirillov>
* 1c49b230f4a - Wizard: force service to always return non-null value (vor 27 Stunden) <Ilya Kirillov>
* 05022109fc2 - Wizard: save some setting values in UI (vor 27 Stunden) <Ilya Kirillov>
* 9e47d0b33cc - Wizard: move Android SDK Setting to AndroidPlugin (vor 27 Stunden) <Ilya Kirillov>
* 9c5ff6c1311 - Wizard: create Gradle wrapper (vor 27 Stunden) <Ilya Kirillov>
* 6228fa4d3e8 - Wizard: remove unused function (vor 27 Stunden) <Ilya Kirillov>
* 7448b8beb01 - Wizard: fix invalid android package name (vor 27 Stunden) <Ilya Kirillov>
* 2600ebb9610 - Wizard: use custom module icons for every module kind (vor 27 Stunden) <Ilya Kirillov>
* 299b0f0102d - Wizard: prettify error messages (vor 27 Stunden) <Ilya Kirillov>
* 72f92d7a3b6 - Wizard: use IntelliJ validator in UI instead of custom one (vor 27 Stunden) <Ilya Kirillov>
* 1431649c4d9 - Wizard: use Kotlin Gradle Icon for Gradle Kotlin build system (vor 27 Stunden) <Ilya Kirillov>
* e1b99580eb6 - Wizard: introduce Android & JS multiplatform project kinds (vor 27 Stunden) <Ilya Kirillov>
* a5a72a89fc8 - Wizard: allow to create multiple JVM targets (vor 27 Stunden) <Ilya Kirillov>
* bb455ec8f6c - Wizard: make error messages in ui clickable (vor 27 Stunden) <Ilya Kirillov>
* 087de68b3a3 - Wizard: flatten JVM targets (vor 27 Stunden) <Ilya Kirillov>
* 54c9582ac4a - Wizard: fix wrong line separators (vor 27 Stunden) <Ilya Kirillov>
* fa4d790f5a2 - Wizard: add jvm target setting for JVM configurations (vor 27 Stunden) <Ilya Kirillov>
* fabb0584dad - Wizard: remove module types for some module configurators (vor 27 Stunden) <Ilya Kirillov>
* 0123dbce211 - Wizard: trim paths in UI (vor 27 Stunden) <Ilya Kirillov>
* 152def62cb6 - Wizard: get current Kotlin version from compiler (vor 27 Stunden) <Ilya Kirillov>
* 50c2c38624c - (tag: build-1.4.0-dev-3295) Tests: fix some tests in formatter for AS (vor 29 Stunden) <Dmitry Gridin>
* ca598b64652 - (tag: build-1.4.0-dev-3294) Formatter: fix indent after trailing comma in calls (vor 32 Stunden) <Dmitry Gridin>
* 1f721796b8c - (tag: build-1.4.0-dev-3289) Add vararg overloads for maxOf/minOf functions #KT-33906 (vor 34 Stunden) <Abduqodiri Qurbonzoda>
* 5aae3b5d274 - (tag: build-1.4.0-dev-3273, origin/rr/4u7/local-cache-directory) Build: Add localBuildCacheDirectory property to KotlinBuildProperties (vor 2 Tagen) <Vyacheslav Gerasimov>
* fc2161c2a69 - (tag: build-1.4.0-dev-3270) Build: Don't cache :kotlin-compiler:proguard (vor 2 Tagen) <Vyacheslav Gerasimov>
* 428dcd847f5 - (tag: build-1.4.0-dev-3265) Flip default value of kotlin.gradle.testing.enabled to true (vor 2 Tagen) <Dmitry Savvinov>
* d82dc86c71f - (tag: build-1.4.0-dev-3264) Reverts commit 13afb2e4 (buildSrc bootstrap version) (vor 2 Tagen) <nataliya.valtman>
* 5e16373af6b - (tag: build-1.4.0-dev-3259) .gradle.kts, changes notifier: process events async and on pooled thread (vor 2 Tagen) <Sergey Rostov>
* 5393074d61b - (tag: build-1.4.0-dev-3257) [NI] Update type of complex subcall for last lambda expressions (vor 2 Tagen) <Mikhail Zarechenskiy>
* 66ef49cecc7 - (tag: build-1.4.0-dev-3256) Fix CCE under composite mode (vor 2 Tagen) <Dmitry Savvinov>
* b21a9476c01 - (tag: build-1.4.0-dev-3253) New J2K: minor, use firstNotNullResult in j2k reference resolver (vor 2 Tagen) <Ilya Kirillov>
* b7711678c27 - EA-218474: fix IAE in resolving empty fqName in new J2K (vor 2 Tagen) <Ilya Kirillov>
* af5a70dcf57 - EA-218043: fix getting resolution facade for empty list of elements in new J2K (vor 2 Tagen) <Ilya Kirillov>
* a64526acfbb - EA-210533: fix NPE in LiftReturnOrAssignmentInspection (vor 2 Tagen) <Ilya Kirillov>
* 9af30f4ac7d - EA-210362: fix invalid cast to KtFile in KtCodeFragment (vor 2 Tagen) <Ilya Kirillov>
* 7f50dcb3a83 - EA-210234: Fix invalid access to Java resolution facade (vor 2 Tagen) <Ilya Kirillov>
* af6d5b76f59 - EA-209576: Fix access to disposed module in gradle importer (vor 2 Tagen) <Ilya Kirillov>
* 2b6a0d6c58d - (tag: build-1.4.0-dev-3252) JVM IR: Don't create $annotations stubs for fake overridden properties (vor 2 Tagen) <Steven Schäfer>