### PR TITLE
[kotlin compiler][update] 1.4.0-dev-4143

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BinaryInterface.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/BinaryInterface.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.backend.konan.descriptors.isAbstract
 import org.jetbrains.kotlin.backend.konan.ir.allParameters
 import org.jetbrains.kotlin.backend.konan.ir.isUnit
 import org.jetbrains.kotlin.backend.konan.isExternalObjCClass
-import org.jetbrains.kotlin.backend.konan.serialization.KonanManglerIr
+import org.jetbrains.kotlin.backend.konan.serialization.AbstractKonanIrMangler
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.util.findAnnotation
 import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
@@ -30,7 +30,8 @@ import org.jetbrains.kotlin.library.uniqueName
 // TODO: do not serialize descriptors of non-exported declarations.
 
 object KonanBinaryInterface {
-    private val mangler = KonanManglerIr
+    private val mangler = object : AbstractKonanIrMangler(true) {}
+
     private val exportChecker = mangler.getExportChecker()
 
     val IrFunction.functionName: String get() = mangler.run { signatureString }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
@@ -101,7 +101,10 @@ internal class RTTIGenerator(override val context: Context) : ContextUtils {
 
                     extendedInfo,
 
-                    Int32(KotlinAbiVersion.CURRENT.version),
+                    // TODO: it used to be a single int32 ABI version,
+                    // but klib abi version is not an int anymore.
+                    // So now this field is just reserved to preserve the layout.
+                    Int32(0),
 
                     Int32(size),
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-1818
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1818,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3929,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-3929
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-3929,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-3929
-kotlinStdlibTestsVersion=1.4.0-dev-3929
-testKotlinCompilerVersion=1.4.0-dev-3929
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4143,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-4143
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4143,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-4143
+kotlinStdlibTestsVersion=1.4.0-dev-4143
+testKotlinCompilerVersion=1.4.0-dev-4143
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/cpp/TypeInfo.h
+++ b/runtime/src/main/cpp/TypeInfo.h
@@ -103,8 +103,8 @@ struct TypeInfo {
     const TypeInfo* typeInfo_;
     // Extended RTTI, to retain cross-version debuggability, since ABI version 5 shall always be at the second position.
     const ExtendedTypeInfo* extendedInfo_;
-    // ABI version.
-    uint32_t abiVersion_;
+    // Unused field.
+    uint32_t unused_;
     // Negative value marks array class/string, and it is negated element size.
     int32_t instanceSize_;
     // Must be pointer to Any for array classes, and null for Any.


### PR DESCRIPTION
* 80caa063b3e - (tag: build-1.4.0-dev-4143) UnusedUnaryOperatorInspection: shouldn't report on annotation entry (vor 6 Stunden) <Dmitry Gridin>
* fded6fb4943 - (tag: build-1.4.0-dev-4138) JVM_IR: fix suspendCoroutineUninterceptedOrReturn (vor 7 Stunden) <Georgy Bronnikov>
* 3cbfdd19f52 - (tag: build-1.4.0-dev-4133) Optimize constraints simplification (vor 8 Stunden) <Ilya Chernikov>
* c2b866fe7ac - Reduce number of constraints simplifications (vor 8 Stunden) <Ilya Chernikov>
* 84a0e39956c - Skip duplicates removal on constraints simplification (vor 8 Stunden) <Ilya Chernikov>
* 6f97745de2b - Optimize MutableDiagnosticsWithSuppression (vor 8 Stunden) <Ilya Chernikov>
* a28c25b8051 - Add NI benchmarks configuration (vor 8 Stunden) <Ilya Chernikov>
* e9cb7770e3c - Fix benchmark compiler configuration (vor 8 Stunden) <Ilya Chernikov>
* 53d289206eb - Optimize hot TypeUtils.contains function (vor 8 Stunden) <Ilya Chernikov>
* 4538e212db2 - Optimize hot addSubTypeConstraintAndIncorporateIt function (vor 8 Stunden) <Ilya Chernikov>
* 357ceeae195 - Avoid unnecessary freshTypeConstructor() calls (vor 8 Stunden) <Ilya Chernikov>
* 54f10a709a3 - Cache isProperType calculations in the constraint system (vor 8 Stunden) <Ilya Chernikov>
* 70c89a28e1a - Stop subtyping constraint search if equality constraints for... (vor 8 Stunden) <Ilya Chernikov>
* b6c94323349 - [minor] Optimize diagnostic reporting a bit (vor 8 Stunden) <Ilya Chernikov>
* 2727507d18f - Fix diagnostic inferred type calculation for null in some cases (vor 8 Stunden) <Ilya Chernikov>
* 997debdd422 - (tag: build-1.4.0-dev-4129) 201: Mute GradleMultiplatformWizardTest.testMobile because of leaked JDK (vor 15 Stunden) <Nikolay Krasko>
* 34fda45113d - 201: Update test data about test run markers under gradle (vor 15 Stunden) <Nikolay Krasko>
* ab141bab1df - 201: Update to 201.6073.9 (vor 15 Stunden) <Nikolay Krasko>
* 0e65d0e00b3 - 201: Mute JS android tests in MultiplatformProjectImportingTest (vor 15 Stunden) <Nikolay Krasko>
* a9044b8a69c - 201: Mute test because of NPE: element.parent must not be null (IDEA-234737) (vor 15 Stunden) <Nikolay Krasko>
* 72a0a5327cf - 201: Fix setup for AbstractKotlinExceptionFilterTest tests (vor 15 Stunden) <Nikolay Krasko>
* 93702600222 - 201: Mute SpringRenameTestGenerated tests (vor 15 Stunden) <Nikolay Krasko>
* 62a772332db - 201: Remove declarations added for dropped newApi in hierarchy (vor 15 Stunden) <Nikolay Krasko>
* 1afd3d929a5 - 201: Update to 201.5985.32 (vor 15 Stunden) <Nikolay Krasko>
* 7c86911f44b - (tag: build-1.4.0-dev-4124) Filter out PSI `values` & `valueOf` methods from Java structure (vor 18 Stunden) <Mikhail Zarechenskiy>
* 1321bf426b8 - (tag: build-1.4.0-dev-4116) [FIR] Define argument lists and their builders more accurately (vor 20 Stunden) <Mikhail Glukhikh>
* 3d17ce05b50 - [FIR] Introduce FirResolvedArgumentList with argument-parameter mapping (vor 20 Stunden) <Mikhail Glukhikh>
* 6b0a3aa1769 - [FIR] Cleanup vararg handling during call completion (vor 20 Stunden) <Mikhail Glukhikh>
* 91d51b93e1f - [FIR] Introduce FirArgumentList node (vor 20 Stunden) <Mikhail Glukhikh>
* 476d3c4092a - (tag: build-1.4.0-dev-4112) Revert "[FIR-TEST] Move FIR ide tests to separate module" (vor 22 Stunden) <Dmitriy Novozhilov>
* b44be51b5c6 - (tag: build-1.4.0-dev-4110) Disable FUS for Code Completion in 1.3.71 (vor 22 Stunden) <Anton Yalyshev>
* a9ab3ae1923 - (tag: build-1.4.0-dev-4102) KT-36047 Support when-with-subject in optimized 'when' generators (vor 24 Stunden) <Dmitry Petrov>
* fd70b10b175 - (tag: build-1.4.0-dev-4093) JVM_IR: Generate suspend fun main wrapper as class instead of reference (vor 25 Stunden) <Ilmir Usmanov>
* e495c35ad7d - (tag: build-1.4.0-dev-4089) Use upper bound as a type for polymorphic serializer (vor 25 Stunden) <Leonid Startsev>
* 15fa6ea7579 - Do not insert @SerializableWith marker annotation if already present (vor 25 Stunden) <Leonid Startsev>
* e20354926bf - Do not check 'no ctor parameters' for serializable enums (vor 25 Stunden) <Leonid Startsev>
* 79fef09bf5e - (tag: build-1.4.0-dev-4083) [JVM IR] Add tests for KT-15971. (vor 26 Stunden) <Mark Punzalan>
* 2239b5ceabd - [JVM IR] Maintain KT-36188 bug compatibility between non-IR and IR backends. (vor 26 Stunden) <Mark Punzalan>
* 435e74b74bc - (tag: build-1.4.0-dev-4081) Redirect warning output to error log when allWarningsAsErrors is enabled (vor 26 Stunden) <Sergey Igushkin>
* 47ebd38534e - FIR2IR: fix origin of object literal constructor call (vor 26 Stunden) <Mikhail Glukhikh>
* 8231377f6ba - FIR2IR: convert qualifiers inside getClass properly (vor 26 Stunden) <Mikhail Glukhikh>
* 1812b490a12 - FIR: set anonymous object constructor return type properly (vor 26 Stunden) <Mikhail Glukhikh>
* d1739289c63 - (tag: build-1.4.0-dev-4077) Uast: `UastFakeLightMethod` hashcode fix (KT-37200) (vor 26 Stunden) <Nicolay Mitropolsky>
* 5bb74d98407 - Fixed generated text from jvm classfile, when quotes is required (vor 26 Stunden) <Alexander Podkhalyuzin>
* 36ec0a2e2e3 - (tag: build-1.4.0-dev-4076) [FIR-TEST] Move FIR ide tests to separate module (vor 27 Stunden) <Dmitriy Novozhilov>
* 78f910e3215 - Regenerate tests (vor 27 Stunden) <Dmitriy Novozhilov>
* 4d2ee279c0e - (tag: build-1.4.0-dev-4070) Remove unneeded workaround for IBM JDK and older intellij-core (vor 27 Stunden) <Alexander Udalov>
* f113c224504 - (tag: build-1.4.0-dev-4068) [JS IR BE] Fix enum entry initialization (vor 28 Stunden) <Svyatoslav Kuzmich>
* 04f9a037966 - (tag: build-1.4.0-dev-4059) [NI] Fix isNullableType for definitely not null type parameter (vor 28 Stunden) <Pavel Kirpichenkov>
* 88ae9bc7d56 - minor: rename test (vor 28 Stunden) <Pavel Kirpichenkov>
* 8af5e2bb04e - (tag: build-1.4.0-dev-4057) Make copy-paste resolve task modal to avoid invalid psi elements (vor 28 Stunden) <Vladimir Dolzhenko>
* 90750483eee - (tag: build-1.4.0-dev-4055) KT-36860 Collect extensions from object on first completion (vor 29 Stunden) <Roman Golyshev>
* 7dc9a2fc647 - (tag: build-1.4.0-dev-4053) [JS IR BE] Add intrinsic for hashCode on Boolean (vor 29 Stunden) <Zalim Bashorov>
* 2103c0e0f83 - [JS IR BE] Add intrinsic for hashCode on String (vor 29 Stunden) <Zalim Bashorov>
* c8efe8c4ecb - Add tests for equals, hashCode, toString in String and Number (vor 29 Stunden) <Zalim Bashorov>
* 8e788e2169f - [stdlib-js-ir] Copy Boolean and String sources and add equals, hashCode, toString (vor 29 Stunden) <Zalim Bashorov>
* 9e59d93ad51 - [JS IR BE] Add intrinsics for hashCode on primitive number types (vor 29 Stunden) <Zalim Bashorov>
* adfb296e456 - [stdlib-js-ir] Add equals, hashCode, toString to some builtins (vor 29 Stunden) <Zalim Bashorov>
* 97e86fb2ce1 - [stdlib-js-ir] Char shouldn't be a data class (vor 29 Stunden) <Zalim Bashorov>
* 7c874ccf0ce - [stdlib-js-ir] Hack: mark Char.toString by JsName to force keeping it (vor 29 Stunden) <Zalim Bashorov>
* 9e7f72382fb - [stdlib-js-ir] Remove BitUtils object and make all members toplevel (vor 29 Stunden) <Zalim Bashorov>
* 62014e6711d - [JS IR BE] Add better error message when some function not found during init JsIrBackendContext (vor 29 Stunden) <Zalim Bashorov>
* 43171f67a84 - [stdlib-js-ir] Cleanup exceptions (vor 29 Stunden) <Zalim Bashorov>
* d22e4495de1 - [JS IR DCE] Improve handling overrides (vor 29 Stunden) <Zalim Bashorov>
* f60d0b2c7ce - [JS IR CLI] Change K2JsIrCompiler#executableScriptFileName's body to `TODO()` and provide a proper fix later (vor 29 Stunden) <Zalim Bashorov>
* 2a7e32d3aea - [JS IR DCE] Add CLI option to print reachability info (vor 29 Stunden) <Zalim Bashorov>
* 16cd3f0cefd - [JS IR DCE] Print reachability info (vor 29 Stunden) <Zalim Bashorov>
* e6657b016f2 - [JS IR DCE] Move withNested fun to get better diff in the next commit (vor 29 Stunden) <Zalim Bashorov>
* 95d248189ff - [JS IR BE] JsClassGenerator: don't use descriptor for error message (vor 29 Stunden) <Zalim Bashorov>
* 01108d595cc - (tag: build-1.4.0-dev-4047) Fix broken test data from 5d73550b (vor 30 Stunden) <Leonid Startsev>
* 63a909dee61 - (tag: build-1.4.0-dev-4045) JS: fix KT-37386 (vor 30 Stunden) <Anton Bannykh>
* 182c1cee054 - (tag: build-1.4.0-dev-4041) [Commonizer] Don't regenerate commonized KLIBs for *-SNAPSHOT versions (vor 31 Stunden) <Dmitriy Dolovov>
* d032f9b9cc9 - (tag: build-1.4.0-dev-4040) JVM_IR: handle common klibs when compiled via cli (vor 31 Stunden) <Georgy Bronnikov>
* 6af099c11a3 - Typo fix (vor 31 Stunden) <Georgy Bronnikov>
* afab52c3bc5 - (tag: build-1.4.0-dev-4038) Remove workarounds that called primary constructor manually (vor 2 Tagen) <Ilya Gorbunov>
* 338dae7a837 - (tag: build-1.4.0-dev-4028, origin/rr/4u7/tools-jar) Build: Apply checkCacheability.gradle.kts to buildSrc (vor 2 Tagen) <Vyacheslav Gerasimov>
* 35dc57d6749 - Build: Sort idea files in ivy repository to stabilize order (vor 2 Tagen) <Vyacheslav Gerasimov>
* da0eeb0c28b - Build: Exclude plugin.xml from runtime classpath normalization (vor 2 Tagen) <Vyacheslav Gerasimov>
* a0b82c4dece - Build: Compile against tollsJarApi in idea-jvm & jvm-debugger-coroutine (vor 2 Tagen) <Vyacheslav Gerasimov>
* f735396ffbe - Build: Make toolsJarApi() helper for JPS build (vor 2 Tagen) <Vyacheslav Gerasimov>
* c75ad13b660 - Build: Remove all code from tools-jar-api leaving only declarations (vor 2 Tagen) <Vyacheslav Gerasimov>
* ef169aa12ba - Build: Use preprocessed tools.jar for compilation (vor 2 Tagen) <Vyacheslav Gerasimov>
* 8fbd22ff731 - (tag: build-1.4.0-dev-4008) Add test to check consistency of pre_release flag in the compiler (vor 2 Tagen) <Mikhail Zarechenskiy>
* 8fdc39ecbcd - Update test data due to using stdlib with a pre_release flag (vor 2 Tagen) <Mikhail Zarechenskiy>
* ae6a603a92e - (tag: build-1.4.0-dev-4007) [Gradle, JS] Fix for produceExecutable in Groovy build script (vor 2 Tagen) <Ilya Goncharov>
* 90d012cecbf - (tag: build-1.4.0-dev-4006) Handle unbound extension receiver in callable reference adaptation (vor 2 Tagen) <Dmitry Petrov>
* e175ff0d739 - KT-36953 break/continue/return/throw have kotlinType Nothing (vor 2 Tagen) <Dmitry Petrov>
* 603685b5a4a - (tag: build-1.4.0-dev-3995) Mute FIR2IR test (pushed as unmuted accidentally?) (vor 2 Tagen) <Mikhail Glukhikh>
* 2651fe9fb8e - FIR2IR: use CLASS kind for anonymous objects (vor 2 Tagen) <Mikhail Glukhikh>
* 9c3dfed2d7d - FIR2IR: provide IR_EXTERNAL_DECLARATION_STUB origin also for members (vor 2 Tagen) <Mikhail Glukhikh>
* e9699e71733 - FIR2IR: provide correct origins for arithmetic operators (vor 2 Tagen) <Mikhail Glukhikh>
* 64e71e9d256 - FIR2IR: use IR_EXTERNAL_DECLARATION_STUB for external classes (vor 2 Tagen) <Mikhail Glukhikh>
* ed6c9e67a10 - FIR2IR: convert qualifiers to companion objects, if any (vor 2 Tagen) <Mikhail Glukhikh>
* 7ea4c20f3de - [FIR TEST] Fix FIR_IDENTICAL adding for Fir2IrTextTestGenerated (vor 2 Tagen) <Mikhail Glukhikh>
* dd7ac1343e6 - (tag: build-1.4.0-dev-3994) [FIR] Unwrap when subject expression recursively in DFA variable storage (vor 2 Tagen) <Dmitriy Novozhilov>
* 676ffff015e - (tag: build-1.4.0-dev-3992) Minor, fix builtinFunctionReferenceOwner.kt for android-tests (vor 2 Tagen) <Alexander Udalov>
* ac6be2edba3 - (tag: build-1.4.0-dev-3987) Treat class files with no bytecode version as having the current version (vor 2 Tagen) <Alexander Udalov>
* 787e4503e53 - Migrate -Xuse-experimental -> -Xopt-in in project sources (vor 2 Tagen) <Alexander Udalov>
* d668808b440 - Migrate Experimental->RequiresOptIn in project sources (vor 2 Tagen) <Alexander Udalov>
* 795d6ab4077 - Migrate UseExperimental->OptIn in project sources (vor 2 Tagen) <Alexander Udalov>
* 125b39d9bee - (tag: build-1.4.0-dev-3982, origin/KT-36044) NI: Temporary apply test data until fix KT-37380 (vor 2 Tagen) <Victor Petukhov>
* 77f85d8b7ce - (tag: build-1.4.0-dev-3978, tag: build-1.4.0-dev-3975) Move to top level: update import directives on the usage site when the declaration to be moved is not private (vor 2 Tagen) <Toshiaki Kameyama>
* b06a3ea5acb - (tag: build-1.4.0-dev-3973) Print out abi version as a full triple (vor 2 Tagen) <Alexander Gorshenev>
* a6357488481 - Provide library producer compiler version in klib abi mismatch disagnostics (vor 2 Tagen) <Alexander Gorshenev>
* fac71ac8121 - Be prepared if in the future we extend klib abi version to a triple (vor 2 Tagen) <Alexander Gorshenev>
* 5d73550b48a - (tag: build-1.4.0-dev-3971) Do not check visibility of enum entries in explicit api mode (vor 2 Tagen) <Leonid Startsev>
* 753d4b3cbd8 - (tag: build-1.4.0-dev-3970) Uast: `UastFakeLightMethod` equality fix (KT-37200) (vor 2 Tagen) <Nicolay Mitropolsky>
* c1f89159d9f - (tag: build-1.4.0-dev-3969) Pill: Add compiler.version module to Pill (vor 2 Tagen) <Yan Zhulanow>
* 7fff4e78e5e - (tag: build-1.4.0-dev-3967) [KLIB] Do not include return type into mangle (vor 2 Tagen) <Roman Artemev>
* 62621de4fc1 - [KLIB] Don't have a special mangle for internal declarations (vor 2 Tagen) <Roman Artemev>
* 7430bfe5187 - [KLIB] Update test data (vor 2 Tagen) <Roman Artemev>
* 7034edac4c6 - [JS IR] Move signature consistency checker into appropriate place (vor 2 Tagen) <Roman Artemev>
* 3c26d388047 - Revert Clear computable when value is calculated in LockBasedStorageManager (vor 2 Tagen) <Vladimir Dolzhenko>
* ddba8e76918 - (tag: build-1.4.0-dev-3965) Extend incremental analysis to object declaration (vor 2 Tagen) <Vladimir Dolzhenko>
* ae208f58a44 - (tag: build-1.4.0-dev-3964) Workaround for KT-37302 (vor 2 Tagen) <Georgy Bronnikov>
* 735fae0e5a0 - (tag: build-1.4.0-dev-3958) JVM_IR: apply TailCallOptimizationLowering to all suspend functions (vor 3 Tagen) <pyos>
* dc388f3f3a7 - (tag: build-1.4.0-dev-3954) JVM_IR: add a test for suspend inline fun with defaults in a class (vor 3 Tagen) <pyos>
* 862cd5665b1 - JVM_IR: add continuations to inline suspend lambdas in the lowering (vor 3 Tagen) <pyos>
* b393f2f6806 - JVM_IR: merge suspend view and suspend stub maps (vor 3 Tagen) <pyos>
* 15a0157c42c - (tag: build-1.4.0-dev-3932, origin/slava/more-maven-deps) FIR: Support proper loading of Map.merge (vor 3 Tagen) <Denis Zharkov>
* 4a1302e3855 - FIR: Add problematic test case (vor 3 Tagen) <Denis Zharkov>
* b2ff4d7f9a1 - FIR: Support expansion of flexible type-alias-based types in inference (vor 3 Tagen) <Denis Zharkov>
* afb84b1d2a6 - FIR: Support type aliased declarations in HtmlFirDump (vor 3 Tagen) <Denis Zharkov>