### PR TITLE
[kotlin compiler][update] 1.4.0-dev-3929

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/InteropLibraryCreation.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/jvm/InteropLibraryCreation.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.library.KotlinLibraryVersioning
 import org.jetbrains.kotlin.library.KotlinAbiVersion
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.SerializedMetadata
+import org.jetbrains.kotlin.library.impl.BuiltInsPlatform
 import org.jetbrains.kotlin.util.removeSuffixIfPresent
 import java.util.*
 
@@ -48,6 +49,8 @@ fun createInteropLibrary(arguments: LibraryCreationArguments) {
             arguments.moduleName,
             version,
             arguments.target,
+
+            BuiltInsPlatform.NATIVE,
             nopack = arguments.nopack
     ).apply {
         val metadata = arguments.metadata.write(ChunkingWriteStrategy())

--- a/build-tools/build.gradle.kts
+++ b/build-tools/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("com.ullink.slack:simpleslackapi:1.2.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0")
 
     implementation("io.ktor:ktor-client-auth:1.2.1")
     implementation("io.ktor:ktor-client-core:1.2.1")

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecutorService.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecutorService.kt
@@ -17,8 +17,9 @@
 package org.jetbrains.kotlin
 
 import groovy.lang.Closure
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.process.ExecResult
@@ -420,14 +421,14 @@ private fun deviceLauncher(project: Project) = object : ExecutorService {
         }
         return out.toString().run {
             check(isNotEmpty())
-            @kotlinx.serialization.Serializable
+            @Serializable
             data class DeviceTarget(val name: String, val udid: String, val state: String, val type: String)
             split("\n")
                     .filter { it.isNotEmpty() }
-                    .map {
-                        Json(JsonConfiguration.Stable.copy(strictMode = false))
+                    .map { Json(JsonConfiguration.Stable.copy(ignoreUnknownKeys = false))
                             .parse(DeviceTarget.serializer(), it)
-                    }.first {
+                    }
+                    .first {
                         it.type == "device" && deviceName?.run { this == it.name } ?: true
                     }
                     .udid

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExternalReportUtils.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExternalReportUtils.kt
@@ -1,13 +1,16 @@
 package org.jetbrains.kotlin
 
-import kotlinx.io.PrintWriter
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
+import kotlinx.serialization.ImplicitReflectionSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.parse
+import kotlinx.serialization.stringify
 import java.io.File
 import java.io.FileReader
+import java.io.PrintWriter
 
 
-@kotlinx.serialization.Serializable
+@Serializable
 data class ExternalTestReport(val statistics: Statistics, val groups: List<KonanTestGroupReport>)
 
 @ImplicitReflectionSerializer

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/KonanTestSuiteReport.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/KonanTestSuiteReport.kt
@@ -1,8 +1,7 @@
 package org.jetbrains.kotlin
 
-import kotlinx.io.PrintWriter
-import kotlinx.io.StringWriter
-import kotlinx.serialization.Optional
+import java.io.PrintWriter
+import java.io.StringWriter
 import kotlinx.serialization.Serializable
 import org.gradle.api.Project
 
@@ -13,7 +12,7 @@ enum class TestStatus {
     SKIPPED
 }
 
-@kotlinx.serialization.Serializable
+@Serializable
 data class Statistics(
         var passed: Int = 0,
         var failed: Int = 0,
@@ -42,20 +41,20 @@ val Statistics.total: Int
 
 class TestFailedException(msg:String) : RuntimeException(msg)
 
-@kotlinx.serialization.Serializable
-data class KonanTestGroupReport(val name:String, val suites:List<KonanTestSuiteReport>)
+@Serializable
+data class KonanTestGroupReport(val name: String, val suites: List<KonanTestSuiteReport>)
 
-@kotlinx.serialization.Serializable
+@Serializable
 data class KonanTestSuiteReport(val name: String, val tests: List<KonanTestCaseReport>)
 
-@kotlinx.serialization.Serializable
-data class KonanTestCaseReport(val name:String, val status: TestStatus, @Optional val comment:String? = null)
+@Serializable
+data class KonanTestCaseReport(val name: String, val status: TestStatus, val comment: String? = null)
 
-class KonanTestSuiteReportEnvironment(val name:String, val project: Project, val statistics: Statistics) {
+class KonanTestSuiteReportEnvironment(val name: String, val project: Project, val statistics: Statistics) {
     private val tc = if (Tc.enabled) TeamCityTestPrinter(project) else null
     val tests = mutableListOf<KonanTestCaseReport>()
     fun executeTest(testName: String, action:() -> Unit) {
-        var test:KonanTestCaseReport? = null
+        var test: KonanTestCaseReport?
         try {
             tc?.startTest(testName)
             action()

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/KotlinNativeTest.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/KotlinNativeTest.kt
@@ -152,7 +152,7 @@ open class KonanGTest : KonanTest() {
     override fun run() {
         doBeforeRun?.execute(this)
         runProcess(
-                executor = project.executor::execute,
+                executor = {project.executor.execute(it)},
                 executable = executable,
                 args = arguments
         ).run {
@@ -242,9 +242,9 @@ open class KonanLocalTest : KonanTest() {
         for (i in 1..times) {
             val args = arguments + (multiArguments?.get(i - 1) ?: emptyList())
             output += if (testData != null)
-                runProcessWithInput(project.executor::execute, executable, args, testData!!)
+                runProcessWithInput({project.executor.execute(it)}, executable, args, testData!!)
             else
-                runProcess(project.executor::execute, executable, args)
+                runProcess({project.executor.execute(it)}, executable, args)
         }
         if (compilerMessages) {
             // TODO: as for now it captures output only in the driver task.

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/Utils.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/Utils.kt
@@ -84,7 +84,7 @@ fun Project.getFilesToCompile(compile: List<String>, exclude: List<String>): Lis
         project.file(f)
                 .walk()
                 .filter { it.isFile && it.name.endsWith(".kt") && !excludeFiles.contains(it.absolutePath) }
-                .map(File::getAbsolutePath)
+                .map{ it.absolutePath }
                 .asIterable()
     }
 }

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/XcRunRuntimeUtils.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/XcRunRuntimeUtils.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlin
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.Xcode
 import kotlin.math.min
@@ -25,7 +26,8 @@ private fun compareStringsAsVersions(version1: String, version2: String): Int {
  * Returns parsed output of `xcrun simctl list runtimes -j`.
  */
 private fun Xcode.getSimulatorRuntimeDescriptors(): List<SimulatorRuntimeDescriptor> =
-     Json.nonstrict.parse(ListRuntimesReport.serializer(), this.simulatorRuntimes).runtimes
+     Json(JsonConfiguration.Stable.copy(ignoreUnknownKeys = true, useArrayPolymorphism = true))
+             .parse(ListRuntimesReport.serializer(), this.simulatorRuntimes).runtimes
 
 /**
  * Returns first available simulator runtime for [target] with at least [osMinVersion] OS version.

--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,7 @@ task detectJarCollision(type: CollisionDetector) {
                                                     "frontend.common", "frontend.java", "cli-common", "ir.tree",
                                                     "ir.psi2ir", "ir.backend.common", "backend.jvm", "backend.js",
                                                     "backend.wasm", "ir.serialization.common", "ir.serialization.js",
-                                                    "ir.serialization.jvm", "jvm",
+                                                    "ir.serialization.jvm", "jvm", "compiler.version",
                                                     "backend-common", "backend", "plugin-api", "light-classes", "cli",
                                                     "cli-js", "incremental-compilation-impl", "js.ast", "js.serializer",
                                                     "js.parser", "js.frontend", "js.translator", "js.dce", "metadata",

--- a/build.gradle
+++ b/build.gradle
@@ -297,6 +297,7 @@ task detectJarCollision(type: CollisionDetector) {
     if (project.hasProperty('kotlinProjectPath')) {
         resolvingRulesWithRegexes[new Regex("META-INF/.+\\.kotlin_module")] = "kotlin-compiler"
         resolvingRules["META-INF/extensions/compiler.xml"] = "kotlin-compiler"
+        resolvingRules["META-INF/compiler.version"] = "kotlin-compiler"
         resolvingRules["kotlinManifest.properties"] = "kotlin-compiler"
         librariesWithIgnoredClassCollisions.addAll(["util", "container", "resolution", "serialization", "psi", "frontend",
                                                     "frontend.common", "frontend.java", "cli-common", "ir.tree",

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.3.70-dev-1070
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3529,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-3529
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3529,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-3529
-kotlinStdlibTestsVersion=1.4.0-dev-3529
-testKotlinCompilerVersion=1.4.0-dev-3529
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3929,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-3929
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3929,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-3929
+kotlinStdlibTestsVersion=1.4.0-dev-3929
+testKotlinCompilerVersion=1.4.0-dev-3929
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.3.70-dev-1070
-buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.3.70-dev-1070,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.4.0-dev-1818
+buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1818,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3929,branch:default:any,pinned:true/artifacts/content/maven
 kotlinVersion=1.4.0-dev-3929

--- a/runtime/src/main/kotlin/kotlin/Primitives.kt
+++ b/runtime/src/main/kotlin/kotlin/Primitives.kt
@@ -1333,6 +1333,7 @@ public final class Float private constructor() : Number(), Comparable<Float> {
      *
      * The resulting `Byte` value is equal to `this.toInt().toByte()`.
      */
+    @Deprecated("Unclear conversion. To achieve the same result convert to Int explicitly and then to Byte.", ReplaceWith("toInt().toByte()"))
     public override fun toByte(): Byte = this.toInt().toByte()
 
     /**
@@ -1347,6 +1348,7 @@ public final class Float private constructor() : Number(), Comparable<Float> {
      *
      * The resulting `Short` value is equal to `this.toInt().toShort()`.
      */
+    @Deprecated("Unclear conversion. To achieve the same result convert to Int explicitly and then to Short.", ReplaceWith("toInt().toShort()"))
     public override fun toShort(): Short = this.toInt().toShort()
 
     /**
@@ -1592,6 +1594,7 @@ public final class Double private constructor() : Number(), Comparable<Double> {
      *
      * The resulting `Byte` value is equal to `this.toInt().toByte()`.
      */
+    @Deprecated("Unclear conversion. To achieve the same result convert to Int explicitly and then to Byte.", ReplaceWith("toInt().toByte()"))
     public override fun toByte(): Byte = this.toInt().toByte()
 
     /**
@@ -1606,6 +1609,7 @@ public final class Double private constructor() : Number(), Comparable<Double> {
      *
      * The resulting `Short` value is equal to `this.toInt().toShort()`.
      */
+    @Deprecated("Unclear conversion. To achieve the same result convert to Int explicitly and then to Short.", ReplaceWith("toInt().toShort()"))
     public override fun toShort(): Short = this.toInt().toShort()
 
     /**

--- a/runtime/src/main/kotlin/kotlin/text/StringNumberConversions.kt
+++ b/runtime/src/main/kotlin/kotlin/text/StringNumberConversions.kt
@@ -52,10 +52,11 @@ external internal fun longToString(value: Long, radix: Int): String
 public actual inline fun Long.toString(radix: Int): String = longToString(this, checkRadix(radix))
 
 /**
- * Returns `true` if the contents of this string is equal to the word "true", ignoring case, and `false` otherwise.
+ * Returns `true` if this string is not `null` and its content is equal to the word "true", ignoring case, and `false` otherwise.
  */
+@SinceKotlin("1.4")
 @kotlin.internal.InlineOnly
-public actual inline fun String.toBoolean(): Boolean = this.equals("true", ignoreCase = true)
+public actual inline fun String?.toBoolean(): Boolean = this.equals("true", ignoreCase = true)
 
 /**
  * Parses the string as a signed [Byte] number and returns the result.

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryWriterImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryWriterImpl.kt
@@ -28,11 +28,12 @@ class KonanLibraryWriterImpl(
         moduleName: String,
         versions: KotlinLibraryVersioning,
         target: KonanTarget,
+        builtInsPlatform: BuiltInsPlatform,
         nopack: Boolean = false,
 
         val layout: KonanLibraryLayoutForWriter = KonanLibraryLayoutForWriter(libDir, target),
 
-        base: BaseWriter = BaseWriterImpl(layout, moduleName, versions, nopack),
+        base: BaseWriter = BaseWriterImpl(layout, moduleName, versions, builtInsPlatform, nopack),
         bitcode: BitcodeWriter = BitcodeWriterImpl(layout),
         metadata: MetadataWriter = MetadataWriterImpl(layout),
         ir: IrWriter = IrMonoliticWriterImpl(layout)
@@ -54,7 +55,7 @@ fun buildLibrary(
     dataFlowGraph: ByteArray?
 ): KonanLibraryLayout {
 
-    val library = KonanLibraryWriterImpl(File(output), moduleName, versions, target, nopack)
+    val library = KonanLibraryWriterImpl(File(output), moduleName, versions, target, BuiltInsPlatform.NATIVE, nopack)
 
     library.addMetadata(metadata)
     if (ir != null) {


### PR DESCRIPTION
* 92a0ddfe715 - (HEAD -> master, tag: build-1.4.0-dev-3929, origin/master, origin/HEAD) NI: discard def not null types if they appear in return positions, in `inv` or `in` variance ^KT-37343 Fixed (vor 18 Stunden) <Victor Petukhov>
* 368b0d9b0bc - (tag: build-1.4.0-dev-3916) [JVM IR] Use reference equality when comparing enums. (vor 3 Tagen) <Mark Punzalan>
* a732e8f5fe8 - (tag: build-1.4.0-dev-3915) [JVM IR] Ensure there is one accessor for each `super` access from a subclass when there are multiple subclasses in a file. (vor 3 Tagen) <Mark Punzalan>
* 34fb636904d - (tag: build-1.4.0-dev-3913) JVM: Generate generic signatures for delegate fields (vor 3 Tagen) <Steven Schäfer>
* 20ea77d55d7 - (tag: build-1.4.0-dev-3900) JVM_IR: refactor ToArrayLowering and make matching more precise (vor 3 Tagen) <pyos>
* a2b6282d499 - (tag: build-1.4.0-dev-3891) Refactor ApiVersion.KOTLIN_1_4 usages in relation to unified null checks (vor 3 Tagen) <Alexander Udalov>
* 98aecbef6b8 - Optimize runtime representation for callable reference subclasses (vor 3 Tagen) <Alexander Udalov>
* 8d7c8672ac1 - Generate reference to existing class for builtin function references (vor 3 Tagen) <Alexander Udalov>
* bfa371ea737 - (tag: build-1.4.0-dev-3884) [FIR] Rewrite casts to reduce performance dispersion (vor 3 Tagen) <simon.ogorodnik>
* 426f498e87d - [FIR] Forking runner for modularized test (vor 3 Tagen) <simon.ogorodnik>
* 63a1e7c6ff5 - [FIR] Add test for #KT-37321 (vor 3 Tagen) <Dmitriy Novozhilov>
* 92449d6d9b3 - [FIR] Organize code for postponed arguments (vor 3 Tagen) <Dmitriy Novozhilov>
* 1c0fd7342fc - [FIR] Support completion of lambdas with type variable as expected type (vor 3 Tagen) <Dmitriy Novozhilov>
* 643d7be12d9 - [FIR] Add base class for `PostponedResolvedAtomMarker` to FIR (vor 3 Tagen) <Dmitriy Novozhilov>
* 2a58fc238ff - [FIR-TEST] Move stdlib tests for delegates to separate directory (vor 3 Tagen) <Dmitriy Novozhilov>
* 3655f0c4997 - [FIR-TEST] Move fixed test from `problems` directory (vor 3 Tagen) <Dmitriy Novozhilov>
* 037b442e860 - (tag: build-1.4.0-dev-3883) JVM_IR: do not explicitly initialize Refs to default values (vor 3 Tagen) <pyos>
* 13b04e63be4 - JVM_IR: wrap inline class objects in unboxed refs (vor 3 Tagen) <pyos>
* 68745ec43f1 - JVM_IR: refactor JvmSharedVariablesManager (vor 3 Tagen) <pyos>
* ed96b81a429 - (tag: build-1.4.0-dev-3881) [Commonzer] Fix ISE during commonization, improve interner performance (vor 3 Tagen) <Dmitriy Dolovov>
* 7da220b0a2b - (tag: build-1.4.0-dev-3878) [Gradle, JS] Check current chosen js compiler for targets in JS and MPP (vor 3 Tagen) <Ilya Goncharov>
* a1263e445e7 - [Gradle, JS] Add redundant methods for single js plugin (vor 3 Tagen) <Ilya Goncharov>
* 8487211ae18 - (tag: build-1.4.0-dev-3874) JVM_IR: refine the condition for mangling names of multifile members (vor 3 Tagen) <pyos>
* 8fbfa8b8193 - (tag: build-1.4.0-dev-3872) [Gradle, JS] Migrate from singletons to classes (vor 3 Tagen) <Ilya Goncharov>
* 82de9305747 - [Gradle, JS] Consider transitivity in cache of npm dependencies (vor 3 Tagen) <Ilya Goncharov>
* 49814c438c1 - [Gradle, JS] Fix naming (vor 3 Tagen) <Ilya Goncharov>
* 2eea8b07600 - [Gradle, JS] Support transitive mode for npm dependencies (vor 3 Tagen) <Ilya Goncharov>
* d108c8ef512 - [Gradle, JS] Move logic of resolving NpmDependency to Npm Api (vor 3 Tagen) <Ilya Goncharov>
* 90f4f5db263 - (tag: build-1.4.0-dev-3870) Internal visibility between common source sets in Gradle (KT-37264) (vor 3 Tagen) <Sergey Igushkin>
* 3858c8e1f8b - Support friend internal visibility in K2Metadata compiler (KT-37264) (vor 3 Tagen) <Sergey Igushkin>
* 04c924a1199 - (tag: build-1.4.0-dev-3865) Remove idea-gradle-tooling-api.jar from IDEA 2020 (vor 3 Tagen) <Natalia Selezneva>
* 33368590e42 - KotlinDslScriptsModelResolver: return back requireTaskRunning override (vor 3 Tagen) <Natalia Selezneva>
* d063dbef107 - Drop modification stamps for gradle scripts after project import (vor 3 Tagen) <Natalia Selezneva>
* 61f55238058 - Added Native-specific checker for properties of top level singletons (#3172) (vor 3 Tagen) <LepilkinaElena>
* eba45d4f89b - (tag: build-1.4.0-dev-3863) KT-36963 Deparenthesize !! argument when generating expression (vor 3 Tagen) <Dmitry Petrov>
* 71e4b0c9ad4 - KT-31649 Use 'Any#hashCode' in generated hashCode if class has none (vor 3 Tagen) <Dmitry Petrov>
* dc6be68a419 - (tag: build-1.4.0-dev-3854) Handle properly lambda change in incremental analysis (vor 3 Tagen) <Vladimir Dolzhenko>
* 93394656a30 - (tag: build-1.4.0-dev-3851) [IR] Supported fake overrides in SAM lowering + enabled test (vor 3 Tagen) <Igor Chevdar>
* 56b983e6255 - (tag: build-1.4.0-dev-3847) Typo fix (vor 3 Tagen) <Georgy Bronnikov>
* 18d95bb670b - (tag: build-1.4.0-dev-3846) JVM_IR: move BridgeLowering lower, remove special case for default arg stubs (vor 3 Tagen) <Georgy Bronnikov>
* af67aff3030 - (tag: build-1.4.0-dev-3842) [FIR] Support `Clonable` (vor 3 Tagen) <Dmitriy Novozhilov>
* 83d01fbaaa8 - [FIR-TEST] Move fixed test from `problems` directory (vor 3 Tagen) <Dmitriy Novozhilov>
* b6b0819f406 - (tag: build-1.4.0-dev-3841) Revert "Since build updated for 193 branch due incompatibility" (vor 3 Tagen) <Alexander Podkhalyuzin>
* 135ae32f758 - (tag: build-1.4.0-dev-3840) Since build updated for 193 branch due incompatibility (vor 3 Tagen) <Alexander Podkhalyuzin>
* 17152899ace - (tag: build-1.4.0-dev-3835) IDE perf tests for K/N: Produce duplicated *.kt files on demand (vor 3 Tagen) <Dmitriy Dolovov>
* 44c8a85241d - IDE perf tests for K/N: Don't run tests on inapplicable host OSes (vor 3 Tagen) <Dmitriy Dolovov>
* 8635045a533 - IDE perf tests for K/N: add more tests (Linux, AndroidNative) (vor 3 Tagen) <Dmitriy Dolovov>
* 80f2c091b44 - IDE perf tests for K/N: keep Kotlin & Gradle versions in *.properties (vor 3 Tagen) <Dmitriy Dolovov>
* c4a89c02011 - IDE perf tests for K/N: check successful Gradle project import (vor 3 Tagen) <Dmitriy Dolovov>
* bb5a639153b - (tag: build-1.4.0-dev-3822) JVM IR: Turn static callable references into singletons (vor 4 Tagen) <Steven Schäfer>
* ac5c255c207 - (tag: build-1.4.0-dev-3814) [NI-TESTS] Add regression tests (vor 4 Tagen) <Pavel Kirpichenkov>
* dc42b20ae32 - [NI] Use alternative to intersection type in public declarations (vor 4 Tagen) <Pavel Kirpichenkov>
* 4038c758ca5 - (tag: build-1.4.0-dev-3811) KT-37131 Record default arguments in argument adaptation (vor 4 Tagen) <Dmitry Petrov>
* 7c7245fbb90 - (tag: build-1.4.0-dev-3804) Build: Add compiler.version to embedded in JPS sync (vor 4 Tagen) <Vyacheslav Gerasimov>
* 1cb52861b17 - Build: Set captureTaskInputFiles for buildScan (vor 4 Tagen) <Vyacheslav Gerasimov>
* c77130d0f38 - Build: Add test for reporting all gradle build cache misses (vor 4 Tagen) <Vyacheslav Gerasimov>
* b3f16cfc967 - Build: Add test for dist artifacts manifests and compiler.version (vor 4 Tagen) <Vyacheslav Gerasimov>
* ebb75813f9d - Build: Don't disable incremental compilation for CI (vor 4 Tagen) <Vyacheslav Gerasimov>
* bab87c98378 - Build: Extract compiler version to separate module to improve caching (vor 4 Tagen) <Vyacheslav Gerasimov>
* c2457cae604 - Read KotlinCompilerVersion from resource file (vor 4 Tagen) <Vyacheslav Gerasimov>
* f8437743c55 - Build: Ignore META-INF/MANIFEST.MF from classpath normalization (vor 4 Tagen) <Vyacheslav Gerasimov>
* d5c851980c4 - (tag: build-1.4.0-dev-3802) `String.toBoolean()` should be `String?.toBoolean()` #KT-14119 (vor 4 Tagen) <Abduqodiri Qurbonzoda>
* b8b1dd753c1 - (tag: build-1.4.0-dev-3801) Add builtins_platform property to klib manifest (vor 4 Tagen) <Dmitry Savvinov>
* 8fcd98639d2 - Minor: merge HierarchicalExpectActualMatchingTests into MultiplatformHighlightingTests (vor 4 Tagen) <Dmitry Savvinov>
* 9eab75650c6 - (tag: build-1.4.0-dev-3798) Remove target name from gradle test filters. (vor 4 Tagen) <Konstantin Tskhovrebov>
* a32f742893f - (tag: build-1.4.0-dev-3797) Inherit `ReadWriteProperty` from `ReadOnlyProperty` #KT-27729 (vor 4 Tagen) <Abduqodiri Qurbonzoda>
* 37425862099 - [FIR-TEST] Unmute some blackbox tests (vor 4 Tagen) <Dmitriy Novozhilov>
* 2bce279a9ee - [FIR] Support smartcasts from lhs of boolean operator with jump in rhs (vor 4 Tagen) <Dmitriy Novozhilov>
* e3e7b40f850 - [FIR] Fix determining coercion to Unit (vor 4 Tagen) <Dmitriy Novozhilov>
* 770dfb69ba0 - [FIR] Analyze all statements in block except last one in independent mode (vor 4 Tagen) <Dmitriy Novozhilov>
* 1c728e81846 - [FIR] Fix return expressions calculator (vor 4 Tagen) <Dmitriy Novozhilov>
* 5f9876479eb - [FIR] Add saving of local context in anonymous functions for further resolve (vor 4 Tagen) <Dmitriy Novozhilov>
* 8023d04c610 - [FIR] Add separate local scope for init blocks (vor 4 Tagen) <Dmitriy Novozhilov>
* 50742a46868 - [FIR] Move local scopes immutable (vor 4 Tagen) <Dmitriy Novozhilov>
* 25dc9f948a5 - Revert "[FIR] Support deserialization of annotations on JVM" (vor 4 Tagen) <Dmitriy Novozhilov>
* a2c24e696f3 - (tag: build-1.4.0-dev-3796) Leverage existing psi2ir function declaration generator in plugin (vor 4 Tagen) <Leonid Startsev>
* fc22cfa896e - String.format does not support no locale #KT-22932 (vor 4 Tagen) <Abduqodiri Qurbonzoda>
* f4d53c18a15 - Fix JarContentTest by adding dependency on jar creating task (vor 4 Tagen) <Alexander Udalov>
* 505ec072bb2 - Remove dependency of JarContentTest on JDK 8 (vor 4 Tagen) <Alexander Udalov>
* d1a29df581e - (tag: build-1.4.0-dev-3792) Revert "Added AllowNullableArrayArgsInMain (1.4+) language setting" (vor 4 Tagen) <Vladimir Dolzhenko>
* 0f7122a88a0 - (tag: build-1.4.0-dev-3791) Support MutablePropertyReferenceN supertypes in LambdaInfo (vor 4 Tagen) <Alexander Udalov>
* 058c6bc5780 - Minor, reformat and slightly refactor JvmRuntimeTypes.kt (vor 4 Tagen) <Alexander Udalov>
* 8588f96ec82 - Fix inspections in kotlin.jvm.internal runtime classes (vor 4 Tagen) <Alexander Udalov>
* aaff1d1670a - Minor, add ReadMe to spec-docs (vor 4 Tagen) <Alexander Udalov>
* 5af4efd5a72 - (tag: build-1.4.0-dev-3789) Remove FIR test data file accidentally left in 8884cbe4 (vor 4 Tagen) <Mikhail Glukhikh>
* db38dfc21bc - (tag: build-1.4.0-dev-3773) Diagnostic test: make messages about FIR_IDENTICAL inconsistency clearer (vor 4 Tagen) <Mikhail Glukhikh>
* 737c91c5cf9 - FIR test merging: compare diagnostic files symbol-by-symbol (vor 4 Tagen) <Mikhail Glukhikh>
* 48d30daa470 - Diagnostic tests: don't create '.fir.kt' file if FIR_IDENTICAL (vor 4 Tagen) <Mikhail Glukhikh>
* 951fb0b7e75 - Move loadTestDataWithoutDiagnostics to FirTestUtils (vor 4 Tagen) <Mikhail Glukhikh>
* 8884cbe4154 - Introduce FIR_IDENTICAL for FIR vs old frontend tests #KT-36879 Fixed (vor 4 Tagen) <Mikhail Glukhikh>
* 186e0b0cba4 - (tag: build-1.4.0-dev-3772) Do not call IR backend when there's a script involved (vor 4 Tagen) <Georgy Bronnikov>
* 03c6f13831f - (tag: build-1.4.0-dev-3771) Add fallback value in K/N version computation (vor 4 Tagen) <Kirill Shmakov>
* 3a4e540d440 - (tag: build-1.4.0-dev-3766) Minor refactoring and style fixes in JarContentTest (vor 4 Tagen) <Alexander Udalov>
* 79790ca227c - Avoid uses of plain "kotlin" in metadata deserialization. (vor 4 Tagen) <Jinseong Jeon>
* 744c4c545e2 - (tag: build-1.4.0-dev-3759) Build: Make DexMethodCount task cacheable, extract print stats to task (vor 5 Tagen) <Vyacheslav Gerasimov>
* 354fb3c4ba7 - (tag: build-1.4.0-dev-3752) JVM_IR: Generate fake continuations and their constructors as public (vor 5 Tagen) <Ilmir Usmanov>
* c94f8d3767d - JVM_IR: Do not generate nullability annotation for synthetic result field (vor 5 Tagen) <Ilmir Usmanov>
* 4b4a6101c1f - JVM_IR: Generate inline functions with reified generics as public synthetic (vor 5 Tagen) <Ilmir Usmanov>
* f8903ca04b9 - JVM_IR: Generate private suspend functions as synthetic package-private (vor 5 Tagen) <Ilmir Usmanov>
* 5826db97c7a - JVM_IR: Do not duplicate inline suspend functions with reified type parameters (vor 5 Tagen) <Ilmir Usmanov>
* 3bf2c17f9ea - (tag: build-1.4.0-dev-3737) KT-37024 Optimized delegated property metadata generation in inline fun (vor 5 Tagen) <Dmitry Petrov>
* 0be5a82460e - (tag: build-1.4.0-dev-3731) Use LightJavaModule.getModule for 193 (vor 5 Tagen) <Vladimir Dolzhenko>
* 1ffde2a3c47 - Minor. Fix test compilation (vor 5 Tagen) <Mikhael Bogdanov>
* 4745cd4fea3 - (tag: build-1.4.0-dev-3726) FIR2IR: refactor 'getArrayType' using standard class ids (vor 5 Tagen) <Mikhail Glukhikh>
* 0c9da6d7151 - FIR2IR: extract 'enumClassModality' (vor 5 Tagen) <Mikhail Glukhikh>
* 76ccaf13ba0 - FIR2IR: cache properties & fields more correctly (vor 5 Tagen) <Mikhail Glukhikh>
* fe658ce47f9 - FIR2IR: remove redundant receiver generation from visitor (vor 5 Tagen) <Mikhail Glukhikh>
* 9788a7cfbcb - FIR2IR: cache constructors and their parents properly (vor 5 Tagen) <Mikhail Glukhikh>
* 0fee8a69468 - FIR2IR: cache functions and their parents properly (vor 5 Tagen) <Mikhail Glukhikh>
* 940567b8bd7 - FIR2IR: set enum class modality properly for complex entries case (vor 5 Tagen) <Mikhail Glukhikh>
* 3ffe1a18761 - FIR2IR: create IrEnumConstructorCall even in complex entries (vor 5 Tagen) <Mikhail Glukhikh>
* 5af3d92271c - FIR2IR: cache enum entry classes properly (vor 5 Tagen) <Mikhail Glukhikh>
* 03eab2ec6cd - FIR2IR: get rid of setParentAndContent + fixes around anonymous objects (vor 5 Tagen) <Mikhail Glukhikh>
* 20eddef06f6 - FIR2IR: eliminate hacky replacement for invoke() & next() calls (vor 5 Tagen) <Mikhail Glukhikh>
* 50c4c3f4fbb - FIR2IR: extract fake override generator (vor 5 Tagen) <Mikhail Glukhikh>
* 0bb3a42cebf - FIR2IR: mute black box test due to parent logic problems (vor 5 Tagen) <Mikhail Glukhikh>
* 698e2594388 - FIR2IR: register file first and convert declarations second (vor 5 Tagen) <Mikhail Glukhikh>
* cfa626ad778 - FIR2IR: introduce conversion scope, remove dispatch receiver for lambdas (vor 5 Tagen) <Mikhail Glukhikh>
* a14cb075c3b - FIR2IR: inline some conversion one-liners (vor 5 Tagen) <Mikhail Glukhikh>
* 4c2522631b4 - FIR2IR (refactoring): introduce Fir2IrTypeConverter (vor 5 Tagen) <Mikhail Glukhikh>
* 9257949a5a2 - Minor: eliminate unused typeContext in FIR2IR (vor 5 Tagen) <Mikhail Glukhikh>
* 211411a920a - Fix FIR test data according to last changes of demiurg (vor 5 Tagen) <Mikhail Glukhikh>
* 32bcab28676 - Switch rest of test to new scheme with configuration kind processing (vor 5 Tagen) <Mikhael Bogdanov>
* 46397dca4a7 - Switch 'AbstractVisualizer' to new scheme with configuration kind (vor 5 Tagen) <Mikhael Bogdanov>
* ae9a91e17dd - Switch 'AbstractCompilerLightClassTest' to new scheme with configuration kind (vor 5 Tagen) <Mikhael Bogdanov>
* f84ac5e3f9d - Remove configuration kind from `AbstractDumpDeclarationsTest` tests (vor 5 Tagen) <Mikhael Bogdanov>
* e3efab57654 - Remove FULL_JDK from `AbstractFirResolveTestCaseWithStdlib` tests (vor 5 Tagen) <Mikhael Bogdanov>
* 0a8454d5fcf - Remove FULL_JDK from `AbstractForeignAnnotationsTest` tests (vor 5 Tagen) <Mikhael Bogdanov>
* 59679476f66 - Always create test files, directive processing would be based on them (vor 5 Tagen) <Mikhael Bogdanov>
* dbdc4d9ee0f - Move 'extractConfigurationKind' to base class, use it in KotlinMultiFileTestWithJava (vor 5 Tagen) <Mikhael Bogdanov>
* 7040857d77c - Convert KotlinMultiFileTestWithJava.java to Kotlin (vor 5 Tagen) <Mikhael Bogdanov>
* 06a36465a5e - Rename .java to .kt (vor 5 Tagen) <Mikhael Bogdanov>
* 999b762288a - Merge 'getTestJdkKind' and 'getJdkKind' and move to base class (vor 5 Tagen) <Mikhael Bogdanov>
* 6e855f3bbdf - Split 'analyzeAndCheck' into 'shouldSkipTest' and 'setupEnvironment' (vor 5 Tagen) <Mikhael Bogdanov>
* 9052ef06a7e - Introduce `configureEnvironment`, avoid 'createEnvironment' calls (vor 5 Tagen) <Mikhael Bogdanov>
* a795c38eb7c - Introduce base class for codegen and diagnostic tests (vor 5 Tagen) <Mikhael Bogdanov>
* b031706ea9c - (tag: build-1.4.0-dev-3723) Added Native-specific frontend checker for `@SharedImmutable` (#3091) (vor 5 Tagen) <LepilkinaElena>
* 8b559b20e29 - (tag: build-1.4.0-dev-3716) Add a test for getOrDefault() bridge (vor 5 Tagen) <Georgy Bronnikov>
* dd7d5dfdb3a - JVM_IR: try to avoid resolveFakeOverride() in BridgeLowering (vor 5 Tagen) <Georgy Bronnikov>
* fa74eabbd12 - (tag: build-1.4.0-dev-3710) use bootstrap.kotlin.default.version bootstrap for buildSrc (vor 5 Tagen) <nataliya.valtman>
* f7a7c169f82 - (tag: build-1.4.0-dev-3705) Changelog: remove "trailing comma" feature from 1.3.70 (vor 5 Tagen) <Yan Zhulanow>
* 9e605b17988 - (tag: build-1.4.0-dev-3695) Remove 1.4-specific language features from 1.3.70 changelog (vor 5 Tagen) <Yan Zhulanow>
* 15e2afe5ab2 - (tag: build-1.4.0-dev-3693) Add checkCanceled on common for autocompletion and highlighting resolve path (vor 5 Tagen) <Vladimir Dolzhenko>
* 9c530b11218 - Add performance stress tests (vor 5 Tagen) <Vladimir Dolzhenko>
* 9ea97a3dfb3 - (tag: build-1.4.0-dev-3691) Update changelog: add changes from 1.3.70 (vor 5 Tagen) <Yan Zhulanow>
* 394c660a82d - (tag: build-1.4.0-dev-3690) Mute a FIR test (vor 5 Tagen) <Georgy Bronnikov>
* 52b88bf753c - (tag: build-1.4.0-dev-3686) Build: Fix various libraryJarWithIr task inputs (vor 6 Tagen) <Vyacheslav Gerasimov>
* 401023a8930 - (tag: build-1.4.0-dev-3681) [FIR] Add test for object inner class  KT-37120 (vor 6 Tagen) <anastasiia.spaseeva>
* 1ce96b74332 - [FIR] Add tests for  KT-37091 , KT-37081 (vor 6 Tagen) <anastasiia.spaseeva>
* 9a352ad7b04 - [FIR] Add tests for KT-37070 , KT-37066 (vor 6 Tagen) <anastasiia.spaseeva>
* 97007ae6c50 - [FIR] Add tests for companionObjectCall (vor 6 Tagen) <anastasiia.spaseeva>
* f678db2f895 - (tag: build-1.4.0-dev-3677) KT-36813 Generate optimizable null checks in JVM_IR (vor 6 Tagen) <Dmitry Petrov>
* a52ef71d487 - (tag: build-1.4.0-dev-3673) Use `createForProduction` for running standalone execution (vor 6 Tagen) <Nikolay Krasko>
* 4ea0b4911a0 - (tag: build-1.4.0-dev-3667) Avoid excessive JavaForKotlinOverridePropertyDescriptors (vor 6 Tagen) <Georgy Bronnikov>
* 0c266f9f45a - Add hashtable test (vor 6 Tagen) <Georgy Bronnikov>
* 4381a2d81bd - (tag: build-1.4.0-dev-3660) [JS IR] Clean up callable reference lowering (vor 6 Tagen) <Roman Artemev>
* 8f0e06ff705 - [JS IR] Fix typo (vor 6 Tagen) <Roman Artemev>
* 98aa73ee6b3 - [JS IR] Fix code clean-up optimizations (vor 6 Tagen) <Roman Artemev>
* 65011f96cc2 - [JS IR] Clean up coroutine code (vor 6 Tagen) <Roman Artemev>
* c4efd5a09b2 - [JS IR] Use `JsThisRef` node for dispatch/instance receivers (vor 6 Tagen) <Roman Artemev>
* 62c86f28139 - [JS IR] Remove filthy hacks from namer (vor 6 Tagen) <Roman Artemev>
* 3c7cc07263d - [JS IR] Clean up code (vor 6 Tagen) <Roman Artemev>
* 133f3d359f6 - [JS IR] remove hacks from DCE (vor 6 Tagen) <Roman Artemev>
* adc022fde83 - Fix some coroutine tests (vor 6 Tagen) <Roman Artemev>
* 4e002a41e6d - [JS IR] Fix visibility & code clean up (vor 6 Tagen) <Roman Artemev>
* 8654dbdc6e8 - [JS IR] Refactor property references (vor 6 Tagen) <Roman Artemev>
* 5dcac16cf7e - [JS IR] Update test data (vor 6 Tagen) <Roman Artemev>
* c2676ded314 - [JS IR] Implement KProperty runtime utils (vor 6 Tagen) <Roman Artemev>
* 6e75b563883 - [JS IR] Fix bridge modality (vor 6 Tagen) <Roman Artemev>
* 161bb724390 - [JS IR] Update test data (vor 6 Tagen) <Roman Artemev>
* 97b97ddbd70 - [JS IR] Fix phases (vor 6 Tagen) <Roman Artemev>
* cf411725215 - [JS IR] A bunch of fixes to make PIR mode work (vor 6 Tagen) <Roman Artemev>
* f8d155c6a31 - [JS IR] Fix native invoke checker (vor 6 Tagen) <Roman Artemev>
* 9e1c52f8cb1 - [JS IR] Fix this reference name generation (vor 6 Tagen) <Roman Artemev>
* 536e3803311 - [JS IR] Fix kotlin.test framework (vor 6 Tagen) <Roman Artemev>
* 293ddb53894 - [JS IR] Fix inline classes for new callable reference scheme (vor 6 Tagen) <Roman Artemev>
* 0e67c6ac7d3 - [JS IR] Update coroutine runtime (vor 6 Tagen) <Roman Artemev>
* b9eff4b2462 - [JS IR] Make coroutines work with new lambda scheme (vor 6 Tagen) <Roman Artemev>
* 3783205fb77 - [JS IR] Lower suspend lambda as a regular lambda (vor 6 Tagen) <Roman Artemev>
* 26237f8bd57 - [JS IR] Implement new function references scheme (vor 6 Tagen) <Roman Artemev>
* 2f087fe7a28 - (tag: build-1.4.0-dev-3654) Build: Fix kotlin-stdlib-js-ir:tryRunFullCli task inputs (vor 6 Tagen) <Vyacheslav Gerasimov>
* b4898e4043c - (tag: build-1.4.0-dev-3650) `Put arguments/parameters on separate/one line` should update trailing comma (vor 6 Tagen) <Dmitry Gridin>
* 173f90c89c4 - AbstractIntentionTest: support code style and registry settings (vor 6 Tagen) <Dmitry Gridin>
* baf2dd6b9b9 - KotlinLightCodeInsightFixtureTestCase: add `configureCodeStyleAndRun` (vor 6 Tagen) <Dmitry Gridin>
* f66b9949463 - (tag: build-1.4.0-dev-3644) JVM_IR: make suspend lambda invoke()/create() creation shorter (vor 6 Tagen) <pyos>
* 6184171a113 - JVM_IR: carry less state while transforming suspend funs into views (vor 6 Tagen) <pyos>
* 5896d8003ec - JVM_IR: unify `generateStateMachineFor{Lambda,NamedFunction}` (vor 6 Tagen) <pyos>
* 159d292ea79 - JVM_IR: make continuation detection more consistent (vor 6 Tagen) <pyos>
* c57f466494b - (tag: build-1.4.0-dev-3641) Build: Use same com.eclipsesource.j2v8 artifact for compilation (vor 6 Tagen) <Vyacheslav Gerasimov>
* a4030d3abf7 - Build: Make JavaExec relative path system independent (vor 6 Tagen) <Vyacheslav Gerasimov>
* 08ac7da7a6b - Build: Fix input declaration for :kotlin-stdlib-js-ir:fullRuntimeSources (vor 6 Tagen) <Vyacheslav Gerasimov>
* bb2cf38617c - Build: Make :kotlin-stdlib-js-ir buildKLib tasks cacheable (vor 6 Tagen) <Vyacheslav Gerasimov>
* d84a6fa7423 - (tag: build-1.4.0-dev-3639) JVM IR: always generate inline class constructor with name 'constructor-impl' (vor 6 Tagen) <Alexander Udalov>
* 688208aa56d - (tag: build-1.4.0-dev-3638) Build: Disable caching of Test tasks with doNotCacheIf (vor 6 Tagen) <Vyacheslav Gerasimov>
* 75a3808230c - (tag: build-1.4.0-dev-3633) Build: Use sourceMapBaseDirs in :kotlin-stdlib-js:compileKotlin2Js (vor 6 Tagen) <Vyacheslav Gerasimov>
* 4b9c7a1ae10 - Advance bootstrap to 1.4.0-dev-1818 (vor 6 Tagen) <Vyacheslav Gerasimov>
* d6ccdb3caa9 - (tag: build-1.4.0-dev-3629) NI: fix `extensionLambdasAndArrow` test (vor 6 Tagen) <Victor Petukhov>
* 6e40117116e - (tag: build-1.4.0-dev-3627) [JVM IR] Refactor PromisedValue... (vor 6 Tagen) <Kristoffer Andersen>
* ad988dbf43a - (tag: build-1.4.0-dev-3622) minor: update test data (vor 6 Tagen) <Pavel Kirpichenkov>
* 23ed6c4a1f1 - [NI] Narrow nullability constraint check in incorporator (vor 6 Tagen) <Pavel Kirpichenkov>
* ec01893237e - (tag: build-1.4.0-dev-3615) [FIR] Resolve return expressions in independent context (vor 6 Tagen) <Dmitriy Novozhilov>
* d4f57fb8359 - [FIR] Support comparision operator and reified parameter reference in html dump (vor 6 Tagen) <Dmitriy Novozhilov>
* 9eeee6aad78 - [FIR-TEST] Move FirBlackBoxCodegenTestGenerated to `:fir2ir` module (vor 6 Tagen) <Dmitriy Novozhilov>
* 54e7c792574 - [FIR] Safe implicit receiver stack in lambda atom for resolve of inner lambdas (vor 6 Tagen) <Dmitriy Novozhilov>
* c7f5a2cba26 - [FIR] Make ImplicitReceiverStack persistent (vor 6 Tagen) <Dmitriy Novozhilov>
* a332a5f26d3 - Add benchmark with case with a lot of implicit receivers (vor 6 Tagen) <Dmitriy Novozhilov>
* 7ee125e1ad2 - [FIR] Add receiver for lambda in position of default argument (vor 6 Tagen) <Dmitriy Novozhilov>
* c12fb1e0693 - [FIR] Fix determining type of when subject in exhaustiveness checker (vor 6 Tagen) <Dmitriy Novozhilov>
* 6d4eb9ae52a - (tag: build-1.4.0-dev-3614) KT-36113: Make KAPT classpath snapshot deterministic (vor 6 Tagen) <Ivan Gavrilovic>
* 9b68e4fe569 - (tag: build-1.4.0-dev-3613) Android/IR: handle nulls from getView/getContainerView (vor 6 Tagen) <pyos>
* 390d062721e - (tag: build-1.4.0-dev-3612) Fix class run configuration applicability (KT-33787) (vor 6 Tagen) <Yan Zhulanow>
* b360fb51192 - Revert "Import Kotlin JUnit run configuration settings from Gradle" (vor 6 Tagen) <Yan Zhulanow>
* 29566723b8c - Partially revert "Prefer Kotlin Gradle test run configurations when possible (KT-33787)" (vor 6 Tagen) <Yan Zhulanow>
* 9016a573cad - Partially revert "Prefer Kotlin Junit test run configurations when possible (KT-33787)" (vor 6 Tagen) <Yan Zhulanow>
* 208c7274dd2 - (tag: build-1.4.0-dev-3611, tag: build-1.4.0-dev-3606) Disable parallel execution for gradle tests (vor 7 Tagen) <Nikolay Krasko>
* c0cd010b7d2 - (tag: build-1.4.0-dev-3603) .gradle.kts: fix freezes by avoiding fs walking (vor 7 Tagen) <Natalia Selezneva>
* 01c4e66edbf - (tag: build-1.4.0-dev-3597) PSI2IR Use resulting descriptor extension receiver type (vor 7 Tagen) <Dmitry Petrov>
* 51749b97479 - NI: don't try to infer visible lambda parameters, if there is single one – extension parameter (vor 7 Tagen) <Victor Petukhov>
* ed83e3ccef2 - (tag: build-1.4.0-dev-3595) Optimize more redundant `kotlin/jvm/internal/Ref`s (vor 7 Tagen) <pyos>
* 7e6d0801235 - (tag: build-1.4.0-dev-3594) JVM_IR: default-initialize variables visible in the LVT (vor 7 Tagen) <pyos>
* ecb74787947 - (tag: build-1.4.0-dev-3593) ExperimentalFixesFactory: `OptIn` shouldn't be added for old version (vor 7 Tagen) <Dmitry Gridin>
* 08dc03a7047 - (tag: build-1.4.0-dev-3587) 201: Fix refineSignaturesWithResolve failure for primary constructors (vor 7 Tagen) <Nikolay Krasko>
* 096ff0e8a9b - 201: Enable mute in KotlinSuggestedRefactoringChangeListenerTest (vor 7 Tagen) <Nikolay Krasko>
* d1a8f577408 - (tag: build-1.4.0-dev-3579) Disable New Inference in JS backend (vor 7 Tagen) <Mikhail Zarechenskiy>
* e6885323dae - (tag: build-1.4.0-dev-3569) Accept incorrect behaviour for run-config tests for AS (vor 7 Tagen) <Dmitry Savvinov>
* 22de20e7e53 - (tag: build-1.4.0-dev-3565) JVM_IR: Generate PUBLIC constructor for suspend lambda (vor 7 Tagen) <Ilmir Usmanov>
* 42420cb6fce - JVM_IR: Generate inner classes for continuations (vor 7 Tagen) <Ilmir Usmanov>
* 536e0e23a0f - JVM_IR: Lazyly generate continuation classes of suspend functions (vor 7 Tagen) <Ilmir Usmanov>
* 91ee63432a7 - (tag: build-1.4.0-dev-3551) Disable CacheResetOnProcessCancele by default (vor 7 Tagen) <Vladimir Dolzhenko>
* 60d592716d0 - Disable KotlinMppTestLogger for non test executions. (vor 7 Tagen) <Konstantin Tskhovrebov>
* 35055d18958 - (tag: build-1.4.0-dev-3543) Fix empty run actions in context menu for non-JVM test results. (vor 7 Tagen) <Konstantin Tskhovrebov>
* dc8f24b8bc0 - (tag: build-1.4.0-dev-3534) Revert "Registry key to show hidden variables in debugger." (vor 7 Tagen) <Vladimir Ilmov>
* 61f8d3e5583 - (tag: build-1.4.0-dev-3532) Minor: update FIR2IR testData (vor 7 Tagen) <Dmitry Petrov>
* 1bad3803816 - (tag: build-1.4.0-dev-3531) FIR: fix test data in IDEA multi-module tests (vor 7 Tagen) <Mikhail Glukhikh>
* 70ee51d88cc - (tag: build-1.4.0-dev-3530) [FIR] Add anonymous objects to CFG (vor 7 Tagen) <Dmitriy Novozhilov>
* e3f1f18ca3e - [FIR] Add empty member scope for type variables (vor 7 Tagen) <Dmitriy Novozhilov>
* 985311d9f06 - [FIR] Implement delegate inference (vor 7 Tagen) <Dmitriy Novozhilov>
* 1003b81c93c - [FIR] Introduce inference session (vor 7 Tagen) <Dmitriy Novozhilov>
* dfa6dfa960a - [FIR] Support deserialization of annotations on JVM (vor 7 Tagen) <Dmitriy Novozhilov>
* 296ee2da4a2 - [FIR] Support `@LowPriorityInOverloadResolution` annotation (vor 7 Tagen) <Dmitriy Novozhilov>
* 4454a0681b3 - [FIR] Get rid of copying function call in process of completion (vor 7 Tagen) <Dmitriy Novozhilov>
* cda8177502f - [FIR] Add `transformDelegate` for FirProperty (vor 7 Tagen) <Dmitriy Novozhilov>
* e8b0ce00e1c - [FIR] Remove useless `file` argument from `FirCallResolver` (vor 7 Tagen) <Dmitriy Novozhilov>
* 807d41028e1 - [FIR] `FirComponentCall` rendered same as `FirFunctionCall` (vor 7 Tagen) <Dmitriy Novozhilov>