### PR TITLE
Fix android executables

### DIFF
--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -497,6 +497,7 @@ quadruple.android_arm32 = arm-linux-androideabi
 clangFlags.android_arm32 = -cc1 -target-cpu arm7tdmi -emit-obj -disable-llvm-optzns -x ir -femulated-tls -mrelocation-model pic
 clangOptFlags.android_arm32 = -O3 -ffunction-sections
 linkerNoDebugFlags.android_arm32 = -Wl,-S
+linkerDynamicFlags.android_arm32 = -shared -Wl,-soname,${File(executable).name}
 clangNooptFlags.android_arm32 = -O1
 targetSysRoot.android_arm32 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_arm32 = -lm -lc++_static -lc++abi -landroid -llog -latomic
@@ -528,6 +529,7 @@ clangNooptFlags.android_arm64 = -O1
 targetSysRoot.android_arm64 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_arm64 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 linkerNoDebugFlags.android_arm64 = -Wl,-S
+linkerDynamicFlags.android_arm64 = -shared -Wl,-soname,${File(executable).name}
 
 # Android X86, based on NDK.
 targetToolchain.macos_x64-android_x86 = target-toolchain-2-osx-android_ndk
@@ -556,6 +558,7 @@ clangNooptFlags.android_x86 = -O1
 targetSysRoot.android_x86 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_x86 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 linkerNoDebugFlags.android_x86 = -Wl,-S
+linkerDynamicFlags.android_x86 = -shared -Wl,-soname,${File(executable).name}
 
 # Android X64, based on NDK.
 targetToolchain.macos_x64-android_x64 = target-toolchain-2-osx-android_ndk
@@ -584,6 +587,7 @@ clangNooptFlags.android_x64 = -O1
 targetSysRoot.android_x64 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_x64 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 linkerNoDebugFlags.android_x64 = -Wl,-S
+linkerDynamicFlags.android_x64 = -shared -Wl,-soname,${File(executable).name}
 
 
 # Windows x86-64, based on mingw-w64.

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -138,7 +138,6 @@ open class AndroidLinker(targetProperties: AndroidConfigurables)
             +"-o"
             +executable
             +"-fPIC"
-            +"-shared"
             +"-target"
             +targetArg!!
             +libDirs
@@ -146,7 +145,6 @@ open class AndroidLinker(targetProperties: AndroidConfigurables)
             if (optimize) +linkerOptimizationFlags
             if (!debug) +linkerNoDebugFlags
             if (dynamic) +linkerDynamicFlags
-            if (dynamic) +"-Wl,-soname,${File(executable).name}"
             +linkerKonanFlags
             +libraries
             +linkerArgs

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -139,7 +139,7 @@ open class AndroidLinker(targetProperties: AndroidConfigurables)
             +executable
             +"-fPIC"
             +"-target"
-            +targetArg!!
+            +clangTarget
             +libDirs
             +objectFiles
             if (optimize) +linkerOptimizationFlags


### PR DESCRIPTION
Presently, it is not possible to build an android executable (ELF) file due to the hardcoded presence of the -shared flag. I haven't tested this as my laptop isn't powerful enough to compile it. The test would be to compile a project with the following buildscript:
```
plugins {
    kotlin("multiplatform") version "1.3.70"
}

repositories {
    mavenCentral()
}

kotlin {
    androidNativeX64("android") {
        binaries {
            executable {
                entryPoint = "example.main"
            }
        }
    }
}
```
and see if it generates a .so or a real executable - as the executable{} block was used, it should be an executable, but currently generates a library.