### PR TITLE
[kotlin compiler][update] 1.4.0-dev-4662

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -309,7 +309,8 @@ task detectJarCollision(type: CollisionDetector) {
                                                     "js.parser", "js.frontend", "js.translator", "js.dce", "metadata",
                                                     "metadata.jvm", "descriptors", "descriptors.jvm", "descriptors.runtime",
                                                     "deserialization", "util.runtime", "type-system", "cones", "resolve",
-                                                    "tree", "psi2fir", "fir2ir", "java", "kotlin-build-common", "lightTree"])
+                                                    "tree", "psi2fir", "fir2ir", "java", "kotlin-build-common", "lightTree",
+                                                    "jvm", "checkers"])
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-1818
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1818,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4271,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-4271
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4271,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-4271
-kotlinStdlibTestsVersion=1.4.0-dev-4271
-testKotlinCompilerVersion=1.4.0-dev-4271
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4662,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-4662
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4662,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-4662
+kotlinStdlibTestsVersion=1.4.0-dev-4662
+testKotlinCompilerVersion=1.4.0-dev-4662
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* f82e2db65dc - (tag: build-1.4.0-dev-4662) Fix effective search scope for find references (vor 22 Stunden) <Vladimir Dolzhenko>
* 6ce8d661ad9 - (tag: build-1.4.0-dev-4651, origin/rr/demiurg906/fir-rr) [FIR] Add nullability to ILT. #KT-37639 Fixed (vor 2 Tagen) <Dmitriy Novozhilov>
* 006e1f65280 - [FIR-TEST] Add test for KT-37638 (vor 2 Tagen) <Dmitriy Novozhilov>
* 5f9f01fe4ea - [FIR] Implement new completion mode calculator (vor 2 Tagen) <Dmitriy Novozhilov>
* ea02855ba6c - [FIR] Fix type arguments and  substitution for flexible types (vor 2 Tagen) <Dmitriy Novozhilov>
* 7bfe7061e76 - [FIR] Add proper nullability for java enums (vor 2 Tagen) <Dmitriy Novozhilov>
* 7764492761c - (tag: build-1.4.0-dev-4637) Resolve failure with surefire on Windows agents in kotlin-java-example (KT-37654) (vor 3 Tagen) <Nikolay Krasko>
* f0dc8092559 - (tag: build-1.4.0-dev-4631) Add explicit api mode flag to top-level kotlin {} DSL block in Gradle (vor 3 Tagen) <Leonid Startsev>
* 59148cdce49 - (tag: build-1.4.0-dev-4630) [Gradle, JS] Fix extracting package json from klib (vor 3 Tagen) <Ilya Goncharov>
* 186302d84e7 - (origin/rr/mb/pr3204) JVM_IR: restore InnerClasses for objects in lambdas (vor 4 Tagen) <pyos>
| * 40a0e31be4a - [Gradle, JS] Add other devtools (vor 3 Tagen) <Ilya Goncharov>
| * 5058c396c11 - [Gradle, JS] Webpack devtool as a String (vor 3 Tagen) <Ilya Goncharov>
| * e951f1a43a7 - (tag: build-1.4.0-dev-4625) Find Usages and Go to declaration of element used via import alias (vor 3 Tagen) <Vladimir Dolzhenko>
| * ced8a926299 - (tag: build-1.4.0-dev-4613) [NI] Prefer between two complex variables one with proper lower bounds (vor 3 Tagen) <Mikhail Zarechenskiy>
| * b0254a27aa3 - (tag: build-1.4.0-dev-4611) Fix. Provide the proper K/N dependencies in leaf HMPP source sets (vor 3 Tagen) <Dmitriy Dolovov>
| * 7f2839ee105 - Fix. Don't inherit K/N dependencies in common source sets (vor 3 Tagen) <Dmitriy Dolovov>
| * 2d8bec19c0f - Minor. Simplify generation of substituted dependencies (vor 3 Tagen) <Dmitriy Dolovov>
| * d84f528a477 - (tag: build-1.4.0-dev-4596) KotlinSdkType: fix i18n for 192 (vor 3 Tagen) <Dmitry Gridin>
| * 39d019ec9d8 - (tag: build-1.4.0-dev-4594) Tests: switch ScriptChangeNotifier off in tests (vor 3 Tagen) <Natalia Selezneva>
| * dd7f10e76ed - (tag: build-1.4.0-dev-4593, origin/rr/gradle/ilgonmic/dsl-unification) [Gradle, JS] Fix after rebase (vor 3 Tagen) <Ilya Goncharov>
| * a07425e7b06 - [Gradle, JS] Fix test (vor 3 Tagen) <Ilya Goncharov>
| * f7a9afbf963 - [Gradle, JS] Remove produceExecutable from tests (vor 3 Tagen) <Ilya Goncharov>
| * 3a262c6eb87 - [Gradle, JS] Fix build for legacy browser with binaries (vor 3 Tagen) <Ilya Goncharov>
| * b25418df690 - [Gradle, JS] Correct renaming (vor 3 Tagen) <Ilya Goncharov>
| * 33992bdc861 - [Gradle, JS] Extract common interface for JsBinary (vor 3 Tagen) <Ilya Goncharov>
| * 3c83a3bd341 - [Gradle, JS] Error if used binaries.executable in both compiler type (vor 3 Tagen) <Ilya Goncharov>
| * cf6b76fdeeb - [Gradle, JS] Rename BuildVariantKind on KotlinJsBinaryType (vor 3 Tagen) <Ilya Goncharov>
| * 260015fe0bc - [Gradle, JS] Migrate from build variants on binaries (vor 3 Tagen) <Ilya Goncharov>
| * e1920110a27 - [Gradle, JS] Remove produceExecutable (vor 3 Tagen) <Ilya Goncharov>
| * 01b44802c88 - [Gradle, JS] Fix compilation after rebase (vor 3 Tagen) <Ilya Goncharov>
| * 158ad630d94 - [Gradle, JS] Fix tests (vor 3 Tagen) <Ilya Goncharov>
| * 2b4f9302dce - [Gradle, JS] Fix naming for webpack tasks (vor 3 Tagen) <Ilya Goncharov>
| * 5828f8cbf25 - [Gradle, JS] Rename KotlinBinaryContainer on KotlinTargetWithBinaries (vor 3 Tagen) <Ilya Goncharov>
| * 19d09fc4206 - [Gradle, JS] Remove redundant build variants for IR (vor 3 Tagen) <Ilya Goncharov>
| * 703ceff9a30 - [Gradle, JS] Return binaries from ir target if it exists (vor 3 Tagen) <Ilya Goncharov>
| * 2d900e22343 - [Gradle, JS] Legacy tooling work with binaries and throw error on it (vor 3 Tagen) <Ilya Goncharov>
| * 1bb6429c5c0 - [Gradle, JS] Link tasks depends on compile tasks (vor 3 Tagen) <Ilya Goncharov>
| * 0a19998ae2c - [Gradle, JS] Binaries dsl (vor 3 Tagen) <Ilya Goncharov>
| * 0c34acd09a3 - [Gradle, JS] Produce executable for ir compilation (vor 3 Tagen) <Ilya Goncharov>
| * 666b9b35454 - [Gradle, JS] Move binaries on compilation level (vor 3 Tagen) <Ilya Goncharov>
| * efb3f16ee43 - [Gradle, JS] Browser with binaries (vor 3 Tagen) <Ilya Goncharov>
| * 2fed8aa7b87 - [Gradle, JS] NodeJs on binaries (vor 3 Tagen) <Ilya Goncharov>
| * 9bff6a709f5 - [Gradle, JS] Add testExecutable for subtargets (vor 3 Tagen) <Ilya Goncharov>
| * 625e94822f7 - [Gradle, JS] Remove redundant baseName (vor 3 Tagen) <Ilya Goncharov>
| * d00c53fd387 - [Gradle, JS] Fix strict type check (vor 3 Tagen) <Ilya Goncharov>
| * e3b5a754cd2 - [Gradle, JS] Register executable tasks for binaries (vor 3 Tagen) <Ilya Goncharov>
| * 9fe0604f008 - Revert "[Gradle, JS] binaries API instead of produce*" (vor 3 Tagen) <Ilya Goncharov>
| * eab6a7d038c - [Gradle, JS] Register link tasks for binaries, not for compilations (vor 3 Tagen) <Ilya Goncharov>
| * ab218317de1 - [Gradle, JS] Fix name for binary (vor 3 Tagen) <Ilya Goncharov>
| * e518998da3a - [Gradle, JS] Remove KotlinJsIrType on BuildVariantKind (vor 3 Tagen) <Ilya Goncharov>
| * 1de720cdd0c - [Gradle, JS] Add link tasks to binaries, add test executable binary type (vor 3 Tagen) <Ilya Goncharov>
| * 99d73d4c791 - [Gradle, JS] binaries API instead of produce* (vor 3 Tagen) <Ilya Goncharov>
| * e2918bf6c8b - [Gradle, JS] binaries.executable works for JS IR (vor 3 Tagen) <Ilya Goncharov>
| * 3974300f224 - [Gradle, JS] Simplify JsBinary (vor 3 Tagen) <Ilya Goncharov>
| * 9d3234495e1 - [Gradle, JS] Add binaries for javascript (vor 3 Tagen) <Ilya Goncharov>
| * c46fa83924e - [Gradle, JS] Extract Binary Container from Native (vor 3 Tagen) <Ilya Goncharov>
| * 98365202878 - (tag: build-1.4.0-dev-4584) [FIR2IR] Generate synthetic bodies for Enum.values() and valueOf() (vor 3 Tagen) <Mikhail Glukhikh>
| * 94fe79578e2 - [FIR2IR] Generate unconditional branch in exhaustive whens (vor 3 Tagen) <Mikhail Glukhikh>
| * 41f5a56cb35 - (tag: build-1.4.0-dev-4581) [Gradle, JS] Fix delegates (vor 3 Tagen) <Ilya Goncharov>
| * 6605199ead9 - [Gradle, JS] Back field to delegate (vor 3 Tagen) <Ilya Goncharov>
| * a533fe26d7d - [Gradle, JS] Non-nullable properties in KotlinWebpack with delegate (vor 3 Tagen) <Ilya Goncharov>
| * 831806fe2fd - (tag: build-1.4.0-dev-4577) Revert "Optimize MutableDiagnosticsWithSuppression" (vor 3 Tagen) <Ilya Chernikov>
| * 4f042cbea5d - (tag: build-1.4.0-dev-4572) [IDE KJS] Recognize and load correctly Kotlin/JS klibs in IDE (vor 3 Tagen) <Zalim Bashorov>
| * d07436c831f - [IDE KJS] Move JsResolverForModuleFactory to proper place (vor 3 Tagen) <Zalim Bashorov>
| * eaac5bdac42 - [IDE KN] Treat klib as Kotlin/Native library iff manifest contains builtins_platform==NATIVE (vor 3 Tagen) <Zalim Bashorov>
| * d247dd21de0 - (tag: build-1.4.0-dev-4570) Added missed :compiler:fir:checkers dependency for kotlin-plugin (vor 3 Tagen) <Vladimir Dolzhenko>
| * c4b8e940619 - (tag: build-1.4.0-dev-4567) [FIR] Add utils for traversing control flow graph (vor 3 Tagen) <Dmitriy Novozhilov>
| * b88cb3f8495 - [FIR] Add visitors for control flow graph (vor 3 Tagen) <Dmitriy Novozhilov>
| * e4588c3decd - [FIR] Add diagnostic component for control flow analysis (vor 3 Tagen) <Dmitriy Novozhilov>
| * 9535df5e2ef - [FIR] Add owner to ControlFlowGraph (vor 3 Tagen) <Dmitriy Novozhilov>
| * 496489cdf49 - [FIR] Introduce CheckerContext for call and declaration checkers (vor 3 Tagen) <Dmitriy Novozhilov>
| * 1c87601486a - [FIR] Split ImplicitReceiverStack to mutable and immutable parts (vor 3 Tagen) <Dmitriy Novozhilov>
| * 3b892fe31ed - (tag: build-1.4.0-dev-4559) NI: exclude reporting of an unsafe call diagnostic for implicit invoke after safe call in cases when `invoke` has type parameters (make NI and OI consistent) (vor 4 Tagen) <Victor Petukhov>
| * 8b330193aca - (tag: build-1.4.0-dev-4554) Minor. Throw proper exception in test framework on directive processing (vor 4 Tagen) <Mikhail Bogdanov>
| * 3f878990147 - Switch converter test to new directive scheme (vor 4 Tagen) <Mikhail Bogdanov>
| * d793fea8d28 - Use multimap for directives (vor 4 Tagen) <Mikhail Bogdanov>
| * 420dd0d4405 - Extract directive map to separate class (vor 4 Tagen) <Mikhail Bogdanov>
| * bc214868efd - Minor. Clean tests (vor 4 Tagen) <Mikhail Bogdanov>
| * ab7e71fd68e - Support per files test directives (vor 4 Tagen) <Mikhael Bogdanov>
| * 34547b4e27a - Minor. Remove redundant getters (vor 4 Tagen) <Mikhael Bogdanov>
| * 507b00ee77a - (tag: build-1.4.0-dev-4552) 201: Fix kotlin-compiler proguard (vor 4 Tagen) <Vyacheslav Gerasimov>
|/  
* be87d5fab58 - (tag: build-1.4.0-dev-4543) JVM_IR: Serialization: do not mess with return types of call expressions (vor 4 Tagen) <Ilmir Usmanov>
* d06c87207c1 - (tag: build-1.4.0-dev-4541) Dump class structure in a test that has an object in a lambda (vor 4 Tagen) <pyos>
* e0a5ab71460 - Do not regenerate objects if all captured lambdas are noinline (vor 4 Tagen) <pyos>
* 54e725668f4 - Ignore reified type parameters when regenerating objects from lambdas (vor 4 Tagen) <pyos>
* 1fd3ac046aa - (tag: build-1.4.0-dev-4536) [FIR] Throw exception if PSI type in ConeDiagnostic helper is improper (vor 4 Tagen) <Mikhail Glukhikh>
* 50a9313a5e8 - [FIR] Support some approximation of effective visibility (vor 4 Tagen) <Mikhail Glukhikh>
* cb3a31af6ee - (tag: build-1.4.0-dev-4514) UAST: implement KotlinUastCodeGenerationPlugin for 201 (vor 4 Tagen) <Dmitry Gridin>
* 81385b73b7d - (tag: build-1.4.0-dev-4513) NI: limit cache size for approximated types during incorporation (vor 4 Tagen) <Victor Petukhov>
* ea59ea8aa2d - NI: avoid creating useless captured types during incorporation (vor 4 Tagen) <Victor Petukhov>
* e34dd27a344 - (tag: build-1.4.0-dev-4508) KT-37240 Use extension "extension" (vor 4 Tagen) <Victor Turansky>
* 90c993334f2 - KT-37240 Deterministic order for webpack config patches (vor 4 Tagen) <Victor Turansky>
* 8ffb63ca6b4 - (tag: build-1.4.0-dev-4503) Ignore test that relies on hashCode implementation (vor 4 Tagen) <Pavel Punegov>
* 2352b1fec5d - (tag: build-1.4.0-dev-4499) JVM_IR: use fresh source map when generating lambda body for inline. (vor 4 Tagen) <Jinseong Jeon>
* 72b80ef1586 - (tag: build-1.4.0-dev-4498) Detect inline cycles faster (vor 4 Tagen) <pyos>
* 39372c06cf8 - (tag: build-1.4.0-dev-4496) [FIR] Move all checkers and theirs infrastructure to separate module (vor 4 Tagen) <Dmitriy Novozhilov>
* cc07ae96b34 - [FIR-TEST] Move analysis tests to separate module (vor 4 Tagen) <Dmitriy Novozhilov>
* 3a479d5d160 - [FIR-TEST] Move FIR ide tests to separate module (vor 4 Tagen) <Dmitriy Novozhilov>
* bcefa68df01 - (tag: build-1.4.0-dev-4485) Always checkout/checkin text files with lf endings (vor 5 Tagen) <Vyacheslav Gerasimov>
* 7dc24a13e49 - Build: Make ProGuard task cacheable (vor 5 Tagen) <Vyacheslav Gerasimov>
* 03613d47087 - (tag: build-1.4.0-dev-4481) JVM_IR: preserve old backend's logic for special mutable collection class stub methods (vor 5 Tagen) <Jiaxiang Chen>
* da1009eb2c9 - (tag: build-1.4.0-dev-4477) Avoid type approximation on generating equality constraints (vor 5 Tagen) <Ilya Chernikov>
* 950ab015965 - Avoid substitution and type approximation for simple calls (vor 5 Tagen) <Ilya Chernikov>
* e1ae81e0a10 - (tag: build-1.4.0-dev-4476) Run inspections after completion of general highlight pass in 201 (vor 5 Tagen) <Vladimir Dolzhenko>
* 3cdcdbf6a88 - Register Kotlin specific highlight passes via highlightingPassFactory in 193+ (vor 5 Tagen) <Vladimir Dolzhenko>
* 2e20cdf2e62 - Update to 201.6487-EAP-CANDIDATE-SNAPSHOT (vor 5 Tagen) <Vladimir Dolzhenko>
* d0319d6b31e - (tag: build-1.4.0-dev-4464) [FIR2IR] Use FirSourceElement.elementType instead of PSI (vor 5 Tagen) <Mikhail Glukhikh>
* 26a63a45ee1 - Introduce FirSourceElement.elementType (vor 5 Tagen) <Mikhail Glukhikh>
* 25ab863af76 - Add FlyweightCapableTreeStructure to FirLightSourceElement & use it (vor 5 Tagen) <Mikhail Glukhikh>
* 59fb96503c3 - Introduce FirModifierList (vor 5 Tagen) <Mikhail Glukhikh>
* 6739135d173 - [FIR2IR] Add pre-caching of built-in classes to avoid their duplications (vor 5 Tagen) <Mikhail Glukhikh>
* 0bf4cac6010 - [FIR2IR] Unmute additional black box test after rebase (vor 5 Tagen) <Mikhail Glukhikh>
* 95108a1bce0 - [FIR2IR] Enable type parameter index >= 0 requirement (vor 5 Tagen) <Mikhail Glukhikh>
* 0f0e5e603d1 - [FIR2IR] Use IR built-in types, their symbols & constructors directly (vor 5 Tagen) <Mikhail Glukhikh>
* 90f6af24f40 - [FIR2IR] Remove unnecessary isBound checks in call generator (vor 5 Tagen) <Mikhail Glukhikh>
* 1036d8a35a8 - [FIR] Provide dispatch receiver for 'field' synthetic variable (vor 5 Tagen) <Mikhail Glukhikh>
* 049bc6a4310 - [FIR2IR] Minor: extract variable (vor 5 Tagen) <Mikhail Glukhikh>
* 51c83e5f62b - [FIR2IR] Move delegating constructor call to body start (vor 5 Tagen) <Mikhail Glukhikh>
* 10c2aa16575 - [FIR2IR] Set origin properly for set field / variable (vor 5 Tagen) <Mikhail Glukhikh>
* c0f8be5d4e6 - [FIR2IR] Generate setter call for assignments, if any (vor 5 Tagen) <Mikhail Glukhikh>
* 53cb9035b63 - [FIR2IR] Use backing field to read property if no getter (vor 5 Tagen) <Mikhail Glukhikh>
* b6fdd6197aa - [FIR2IR] Extract CallGenerator from the main visitor (vor 5 Tagen) <Mikhail Glukhikh>
* 5357e7b3abc - [FIR2IR] Extract ClassMemberGenerator from the main visitor (vor 5 Tagen) <Mikhail Glukhikh>
* 63aa5191da9 - Move Fir2IrFakeOverrideGenerator to 'backend.generators' package (vor 5 Tagen) <Mikhail Glukhikh>
* 8f27129c36e - [FIR2IR] Introduce & use components storage (vor 5 Tagen) <Mikhail Glukhikh>
* 175145ce4e4 - [FIR2IR] Extract separate classifier storage from declaration storage (vor 5 Tagen) <Mikhail Glukhikh>
* 95b77f63860 - (tag: build-1.4.0-dev-4462) AddJvmOverloadsIntention: disable for annotation classes (vor 5 Tagen) <Dmitry Gridin>
* 084276ef1f0 - (tag: build-1.4.0-dev-4459) Suppress suggested refactoring for unused private and local declarations (vor 5 Tagen) <Valentin Kipyatkov>
* e95d1c1224e - Do not suggest to update usages on renaming duplicated method or property (vor 5 Tagen) <Valentin Kipyatkov>
* 395ba7d008d - Using new API (vor 5 Tagen) <Valentin Kipyatkov>
* 7a3f6f53122 - (tag: build-1.4.0-dev-4457, tag: build-1.4.0-dev-4455) Formatter: fix continuation indent in call chain (vor 5 Tagen) <Dmitry Gridin>
* 2c065033114 - (tag: build-1.4.0-dev-4450) JVM_IR: partially fix inline methods using captured crossinline lambdas (vor 5 Tagen) <pyos>
* dd27b3d4f12 - (tag: build-1.4.0-dev-4447) KT-36973 Keep private default interface members private (vor 5 Tagen) <Dmitry Petrov>
* 1c24a97b9e8 - (tag: build-1.4.0-dev-4442) KT-36972 Don't create proxies for companion @JvmStatic $default in host (vor 5 Tagen) <Dmitry Petrov>
* 897c48f97ea - (tag: build-1.4.0-dev-4438, tag: build-1.4.0-dev-4436) Add more robust check for plugin application order (KT-37245) (vor 5 Tagen) <Yan Zhulanow>
* 0247a300d1e - (tag: build-1.4.0-dev-4435, origin/rr/Alefas/tests) Experimental features EP + completion.stats optional dependency (vor 5 Tagen) <Alexander Podkhalyuzin>
* f85022532d0 - (tag: build-1.4.0-dev-4430, origin/rr/kishmakov/xcworkspace) [FIR] Rename `FirArraySetCall` to `FirAugmentedArraySetCall` (vor 5 Tagen) <Dmitriy Novozhilov>
* 2b986194fb1 - [FIR] Add desugaring of array assignments and resolve of it (vor 5 Tagen) <Dmitriy Novozhilov>
* 26f919df032 - (tag: build-1.4.0-dev-4425) Fix some nullable usages of not-null type parameters (KT-36770) (vor 5 Tagen) <Mikhail Glukhikh>
* a2e7b6d20ef - (tag: build-1.4.0-dev-4424) FIR: Do not add "field" to accessor of a property with receiver (vor 5 Tagen) <Denis Zharkov>
* ade18d144a0 - (tag: build-1.4.0-dev-4415) KT-36810 Implement javaPrimitiveType intrinsic in JVM_IR (vor 5 Tagen) <Dmitry Petrov>
* 2851fab281e - KT-36809 Implement javaObjectType intrinsic in JVM_IR (vor 5 Tagen) <Dmitry Petrov>
* aecd12fa125 - (tag: build-1.4.0-dev-4410) Minor. Regenerate tests (vor 6 Tagen) <Mikhail Bogdanov>
* 2e542da91d3 - (tag: build-1.4.0-dev-4395) JVM_IR: fix accesses from crossinline lambdas in other packages again (vor 6 Tagen) <pyos>
* 7a1eb9214d0 - (tag: build-1.4.0-dev-4386) FIR: Fix resolution for lambda returning resolved qualifier (vor 6 Tagen) <Denis Zharkov>
* e1312a752a1 - FIR: Allow a field override another field with the same name (vor 6 Tagen) <Denis Zharkov>
* 7203499b7aa - FIR: Fix visibility check for protected within a companion (vor 6 Tagen) <Denis Zharkov>
* 170978a4f1b - FIR: Move fixed tests from problems directory to common (vor 6 Tagen) <Denis Zharkov>
* a1b0b155218 - FIR: Add test for KT-37478 (vor 6 Tagen) <Denis Zharkov>
* b71b0fa32c4 - (tag: build-1.4.0-dev-4379) Update stepping tests to inspect source name, instead of method info. (vor 6 Tagen) <Jinseong Jeon>
* 5dc1651a448 - JVM: missed line number for return expression. (vor 6 Tagen) <Jinseong Jeon>
* c29f76580c7 - (tag: build-1.4.0-dev-4373, tag: build-1.4.0-dev-4367) Don't show modal progress dialog on calculate method parameter hint info (vor 6 Tagen) <Vladimir Dolzhenko>
* 6809f4439c1 - (tag: build-1.4.0-dev-4361) Fix range-based 'for' loop with 'continue' in range bounds (vor 6 Tagen) <Dmitry Petrov>
* d5b65abc5da - KT-37505 Add box test (vor 6 Tagen) <Dmitry Petrov>
* 3dc898b8ca7 - (tag: build-1.4.0-dev-4359) Fix for change signature refactoring type resolve (vor 6 Tagen) <Igor Yakovlev>
* 64bcc6d54f4 - KotlinChangeSignature refactoring remove deprecated usage + refactoring (vor 6 Tagen) <Igor Yakovlev>
* 309ceef49a6 - (tag: build-1.4.0-dev-4354) i18n: remove template name from bundle (vor 6 Tagen) <Dmitry Gridin>
* eb68a0de478 - (tag: build-1.4.0-dev-4347) Android import: simplify the check for android plugin version (vor 6 Tagen) <Vyacheslav Karpukhin>
* 45cba7b4081 - (tag: build-1.4.0-dev-4345) Update to 201.6251.22-EAP-SNAPSHOT (vor 6 Tagen) <Nikolay Krasko>
* f226d855e17 - (tag: build-1.4.0-dev-4344, origin/fir/semoro/fixOldFe) Fix NI flag in modularized test for old frontend (vor 7 Tagen) <simon.ogorodnik>
* 4844a907887 - [FIR] KT-37453: Type argument mapping (vor 7 Tagen) <simon.ogorodnik>
* 6a1e35389c8 - (tag: build-1.4.0-dev-4338) JVM IR: Mangle interface implementation methods in inline classes (vor 7 Tagen) <Steven Schäfer>
* d21be3b6657 - (tag: build-1.4.0-dev-4330) Revert back fetchAnalysisResultsForElement (vor 7 Tagen) <Vladimir Dolzhenko>
* af1e3fb10d5 - (tag: build-1.4.0-dev-4328) UL properties supports JvmSynthetic annotation for get: and set: modifiers (vor 7 Tagen) <Igor Yakovlev>
* 0e26194a279 - (tag: build-1.4.0-dev-4321, origin/rr/vladimiri/coroutine-debugger-verify) [FIR] Test for KT-37431 (vor 7 Tagen) <anastasiia.spaseeva>
* 1b479c49a80 - (tag: build-1.4.0-dev-4320) [FIR] Fix exhaustiveness checking for conditions with equals to object (vor 7 Tagen) <Dmitriy Novozhilov>
* 3765a1efafa - [FIR] Add `values` and `valueOf` to deserialized enums (vor 7 Tagen) <Dmitriy Novozhilov>
* caec5fe3521 - [FIR-TEST] Add test for KT-37478 (vor 7 Tagen) <Dmitriy Novozhilov>
* 37aa234bb76 - [FIR] Fix transform of subject of when expressions with subject variable (vor 7 Tagen) <Dmitriy Novozhilov>
* 820da6edaa3 - [FIR] Don't set up expected type for function body (vor 7 Tagen) <Dmitriy Novozhilov>
* 813003e12ef - [FIR] Approximate statements with ILT without expected type (vor 7 Tagen) <Dmitriy Novozhilov>
* 698f78570d9 - [FIR] Add ability to pass `data=null` to transformInplace with data producer (vor 7 Tagen) <Dmitriy Novozhilov>
* fe95e37c88b - [FIR] Add equality to Unit constraint for lambda without return expressions (vor 7 Tagen) <Dmitriy Novozhilov>
* fc2e7da2a92 - [FIR] Don't pass flow from inplace lambdas while resolve delegates (vor 7 Tagen) <Dmitriy Novozhilov>
* e90d86e1b47 - [FIR] Add cfg for delegating constructor calls (vor 7 Tagen) <Dmitriy Novozhilov>
* 83257d00b9b - [FIR] Pass flow from postponed lambdas to closest completed call (vor 7 Tagen) <Dmitriy Novozhilov>
* 3a5c30a581e - [FIR] Remove `ortho` splines mode from CFG dump (vor 7 Tagen) <Dmitriy Novozhilov>
* f83cedd244e - [FIR] Don't render call arguments in cfg dump (vor 7 Tagen) <Dmitriy Novozhilov>
* 8e295de5938 - (tag: build-1.4.0-dev-4318) [KLIB] Make sure float/double bits have fixed representation for NaN. (vor 7 Tagen) <Roman Artemev>
* 5fb46e05da4 - (tag: build-1.4.0-dev-4315) K/N in IDE: Remove empty argument in run task in the default K/N template in IDEA (vor 7 Tagen) <Dmitriy Dolovov>
* 94df78aea0a - K/N in IDE: Drop support of "konan.native" package (vor 7 Tagen) <Dmitriy Dolovov>
* f3f971005dc - [Commonizer] GC obsolete & unused commonized libraries to free disk space (vor 7 Tagen) <Dmitriy Dolovov>
* 75f1fb0237b - (tag: build-1.4.0-dev-4312) EqualsOrHashCodeInspection: update bundle for 201 (vor 7 Tagen) <Dmitry Gridin>
* d30844310a6 - i18n: remove `html` wrap from `.properties` (vor 7 Tagen) <Dmitry Gridin>
* f12ed33a70b - AbstractKotlinBundle: introduce `withHtml` (vor 7 Tagen) <Dmitry Gridin>
* c7a21a094f9 - i18n: fix findUsages for 201 (vor 7 Tagen) <Dmitry Gridin>
* 49cdea7fdb9 - i18n: fix findUsages dialogs (vor 7 Tagen) <Dmitry Gridin>
* 3c8ea8c08da - i18n: fix compilation for 191 (vor 7 Tagen) <Dmitry Gridin>
* 3c812c1ad14 - i18n: update bundle for `IdeErrorMessages` (vor 7 Tagen) <Dmitry Gridin>
* 01f98979b7f - i18n: update bundle for *.form (vor 7 Tagen) <Dmitry Gridin>
* 7886cb4c448 - i18n: fix tests (vor 7 Tagen) <Dmitry Gridin>
* 036bc3b9405 - i18n: update bundle for idea (vor 7 Tagen) <Dmitry Gridin>
* 1b9bb77b2fc - i18n: fix tests (vor 7 Tagen) <Dmitry Gridin>
* f66e985821e - i18n: update bundle for jvm-debugger (vor 7 Tagen) <Dmitry Gridin>
* d348d4418e5 - i18n: add bundle for idea-repl (vor 7 Tagen) <Dmitry Gridin>
* 99a7764b047 - i18n: add bundle for idea-live-templates (vor 7 Tagen) <Dmitry Gridin>
* 3e76678726d - i18n: update bundle for idea-jvm (vor 7 Tagen) <Dmitry Gridin>
* d099723ea59 - i18n: update bundle for idea-gradle (vor 7 Tagen) <Dmitry Gridin>
* 22c94026c68 - i18n: add bundle for idea-completion (vor 7 Tagen) <Dmitry Gridin>
* 4a7160b51aa - i18n: update bundle for idea-analysis (vor 7 Tagen) <Dmitry Gridin>
* 5bd44b73b22 - i18n: fix bundle location (vor 7 Tagen) <Dmitry Gridin>
* 2518b8053b3 - i18n: add @NonNls to NodeIndentStrategy (vor 7 Tagen) <Dmitry Gridin>
* c1dc72e6770 - i18n: add bundle for idea/intentions (vor 7 Tagen) <Dmitry Gridin>
* a3defb300a7 - i18n: fix tests (vor 7 Tagen) <Dmitry Gridin>
* f1cdf147d56 - i18n: fix compilation (vor 7 Tagen) <Dmitry Gridin>
* e42bec8ea21 - i18n: fix text (vor 7 Tagen) <Dmitry Gridin>
* 7507d62ec3f - i18n: replace `KotlinBundleBase` with `AbstractKotlinBundle` (vor 7 Tagen) <Dmitry Gridin>
* 0a3e577b6cf - i18n: add bundle for idea/inspections (vor 7 Tagen) <Dmitry Gridin>
* 76ac4ffb96c - i18n: add bundle for idea/inspections/* (vor 7 Tagen) <Dmitry Gridin>
* 3035477e0c8 - i18n: add bundle for idea/codeInsight (vor 7 Tagen) <Dmitry Gridin>
* 4eb50ed17cd - i18n: add bundle for idea/actions (vor 7 Tagen) <Dmitry Gridin>
* 1af85533603 - i18n: add bundle for idea/quickfix (vor 7 Tagen) <Dmitry Gridin>
* ae96a68bd1d - i18n: createByPattern: add `@NonNls` to parameters (vor 7 Tagen) <Dmitry Gridin>
* 2b8373447ae - i18n: KtPsiFactory: add `@NonNls` to parameters (vor 7 Tagen) <Dmitry Gridin>
* 07861fdc6fe - i18n: add bundle for idea/quickfix/* (vor 7 Tagen) <Dmitry Gridin>
* a6269004c56 - i18n: add bundle for idea/refactoring/ui (vor 7 Tagen) <Dmitry Gridin>
* a589d8869b4 - i18n: add bundle for idea/refactoring/safeDelete (vor 7 Tagen) <Dmitry Gridin>
* afeff3a6c88 - i18n: fix tests (vor 7 Tagen) <Dmitry Gridin>
* c3cbcc08427 - i18n: move all kotlin bundles to resources/messages directories (vor 7 Tagen) <Roman Golyshev>
* 1dded486f18 - i18n: fix bundle messages/testData messages where necessary (vor 7 Tagen) <Roman Golyshev>
* e1cb5613984 - i18n: add bundle for idea/refactoring/rename (vor 7 Tagen) <Roman Golyshev>
* 4fc76e25a86 - i18n: add bundle for idea/refactoring/pushDown (vor 7 Tagen) <Roman Golyshev>
* 37e1333fe17 - i18n: add bundle for idea/refactoring/pullUp (vor 7 Tagen) <Roman Golyshev>
* 73de63cefcc - i18n: add bundle for idea/refactoring/move (vor 7 Tagen) <Roman Golyshev>
* 93493bdc094 - i18n: add bundle for idea/refactoring/memberInfo (vor 7 Tagen) <Roman Golyshev>
* 1c5b371249e - i18n: fix compilation (vor 7 Tagen) <Dmitry Gridin>
* 94d10c7c632 - i18n: move to KotlinBundle (vor 7 Tagen) <Dmitry Gridin>
* bb6bdf0b697 - i18n: add bundle for idea/refactoring/introduce (vor 7 Tagen) <Dmitry Gridin>
* 7564c91eddb - i18n: add bundle for idea/refactoring/inline (vor 7 Tagen) <Dmitry Gridin>
* 4d8375b571a - i18n: add bundle for idea/refactoring/cutPaste (vor 7 Tagen) <Dmitry Gridin>
* a1d7bd461d2 - i18n: add bundle for idea/refactoring/copy (vor 7 Tagen) <Dmitry Gridin>
* 7e5c5927f03 - i18n: add bundle for idea/refactoring/changeSignature (vor 7 Tagen) <Dmitry Gridin>
* 8de7d303a04 - i18n: add @NotNls to bundles (vor 7 Tagen) <Dmitry Gridin>
* 354c9c913a1 - i18n: add bundle for idea/reporter (vor 7 Tagen) <Dmitry Gridin>
* e778a3fe343 - i18n: add bundle for idea/roots (vor 7 Tagen) <Dmitry Gridin>
* 947cb6c5c8c - i18n: add bundle for idea/script (vor 7 Tagen) <Dmitry Gridin>
* 7009aa6ecb5 - i18n: add bundle for idea/slicer (vor 7 Tagen) <Dmitry Gridin>
* a41f3ff17d3 - i18n: add bundle for idea/testIntegration (vor 7 Tagen) <Dmitry Gridin>
* 1aa48e5f26c - i18n: add bundle for idea/update (vor 7 Tagen) <Dmitry Gridin>
* 7f1aab53553 - i18n: add bundle for idea/versions (vor 7 Tagen) <Dmitry Gridin>
* 670c529ded3 - i18n: add bundle for idea/internal (vor 7 Tagen) <Dmitry Gridin>
* c2d41744d05 - i18n: add bundle for idea/imports (vor 7 Tagen) <Dmitry Gridin>
* 4c9e7773ad2 - i18n: fix bundle for idea/findUsages (vor 7 Tagen) <Dmitry Gridin>
* 20ec600e2dd - i18n: add bundle for idea/highlighter (vor 7 Tagen) <Dmitry Gridin>
* f837b01f855 - i18n: add bundle for idea/hierarchy (vor 7 Tagen) <Dmitry Gridin>
* a3f1dde4136 - i18n: add bundle for idea/framework (vor 7 Tagen) <Dmitry Gridin>
* 6ad1a9224c8 - i18n: add bundle for idea/formatter (vor 7 Tagen) <Dmitry Gridin>
* 040204e36e8 - i18n: Internationalize part of the 'idea' module (vor 7 Tagen) <Yan Zhulanow>
* fff9ab5ac3d - i18n: add bundle for idea/findUsages (vor 7 Tagen) <Dmitry Gridin>
* dab6a12121e - i18n: add bundle for idea/filters (vor 7 Tagen) <Dmitry Gridin>
* d26a75055d7 - i18n: add bundle for idea/facet (vor 7 Tagen) <Dmitry Gridin>
* f59cb3e8cae - i18n: add bundle for idea/editor (vor 7 Tagen) <Dmitry Gridin>
* e2bb3204bb0 - i18n: add bundle for idea/copy (vor 7 Tagen) <Dmitry Gridin>
* 177b7eb0243 - i18n: fix compilation 192 (vor 7 Tagen) <Dmitry Gridin>
* 2da27a9e6a9 - i18n: add bundle for idea/configuration (vor 7 Tagen) <Dmitry Gridin>
* ddd6f81581e - i18n: add bundle for j2k (vor 7 Tagen) <Dmitry Gridin>
* 540c0859c25 - i18n: fix properties in idea-gradle (vor 7 Tagen) <Dmitry Gridin>
* 7a40274b710 - i18n: Unify string naming in KotlinBundle (vor 7 Tagen) <Yan Zhulanow>
* 4cc19d3fda8 - i18n: Add bundle for idea-jvm (vor 7 Tagen) <Yan Zhulanow>
* 40bdc099e34 - i18n: Add bundle for idea-gradle-native (vor 7 Tagen) <Yan Zhulanow>
* 4e634b2b015 - i18n: Add bundle for idea-new-project-wizard (vor 7 Tagen) <Yan Zhulanow>
* f1d21b02e92 - i18n: Add bundle for idea-native (vor 7 Tagen) <Yan Zhulanow>
* 2702be564a6 - i18n: Add bundle for idea-maven (vor 7 Tagen) <Yan Zhulanow>
* 830c7cef07c - i18n: Add bundle for JVM debugger (evaluation) (vor 7 Tagen) <Yan Zhulanow>
* 7f80fb8b981 - i18n: Add bundle for JVM debugger (coroutine) (vor 7 Tagen) <Yan Zhulanow>
* e0d5607fcd9 - i18n: Add bundle for JVM debugger (core) (vor 7 Tagen) <Yan Zhulanow>
* b0cd9911a49 - i18n: Add bundle for New J2K (vor 7 Tagen) <Yan Zhulanow>
* eabcff5c2ad - i18n: Add bundle for New J2K services (vor 7 Tagen) <Yan Zhulanow>
* 59b55053795 - i18n: Add bundle for idea-git (vor 7 Tagen) <Yan Zhulanow>
* 3b931514ac4 - i18n: Extract common caching code from bundles, J2K existing bundles (vor 7 Tagen) <Yan Zhulanow>
* 207ecf757b9 - Rename .java to .kt (vor 7 Tagen) <Yan Zhulanow>
* 386fa50e99c - i18n: add bundle for idea-gradle (vor 7 Tagen) <Dmitry Gridin>
* dd6abec660f - i18n: rewrite bundles with `AbstractKotlinBundle` (vor 7 Tagen) <Dmitry Gridin>
* 35f4ff000be - i18n: add bundle for idea-gradle (vor 7 Tagen) <Dmitry Gridin>
* 3aa97643f57 - i18n: add bundle for idea-core (vor 7 Tagen) <Dmitry Gridin>
* d6442142510 - i18n: add bundle for ide-common (vor 7 Tagen) <Dmitry Gridin>
* 7e3c07865c2 - i18n: add bundle for formatter (vor 7 Tagen) <Dmitry Gridin>
* c8c316c3790 - i18n: introduce AbstractKotlinBundle (vor 7 Tagen) <Dmitry Gridin>
* a0aeb1554d3 - (origin/rr/gradle/igushkin/fix-kt-37241-kapt-classpath-filter-exists) Filter kapt generate stubs classpath for non-existent entries (KT-37241) (vor 10 Tagen) <Sergey Igushkin>
* 364d97e9501 - Invalidate partialBodyResolveCache on OCB instead of PSI modification (vor 7 Tagen) <Vladimir Dolzhenko>
* 9fdf8530ff1 - (tag: build-1.4.0-dev-4308) Add checkCanceled in loops in KotlinImportOptimizer to avoid freezes (vor 7 Tagen) <Vladimir Dolzhenko>
* ce9297c5d68 - Be able to find annotated property accessor (vor 7 Tagen) <Vladimir Dolzhenko>
* 04ef1081b31 - (tag: build-1.4.0-dev-4300) Disable `stats-collector` dependency for Android Studio (vor 7 Tagen) <Roman Golyshev>
* 5474d5f1d34 - (tag: build-1.4.0-dev-4295) Support debug in Gradle tasks responsible for K/N tests (vor 7 Tagen) <Kirill Shmakov>
* a1eff7f4af0 - (tag: build-1.4.0-dev-4292) [IR] Set source offsets in SAM lowering (vor 7 Tagen) <Igor Chevdar>