### PR TITLE
Ignore unknown keys in idb's json output that lists targets

### DIFF
--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecutorService.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecutorService.kt
@@ -425,7 +425,7 @@ private fun deviceLauncher(project: Project) = object : ExecutorService {
             data class DeviceTarget(val name: String, val udid: String, val state: String, val type: String)
             split("\n")
                     .filter { it.isNotEmpty() }
-                    .map { Json(JsonConfiguration.Stable.copy(ignoreUnknownKeys = false))
+                    .map { Json(JsonConfiguration.Stable.copy(ignoreUnknownKeys = true))
                             .parse(DeviceTarget.serializer(), it)
                     }
                     .first {


### PR DESCRIPTION
idb's output conains also keys that are not listed in `DeviceTarget` class. So all unrecognized keys in deserializer should be ignored.