### PR TITLE
[kotlin compiler][update] 1.4.0-dev-4271

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-1818
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1818,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4143,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-4143
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4143,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-4143
-kotlinStdlibTestsVersion=1.4.0-dev-4143
-testKotlinCompilerVersion=1.4.0-dev-4143
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4271,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-4271
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4271,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-4271
+kotlinStdlibTestsVersion=1.4.0-dev-4271
+testKotlinCompilerVersion=1.4.0-dev-4271
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/generator/build.gradle
+++ b/runtime/generator/build.gradle
@@ -2,10 +2,14 @@ configurations {
     generatorRuntime
 }
 
+repositories {
+  maven { url buildKotlinCompilerRepo }
+}
+
 dependencies {
-    generatorRuntime "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
+    generatorRuntime "org.jetbrains.kotlin:kotlin-stdlib:${kotlinStdlibVersion}"
     generatorRuntime "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
-    generatorRuntime "org.jetbrains.kotlin:kotlin-stdlib-gen:${kotlinVersion}"
+    generatorRuntime "org.jetbrains.kotlin:kotlin-stdlib-gen:${kotlinStdlibVersion}"
 }
 
 task run(type: JavaExec) {

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -240,7 +240,25 @@ public actual fun CharArray.asList(): List<Char> {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>): Boolean {
+    return this.contentDeepEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *deeply* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The specified arrays are also considered deeply equal if both are `null`.
+ * 
+ * If two corresponding elements are nested arrays, they are also compared deeply.
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ * 
+ * The elements of other types are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun <T> Array<out T>?.contentDeepEquals(other: Array<out T>?): Boolean {
     return contentDeepEqualsImpl(other)
 }
 
@@ -251,7 +269,19 @@ public actual infix fun <T> Array<out T>.contentDeepEquals(other: Array<out T>):
  * If any of arrays contains itself on any nesting level the behavior is undefined.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentDeepHashCode(): Int {
+    return this.contentDeepHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level the behavior is undefined.
+ */
+@SinceKotlin("1.4")
+public actual fun <T> Array<out T>?.contentDeepHashCode(): Int {
     return contentDeepHashCodeImpl()
 }
 
@@ -265,7 +295,22 @@ public actual fun <T> Array<out T>.contentDeepHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentDeepToString(): String {
+    return this.contentDeepToString()
+}
+
+/**
+ * Returns a string representation of the contents of this array as if it is a [List].
+ * Nested arrays are treated as lists too.
+ * 
+ * If any of arrays contains itself on any nesting level that reference
+ * is rendered as `"[...]"` to prevent recursion.
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentDeepToString
+ */
+@SinceKotlin("1.4")
+public actual fun <T> Array<out T>?.contentDeepToString(): String {
     return contentDeepToStringImpl()
 }
 
@@ -277,13 +322,9 @@ public actual fun <T> Array<out T>.contentDeepToString(): String {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boolean {
-    if (this === other) return true
-    if (size != other.size) return false
-    for (i in indices) {
-        if (this[i] != other[i]) return false
-    }
-    return true
+    return this.contentEquals(other)
 }
 
 /**
@@ -294,13 +335,9 @@ public actual infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boo
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
-    if (this === other) return true
-    if (size != other.size) return false
-    for (i in indices) {
-        if (this[i] != other[i]) return false
-    }
-    return true
+    return this.contentEquals(other)
 }
 
 /**
@@ -311,13 +348,9 @@ public actual infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
-    if (this === other) return true
-    if (size != other.size) return false
-    for (i in indices) {
-        if (this[i] != other[i]) return false
-    }
-    return true
+    return this.contentEquals(other)
 }
 
 /**
@@ -328,13 +361,9 @@ public actual infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun IntArray.contentEquals(other: IntArray): Boolean {
-    if (this === other) return true
-    if (size != other.size) return false
-    for (i in indices) {
-        if (this[i] != other[i]) return false
-    }
-    return true
+    return this.contentEquals(other)
 }
 
 /**
@@ -345,13 +374,9 @@ public actual infix fun IntArray.contentEquals(other: IntArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun LongArray.contentEquals(other: LongArray): Boolean {
-    if (this === other) return true
-    if (size != other.size) return false
-    for (i in indices) {
-        if (this[i] != other[i]) return false
-    }
-    return true
+    return this.contentEquals(other)
 }
 
 /**
@@ -362,13 +387,9 @@ public actual infix fun LongArray.contentEquals(other: LongArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
-    if (this === other) return true
-    if (size != other.size) return false
-    for (i in indices) {
-        if (!this[i].equals(other[i])) return false
-    }
-    return true
+    return this.contentEquals(other)
 }
 
 /**
@@ -379,8 +400,138 @@ public actual infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
+    return this.contentEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
+public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean {
+    return this.contentEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
+public actual infix fun CharArray.contentEquals(other: CharArray): Boolean {
+    return this.contentEquals(other)
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun <T> Array<out T>?.contentEquals(other: Array<out T>?): Boolean {
     if (this === other) return true
+    if (this === null || other === null) return false
+    if (size != other.size) return false
+    for (i in indices) {
+        if (this[i] != other[i]) return false
+    }
+    return true
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun ByteArray?.contentEquals(other: ByteArray?): Boolean {
+    if (this === other) return true
+    if (this === null || other === null) return false
+    if (size != other.size) return false
+    for (i in indices) {
+        if (this[i] != other[i]) return false
+    }
+    return true
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun ShortArray?.contentEquals(other: ShortArray?): Boolean {
+    if (this === other) return true
+    if (this === null || other === null) return false
+    if (size != other.size) return false
+    for (i in indices) {
+        if (this[i] != other[i]) return false
+    }
+    return true
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun IntArray?.contentEquals(other: IntArray?): Boolean {
+    if (this === other) return true
+    if (this === null || other === null) return false
+    if (size != other.size) return false
+    for (i in indices) {
+        if (this[i] != other[i]) return false
+    }
+    return true
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun LongArray?.contentEquals(other: LongArray?): Boolean {
+    if (this === other) return true
+    if (this === null || other === null) return false
+    if (size != other.size) return false
+    for (i in indices) {
+        if (this[i] != other[i]) return false
+    }
+    return true
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun FloatArray?.contentEquals(other: FloatArray?): Boolean {
+    if (this === other) return true
+    if (this === null || other === null) return false
     if (size != other.size) return false
     for (i in indices) {
         if (!this[i].equals(other[i])) return false
@@ -395,9 +546,28 @@ public actual infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
-@SinceKotlin("1.1")
-public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean {
+@SinceKotlin("1.4")
+public actual infix fun DoubleArray?.contentEquals(other: DoubleArray?): Boolean {
     if (this === other) return true
+    if (this === null || other === null) return false
+    if (size != other.size) return false
+    for (i in indices) {
+        if (!this[i].equals(other[i])) return false
+    }
+    return true
+}
+
+/**
+ * Returns `true` if the two specified arrays are *structurally* equal to one another,
+ * i.e. contain the same number of the same elements in the same order.
+ * 
+ * The elements are compared for equality with the [equals][Any.equals] function.
+ * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
+ */
+@SinceKotlin("1.4")
+public actual infix fun BooleanArray?.contentEquals(other: BooleanArray?): Boolean {
+    if (this === other) return true
+    if (this === null || other === null) return false
     if (size != other.size) return false
     for (i in indices) {
         if (this[i] != other[i]) return false
@@ -412,9 +582,10 @@ public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
-@SinceKotlin("1.1")
-public actual infix fun CharArray.contentEquals(other: CharArray): Boolean {
+@SinceKotlin("1.4")
+public actual infix fun CharArray?.contentEquals(other: CharArray?): Boolean {
     if (this === other) return true
+    if (this === null || other === null) return false
     if (size != other.size) return false
     for (i in indices) {
         if (this[i] != other[i]) return false
@@ -426,84 +597,89 @@ public actual infix fun CharArray.contentEquals(other: CharArray): Boolean {
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentHashCode(): Int {
-    var result = 1
-    for (element in this)
-        result = 31 * result + element.hashCode()
-    return result
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ByteArray.contentHashCode(): Int {
-    var result = 1
-    for (element in this)
-        result = 31 * result + element.hashCode()
-    return result
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ShortArray.contentHashCode(): Int {
-    var result = 1
-    for (element in this)
-        result = 31 * result + element.hashCode()
-    return result
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun IntArray.contentHashCode(): Int {
-    var result = 1
-    for (element in this)
-        result = 31 * result + element.hashCode()
-    return result
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun LongArray.contentHashCode(): Int {
-    var result = 1
-    for (element in this)
-        result = 31 * result + element.hashCode()
-    return result
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun FloatArray.contentHashCode(): Int {
-    var result = 1
-    for (element in this)
-        result = 31 * result + element.hashCode()
-    return result
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun DoubleArray.contentHashCode(): Int {
-    var result = 1
-    for (element in this)
-        result = 31 * result + element.hashCode()
-    return result
+    return this.contentHashCode()
 }
 
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun BooleanArray.contentHashCode(): Int {
+    return this.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
+public actual fun CharArray.contentHashCode(): Int {
+    return this.contentHashCode()
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun <T> Array<out T>?.contentHashCode(): Int {
+    if (this === null) return 0
     var result = 1
     for (element in this)
         result = 31 * result + element.hashCode()
@@ -513,8 +689,93 @@ public actual fun BooleanArray.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
-@SinceKotlin("1.1")
-public actual fun CharArray.contentHashCode(): Int {
+@SinceKotlin("1.4")
+public actual fun ByteArray?.contentHashCode(): Int {
+    if (this === null) return 0
+    var result = 1
+    for (element in this)
+        result = 31 * result + element.hashCode()
+    return result
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun ShortArray?.contentHashCode(): Int {
+    if (this === null) return 0
+    var result = 1
+    for (element in this)
+        result = 31 * result + element.hashCode()
+    return result
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun IntArray?.contentHashCode(): Int {
+    if (this === null) return 0
+    var result = 1
+    for (element in this)
+        result = 31 * result + element.hashCode()
+    return result
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun LongArray?.contentHashCode(): Int {
+    if (this === null) return 0
+    var result = 1
+    for (element in this)
+        result = 31 * result + element.hashCode()
+    return result
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun FloatArray?.contentHashCode(): Int {
+    if (this === null) return 0
+    var result = 1
+    for (element in this)
+        result = 31 * result + element.hashCode()
+    return result
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun DoubleArray?.contentHashCode(): Int {
+    if (this === null) return 0
+    var result = 1
+    for (element in this)
+        result = 31 * result + element.hashCode()
+    return result
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun BooleanArray?.contentHashCode(): Int {
+    if (this === null) return 0
+    var result = 1
+    for (element in this)
+        result = 31 * result + element.hashCode()
+    return result
+}
+
+/**
+ * Returns a hash code based on the contents of this array as if it is [List].
+ */
+@SinceKotlin("1.4")
+public actual fun CharArray?.contentHashCode(): Int {
+    if (this === null) return 0
     var result = 1
     for (element in this)
         result = 31 * result + element.hashCode()
@@ -527,8 +788,9 @@ public actual fun CharArray.contentHashCode(): Int {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun <T> Array<out T>.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -537,8 +799,9 @@ public actual fun <T> Array<out T>.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ByteArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -547,8 +810,9 @@ public actual fun ByteArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun ShortArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -557,8 +821,9 @@ public actual fun ShortArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun IntArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -567,8 +832,9 @@ public actual fun IntArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun LongArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -577,8 +843,9 @@ public actual fun LongArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun FloatArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -587,8 +854,9 @@ public actual fun FloatArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun DoubleArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -597,8 +865,9 @@ public actual fun DoubleArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun BooleanArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
 }
 
 /**
@@ -607,8 +876,99 @@ public actual fun BooleanArray.contentToString(): String {
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
 @SinceKotlin("1.1")
+@kotlin.internal.LowPriorityInOverloadResolution
 public actual fun CharArray.contentToString(): String {
-    return joinToString(", ", "[", "]")
+    return this.contentToString()
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun <T> Array<out T>?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun ByteArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun ShortArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun IntArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun LongArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun FloatArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun DoubleArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun BooleanArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
+}
+
+/**
+ * Returns a string representation of the contents of the specified array as if it is [List].
+ * 
+ * @sample samples.collections.Arrays.ContentOperations.contentToString
+ */
+@SinceKotlin("1.4")
+public actual fun CharArray?.contentToString(): String {
+    return this?.joinToString(", ", "[", "]") ?: "null"
 }
 
 /**

--- a/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Arrays.kt
@@ -46,7 +46,8 @@ public inline fun <T> Array<out T>.subarrayContentToString(offset: Int, length: 
  */
 @SinceKotlin("1.1")
 @UseExperimental(ExperimentalUnsignedTypes::class)
-internal fun <T> Array<out T>.contentDeepHashCodeImpl(): Int {
+internal fun <T> Array<out T>?.contentDeepHashCodeImpl(): Int {
+    if (this == null) return 0
     var result = 1
     for (element in this) {
         val elementHash = when (element) {

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/KonanLibrary.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/KonanLibrary.kt
@@ -10,8 +10,6 @@ const val KLIB_PROPERTY_INTEROP = "interop"
 const val KLIB_PROPERTY_EXPORT_FORWARD_DECLARATIONS = "exportForwardDeclarations"
 const val KLIB_PROPERTY_INCLUDED_HEADERS = "includedHeaders"
 
-const val KLIB_INTEROP_IR_PROVIDER_IDENTIFIER = "kotlin.native.cinterop"
-
 interface TargetedLibrary {
     val targetList: List<String>
     val includedPaths: List<String>


### PR DESCRIPTION
* 9904304e071 - (tag: build-1.4.0-dev-4271) (CoroutineDebugger) StackFrameInterceptor service added to KotlinPositionManager, dependency cleanup (vor 23 Stunden) <Vladimir Ilmov>
* 0af61293d5d - (tag: build-1.4.0-dev-4269) Fix ExtensionTestUtil compilation for 191; CustomUsageSearcherTest compilation for 201 (vor 2 Tagen) <Vladimir Dolzhenko>
* 57fd449288a - (tag: build-1.4.0-dev-4260) Minor, add check of const field modifiers to codegen test (vor 3 Tagen) <Alexander Udalov>
* 1e3e791d432 - (tag: build-1.4.0-dev-4257) Fix compilation error in `MLCompletionForKotlin` bunch files (vor 3 Tagen) <Roman Golyshev>
* 9daed1f2c60 - (tag: build-1.4.0-dev-4256, tag: build-1.4.0-dev-4252) Revert "[FIR-TEST] Move FIR ide tests to separate module" (vor 3 Tagen) <Dmitriy Novozhilov>
* bdd88e16553 - (tag: build-1.4.0-dev-4249) JVM_IR: place suspend markers in faux lambdas around inline references (vor 3 Tagen) <pyos>
* f29e665dce9 - (tag: build-1.4.0-dev-4245) Add "ML completion for Kotlin" experimental feature checkbox (vor 3 Tagen) <Roman Golyshev>
* 4c6ea7c26a4 - (tag: build-1.4.0-dev-4241) KT-36808 Sink down member function `Flow.collect` in the completion (vor 3 Tagen) <Roman Golyshev>
* d27954a6d4c - (tag: build-1.4.0-dev-4237, tag: build-1.4.0-dev-4234) [IR] Use erased types in backing field initializer in case of generic delegated property (vor 3 Tagen) <Roman Artemev>
* 13a73b67de4 - [IR] Fix IrPropertyReference for delegated property (vor 3 Tagen) <Roman Artemev>
* 34c17e2bed0 - [KLIB] Add regression to about VarAsFun type parameter leak (vor 3 Tagen) <Roman Artemev>
* 8c1772d623d - [KLIB] Add regression test (vor 3 Tagen) <Roman Artemev>
* 09239743c1d - (tag: build-1.4.0-dev-4228) Fix compilation KotlinCopyPasteReferenceProcessor for 191, 192 (vor 3 Tagen) <Vladimir Dolzhenko>
* 123311007b8 - (tag: build-1.4.0-dev-4227) Fix compilation CustomUsageSearcherTest for 191, 201 (vor 3 Tagen) <Vladimir Dolzhenko>
* 31776d9a3bd - (tag: build-1.4.0-dev-4226) [CFA] Mark arguments of all annotation calls as `USED_AS_EXPRESSION` (vor 3 Tagen) <Dmitriy Novozhilov>
* b9ffed3f04a - (tag: build-1.4.0-dev-4225) Replace `ConfigurationFactory` with `SimpleConfigurationType` (vor 3 Tagen) <Dmitry Gridin>
* 43d6ddd4058 - (tag: build-1.4.0-dev-4220) Minor, fix typo in KotlinChunk.kt (vor 3 Tagen) <Alexander Udalov>
* 20c4a7b2443 - (tag: build-1.4.0-dev-4217) [FIR2IR] Introduce staged transformation (first step) (vor 3 Tagen) <Mikhail Glukhikh>
* a9f7ff254b8 - (tag: build-1.4.0-dev-4215) Add -Xno-optimized-callable-references to disable KT-27362 optimization (vor 3 Tagen) <Alexander Udalov>
* ae4629a5a60 - (tag: build-1.4.0-dev-4214) Fetch analysis results if it is available (vor 3 Tagen) <Vladimir Dolzhenko>
* 7cf8697e309 - (tag: build-1.4.0-dev-4209) [JS BEs] use star projection when type parameter used recursively (vor 3 Tagen) <Zalim Bashorov>
* 8c7562d338c - [CJS BE] don't crash when intersection types passed for a reified parameter (vor 3 Tagen) <Zalim Bashorov>
* 415893b8aab - [JS CLI] revert disabling NI by default (vor 4 Tagen) <Zalim Bashorov>
* 5188bc6584d - [JS FE] remove unused ReleaseCoroutinesDisabledLanguageVersionSettings (vor 4 Tagen) <Zalim Bashorov>
* 87242b419aa - (tag: build-1.4.0-dev-4207) Improvements in KotlinCopyPasteReferenceProcessor (vor 4 Tagen) <Vladimir Dolzhenko>
* b1c4b5f51ba - (tag: build-1.4.0-dev-4203) NI: Analyze lambdas which are return arguments of another lambda (vor 4 Tagen) <Victor Petukhov>
* 426738b7d49 - (tag: build-1.4.0-dev-4199) JVM_IR: Cache stubs in CollectionStubMethodLowering (vor 4 Tagen) <Georgy Bronnikov>
* 92268c8144d - JVM_IR: do not generate excessive stubs for immutable collections (vor 4 Tagen) <Georgy Bronnikov>
* 9955f342c0c - (tag: build-1.4.0-dev-4189) [FIR-TEST] Move FIR ide tests to separate module (vor 4 Tagen) <Dmitriy Novozhilov>
* b1fac4e7219 - (tag: build-1.4.0-dev-4186) Implement reduceIndexedOrNull and reduceRightIndexedOrNull #KT-36866 (vor 4 Tagen) <Abduqodiri Qurbonzoda>
* b60633d79a0 - Add associateWith to Array<T> #KT-30372 (vor 4 Tagen) <Abduqodiri Qurbonzoda>
* e632d589360 - (tag: build-1.4.0-dev-4185) Nullable Array.contentEquals/contentHashCode/contentToString #KT-34161 (vor 4 Tagen) <Abduqodiri Qurbonzoda>
* 179ec41a6b4 - (tag: build-1.4.0-dev-4183) [JS BEs] Generate tests for whole "codegen/boxInline" (vor 4 Tagen) <Zalim Bashorov>
* fe3a81ebc92 - [JS BEs] Minor: fix warnings in abstract classes for generated tests (vor 4 Tagen) <Zalim Bashorov>
* c664bfc62bb - (tag: build-1.4.0-dev-4179) Update property delegate test data (vor 4 Tagen) <Abduqodiri Qurbonzoda>
* 3762b5cba7c - (tag: build-1.4.0-dev-4170) Minor, remove extraneous field CodegenTestCase.coroutinesPackage (vor 4 Tagen) <Alexander Udalov>
* 244db9bcf9e - JVM IR: don't rename fake overrides for fields (vor 4 Tagen) <Alexander Udalov>
* 9ceca69154c - (tag: build-1.4.0-dev-4169) Do not stop searchTextOccurrences when isSearchForTextOccurrences is false (vor 4 Tagen) <kovalp>
* 6fd8ccc293e - (tag: build-1.4.0-dev-4166) [FIR2IR] Support (simple) conversion of captured types (vor 4 Tagen) <Mikhail Glukhikh>
* e919e7b79a8 - (tag: build-1.4.0-dev-4157) [Gradle][Native][Cache] Don't skip metadata-based interop libraries (vor 4 Tagen) <Sergey Bogolepov>
* c0b15b1768e - (tag: build-1.4.0-dev-4155) KT-37448 'this' in delegating constructor call may refer to outer object (vor 4 Tagen) <Dmitry Petrov>
* 2bd58727823 - (tag: build-1.4.0-dev-4152) 201: [Gradle, JS] Non jvm configurator from xml including (vor 4 Tagen) <Ilya Goncharov>
* dc2dd2e3e30 - [Gradle, JS] Remove idle test runner (vor 4 Tagen) <Ilya Goncharov>
* 8c8307d0d2e - 201: [Gradle, JS] Remove redundant non jvm configurator for 201 (vor 4 Tagen) <Ilya Goncharov>
* 857f3335bb6 - [Gradle, JS] TestFramework is public to detect it in debug extension (vor 4 Tagen) <Ilya Goncharov>
* 3728dd45ce8 - [Gradle, JS] Remove redundant hacks for debug (vor 4 Tagen) <Ilya Goncharov>
* 7efab887aa5 - (tag: build-1.4.0-dev-4151) JVM_IR: Do not generate accessor for private function (vor 4 Tagen) <Ilmir Usmanov>