### PR TITLE
Add SIZE_BITS and SIZE_BYTES for Double and Float

### DIFF
--- a/backend.native/tests/stdlib_external/utils.kt
+++ b/backend.native/tests/stdlib_external/utils.kt
@@ -24,3 +24,6 @@ internal actual inline fun testOnNonJvm6And7(f: () -> Unit) {
 
 actual fun testOnJvm(action: () -> Unit) {}
 actual fun testOnJs(action: () -> Unit) {}
+
+
+public actual val isFloat32RangeEnforced: Boolean get() = true

--- a/runtime/src/main/kotlin/kotlin/Primitives.kt
+++ b/runtime/src/main/kotlin/kotlin/Primitives.kt
@@ -1158,18 +1158,31 @@ public final class Float private constructor() : Number(), Comparable<Float> {
          * A constant holding the positive infinity value of Float.
          */
         @Suppress("DIVISION_BY_ZERO")
-        public val POSITIVE_INFINITY: Float = 1.0f / 0.0f
+        public const val POSITIVE_INFINITY: Float = 1.0f / 0.0f
 
         /**
          * A constant holding the negative infinity value of Float.
          */
         @Suppress("DIVISION_BY_ZERO")
-        public val NEGATIVE_INFINITY: Float = -1.0f / 0.0f
+        public const val NEGATIVE_INFINITY: Float = -1.0f / 0.0f
 
         /**
          * A constant holding the "not a number" value of Float.
          */
-        public val NaN: Float = kotlinx.cinterop.bitsToFloat(0x7fc00000)
+        @Suppress("DIVISION_BY_ZERO")
+        public const val NaN: Float = -(0.0f / 0.0f)
+
+        /**
+         * The number of bytes used to represent an instance of Float in a binary form.
+         */
+        @SinceKotlin("1.4")
+        public const val SIZE_BYTES: Int = 4
+
+        /**
+         * The number of bits used to represent an instance of Float in a binary form.
+         */
+        @SinceKotlin("1.4")
+        public const val SIZE_BITS: Int = 32
     }
 
     /**
@@ -1415,18 +1428,31 @@ public final class Double private constructor() : Number(), Comparable<Double> {
          * A constant holding the positive infinity value of Double.
          */
         @Suppress("DIVISION_BY_ZERO")
-        public val POSITIVE_INFINITY: Double = 1.0 / 0.0
+        public const val POSITIVE_INFINITY: Double = 1.0 / 0.0
 
         /**
          * A constant holding the negative infinity value of Double.
          */
         @Suppress("DIVISION_BY_ZERO")
-        public val NEGATIVE_INFINITY: Double = -1.0 / 0.0
+        public const val NEGATIVE_INFINITY: Double = -1.0 / 0.0
 
         /**
          * A constant holding the "not a number" value of Double.
          */
-        public val NaN: Double = kotlinx.cinterop.bitsToDouble(0x7ff8000000000000L)
+        @Suppress("DIVISION_BY_ZERO")
+        public const val NaN: Double = -(0.0 / 0.0)
+
+        /**
+         * The number of bytes used to represent an instance of Double in a binary form.
+         */
+        @SinceKotlin("1.4")
+        public const val SIZE_BYTES: Int = 8
+
+        /**
+         * The number of bits used to represent an instance of Double in a binary form.
+         */
+        @SinceKotlin("1.4")
+        public const val SIZE_BITS: Int = 64
     }
 
     /**


### PR DESCRIPTION
Common part is reviewed in https://upsource.jetbrains.com/kotlin/review/KOTLIN-CR-3918

In addition to new constants SIZE_BITS and SIZE_BYTES, there are properties in `Double/Float`: `POSITIVE_INFINITY`, `NEGATIVE_INFINITY`, `NaN` and so on, that are now constant in common builtins. 
However here, I can't make them constant due to the bug in constant initiazers: https://youtrack.jetbrains.com/issue/KT-37212
~Surprisingly, tests that expect MIN/MAX VALUE to be constants still pass, even though they are not constants in Native.~ - ah, that's because they are already constants in K/N. So KT-37212 is somewhat a blocker, though I think we can live up to RC with this constant inconsistency.