### PR TITLE
Fixing KT-37212

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1657,8 +1657,8 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
             IrConstKind.Int    -> return Int32(value.value as Int).llvm
             IrConstKind.Long   -> return Int64(value.value as Long).llvm
             IrConstKind.String -> return evaluateStringConst(value as IrConst<String>)
-            IrConstKind.Float  -> return LLVMConstRealOfString(floatType, (value.value as Float).toString())!!
-            IrConstKind.Double -> return LLVMConstRealOfString(doubleType, (value.value as Double).toString())!!
+            IrConstKind.Float  -> return Float32(value.value as Float).llvm
+            IrConstKind.Double -> return Float64(value.value as Double).llvm
         }
         TODO(ir2string(value))
     }

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2544,6 +2544,10 @@ task concatenation(type: KonanLocalTest) {
     source = "codegen/basics/concatenation.kt"
 }
 
+task const_infinity(type: KonanLocalTest) {
+    source = "codegen/basics/const_infinity.kt"
+}
+
 task lambda1(type: KonanLocalTest) {
     goldValue = "lambda\n"
     source = "codegen/lambda/lambda1.kt"

--- a/backend.native/tests/codegen/basics/const_infinity.kt
+++ b/backend.native/tests/codegen/basics/const_infinity.kt
@@ -7,12 +7,15 @@ package codegen.basics.const_infinity
 
 import kotlin.test.*
 
+//Original issue here https://youtrack.jetbrains.com/issue/KT-37212
+@Suppress("DIVISION_BY_ZERO")
 const val fpInfConst = 1.0F / 0.0F
+@Suppress("DIVISION_BY_ZERO")
 val fpInfVal = 1.0F / 0.0F
 
 @Test
 fun runTest() {
-    if (fpInfConst!=Float.POSITIVE_INFINITY) throw Error()
-    if (fpInfVal != Float.POSITIVE_INFINITY) throw Error()
-    if (fpInfConst!=fpInfVal) throw Error()
+    assertEquals(fpInfConst, Float.POSITIVE_INFINITY)
+    assertEquals(fpInfVal, Float.POSITIVE_INFINITY)
+    assertEquals(fpInfConst, fpInfVal)
 }

--- a/backend.native/tests/codegen/basics/const_infinity.kt
+++ b/backend.native/tests/codegen/basics/const_infinity.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package codegen.basics.const_infinity
+
+import kotlin.test.*
+
+const val fpInfConst = 1.0F / 0.0F
+val fpInfVal = 1.0F / 0.0F
+
+@Test
+fun runTest() {
+    if (fpInfConst!=Float.POSITIVE_INFINITY) throw Error()
+    if (fpInfVal != Float.POSITIVE_INFINITY) throw Error()
+    if (fpInfConst!=fpInfVal) throw Error()
+}


### PR DESCRIPTION
[YT ticket here](https://youtrack.jetbrains.com/issue/KT-37212).
Initializing constant value with an infinity makes the value equal to zero.
Unification of the floating-point constants evaluation with other primitive types fixes it. Seems like the `LLVMConstRealOfString` caused the problem for some reason.
