### PR TITLE
Fix #4016

### DIFF
--- a/libclangext/build.gradle
+++ b/libclangext/build.gradle
@@ -42,7 +42,7 @@ model {
             binaries.withType(StaticLibraryBinarySpec) { binary ->
                 if (!project.parent.convention.plugins.platformInfo.isWindows())
                     cppCompiler.args "-fPIC"
-                cppCompiler.args "--std=c++14", "-g", "-I${llvmDir}/include"
+                cppCompiler.args "--std=c++11", "-g", "-I${llvmDir}/include"
                 if (isEnabled) {
                     cppCompiler.args '-DLIBCLANGEXT_ENABLE=1'
                 }


### PR DESCRIPTION
Change `libclangext/build.gradle`'s CPP compiler standard library version to C++11, as C++14 is not fully implemented by the version of clang shipped with Kotlin/Native. See issue https://github.com/ericniebler/range-v3/issues/337 for more details. 