### PR TITLE
[Interop][Metadata] Avoid unnecessary backticks

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/KotlinCodeModel.kt
@@ -60,11 +60,11 @@ data class Classifier(
         return this.copy(nestedNames = nestedNames + name)
     }
 
-    val relativeFqName: String get() = buildString {
-        append(topLevelName.asSimpleName())
+    fun getRelativeFqName(asSimpleName: Boolean = true): String = buildString {
+        append(topLevelName.run { if (asSimpleName) asSimpleName() else this })
         nestedNames.forEach {
             append('.')
-            append(it.asSimpleName())
+            append(it.run { if (asSimpleName) asSimpleName() else this })
         }
     }
 
@@ -73,7 +73,7 @@ data class Classifier(
             append(pkg)
             append('.')
         }
-        append(relativeFqName)
+        append(getRelativeFqName())
     }
 }
 
@@ -263,7 +263,7 @@ abstract class KotlinFile(
 
     override fun reference(classifier: Classifier): String = if (classifier.topLevelName in namesToBeDeclared) {
         if (classifier.pkg == this.pkg) {
-            classifier.relativeFqName
+            classifier.getRelativeFqName()
         } else {
             // Don't import if would clash with own declaration:
             classifier.fqName
@@ -275,7 +275,7 @@ abstract class KotlinFile(
     } else {
         if (tryImport(classifier)) {
             // Is successfully imported:
-            classifier.relativeFqName
+            classifier.getRelativeFqName()
         } else {
             classifier.fqName
         }
@@ -298,7 +298,7 @@ abstract class KotlinFile(
 
         if (!classifier.isTopLevel) {
             throw IllegalArgumentException(
-                    "'${classifier.relativeFqName}' is not top-level thus can't be declared at file scope"
+                    "'${classifier.getRelativeFqName()}' is not top-level thus can't be declared at file scope"
             )
         }
 

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/ObjCStubs.kt
@@ -172,7 +172,7 @@ private class ObjCMethodStubBuilder(
                     val clazz = context.getKotlinClassFor(container.clazz, isMeta = false).type
 
                     annotations.add(0, deprecatedInit(
-                            clazz.classifier.relativeFqName,
+                            clazz.classifier.getRelativeFqName(),
                             kotlinMethodParameters.map { it.name },
                             factory = true
                     ))

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrExtensions.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrExtensions.kt
@@ -70,7 +70,7 @@ val ClassStub.explicitPrimaryConstructor: ConstructorStub?
     get() = functions.filterIsInstance<ConstructorStub>().firstOrNull(ConstructorStub::isPrimary)
 
 fun ClassStub.nestedName(): String =
-        classifier.relativeFqName.substringAfterLast('.')
+        classifier.getRelativeFqName().substringAfterLast('.')
 
 fun ConstantStub.determineConstantAnnotationClassifier(): Classifier = when (this) {
     is StringConstantStub -> "String"

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrMetadataEmitter.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrMetadataEmitter.kt
@@ -254,7 +254,7 @@ private class MappingExtensions(
                 append('/')
             }
             // Nested classes should dot-separated.
-            append(relativeFqName)
+            append(getRelativeFqName(asSimpleName = false))
         }
 
     val PropertyStub.flags: Flags


### PR DESCRIPTION
`Classifier.relativeFqName` returns fully-qualified name where parts may be backticked.
We don't need backticks in case of metadata output because names in metadata are already "parsed".