### PR TITLE
Fix #4002

### DIFF
--- a/backend.native/tests/objcexport/expectedLazy.h
+++ b/backend.native/tests/objcexport/expectedLazy.h
@@ -191,6 +191,19 @@ __attribute__((swift_name("CoroutinesKt")))
 + (BOOL)callSuspendBridgeBridge:(KtAbstractSuspendBridge *)bridge resultHolder:(KtResultHolder<KtKotlinUnit *> *)resultHolder error:(NSError * _Nullable * _Nullable)error __attribute__((swift_name("callSuspendBridge(bridge:resultHolder:)")));
 @end;
 
+__attribute__((swift_name("GH4002ArgumentBase")))
+@interface KtGH4002ArgumentBase : KtBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("GH4002Argument")))
+@interface KtGH4002Argument : KtGH4002ArgumentBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+@end;
+
 __attribute__((objc_subclassing_restricted))
 __attribute__((swift_name("DelegateClass")))
 @interface KtDelegateClass : KtBase <KtKotlinReadWriteProperty>

--- a/backend.native/tests/objcexport/gh4002.kt
+++ b/backend.native/tests/objcexport/gh4002.kt
@@ -1,0 +1,4 @@
+package gh4002
+
+open class GH4002ArgumentBase
+class GH4002Argument : GH4002ArgumentBase()

--- a/backend.native/tests/objcexport/gh4002.swift
+++ b/backend.native/tests/objcexport/gh4002.swift
@@ -1,0 +1,26 @@
+import Kt
+
+// See https://github.com/JetBrains/kotlin-native/issues/4002
+
+class GH4002Base0 : NSObject, NSCoding {
+  required init(coder: NSCoder) { fatalError() }
+
+  func encode(with coder: NSCoder) { fatalError() }
+}
+
+class GH4002Base1<T : GH4002ArgumentBase> : GH4002Base0 {}
+
+@objc(ObjCGH4002)
+class GH4002 : GH4002Base1<GH4002Argument> {}
+
+private func test1() throws {
+    try assertEquals(actual: String(cString: class_getName(GH4002.self)), expected: "ObjCGH4002")
+}
+
+class Gh4002Tests : SimpleTestProvider {
+    override init() {
+        super.init()
+
+        test("Test1", test1)
+    }
+}

--- a/runtime/src/main/cpp/ObjCExport.mm
+++ b/runtime/src/main/cpp/ObjCExport.mm
@@ -325,6 +325,9 @@ static void initTypeAdapters() {
 }
 
 static void Kotlin_ObjCExport_initializeImpl() {
+  RuntimeCheck(Kotlin_ObjCExport_toKotlinSelector != nullptr, "unexpected initialization order");
+  RuntimeCheck(Kotlin_ObjCExport_releaseAsAssociatedObjectSelector != nullptr, "unexpected initialization order");
+
   initTypeAdapters();
 
   SEL toKotlinSelector = Kotlin_ObjCExport_toKotlinSelector;

--- a/runtime/src/objc/cpp/ObjCExportClasses.mm
+++ b/runtime/src/objc/cpp/ObjCExportClasses.mm
@@ -36,12 +36,18 @@ extern "C" id objc_autoreleaseReturnValue(id self);
 -(BOOL)_tryRetain;
 @end;
 
+static void injectToRuntime();
+
 @implementation KotlinBase {
   BackRefFromAssociatedObject refHolder;
 }
 
 -(KRef)toKotlin:(KRef*)OBJ_RESULT {
   RETURN_OBJ(refHolder.ref());
+}
+
++(void)load {
+  injectToRuntime();
 }
 
 +(void)initialize {
@@ -204,7 +210,6 @@ OBJ_GETTER(Kotlin_boxDouble, KDouble value);
 }
 @end;
 
-__attribute__((constructor))
 static void injectToRuntime() {
   RuntimeCheck(Kotlin_ObjCExport_toKotlinSelector == nullptr, "runtime injected twice");
   Kotlin_ObjCExport_toKotlinSelector = @selector(toKotlin:);


### PR DESCRIPTION
Fix ObjCExport initialization order when static initializer triggers
early KotlinBase initialization.
For example, _swift_eager_class_initialization can do this.