### PR TITLE
[kotlin compiler][update] 1.4.0-dev-5111

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/StubGenerator.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/wasm/StubGenerator.kt
@@ -215,7 +215,7 @@ val Operation.wasmTypedReturnMapping get() = returnType.wasmTypedReturnMapping()
 
 val Attribute.wasmTypedReturnMapping get() = type.wasmTypedReturnMapping()
 
-fun List<Arg>.wasmTypedMapping()
+fun List<Arg>.wasmTypedMapping():List<String>
     = this.map(Arg::wasmTypedMapping)
 
 // TODO: more complex return types, such as returning a pair of Ints

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/injection.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/injection.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.descriptors.PackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.CompositePackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.frontend.di.configureModule
-import org.jetbrains.kotlin.platform.konan.KonanPlatforms
+import org.jetbrains.kotlin.platform.konan.NativePlatforms
 import org.jetbrains.kotlin.resolve.*
 import org.jetbrains.kotlin.resolve.konan.platform.NativePlatformAnalyzerServices
 import org.jetbrains.kotlin.resolve.lazy.KotlinCodeAnalyzer
@@ -28,7 +28,7 @@ fun createTopDownAnalyzerProviderForKonan(
         initContainer: StorageComponentContainer.() -> Unit
 ): ComponentProvider {
     return createContainer("TopDownAnalyzerForKonan", NativePlatformAnalyzerServices) {
-        configureModule(moduleContext, KonanPlatforms.defaultKonanPlatform, NativePlatformAnalyzerServices, bindingTrace, languageVersionSettings)
+        configureModule(moduleContext, NativePlatforms.defaultNativePlatform, NativePlatformAnalyzerServices, bindingTrace, languageVersionSettings)
 
         useInstance(declarationProviderFactory)
         useImpl<AnnotationResolverImpl>()

--- a/build.gradle
+++ b/build.gradle
@@ -306,6 +306,7 @@ task detectJarCollision(type: CollisionDetector) {
         resolvingRules["META-INF/compiler.version"] = "kotlin-compiler"
         resolvingRules["kotlinManifest.properties"] = "kotlin-compiler"
         librariesWithIgnoredClassCollisions.addAll(["util", "container", "resolution", "serialization", "psi", "frontend",
+                                                    "config", "config.jvm", "js.config", "javac-wrapper",
                                                     "frontend.common", "frontend.java", "cli-common", "ir.tree",
                                                     "ir.psi2ir", "ir.backend.common", "backend.jvm", "backend.js",
                                                     "backend.wasm", "ir.serialization.common", "ir.serialization.js",

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,15 +15,15 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.4.0-dev-1818
-buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1818,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.4.0-dev-5097
+buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5097,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4995,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-4995
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-4995,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-4995
-kotlinStdlibTestsVersion=1.4.0-dev-4995
-testKotlinCompilerVersion=1.4.0-dev-4995
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5111,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-5111
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5111,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-5111
+kotlinStdlibTestsVersion=1.4.0-dev-5111
+testKotlinCompilerVersion=1.4.0-dev-5111
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* ab56ec74812 - (tag: build-1.4.0-dev-5111) [Gradle, JS] Use standard instance filtering (vor 5 Stunden) <Ilya Goncharov>
* bc22489aab9 - [Gradle, JS] Fix link task options for IR tooling (vor 5 Stunden) <Ilya Goncharov>
* f011d2794a5 - (tag: build-1.4.0-dev-5109) Fix freeze on configure kotlin for the project (vor 6 Stunden) <Vladimir Dolzhenko>
* 2c69d829166 - (tag: build-1.4.0-dev-5102) Update directory-maven-plugin to the latest version: 0.3.1 (vor 8 Stunden) <Ilya Gorbunov>
* 9bbfe9c1acb - (tag: build-1.4.0-dev-5097, origin/rr/ddol/work2) Rename: KonanPlatform, KonanPlatforms -> NativePlatform, NativePlatforms (vor 20 Stunden) <Dmitriy Dolovov>
* dfbbae39912 - IDE, Common: Don't create KLIB metadata factories for each new KLIB (vor 20 Stunden) <Dmitriy Dolovov>
* 5b9770a4dd3 - IDE, JS: Don't create KLIB metadata factories for each new KLIB library (vor 20 Stunden) <Dmitriy Dolovov>
* cc6e4e5cfb1 - IDE, Native: Don't produce CompositePackageFragmentProvider when unnecessary (vor 20 Stunden) <Dmitriy Dolovov>
* 87da4be9bb1 - (tag: build-1.4.0-dev-5087) Move parametersMap.kt to 'cli-common' (vor 2 Tagen) <Alexander Udalov>
* 92534eadaa0 - Remove dependency of 'resolution' on 'deserialization' (vor 2 Tagen) <Alexander Udalov>
* b6fdc96994b - Reverse dependency 'psi' <-> 'frontend.common' (vor 2 Tagen) <Alexander Udalov>
* d70271b6aaa - Move RequireKotlinNames to 'descriptors' (vor 2 Tagen) <Alexander Udalov>
* 844b0078ba2 - Minor, remove unneeded dependency of 'js.parser' on 'util' (vor 2 Tagen) <Alexander Udalov>
* 9dd8b1821ab - Move CoroutineLanguageVersionSettingsUtil to 'config' (vor 2 Tagen) <Alexander Udalov>
* db9347cb560 - Move JVM-specific analysis flags to 'config.jvm' (vor 2 Tagen) <Alexander Udalov>
* 7bb77e5672f - Move JS binary version utilities to 'js.config' (vor 2 Tagen) <Alexander Udalov>
* fe5104b8654 - Move package org.jetbrains.kotlin.incremental.js to 'js.config' (vor 2 Tagen) <Alexander Udalov>
* 4dcd0d1cb6c - Extract module 'config' out of 'frontend' (vor 2 Tagen) <Alexander Udalov>
* 143aef938b2 - Extract module 'js.config' out of 'js.frontend' (vor 2 Tagen) <Alexander Udalov>
* 15d2a061326 - Extract module 'config.jvm' out of 'frontend.java' (vor 2 Tagen) <Alexander Udalov>
* 90ae416b72d - Minor, move KotlinTypeRefinerImpl out of 'config' package (vor 2 Tagen) <Alexander Udalov>
* 4aa47be2024 - Move CommonResolverForModuleFactory to 'frontend' (vor 2 Tagen) <Alexander Udalov>
* 9e014e462b6 - Do not use CommonPlatforms directly in CommonResolverForModuleFactory (vor 2 Tagen) <Alexander Udalov>
* 8dd04789adf - Remove obsolete InlineStrategy (vor 2 Tagen) <Alexander Udalov>
* 4156a9c80b0 - Extract javac-wrapper into a separate module (vor 2 Tagen) <Alexander Udalov>
* aad7354a3b2 - Minor, remove obsolete jvmTarget modifications in compiler modules (vor 2 Tagen) <Alexander Udalov>
* f403a0da823 - (tag: build-1.4.0-dev-5080) README Update IDEA plugin dist path (vor 2 Tagen) <Victor Turansky>
* d808ef10b21 - (tag: build-1.4.0-dev-5075) Added some tests on local classes in inline bodies (vor 2 Tagen) <Igor Chevdar>
* e2a378bed74 - [JS_IR] More subtle local classes copying in inliner (vor 2 Tagen) <Igor Chevdar>
* 90abf1fda07 - [JS_IR] Don't capture the bound receiver of a CR (vor 2 Tagen) <Igor Chevdar>
* 643e5814484 - [IR] Supported extraction of local classes from inline bodies (vor 2 Tagen) <Igor Chevdar>
* 7a48c3a9456 - [IR] Made currentDeclarationParent nullable (vor 2 Tagen) <Igor Chevdar>
* 09304bbd542 - (tag: build-1.4.0-dev-5074) ConvertToAnonymousObjectFix: do not suggest when there is no lambda (vor 2 Tagen) <Toshiaki Kameyama>
* d3c54f664b8 - (tag: build-1.4.0-dev-5064) Wizard: fix 191 tests (vor 3 Tagen) <Ilya Kirillov>
* 8447701d741 - (tag: build-1.4.0-dev-5057) Use stable order and constant timestamps in merged sources jar (vor 3 Tagen) <Ilya Gorbunov>
* 042424d5992 - (tag: build-1.4.0-dev-5052) KT-27524 Don't box (some) inline classes in suspend fun return (vor 3 Tagen) <Dmitry Petrov>
* d8bc29e6c69 - (tag: build-1.4.0-dev-5051) [FIR] Eliminate obsolete NO_SUPERTYPE diagnostic from builder (vor 3 Tagen) <Mikhail Glukhikh>
* b38d30bab00 - [FIR] Support several super-related diagnostics (vor 3 Tagen) <Nick>
* 5570a5fe74b - (tag: build-1.4.0-dev-5049) [JVM_IR] Use iinc for incrementing Int variables. (vor 3 Tagen) <Mads Ager>
* 58685be4e2f - (tag: build-1.4.0-dev-5047, tag: build-1.4.0-dev-5043) IR: Don't use IrStringConcatenation for ordinary toString calls (vor 3 Tagen) <Steven Schäfer>
* c1b9fdd2f37 - (tag: build-1.4.0-dev-5038) Fix diagnostic test data to be consistent with FIR test data (vor 3 Tagen) <Mikhail Glukhikh>
* c518868c030 - Disable UnusedMainParameterInspection by default (vor 3 Tagen) <Mikhail Glukhikh>
* 7bfd354a775 - Don't report UNUSED_PARAMETER in main from object #KT-37718 Fixed (vor 3 Tagen) <Mikhail Glukhikh>
* cec0f585441 - [FIR] Introduce & use toFirLightSourceElement (vor 3 Tagen) <Mikhail Glukhikh>
* 6a5acc024a9 - [FIR] Rename PSI version of toFirSourceElement (vor 3 Tagen) <Mikhail Glukhikh>
* b27152f903b - Replace some FIR syntax errors with more proper diagnostics (vor 3 Tagen) <Mikhail Glukhikh>
* 2f63c8a46a4 - [FIR] Enhance diagnostic DSL to be able to use concrete factories (vor 3 Tagen) <Mikhail Glukhikh>
* a1d81aa15f4 - (tag: build-1.4.0-dev-5034) [FIR-TEST] Fix diff between FIR and old FE testdata (vor 3 Tagen) <Dmitriy Novozhilov>
* b0d96eb1403 - (tag: build-1.4.0-dev-5026) Revert "Workaround for KT-37302" (vor 3 Tagen) <Georgy Bronnikov>
* cd440841a5c - (tag: build-1.4.0-dev-5021) Fix regex in KotlinPluginCompatibilityVerifier to support release and milestones (vor 3 Tagen) <Dmitry Savvinov>
* dfaebf3cdb4 - Minor: make KotlinPluginVersion public (vor 3 Tagen) <Dmitry Savvinov>
* b7d8e879a65 - (tag: build-1.4.0-dev-5016) [FIR] Support 4 diagnostics for pairs of modifiers (vor 3 Tagen) <FenstonSingel>
* 311a91af79c - (tag: build-1.4.0-dev-5010) Fix: forgot to write services for 191 (vor 3 Tagen) <Yaroslav Chernyshev>
* 674f1d129f6 - (tag: build-1.4.0-dev-5006) Clean up of plugin-common.xml and convert components to services (vor 3 Tagen) <Vladimir Dolzhenko>
* 87006036be0 - (tag: build-1.4.0-dev-5005) [IR] Forbid unbound type parameters (vor 3 Tagen) <Roman Artemev>
* 6e01ec8dd3c - [IR] Fix translation of synthetic generic java properties (vor 3 Tagen) <Roman Artemev>
* 4bebfd33b93 - [IR] Fix unbound type parameter symbol for jvm corner cases (vor 3 Tagen) <Roman Artemev>
* 48fb2797216 - (tag: build-1.4.0-dev-5001) [FIR] Add constraint to flexible type for declared argument for java parameter (vor 3 Tagen) <Dmitriy Novozhilov>
* 3acb64c5369 - [FIR] Add flexible default upper bound for java type parameters (vor 3 Tagen) <Dmitriy Novozhilov>