### PR TITLE
[kotlin compiler][update] 1.4.0-dev-3529

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3327,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-3327
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3327,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-3327
-kotlinStdlibTestsVersion=1.4.0-dev-3327
-testKotlinCompilerVersion=1.4.0-dev-3327
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3529,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-3529
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3529,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-3529
+kotlinStdlibTestsVersion=1.4.0-dev-3529
+testKotlinCompilerVersion=1.4.0-dev-3529
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 266149b88c6 - (tag: build-1.4.0-dev-3529) RedundantLetInspection: fix false positive with nullable receiver extension call (vor 6 Stunden) <Toshiaki Kameyama>
* a6139f36354 - (tag: build-1.4.0-dev-3528) Wizard: minor: fix YamlParsingError package (vor 15 Stunden) <Ilya Kirillov>
* a9c96a7cde5 - Wizard: move downloading Kotlin version phase to the end (vor 18 Stunden) <Ilya Kirillov>
* a03510e3c09 - Wizard: add tags for project templates (vor 18 Stunden) <Ilya Kirillov>
* d639816393e - Wizard: use kotlinx-collections-immutable for storing IRs (vor 18 Stunden) <Ilya Kirillov>
* e38448c6f27 - (tag: build-1.4.0-dev-3527, tag: build-1.4.0-dev-3524, tag: build-1.4.0-dev-3522, tag: build-1.4.0-dev-3519, tag: build-1.4.0-dev-3515) No need to hack PsiSubstitutor anymore in AS 40 (KT-36039) (vor 2 Tagen) <Nikolay Krasko>
* b1ca06b21db - (tag: build-1.4.0-dev-3513) Build: Add missing tools.jar to performance tests runtime (vor 2 Tagen) <Vyacheslav Gerasimov>
* 05b5894ef18 - (tag: build-1.4.0-dev-3507) Build: Use configurations property for shadowJar in :kotlin-main-kts (vor 2 Tagen) <Vyacheslav Gerasimov>
* 0db69cadb60 - Build: Make all compile dependencies on toolsJar compileOnly (vor 2 Tagen) <Vyacheslav Gerasimov>
* 8e0f403f020 - Build: normalize inputs of :kotlin-reflect:stripMetadata as classpath (vor 2 Tagen) <Vyacheslav Gerasimov>
* 6e2fb72bb67 - Build: Make :kotlin-reflect:relocateCoreSources task cacheable (vor 2 Tagen) <Vyacheslav Gerasimov>
* 0ebc11270b9 - Build: Remove duplicated manifestAttributes call from reflectShadowJar (vor 2 Tagen) <Vyacheslav Gerasimov>
* 54d8afea40b - Build: Disable caching for Test tasks until we are sure it is safe (vor 2 Tagen) <Vyacheslav Gerasimov>
* 5195cc8c12a - Build: Add buildserver.labs.intellij.net to valid hosts in caching check (vor 2 Tagen) <Vyacheslav Gerasimov>
* b64c7cce840 - Build: Use Jar task for :kotlin-compiler:packCompiler (vor 2 Tagen) <Vyacheslav Gerasimov>
* 35c4cc6d454 - Build: Use Jar task instead ShadowJar task in :kotlin-daemon-client-new (vor 2 Tagen) <Vyacheslav Gerasimov>
* 07949aaf4f7 - Build: Use Jar task instead ShadowJar task in :kotlin-daemon (vor 2 Tagen) <Vyacheslav Gerasimov>
* 6c8c126ebc0 - (tag: build-1.4.0-dev-3506) as40: Update to AS 4.0 Beta 1 (vor 2 Tagen) <Vyacheslav Gerasimov>
* 7359bb8a008 - (tag: build-1.4.0-dev-3503) Fix tests freeze because of ScriptChangesNotifier (KT-37112) (vor 3 Tagen) <Sergey Rostov>
* 03913ff029d - (tag: build-1.4.0-dev-3501) KT-33119 Generate IINC for primitive types only (vor 3 Tagen) <Dmitry Petrov>
* 2010d8d2b91 - (tag: build-1.4.0-dev-3500) KT-36956 fix back-end part in JVM and JVM_IR (vor 3 Tagen) <Dmitry Petrov>
* f764d3a0213 - (tag: build-1.4.0-dev-3498) testCompileOnlyDependencyProcessingForMetadataCompilations -> Gradle 5+ (vor 3 Tagen) <Sergey Igushkin>
* b8602fa31a9 - Fix missing installation dependencies in Gradle integration tests (vor 3 Tagen) <Sergey Igushkin>
* 197e096017c - (tag: build-1.4.0-dev-3497) Disable PerformanceNativeProjectsTest (vor 3 Tagen) <Vladimir Dolzhenko>
* bc0e466981b - Add undo typing kts performance test (vor 3 Tagen) <Vladimir Dolzhenko>
* 4ac45eb38be - (tag: build-1.4.0-dev-3494) JVM IR: Fix inline class constructors taking default values of inline class type. (vor 3 Tagen) <Steven Schäfer>
* 846e50a0c03 - (tag: build-1.4.0-dev-3478) Backport ActionUtil.underModalProgress to fix 191/192 compilation (vor 3 Tagen) <Vladimir Dolzhenko>
* d47fc7280ba - (tag: build-1.4.0-dev-3475) Fix testUnresolvedMultiline test data (vor 3 Tagen) <Nikolay Krasko>
* 50c92f2a050 - Bad string interpolation for empty string in batch (KT-37090) (vor 3 Tagen) <Nikolay Krasko>
* b173284d1da - (tag: build-1.4.0-dev-3473) Add tests for super calls in inline classes (vor 3 Tagen) <Steven Schäfer>
* 0fe8fec1d13 - Mute FIR tests (vor 3 Tagen) <Steven Schäfer>
* 465e9f2d686 - JVM IR: Always produce stubs for interface methods in inline classes (vor 3 Tagen) <Steven Schäfer>
* 8c9ebc1bf90 - JVM IR: Initialize parent field in InlineCallableReferenceToLambda (vor 3 Tagen) <Steven Schäfer>
* c2eab08cc9c - (tag: build-1.4.0-dev-3467) FIR: fix arose problem with smartcast un-stability (vor 3 Tagen) <Mikhail Glukhikh>
* d5fbd93fe6e - Unmute additional FIR black box tests (vor 3 Tagen) <Mikhail Glukhikh>
* 9e69ffad36d - FIR2IR (refactoring): introduce ConversionTypeContext (vor 3 Tagen) <Mikhail Glukhikh>
* 883dd95e3c3 - FIR: fix class / constructor type parameter duplication (vor 3 Tagen) <Mikhail Glukhikh>
* 2308e5bb7ce - FIR2IR: in case of use-site generic type use call from original class (vor 3 Tagen) <Mikhail Glukhikh>
* 096dc257019 - FIR: change callableId of fake overrides to derived class owner (vor 3 Tagen) <Mikhail Glukhikh>
* db7401d8eb2 - FIR2IR: set GET_PROPERTY origin for property reads (vor 3 Tagen) <Mikhail Glukhikh>
* e066afc67f4 - FIR2IR: set parents for external enum entries (vor 3 Tagen) <Mikhail Glukhikh>
* 5b3b35cd78d - FIR2IR: set "external stub" origin for external enum entries (vor 3 Tagen) <Mikhail Glukhikh>
* 3a3d6e740cc - FIR2IR: correctly set type parameters of property accessors (vor 3 Tagen) <Mikhail Glukhikh>
* 50abb072455 - [FIR] Record & use type arguments of FirQualifiedAccessExpression (vor 3 Tagen) <Mikhail Glukhikh>
* f53b059410e - (tag: build-1.4.0-dev-3460) [Gradle, tests] Fix native compiler arguments test for Windows (vor 3 Tagen) <Ilya Matveev>
* 0b9106b0f89 - (tag: build-1.4.0-dev-3457) CanBePrimaryConstructorPropertyInspection: do not report for 'open' property used in class initializer in 'open' class (vor 3 Tagen) <Toshiaki Kameyama>
* 963258189a3 - (tag: build-1.4.0-dev-3455) JVM_IR: change parameter type computation in InlineCallableReferenceToLambda (vor 3 Tagen) <Georgy Bronnikov>
* 456139fc5e7 - (tag: build-1.4.0-dev-3451) JVM_IR: cache signatures in BridgeLowering (vor 3 Tagen) <pyos>
* 97e320b57f1 - (tag: build-1.4.0-dev-3446) Don't show IR_COMPILED_CLASS error in IJ when it arises in module with backend IR enabled (vor 3 Tagen) <Ilya Kirillov>
* 7a4d414c596 - (tag: build-1.4.0-dev-3445) 201: Mute SuggestedRefactoring tests (vor 3 Tagen) <Nikolay Krasko>
* 6a9dfd49359 - 201: Mute HierarchicalMultiplatformProjectImportingTest: No module dependency found (vor 3 Tagen) <Nikolay Krasko>
* 774db02b231 - 201: Mute quick fix tests: Range must be inside element being annotated (vor 3 Tagen) <Nikolay Krasko>
* 06adac1abfa - 201: Mute TodoSearchTest: duplicate TODO items (vor 3 Tagen) <Nikolay Krasko>
* 543168c61d5 - 201: Mute incremental compilation tests with constants (vor 3 Tagen) <Nikolay Krasko>
* 8501ea78c84 - 201: Mute a lot of tests with enums (vor 3 Tagen) <Nikolay Krasko>
* 79e663828a2 - 201: Mute QuickFixTestGenerate: Range must be inside element being annotated (vor 3 Tagen) <Nikolay Krasko>
* f5a97ea56ef - 201: Mute GradleScriptInputsWatcherTest failures (vor 3 Tagen) <Nikolay Krasko>
* dad7fd383cf - 201: Upgrade nodejs plugin in 201 branch (vor 3 Tagen) <Nikolay Krasko>
* f0a4f838f29 - 201: Mute NewMultiplatformProjectImportingTest tests (vor 3 Tagen) <Nikolay Krasko>
* f4cd25ce721 - 201: Mute MultiplatformProjectImportingTest tests (vor 3 Tagen) <Nikolay Krasko>
* 67dee52b8af - 201: Mute NewJavaToKotlinConverterSingleFileTestGenerated tests (vor 3 Tagen) <Nikolay Krasko>
* 958b8a0b104 - 201: Fix maven plugin loading by adding repository-search to runtime (vor 3 Tagen) <Nikolay Krasko>
* 0fcd011abb5 - 201: Fix loading project in configuration tests (vor 3 Tagen) <Nikolay Krasko>
* 1a01ba0ae59 - 201: Trick idea home path exception with custom `idea.home` variable (vor 3 Tagen) <Nikolay Krasko>
* da2683d1809 - Copy 192 muted tests (vor 3 Tagen) <Nikolay Krasko>
* dd21736471c - Register JDK for default project to prevent create leaking one for Gradle import (vor 3 Tagen) <Nikolay Krasko>
* c9fd79c311c - Enable mute in code for all KotlinLightCodeInsightFixtureTestCaseBase (vor 3 Tagen) <Nikolay Krasko>
* 1c0a9d29818 - Minor: better asserts in TodoSearchTest.kt (vor 3 Tagen) <Nikolay Krasko>
* 26df2a5c68a - Enable mute test with database in BaseKotlinJpsBuildTestCase (vor 3 Tagen) <Nikolay Krasko>
* 31ba40cc99a - Ignore auto-mute files (vor 3 Tagen) <Nikolay Krasko>
* c22272bbcaf - Enable mute for KotlinCompletionTestCase (vor 3 Tagen) <Nikolay Krasko>
* 66e2f95dbae - Update method after UsefulTestCase update to make in work in 201 (vor 3 Tagen) <Nikolay Krasko>
* 3c3b1bb5e4d - Support auto-mute in parametrized JUnit 4 tests (vor 3 Tagen) <Nikolay Krasko>
* f042b043206 - Minor: remove unneeded class (vor 3 Tagen) <Nikolay Krasko>
* 14f7529c1bc - (tag: build-1.4.0-dev-3444) [NI] Reanalyze coroutine-block if there is inapplicable call (vor 3 Tagen) <Mikhail Zarechenskiy>
* aab8555d653 - (tag: build-1.4.0-dev-3442) Move adjustExtractionData.performAnalysis under modal progress (vor 3 Tagen) <Vladimir Dolzhenko>
* ec431460b32 - Do not lookup for kotlin tests in non kotlin files (vor 3 Tagen) <Vladimir Dolzhenko>
* 2a27ca828cf - Commit document before actual imports optimization (vor 3 Tagen) <Vladimir Dolzhenko>
* acc4118903f - Provide import alias suggestion for Companion (vor 3 Tagen) <Vladimir Dolzhenko>
* 3ec2095c9f3 - Don't log ControlFlowException (vor 3 Tagen) <Vladimir Dolzhenko>
* 3881220386e - (tag: build-1.4.0-dev-3441) JVM IR: Box arguments in abstract method stubs for "remove" bridges (vor 3 Tagen) <Steven Schäfer>
* 86f9cb6eef9 - (tag: build-1.4.0-dev-3435) Adds AdditionalExtractableAnalyser EP. (vor 3 Tagen) <kovalp>
* b53cb5cb4cb - (tag: build-1.4.0-dev-3426) Cover with a test current Double/Float companion values access (vor 3 Tagen) <Ilya Gorbunov>
* 1f47c6d54ff - (tag: build-1.4.0-dev-3425) Add missed calcHashCode for ModuleSourceScope subclasses (vor 4 Tagen) <Vladimir Dolzhenko>
* 035cc57cf47 - (tag: build-1.4.0-dev-3420) JVM_IR: don't remap current method signature when detecting clashes (vor 4 Tagen) <pyos>
* ad0070ed8a6 - (tag: build-1.4.0-dev-3419) KT-37059 Support 'String?.plus(Any?)' in JVM_IR (vor 4 Tagen) <Dmitry Petrov>
* f9483b1f4fe - (tag: build-1.4.0-dev-3400) [FIR] KT-37027: Add 'out' projection to vararg elements (vor 4 Tagen) <simon.ogorodnik>
* f405b3f8270 - [FIR] Reorganize ConeKotlinTypeProjection hierarchy (vor 4 Tagen) <simon.ogorodnik>
* 7c4f59dfcbe - [FIR] KT-37009: Fix loss of bound smart-cast due to synthetic removal (vor 4 Tagen) <simon.ogorodnik>
* ec936b72868 - [FIR] Setup FIR tests configuration (vor 4 Tagen) <simon.ogorodnik>
* fbf4abf0cf3 - (tag: build-1.4.0-dev-3399) FIR: Unignore FIR2IR test (vor 4 Tagen) <Denis Zharkov>
* 53454a783c6 - (tag: build-1.4.0-dev-3398) Fix project compilation (vor 4 Tagen) <Denis Zharkov>
* 8fca343ef00 - (tag: build-1.4.0-dev-3395) FIR: Support FirComparisonOperator in Fir2Ir (vor 4 Tagen) <Denis Zharkov>
* 434444cd699 - FIR: Support FirComparisonOperator in body transformers and DFA (vor 4 Tagen) <Denis Zharkov>
* c3aed433aea - FIR: Support FirComparisonOperator in builders (vor 4 Tagen) <Denis Zharkov>
* 80b7fbd07a7 - FIR: Add new nodes kind for comparison operator (vor 4 Tagen) <Denis Zharkov>
* 3ecee5c7cda - (tag: build-1.4.0-dev-3389) [JS IR BE] Implement kotlin.js.jsTypeOf as intrinsics (vor 4 Tagen) <Svyatoslav Kuzmich>
* dff7d7b7b98 - [PSI2IR] Patch parents before referenceExpectsForUsedActuals (vor 4 Tagen) <Svyatoslav Kuzmich>
* 1e02fa3db9a - [JS IR BE] Create temporary variables with wrapped descriptors. (vor 4 Tagen) <Svyatoslav Kuzmich>
* 8877bac873b - [JS IR BE] Don't fail typeOf lowering on reified type parameters. (vor 4 Tagen) <Svyatoslav Kuzmich>
* b359bf1859b - [JS IR BE] Stop checking mangling for klib-to-js compilation. (vor 4 Tagen) <Svyatoslav Kuzmich>
* cd80eced32e - [JS IR BE] Use fresh name for external JsModule declarations. (vor 4 Tagen) <Svyatoslav Kuzmich>
* 5c6f452c105 - (tag: build-1.4.0-dev-3386) Revert "add cleanup dependencies tasks for buildSrc" (vor 4 Tagen) <nataliya.valtman>
* e7816b4ec2f - (tag: build-1.4.0-dev-3383) JS: support callable references with vararg and default parameters conversion (vor 4 Tagen) <Anton Bannykh>
* f6a23ea441d - [FIR] Add infrastructure for call checkers (vor 4 Tagen) <Dmitriy Novozhilov>
* 9cee2962dbd - [FIR] Add more nodes for declaration checkers (vor 4 Tagen) <Dmitriy Novozhilov>
* 04424a1ec35 - (tag: build-1.4.0-dev-3382) Reduce UI freezes by preparing affected Gradle project files lists in advance, once per event. isRelevant() method is a hotspot, as it is called for each file in bulk VFS event (vor 4 Tagen) <Nikita Skvortsov>
* a9e03937a30 - (tag: build-1.4.0-dev-3381) Minor. Update tests to support them on Android (vor 4 Tagen) <Mikhael Bogdanov>
* 8a8536f8aec - (tag: build-1.4.0-dev-3379, minamoto/1.4.0/rr/build/konan-version) add cleanup dependencies tasks for buildSrc (vor 4 Tagen) <nataliya.valtman>
* ea7b5827ab3 - Minor: update testData for bytecode listing tests (vor 4 Tagen) <Dmitry Petrov>
* 5827be41825 - (tag: build-1.4.0-dev-3371) Tests: fix test for AS 3.6 (vor 4 Tagen) <Dmitry Gridin>
* ca3c72c1439 - (tag: build-1.4.0-dev-3369) IDE perf tests for Kotlin/Native projects (vor 4 Tagen) <Dmitriy Dolovov>
* f5e6001d82e - (tag: build-1.4.0-dev-3366) Registry key to show hidden variables in debugger. (vor 4 Tagen) <Vladimir Ilmov>
* e19c0c97680 - (tag: build-1.4.0-dev-3360) Update idea-completion testData after introducing vararg maxOf/minOf (vor 4 Tagen) <Abduqodiri Qurbonzoda>
* 12bf8a44e78 - (tag: build-1.4.0-dev-3357) Minor changes after code review (vor 5 Tagen) <Valentin Kipyatkov>
* b9a9000569f - Suggested Rename and Change Signature implementation for Kotlin (vor 5 Tagen) <Valentin Kipyatkov>
* a01b840eab1 - (tag: build-1.4.0-dev-3353) Android Import: Search for Android SDK using public API instead of reflection (vor 5 Tagen) <Vyacheslav Karpukhin>
* ec23c252869 - (tag: build-1.4.0-dev-3351, tag: build-1.4.0-dev-3350) [Commonizer] Friendly displaying commonized KLIBs in IDE (vor 5 Tagen) <Dmitriy Dolovov>
* 23e218396e6 - (tag: build-1.4.0-dev-3341, tag: build-1.4.0-dev-3339) JS: support SAM conversion (vor 5 Tagen) <Anton Bannykh>
* 2742e643c1c - JS: prohibit `external fun interface` (vor 5 Tagen) <Anton Bannykh>
* f20ed39b925 - Fix a typo in an error message (vor 5 Tagen) <Anton Bannykh>
* a01e66a6187 - Run IrJsTypeScriptExportTestGenerated tests with `jsIrTest` instead of `jsTest` (vor 5 Tagen) <Anton Bannykh>
* c1d350f8f37 - [JVM IR] Added null-checks of handler for non-super $default calls (vor 5 Tagen) <Kristoffer Andersen>
* fe50bb4b939 - (tag: build-1.4.0-dev-3333) KProperty and ReadOnlyProperty type parameter names #KT-16529 (vor 5 Tagen) <Abduqodiri Qurbonzoda>