### PR TITLE
Fix and simplify dependencies

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -225,11 +225,9 @@ TaskCollection<Task> tasksOf(Class<? extends Task> type, Closure<Boolean> filter
 }
 
 run {
-    dependsOn(tasksOf(KonanTest.class, { it instanceof KonanLocalTest ||
-            it instanceof KonanStandaloneTest // includes driver, interop and library tests
-    }))
+    dependsOn(tasksOf(KonanTest) {})
     // Add framework tests
-    dependsOn(project.tasks.withType(FrameworkTest))
+    dependsOn(tasksOf(FrameworkTest) {})
 }
 
 task sanity {
@@ -238,13 +236,11 @@ task sanity {
             update_external_tests()
         }
     }
-    def platformLibsTasks = targetList.collect { "${it}PlatformLibs" } + ["distPlatformLibs"]
-    dependsOn(tasksOf(KonanTest.class) { task ->
-        (task instanceof KonanLocalTest || task instanceof KonanStandaloneTest) &&
+    def platformLibsTasks = targetList.collect { ":${it}PlatformLibs" } + ":distPlatformLibs"
+    dependsOn(tasksOf(KonanTest) { task ->
         task.getDependsOn().every { !platformLibsTasks.contains(it) } &&
         task.name != "library_mismatch" // This test requires the wasm32 stdlib which is unavailable during a sanity run.
     })
-    dependsOn(tasksOf(KonanTest.class, { it instanceof KonanGTest }))
 }
 
 // Collect reports in one json.
@@ -410,7 +406,8 @@ task run_external () {
     createTestTasks(externalTestsDir, RunExternalTestGroup) { }
 
     // Set up dependencies.
-    dependsOn(tasksOf(OldKonanTest.class, { it instanceof RunExternalTestGroup || it instanceof KonanGTest }))
+    dependsOn(tasksOf(RunExternalTestGroup) {})
+    dependsOn("stdlibTest")
 }
 
 task daily() {


### PR DESCRIPTION
* Fix platformLibs deps: as soon as we dependencies for platform libs are being as as a string dependency like `:distPlatforLibs`, the filter should also contain `:` symbol.
* Cleanup and simplify other dependencies on KonanTest tasks.