### PR TITLE
[IR] Run lowerings before inlining on the entire IR

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3301,6 +3301,12 @@ linkTest("inline_defaultArgs_linkTest") {
     lib = "codegen/inline/defaultArgs_linkTest_lib.kt"
 }
 
+linkTest("inline_sharedVar_linkTest") {
+    goldValue = "6\n"
+    source = "codegen/inline/sharedVar_linkTest_main.kt"
+    lib = "codegen/inline/sharedVar_linkTest_lib.kt"
+}
+
 def generateWithSpaceDefFile() {
     def mapOption = "--Map \"${buildDir}/cutom map.map\""
     if (isAppleTarget(project)) {

--- a/backend.native/tests/codegen/inline/sharedVar_linkTest_lib.kt
+++ b/backend.native/tests/codegen/inline/sharedVar_linkTest_lib.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package a
+
+fun IntArray.forEachNoInline(block: (Int) -> Unit) = this.forEach { block(it) }
+
+inline fun fold(initial: Int, values: IntArray, crossinline block: (Int, Int) -> Int): Int {
+    var res = initial
+    values.forEachNoInline {
+        res = block(res, it)
+    }
+    return res
+}

--- a/backend.native/tests/codegen/inline/sharedVar_linkTest_main.kt
+++ b/backend.native/tests/codegen/inline/sharedVar_linkTest_main.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+import a.*
+
+fun main() {
+    println(fold(0, intArrayOf(1, 2, 3)) { x, y -> x + y })
+}


### PR DESCRIPTION
Since inlining is a cross-module operation (we need to know the bodies of
inline functions), all lowerings that are supposed to run before the inliner,
need to be run on the entire IR (granted, they can be run only on the inline functions,
but, for simplicity, just run them on the entire IR)