### PR TITLE
Support suppressed exceptions

### DIFF
--- a/backend.native/tests/stdlib_external/utils.kt
+++ b/backend.native/tests/stdlib_external/utils.kt
@@ -27,3 +27,5 @@ actual fun testOnJs(action: () -> Unit) {}
 
 
 public actual val isFloat32RangeEnforced: Boolean get() = true
+
+public actual val supportsSuppressedExceptions: Boolean get() = true

--- a/runtime/src/main/kotlin/kotlin/Throwable.kt
+++ b/runtime/src/main/kotlin/kotlin/Throwable.kt
@@ -27,7 +27,7 @@ public open class Throwable(open val message: String?, open val cause: Throwable
     constructor() : this(null, null)
 
     @get:ExportForCppRuntime("Kotlin_Throwable_getStackTrace")
-    private val stackTrace = getCurrentStackTrace()
+    private val stackTrace: NativePtrArray = getCurrentStackTrace()
 
     private val stackTraceStrings: Array<String> by lazy {
         getStackTraceStrings(stackTrace).freeze()
@@ -45,40 +45,83 @@ public open class Throwable(open val message: String?, open val cause: Throwable
     /**
      * Prints the [detailed description][Throwable.stackTraceToString] of this throwable to the standard output.
      */
-    public fun printStackTrace(): Unit = dumpStackTrace("", "", { println(it) }, mutableSetOf())
+    public fun printStackTrace(): Unit = ExceptionTraceBuilder(this).print()
 
-    internal fun dumpStackTrace(): String = buildString {
-        dumpStackTrace("", "", { appendln(it) }, mutableSetOf())
-    }
+    internal fun dumpStackTrace(): String = ExceptionTraceBuilder(this).build()
 
-    private fun Throwable.dumpStackTrace(indent: String, qualifier: String, writeln: (String) -> Unit, visited: MutableSet<Throwable>) {
-        this.dumpSelfTrace(indent, qualifier, writeln, visited) || return
+    private class ExceptionTraceBuilder(private val top: Throwable) {
+        private val target = StringBuilder()
+        private var printOut = false
+        private val visited = mutableSetOf<Throwable>()
 
-        var cause = this.cause
-        while (cause != null) {
-            // TODO: should skip common stack frames
-            cause.dumpSelfTrace(indent, "Caused by: ", writeln, visited)
-            cause = cause.cause
+        fun build(): String {
+            top.dumpFullTrace("", "")
+            return target.toString()
         }
-    }
 
-    private fun Throwable.dumpSelfTrace(indent: String, qualifier: String, writeln: (String) -> Unit, visited: MutableSet<Throwable>): Boolean {
-        if (!visited.add(this)) {
-            writeln(indent + qualifier + "[CIRCULAR REFERENCE, SEE ABOVE: $this]")
-            return false
+        fun print() {
+            printOut = true
+            top.dumpFullTrace("", "")
         }
-        writeln(indent + qualifier + this.toString())
-        for (element in stackTraceStrings) {
-            writeln("$indent\tat $element")
-        }
-        val suppressed = suppressedExceptionsList
-        if (!suppressed.isNullOrEmpty()) {
-            val suppressedIndent = indent + '\t'
-            for (s in suppressed) {
-                s.dumpStackTrace(suppressedIndent, "Suppressed: ", writeln, visited)
+
+        private fun StringBuilder.endln() {
+            if (printOut) {
+                println(this)
+                clear()
+            } else {
+                appendln()
             }
         }
-        return true
+
+        private fun Throwable.dumpFullTrace(indent: String, qualifier: String) {
+            this.dumpSelfTrace(indent, qualifier) || return
+
+            var cause = this.cause
+            while (cause != null) {
+                cause.dumpSelfTrace(indent, "Caused by: ")
+                cause = cause.cause
+            }
+        }
+
+        private fun Throwable.dumpSelfTrace(indent: String, qualifier: String): Boolean {
+            if (!visited.add(this)) {
+                target.append(indent).append(qualifier).append("[CIRCULAR REFERENCE, SEE ABOVE: ").append(this).append("]").endln()
+                return false
+            }
+            target.append(indent).append(qualifier).append(this).endln()
+            // leave 1 common frame to ease matching with the top exception stack
+            val commonFrames = (commonStackFrames() - 1).coerceAtLeast(0)
+            for (frameIndex in 0 until stackTraceStrings.size - commonFrames) {
+                val element = stackTraceStrings[frameIndex]
+                target.append(indent).append("    at ").append(element).endln()
+            }
+            if (commonFrames > 0) {
+                target.append(indent).append("    ... and ").append(commonFrames).append(" more common stack frames skipped").endln()
+            }
+            val suppressed = suppressedExceptionsList
+            if (!suppressed.isNullOrEmpty()) {
+                val suppressedIndent = indent + "    "
+                for (s in suppressed) {
+                    s.dumpFullTrace(suppressedIndent, "Suppressed: ")
+                }
+            }
+            return true
+        }
+
+        private fun Throwable.commonStackFrames(): Int {
+            if (top === this) return 0
+            val topStack = top.stackTrace
+            val topSize = topStack.size
+            val thisStack = this.stackTrace
+            val thisSize = thisStack.size
+            val maxSize = minOf(topSize, thisSize)
+            var frame = 0
+            while (frame < maxSize) {
+                if (thisStack[thisSize - 1 - frame] != topStack[topSize - 1 - frame]) break
+                frame++
+            }
+            return frame
+        }
     }
 
 

--- a/runtime/src/main/kotlin/kotlin/Throwable.kt
+++ b/runtime/src/main/kotlin/kotlin/Throwable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -156,6 +156,14 @@ private external fun getStackTraceStrings(stackTrace: NativePtrArray): Array<Str
  */
 @SinceKotlin("1.4")
 public actual fun Throwable.stackTraceToString(): String = dumpStackTrace()
+
+/**
+ * Prints the [detailed description][Throwable.stackTraceToString] of this throwable to the standard output.
+ */
+@SinceKotlin("1.4")
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+@kotlin.internal.InlineOnly
+public actual inline fun Throwable.printStackTrace(): Unit = printStackTrace()
 
 /**
  * Adds the specified exception to the list of exceptions that were

--- a/runtime/src/main/kotlin/kotlin/Throwable.kt
+++ b/runtime/src/main/kotlin/kotlin/Throwable.kt
@@ -43,34 +43,45 @@ public open class Throwable(open val message: String?, open val cause: Throwable
             (0 until stackTrace.size).map { index -> stackTrace[index].toLong() }
 
     /**
-     * Prints the stack trace of this throwable to the standard output.
+     * Prints the [detailed description][Throwable.stackTraceToString] of this throwable to the standard output.
      */
-    public fun printStackTrace(): Unit = dumpStackTrace { println(it) }
+    public fun printStackTrace(): Unit = dumpStackTrace("", "") { println(it) }
 
     internal fun dumpStackTrace(): String = buildString {
-        dumpStackTrace { appendln(it) }
+        dumpStackTrace("", "") { appendln(it) }
     }
 
-    private inline fun writeStackTraceElements(throwable: Throwable, writeln: (String) -> Unit) {
-        for (element in throwable.stackTraceStrings) {
-            writeln("        at $element")
-        }
-    }
-
-    private inline fun dumpStackTrace(crossinline writeln: (String) -> Unit) {
-        writeln(this@Throwable.toString())
-
-        writeStackTraceElements(this, writeln)
+    private fun Throwable.dumpStackTrace(indent: String, qualifier: String, writeln: (String) -> Unit) {
+        this.dumpSelfTrace(indent, qualifier, writeln)
 
         var cause = this.cause
         while (cause != null) {
             // TODO: should skip common stack frames
-            writeln("Caused by: $cause")
-            writeStackTraceElements(cause, writeln)
+            cause.dumpSelfTrace(indent, "Caused by: ", writeln)
             cause = cause.cause
         }
     }
 
+    private fun Throwable.dumpSelfTrace(indent: String, qualifier: String, writeln: (String) -> Unit) {
+        writeln(indent + qualifier + this.toString())
+        for (element in stackTraceStrings) {
+            writeln("$indent\tat $element")
+        }
+        val suppressed = suppressedExceptionsList
+        if (!suppressed.isNullOrEmpty()) {
+            val suppressedIndent = indent + '\t'
+            for (s in suppressed) {
+                s.dumpStackTrace(suppressedIndent, "Suppressed: ", writeln)
+            }
+        }
+    }
+
+
+    /**
+     * Returns the short description of this throwable consisting of
+     * the exception class name (fully qualified if possible)
+     * followed by the exception message if it is not null.
+     */
     public override fun toString(): String {
         val kClass = this::class
         val s = kClass.qualifiedName ?: kClass.simpleName ?: "Throwable"
@@ -86,6 +97,17 @@ private external fun getCurrentStackTrace(): NativePtrArray
 @SymbolName("Kotlin_getStackTraceStrings")
 private external fun getStackTraceStrings(stackTrace: NativePtrArray): Array<String>
 
+/**
+ * Returns the detailed description of this throwable with its stack trace.
+ *
+ * The detailed description includes:
+ * - the short description (see [Throwable.toString]) of this throwable;
+ * - the complete stack trace;
+ * - detailed descriptions of the exceptions that were [suppressed][suppressedExceptions] in order to deliver this exception;
+ * - the detailed description of each throwable in the [Throwable.cause] chain.
+ */
+@SinceKotlin("1.4")
+public actual fun Throwable.stackTraceToString(): String = dumpStackTrace()
 
 /**
  * Adds the specified exception to the list of exceptions that were


### PR DESCRIPTION
This PR introduces implementations for the following common API:
- `Throwable.addSuppressed(Throwable)`
- `Throwable.suppressedExceptions: List<Throwable>`
- `Throwable.stackTraceToString()`
- makes `printStackTrace` common
https://youtrack.jetbrains.com/issue/KT-35013
https://youtrack.jetbrains.com/issue/KT-37603
https://youtrack.jetbrains.com/issue/KT-38044

Also it refactors stack trace rendering in order to:
- add suppressed exceptions support
- omit common stackframes of causes and suppressed exceptions
- reuse the single stringbuilder for all string concatenations during the exception stacktrace rendering or printout.

Common part is reviewed in https://upsource.jetbrains.com/kotlin/review/KOTLIN-CR-3982