### PR TITLE
[kotlin compiler][update] 1.4.0-dev-5257

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -129,7 +129,6 @@ configurations {
     kotlin_stdlib_jar
     kotlin_reflect_jar
     kotlin_script_runtime_jar
-    kotlin_native_utils_jar
     trove4j_jar
     kotlinCommonSources
 
@@ -149,7 +148,6 @@ dependencies {
     kotlin_stdlib_jar "$kotlinStdLibModule@jar"
     kotlin_reflect_jar "$kotlinReflectModule@jar"
     kotlin_script_runtime_jar "$kotlinScriptRuntimeModule@jar"
-    kotlin_native_utils_jar "$kotlinNativeUtilsModule@jar"
 
     [kotlinCommonStdlibModule, kotlinTestCommonModule, kotlinTestAnnotationsCommonModule].each {
         kotlinCommonSources(it) { transitive = false }
@@ -250,7 +248,7 @@ jar {
     dependsOn ':runtime:hostRuntime', 'external_jars'
 }
 
-def externalJars = ['compiler', 'stdlib', 'reflect', 'script_runtime', 'native_utils']
+def externalJars = ['compiler', 'stdlib', 'reflect', 'script_runtime']
 
 task trove4jCopy(type: Copy) {
     from configurations.getByName("trove4j_jar") {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.context.ProjectContext
 import org.jetbrains.kotlin.descriptors.PackageFragmentProvider
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.descriptors.konan.CurrentKlibModuleOrigin
-import org.jetbrains.kotlin.backend.konan.descriptors.isKonanStdlib
+import org.jetbrains.kotlin.descriptors.konan.isNativeStdlib
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.util.KlibMetadataFactories
 import org.jetbrains.kotlin.library.KotlinLibrary
@@ -52,7 +52,7 @@ internal object TopDownAnalyzerFacadeForKonan {
                 config.friendModuleFiles)
 
         val additionalPackages = mutableListOf<PackageFragmentProvider>()
-        if (!module.isKonanStdlib()) {
+        if (!module.isNativeStdlib()) {
             val dependencies = listOf(module) + resolvedDependencies.moduleDescriptors.resolvedDescriptors + resolvedDependencies.moduleDescriptors.forwardDeclarationsModule
             module.setDependencies(dependencies, resolvedDependencies.friends)
         } else {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.backend.konan.descriptors.isKonanStdlib
+import org.jetbrains.kotlin.descriptors.konan.isNativeStdlib
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
@@ -257,7 +257,7 @@ internal val psiToIrPhase = konanUnitPhase(
 
             functionIrClassFactory.module =
                     (listOf(irModule!!) + deserializer.modules.values)
-                            .single { it.descriptor.isKonanStdlib() }
+                            .single { it.descriptor.isNativeStdlib() }
         },
         name = "Psi2Ir",
         description = "Psi to IR conversion",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/utils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/utils.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.descriptors.konan.DeserializedKlibModuleOrigin
 import org.jetbrains.kotlin.descriptors.konan.klibModuleOrigin
 import org.jetbrains.kotlin.descriptors.konan.kotlinLibrary
 import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
-import org.jetbrains.kotlin.konan.library.KONAN_STDLIB_NAME
 import org.jetbrains.kotlin.library.BaseKotlinLibrary
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.*
@@ -51,8 +50,12 @@ fun DeclarationDescriptor.findTopLevelDescriptor(): DeclarationDescriptor {
     else this.containingDeclaration!!.findTopLevelDescriptor()
 }
 
-val ModuleDescriptor.isForwardDeclarationModule get() =
-    name == Name.special("<forward declarations>")
+val ModuleDescriptor.isForwardDeclarationModule: Boolean
+    get() {
+        // TODO: use KlibResolvedModuleDescriptorsFactoryImpl.FORWARD_DECLARATIONS_MODULE_NAME instead of
+        //  manually created Name instance
+        return name == Name.special("<forward declarations>")
+    }
 
 fun BaseKotlinLibrary.isInteropLibrary() =
         manifestProperties["ir_provider"] == KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
@@ -60,7 +63,3 @@ fun BaseKotlinLibrary.isInteropLibrary() =
 fun ModuleDescriptor.isFromInteropLibrary() =
         if (klibModuleOrigin !is DeserializedKlibModuleOrigin) false
         else kotlinLibrary.isInteropLibrary()
-
-private val STDLIB_MODULE_NAME = Name.special("<$KONAN_STDLIB_NAME>")
-
-fun ModuleDescriptor.isKonanStdlib() = name == STDLIB_MODULE_NAME

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportLazy.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportLazy.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.backend.konan.objcexport
 
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.analyzer.ModuleInfo
-import org.jetbrains.kotlin.backend.konan.descriptors.isKonanStdlib
+import org.jetbrains.kotlin.descriptors.konan.isNativeStdlib
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.Annotations
@@ -445,7 +445,7 @@ private fun createNamerConfiguration(configuration: ObjCExportLazy.Configuration
 
 // TODO: find proper solution.
 private fun ModuleDescriptor.isStdlib(): Boolean =
-        this.builtIns == this || this.isCommonStdlib() || this.isKonanStdlib()
+        this.builtIns == this || this.isCommonStdlib() || this.isNativeStdlib()
 
 private val kotlinSequenceClassId = ClassId.topLevel(FqName("kotlin.sequences.Sequence"))
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportNamer.kt
@@ -8,7 +8,7 @@ package org.jetbrains.kotlin.backend.konan.objcexport
 import org.jetbrains.kotlin.backend.konan.cKeywords
 import org.jetbrains.kotlin.backend.konan.descriptors.isArray
 import org.jetbrains.kotlin.backend.konan.descriptors.isInterface
-import org.jetbrains.kotlin.backend.konan.descriptors.isKonanStdlib
+import org.jetbrains.kotlin.descriptors.konan.isNativeStdlib
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
@@ -855,7 +855,7 @@ private fun ObjCExportMapper.canHaveSameName(first: PropertyDescriptor, second: 
 }
 
 internal val ModuleDescriptor.namePrefix: String get() {
-    if (this.isKonanStdlib()) return "Kotlin"
+    if (this.isNativeStdlib()) return "Kotlin"
 
     return abbreviate(this.name.asString().let { it.substring(1, it.lastIndex) })
 }

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -208,6 +208,7 @@ def update_external_tests() {
             include 'common/**'
             include 'test/**'
             exclude 'test/js/**'
+            include 'kotlin-test/**'
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,6 @@ ext {
     kotlinTestAnnotationsCommonModule="org.jetbrains.kotlin:kotlin-test-annotations-common:${kotlinStdlibVersion}:sources"
     kotlinReflectModule="org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
     kotlinScriptRuntimeModule="org.jetbrains.kotlin:kotlin-script-runtime:${kotlinVersion}"
-    kotlinNativeUtilsModule="org.jetbrains.kotlin:kotlin-native-utils:${kotlinVersion}"
     kotlinUtilKliMetadatabModule="org.jetbrains.kotlin:kotlin-util-klib-metadata:${kotlinVersion}"
 
     konanVersionFull = CompilerVersionGeneratedKt.getCurrentCompilerVersion()
@@ -299,7 +298,7 @@ task detectJarCollision(type: CollisionDetector) {
     resolvingRules["org/jetbrains/kotlin/builtins/konan/KonanBuiltIns.class"] = "kotlin-compiler"
     resolvingRules["org/jetbrains/kotlin/resolve/konan/platform/NativeInliningRule.class"] = "kotlin-compiler"
     resolvingRules["org/jetbrains/kotlin/resolve/konan/platform/NativePlatformAnalyzerServices.class"] = "kotlin-compiler"
-    librariesWithIgnoredClassCollisions.addAll(["kotlin-util-klib", "kotlin-util-io", "kotlinx-metadata-klib"])
+    librariesWithIgnoredClassCollisions.addAll(["kotlin-util-klib", "kotlin-util-io", "kotlinx-metadata-klib", "kotlin-native-utils"])
     if (project.hasProperty('kotlinProjectPath')) {
         resolvingRulesWithRegexes[new Regex("META-INF/.+\\.kotlin_module")] = "kotlin-compiler"
         resolvingRules["META-INF/extensions/compiler.xml"] = "kotlin-compiler"

--- a/build.gradle
+++ b/build.gradle
@@ -281,6 +281,7 @@ task detectJarCollision(type: CollisionDetector) {
     resolvingRules["META-INF/metadata.kotlin_module"] = "kotlin-compiler"
     resolvingRules["META-INF/type-system.kotlin_module"] = "kotlin-compiler"
     resolvingRules["META-INF/util.runtime.kotlin_module"] = "kotlin-compiler"
+    resolvingRules["META-INF/kotlin-native-utils.kotlin_module"] = "kotlin-compiler"
 
     // These collisions are introduced by kotlinx-metadata-klib.
     resolvingRules["META-INF/serialization.kotlin_module"] = "kotlin-compiler"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,9 +20,9 @@ buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds
 remoteRoot=konan_tests
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5111,branch:default:any,pinned:true/artifacts/content/maven
 kotlinVersion=1.4.0-dev-5111
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5111,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-5111
-kotlinStdlibTestsVersion=1.4.0-dev-5111
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5188,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-5188
+kotlinStdlibTestsVersion=1.4.0-dev-5188
 testKotlinCompilerVersion=1.4.0-dev-5111
 konanVersion=1.4.0-M2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-5097
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5097,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5111,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-5111
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5188,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-5188
-kotlinStdlibTestsVersion=1.4.0-dev-5188
-testKotlinCompilerVersion=1.4.0-dev-5111
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5257,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-5257
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5257,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-5257
+kotlinStdlibTestsVersion=1.4.0-dev-5257
+testKotlinCompilerVersion=1.4.0-dev-5257
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
+++ b/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/main.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.konan.util.DependencyProcessor
 import org.jetbrains.kotlin.library.unpackZippedKonanLibraryTo
 import org.jetbrains.kotlin.konan.util.KlibMetadataFactories
 import org.jetbrains.kotlin.backend.common.serialization.metadata.DynamicTypeDeserializer
-import org.jetbrains.kotlin.backend.konan.descriptors.isKonanStdlib
+import org.jetbrains.kotlin.descriptors.konan.isNativeStdlib
 import org.jetbrains.kotlin.builtins.konan.KonanBuiltIns
 import org.jetbrains.kotlin.descriptors.deserialization.PlatformDependentTypeTransformer
 import org.jetbrains.kotlin.util.Logger
@@ -167,7 +167,7 @@ class Library(val name: String, val requestedRepository: String?, val target: St
         val module = KlibFactories.DefaultDeserializedDescriptorFactory.createDescriptorAndNewBuiltIns(library, versionSpec, storageManager, null)
 
         val defaultModules = mutableListOf<ModuleDescriptorImpl>()
-        if (!module.isKonanStdlib()) {
+        if (!module.isNativeStdlib()) {
             val resolver = resolverByName(
                     emptyList(),
                     distributionKlib = Distribution().klib,

--- a/runtime/src/main/kotlin/kotlin/test/Assertions.kt
+++ b/runtime/src/main/kotlin/kotlin/test/Assertions.kt
@@ -38,4 +38,10 @@ internal actual fun <T : Throwable> checkResultIsFailure(exceptionClass: KClass<
     )
 }
 
+/** Platform-specific construction of AssertionError with cause */
+@Suppress("NOTHING_TO_INLINE")
+internal actual inline fun AssertionErrorWithCause(message: String?, cause: Throwable?): AssertionError =
+        AssertionError(message, cause)
+
+
 internal actual fun lookupAsserter(): Asserter = DefaultAsserter

--- a/runtime/src/main/kotlin/kotlin/test/Assertions.kt
+++ b/runtime/src/main/kotlin/kotlin/test/Assertions.kt
@@ -33,7 +33,7 @@ internal actual fun <T : Throwable> checkResultIsFailure(exceptionClass: KClass<
                     @Suppress("UNCHECKED_CAST")
                     return e as T
                 }
-                asserter.fail(messagePrefix(message) + "Expected an exception of ${exceptionClass.qualifiedName} to be thrown, but was $e")
+                asserter.fail(messagePrefix(message) + "Expected an exception of ${exceptionClass.qualifiedName} to be thrown, but was $e", e)
             }
     )
 }


### PR DESCRIPTION
* 435a7e7e263 - (tag: build-1.4.0-dev-5257) i18n: fix name for `LiftReturnOutFix` (vor 9 Stunden) <Dmitry Gridin>
* 5411b85cb92 - (tag: build-1.4.0-dev-5255) Minor. Rename isKonanStdlib() into isNativeStdlib() (vor 9 Stunden) <Dmitriy Dolovov>
* e69b2ed47d2 - Drop redundant dependencies on :native:kotlin-native-utils (vor 9 Stunden) <Dmitriy Dolovov>
* 31a1f8ff4bf - Include :native:kotlin-native-utils into kotlin-compiler.jar (vor 9 Stunden) <Dmitriy Dolovov>
* 28cb9d4e132 - Gradle: Remove redundant dependency on 'kotlin-native-utils' artifact (vor 9 Stunden) <Dmitriy Dolovov>
* 5f5f2193678 - Keep KonanPlatformKt.isNative for backward compatibility (vor 9 Stunden) <Dmitriy Dolovov>
* 10d5726a02b - (tag: build-1.4.0-dev-5251) Update test data that depends on stdlib method docs (vor 14 Stunden) <Ilya Gorbunov>
* 6eebe21897c - (tag: build-1.4.0-dev-5248) Remove redundant backticks: fix false positive for multiple underscores (vor 16 Stunden) <Toshiaki Kameyama>
* 34cfe7dfdb0 - (tag: build-1.4.0-dev-5247)  "Add missing component" intention: fix it works correctly if entries is empty (vor 16 Stunden) <Toshiaki Kameyama>
* 0a215cafa74 - (tag: build-1.4.0-dev-5244) README Update 'Gradle properties' link (vor 16 Stunden) <Victor Turansky>
* 136a64a0b71 - (tag: build-1.4.0-dev-5243) README Kotlin DSL script for composite build (vor 16 Stunden) <Victor Turansky>
* e5b4b03314e - (tag: build-1.4.0-dev-5228) RedundantLambdaArrowInspection: fix false positive when receiver is qualified expression (vor 20 Stunden) <Toshiaki Kameyama>
* 487e1ddddc7 - (tag: build-1.4.0-dev-5227) Wizard: do not update path & artifactId value for invalid project name (vor 20 Stunden) <Ilya Kirillov>
* fef3ea573b6 - Wizard: allow "-" char in artifactId/groupId & fix their error messages (vor 20 Stunden) <Ilya Kirillov>
* 630adb34dbc - (tag: build-1.4.0-dev-5226) [FIR] Don't provide receiver as value in delegated constructor call (vor 20 Stunden) <Mikhail Glukhikh>
* a377a6fccbe - [FIR2IR] Handle references to constructors separately (vor 20 Stunden) <Mikhail Glukhikh>
* 282509b0da0 - [FIR2IR] Provide object receivers for callable references (vor 20 Stunden) <Mikhail Glukhikh>
* 51de319cc45 - (tag: build-1.4.0-dev-5221) New J2K: fix IOOB exception on inference (vor 21 Stunden) <Ilya Kirillov>
* 98f2604df0a - New J2K: introduce type alias symbol (vor 21 Stunden) <Ilya Kirillov>
* bc522812081 - New J2K: convert Java method reference to Kotlin one on copy-pasting Java code (vor 21 Stunden) <Ilya Kirillov>
* d6d843aaed6 - New J2K: fix assignment target in ConvertGettersAndSettersToPropertyProcessing (vor 21 Stunden) <Ilya Kirillov>
* b3e728f4fbc - New J2K: don't allow open modifier on top-level/private declarations (vor 21 Stunden) <Ilya Kirillov>
* 4d4aa885348 - New J2K: handle spaces in array dimensions declaration (vor 21 Stunden) <Ilya Kirillov>
* 353e884c8f5 - New J2K: do not merge methods if there are vararg parameters present (vor 21 Stunden) <Ilya Kirillov>
* 4a450ab6243 - New J2K: do not use unicode symbol in bundle (vor 21 Stunden) <Ilya Kirillov>
* 78d2aaa0218 - New J2K: handle null Java type (vor 21 Stunden) <Ilya Kirillov>
* 113561f5f5f - (tag: build-1.4.0-dev-5213) Execute reloadDefinitionsBy on a pooled thread (vor 23 Stunden) <Vladimir Dolzhenko>
* 9f09e50a283 - ApplicationUtils syntax improvements (vor 23 Stunden) <Vladimir Dolzhenko>
* 23ea2446e05 - (tag: build-1.4.0-dev-5205) IDEA: add a couple "navigate to inline function call site" tests (vor 24 Stunden) <pyos>
* 9d7db101e66 - JVM: refactor SMAP stuff some more (vor 24 Stunden) <pyos>
* e98bdc6f8e5 - JVM: preserve call site markers when inlining lambdas (vor 24 Stunden) <pyos>
* 9d21800d8f9 - JVM: fix SMAP range extension logic (vor 24 Stunden) <pyos>
* b4d7dfd02cb - (tag: build-1.4.0-dev-5200) Advance minimal Gradle version for .gradle.kts tests to 5.0 (vor 25 Stunden) <Ilya Gorbunov>
* bc5605dcdcb - Mute stepping test, KT-37879 (vor 25 Stunden) <Ilya Gorbunov>
* 4a8dbccceef - Advance bootstrap to 1.4.0-dev-5087 (vor 25 Stunden) <Ilya Gorbunov>
* 6b11decf527 - Enable option -Xno-optimized-callable-references in the whole project (vor 25 Stunden) <Ilya Gorbunov>
* 38a719cb22a - (tag: build-1.4.0-dev-5199) [NI] Fix trace manipulations for builder inference and ::-expressions (vor 25 Stunden) <Mikhail Zarechenskiy>
* 6213680604c - (tag: build-1.4.0-dev-5198) Mute GradleKtsImportTest.testError for AS (vor 25 Stunden) <Natalia Selezneva>
* ccf5a2b4adf - (tag: build-1.4.0-dev-5196) [Gradle, JS] KT-36784 Add additional args for npm install (vor 26 Stunden) <Ilya Goncharov>
* 14f0091c84c - [Gradle, JS] KT-36784 Add tests on local npm dependencies in composite (vor 26 Stunden) <Ilya Goncharov>
* 149d7fb33a9 - [Gradle, JS] KT-36784 Fix requireing of node modules (vor 26 Stunden) <Ilya Goncharov>
* f30875f79ba - [Gradle, JS] KT-36784 Move fromSrcPackageJson (vor 26 Stunden) <Ilya Goncharov>
* 253b8587e43 - [Gradle, JS] KT-36784 Composite build test (vor 26 Stunden) <Ilya Goncharov>
* 568ef5dc5f2 - [Gradle, JS] KT-36784 Fix depends on for package json umbrella (vor 26 Stunden) <Ilya Goncharov>
* e27c334d4af - [Gradle, JS] Fix package.json file (vor 26 Stunden) <Ilya Goncharov>
* fa632a2aea0 - [Gradle, JS] KT-36784 Input as composite package.json (vor 26 Stunden) <Ilya Goncharov>
* e85501337e3 - [Gradle, JS] Imported dependencies as file dependencies, not workspaces (vor 26 Stunden) <Ilya Goncharov>
* 98f012b1c86 - [Gradle, JS] KT-36784 Dependencies for workspaces (vor 26 Stunden) <Ilya Goncharov>
* 2cee63f7530 - [Gradle, JS] KT-36784 Remove inter workspace dependencies (vor 26 Stunden) <Ilya Goncharov>
* d0f4cdef687 - [Gradle, JS] KT-36784 Fix relative folder (vor 26 Stunden) <Ilya Goncharov>
* 1ef37b62034 - [Gradle, JS] KT-36784 Add composite dependencies to hook (vor 26 Stunden) <Ilya Goncharov>
* d3cb31c5842 - [Gradle, JS] KT-36784 Add internalCompositeDependencies as inputs (vor 26 Stunden) <Ilya Goncharov>
* 1c04ac71e95 - [Gradle, JS] Formatting dependency resolution for npm (vor 26 Stunden) <Ilya Goncharov>
* ba6cadfc384 - [Gradle, JS] Use name of included build by root project (vor 26 Stunden) <Ilya Goncharov>
* c5c3f52b813 - [Gradle, JS] Umbrella package json task (vor 26 Stunden) <Ilya Goncharov>
* 63487c3836c - [Gradle, JS] Scan all packages in included build (vor 26 Stunden) <Ilya Goncharov>
* 7ad489883d7 - [Gradle, JS] Hardcode with composite build (vor 26 Stunden) <Ilya Goncharov>
* ae021e21db4 - [Gradle, JS] GradleNodeModuleBuilder use files instead of artifacts (vor 26 Stunden) <Ilya Goncharov>
* be4c3018082 - [Gradle, JS] Abstractize GradleNodeModulesCache.kt (vor 26 Stunden) <Ilya Goncharov>
* 77139a3a109 - [Gradle, JS] Add internal composite dependencies (vor 26 Stunden) <Ilya Goncharov>
* cdc53f5fecf - (tag: build-1.4.0-dev-5188) Minor kotlin-test doc fixes (vor 27 Stunden) <Ilya Gorbunov>
* 96ed87d81bb - assertFailsWith: set unexpected exception as a cause of assertion error (vor 27 Stunden) <Ilya Gorbunov>
* 2bb36899da3 - Introduce 'fail' method to throw AssertionError with cause (vor 27 Stunden) <Ilya Gorbunov>
* d2ff98fcb15 - Pack kotlin-test common tests into stdlib tests zip for native (vor 27 Stunden) <Ilya Gorbunov>
* ff104f40374 - (tag: build-1.4.0-dev-5186) [FIR2IR] Set proper visibility of backing fields (vor 28 Stunden) <Jinseong Jeon>
* 6a1923a4777 - (tag: build-1.4.0-dev-5182) "Convert to anonymous object" intention: suggest for kotlin fun interface (vor 28 Stunden) <Toshiaki Kameyama>
* 0abe3a6c39d - (tag: build-1.4.0-dev-5181) [NI] Report not-a-class LHS error for callable reference arguments (vor 29 Stunden) <Pavel Kirpichenkov>
* b7ea590e237 - [IDEA] Add HTML render for ambiguous callable references diagnostic (vor 29 Stunden) <Pavel Kirpichenkov>
* a416fde8141 - [NI] Move abstract class instantiation check to call checkers (vor 29 Stunden) <Pavel Kirpichenkov>
* 3f00de5d7b6 - (tag: build-1.4.0-dev-5180) Uast: fallback to call braces in getting the anchor for call-expressions in complex cases (KT-36273) (vor 29 Stunden) <Nicolay Mitropolsky>
* f98a1de7c3a - Uast:  making `convertDeclaration` always convert the `originalElement` (KT-35848) (vor 29 Stunden) <Nicolay Mitropolsky>
* 61ad32f0127 - (tag: build-1.4.0-dev-5176) Samples of Map functions "contains" and "isNotEmpty" (vor 2 Tagen) <Miguel Serra>
* 606b4db48ac - Improve samples for partition: add destructuring (vor 2 Tagen) <Ilya Gorbunov>
* 7bb7c86fa99 - Add samples for partition (vor 2 Tagen) <n-p-s>
* dd2aa3de284 - Add sample for filterNot and improve sample for filter (vor 2 Tagen) <Ilya Gorbunov>
* f887a292799 - Add sample for filter (vor 2 Tagen) <Brian Plummer>
* 840f2228670 - Add sample for filterNotNull (vor 2 Tagen) <adammc331>
* e8ee405cdbd - Add sample for text version of chunked (vor 2 Tagen) <Scott Weber>
* 3f9892a49df - (tag: build-1.4.0-dev-5168) Revert "Avoid run DefinitionsCollectorBackgroundTask on AWT in tests" (vor 2 Tagen) <Vladimir Dolzhenko>
* 4ade669b9bd - (tag: build-1.4.0-dev-5164) Minor: unmute 2 tests fixed in FIR (vor 2 Tagen) <Dmitry Petrov>
* 0397470b857 - (tag: build-1.4.0-dev-5158) [Spec tests] Update tests with spec version 0.1-313 (vor 2 Tagen) <anastasiia.spaseeva>
* 52cc7aa117f - (tag: build-1.4.0-dev-5155) Avoid run DefinitionsCollectorBackgroundTask on AWT in tests (vor 2 Tagen) <Vladimir Dolzhenko>
* 5f66458cb53 - Fix flaky ConfigureKotlinTest (vor 2 Tagen) <Vladimir Dolzhenko>
* d0e28d7c8da - (tag: build-1.4.0-dev-5154) Ignore Java-sepcific test in Native (vor 2 Tagen) <Pavel Punegov>
* 02b651ef28d - (tag: build-1.4.0-dev-5152) 201: Update to 201.6668.13 (vor 2 Tagen) <Nikolay Krasko>
* 1c3c1546b50 - Fix JSR223 dependency on daemon in tests (vor 2 Tagen) <Nikolay Krasko>
* 46174a8c321 - 201: Apply workaround for IDEA execution in daemon main (vor 2 Tagen) <Nikolay Krasko>
* 148cbe87f47 - 201: Use idea.plugins.compatible.build to avoid problems with build number (vor 2 Tagen) <Nikolay Krasko>
* a8c3e4aa6f8 - 201: Add additional registry key (vor 2 Tagen) <Nikolay Krasko>
* e618c211b47 - Run test with full path to maven (KT-37654) (vor 2 Tagen) <Nikolay Krasko>
* 5fe28b31799 - (tag: build-1.4.0-dev-5150) IR: explicitly pass isFakeOverride to buildFun and friends (vor 2 Tagen) <Georgy Bronnikov>
* fb6956f8420 - IR common: use .isFakeOverride instead of checking origin (vor 2 Tagen) <Georgy Bronnikov>
* 2784e30fd45 - JVM_IR: use .isFakeOverride instead of testing origin (vor 2 Tagen) <Georgy Bronnikov>
* 0480f2d170b - [JS IR] Fix usages of 'IrDeclarationOrigin.FAKE_OVERRIDE' (vor 2 Tagen) <Roman Artemev>
* e4ad6698fb7 - [IR] Fix fake override checkers (vor 2 Tagen) <Roman Artemev>
* cec64a2ec79 - (tag: build-1.4.0-dev-5148) KT-37861 'this' is uninitialized in constructor default parameters (vor 2 Tagen) <Dmitry Petrov>
* 078cf02c8a0 - (tag: build-1.4.0-dev-5147) FIR: Provide dispatch receiver for 'field' according to property type (vor 2 Tagen) <Jinseong Jeon>
* a0978a50e82 - [FIR2IR] Correct 'this' conversion when it points to non-closest class (vor 2 Tagen) <Mikhail Glukhikh>
* 4388b30f87c - [FIR] Fix anonymous object handling as 'this' receiver (vor 2 Tagen) <Jinseong Jeon>
* c8206c46665 - (tag: build-1.4.0-dev-5146) [Spec tests] Fix mistakes during parsing compiler tests to extract spec links (vor 2 Tagen) <Victor Petukhov>
* d1fc6ff6ee7 - (tag: build-1.4.0-dev-5145) [FIR2IR] Don't provide backing field symbols for non-Java property refs (vor 2 Tagen) <Mikhail Glukhikh>
* d4ae9924175 - [FIR] Apply type arguments for callable references (vor 2 Tagen) <Mikhail Glukhikh>
* 8fbc6e37e5a - [FIR2IR] Rename: CallGenerator -> CallAndReferenceGenerator (vor 2 Tagen) <Mikhail Glukhikh>
* 810b607a655 - [FIR2IR] Provide receivers also for property callable references (vor 2 Tagen) <Mikhail Glukhikh>
* 697006d782a - [FIR2IR] Re-use receiver application logic in callable ref conversion (vor 2 Tagen) <Mikhail Glukhikh>
* 1b1902f6ee5 - [FIR2IR] Move callable reference conversion to CallGenerator (vor 2 Tagen) <Mikhail Glukhikh>
* d8539fdde91 - [FIR2IR] Add dispatch & extension receivers to callable references (vor 2 Tagen) <Juan Chen>
* 5414b9dfb30 - (tag: build-1.4.0-dev-5141) Refactor Move refactoring (vor 2 Tagen) <Igor Yakovlev>
* a9de0a219b0 - Refactor of Move refactoring (vor 2 Tagen) <Igor Yakovlev>
* 8877559c027 - Add FUS support to move refactoring (vor 2 Tagen) <Anton Yalyshev>
* f489eda0e7a - Remove TextOccurrencesUtil.findNonCodeUsages reprecated usages for 201 platform (vor 2 Tagen) <Igor Yakovlev>
* b205b017fe4 - Fixed references move refactoring for NonCode usages (vor 2 Tagen) <Igor Yakovlev>
* aef8028a9c7 - Fix changing kotlin class usages in java while move refactoring (vor 2 Tagen) <Igor Yakovlev>
* ff831aded48 - Move refactoring on kts fixes (vor 2 Tagen) <Igor Yakovlev>
* e05df9d8382 - Add expect/actual move refactoring support (vor 2 Tagen) <Igor Yakovlev>
* bd851bf2fb8 - (tag: build-1.4.0-dev-5133) Unmute enum tests for IDEA 201 (vor 2 Tagen) <Igor Yakovlev>
* 43468c6d555 - Filter enum synthetic methods for stub based classes (vor 2 Tagen) <Igor Yakovlev>
* 172a45a6379 - (tag: build-1.4.0-dev-5129) Gradle, native: Fix building platform libraries for MIPS (vor 2 Tagen) <Ilya Matveev>
* 872b140500a - (tag: build-1.4.0-dev-5123) Uast: support for annotated expressions (KT-35801) (vor 2 Tagen) <Nicolay Mitropolsky>
* c4bd1ce73c4 - Uast: considering top reified functions as `static` (KT-37613) (vor 2 Tagen) <Nicolay Mitropolsky>
* 0ca67c1bace - Uast: handling reified methods receivers (KT-37613) (vor 2 Tagen) <Nicolay Mitropolsky>
* d6d19b563d0 - (tag: build-1.4.0-dev-5116) [Spec tests] Exclude spec consistency test from common `test` task (vor 2 Tagen) <Victor Petukhov>
* 218c13efc51 - [FIR] Remove links to spec sentences during comparison fir and old front-end test data (vor 2 Tagen) <Victor Petukhov>
* a29385e758a - [Spec tests] Small clean-up CheckerTestUtil and around it (vor 2 Tagen) <Victor Petukhov>
* 90d1cdf2e1c - [Spec tests] Add tests for section call-with-trailing-lambda-expressions (vor 2 Tagen) <anastasiia.spaseeva>
* 4736b3b348f - [Spec tests] Add tests for call-with-named-parameters (vor 2 Tagen) <anastasiia.spaseeva>
* bb1ee952ba0 - [Spec tests] Add tests for call-without-an-explicit-receiver, receivers (vor 2 Tagen) <anastasiia.spaseeva>
* 35de6a3f6eb - [Spec tests] Add tests for overload-resolution, building-the-overload-candidate-set-ocs, operator-call:   -properties available through the invoke convention are non-eligible for operator calls   -smart casts and overload-resolution   -candidate sets (vor 2 Tagen) <anastasiia.spaseeva>
* 4301744d2df - [Spec tests] Add test for infix fun + KT-36786 (vor 2 Tagen) <anastasiia.spaseeva>
* c9bb994fb50 - [Spec tests] Add tests to check overload resolution for implicitly imported infix functions (vor 2 Tagen) <anastasiia.spaseeva>
* 9711fda3538 - [Spec tests] Add tests for property-like callables prioritization (vor 2 Tagen) <anastasiia.spaseeva>
* 157e33d08b1 - [Spec tests] Add tests for receivers prioritization (vor 2 Tagen) <anastasiia.spaseeva>
* 3b35374186b - [Spec tests] Add diagnostics tests for building-the-overload-candidate-set-ocs, call-with-an-explicit-receiver (vor 2 Tagen) <anastasiia.spaseeva>
* 81b6e5a3737 - [Spec tests] Add box tests for callables-and-invoke-convention to check priority (vor 2 Tagen) <anastasiia.spaseeva>
* f7ff60cb77c - [Spec tests] Add DEBUG_INFO_AS_CALL diagnostic tag for callable references (vor 2 Tagen) <anastasiia.spaseeva>
* 008a0df28f8 - [Spec tests] DEBUG_INFO_LEAKING_THIS diagnostics type is changed from error to  info (vor 2 Tagen) <anastasiia.spaseeva>
* f76faaf1b0d - [Spec tests] Unify platform dependent part of fixed exception (vor 2 Tagen) <Victor Petukhov>
* 5986ffae1ec - [Spec tests] Add tests for expressions and statements (vor 2 Tagen) <anastasiia.spaseeva>
* 5f4a94a1b37 - [Spec tests] Enable running spec tests at all for remote run (vor 2 Tagen) <anastasiia.spaseeva>
* 509036b08b2 - [Spec tests] Update spec tests metadata (vor 2 Tagen) <anastasiia.spaseeva>
* 8b307c0a2a8 - [Spec tests] KT-35494 test update (vor 2 Tagen) <anastasiia.spaseeva>
* 1caafdc9d41 - [Spec tests] Updating tests for kotlin 1.4.0 (vor 2 Tagen) <anastasiia.spaseeva>
* ab3b63c92a0 - [Spec tests] Apply changes in parse trees due to trailing comma introducing (vor 2 Tagen) <Victor Petukhov>
* f62901d7d9b - [Spec tests] Actualize spec tests (vor 2 Tagen) <victor.petukhov>
* 2dbce2cc410 - [Spec tests] Link diagnostic tests for when expression with Kotlin specification (vor 2 Tagen) <victor.petukhov>
* c338fdd677e - (tag: build-1.4.0-dev-5114, origin/rr/dimonchik0036/i18n) i18n: cleanup `ChangeVisibilityModifierIntention` (vor 2 Tagen) <Dmitry Gridin>
* 81d35e1e61c - i18n: add dynamic text getters for `SelfTargetingIntention` (vor 2 Tagen) <Dmitry Gridin>
* d9c356b041e - i18n: add `displayedName` to `ModuleTestSourceInfo` (vor 2 Tagen) <Dmitry Gridin>
* a19d42b81b4 - i18n: update bundle for inspections (vor 2 Tagen) <Dmitry Gridin>
* ebc255c74d8 - i18n: update bundle in `plugin-common.xml` (vor 2 Tagen) <Dmitry Gridin>
* ee2d9d19c11 - i18n: update bundle in `idea-debugger (vor 2 Tagen) <Dmitry Gridin>
* 318ca1c5e81 - i18n: update bundle in `idea-repl (vor 2 Tagen) <Dmitry Gridin>
* c642ca45de0 - i18n: update bundle in `idea-maven (vor 2 Tagen) <Dmitry Gridin>
* ab07fa5f6cc - i18n: fix `IdeaModuleInfos` (vor 2 Tagen) <Dmitry Gridin>
* a5cc11317ef - i18n: fix `KotlinSuppressableWarningProblemGroup` (vor 2 Tagen) <Dmitry Gridin>
* 77a043fe1ac - i18n: update bundle in `idea-jvm (vor 2 Tagen) <Dmitry Gridin>
* 0e82c66dac8 - i18n: update bundle in `idea-gradle-native` (vor 2 Tagen) <Dmitry Gridin>
* 39f7855202c - i18n: update bundle in `idea-gradle` (vor 2 Tagen) <Dmitry Gridin>
* 62760bdac3d - i18n: update bundle in `idea-gradle` (vor 2 Tagen) <Dmitry Gridin>
* 025d8a80e3f - i18n: update bundle in `idea-core` (vor 2 Tagen) <Dmitry Gridin>
* c70809553f8 - i18n, KotlinSurrounderUtils: convert field to function (vor 2 Tagen) <Dmitry Gridin>
* 986bc3fb8f5 - i18n: update bundle in `idea-analysis` (vor 2 Tagen) <Dmitry Gridin>
* 871a6caddbc - i18n: remove duplication in IdeErrorMessages (vor 2 Tagen) <Dmitry Gridin>
* 54a3d8e3ada - i18n: update bundle for `KotlinSuppressableWarningProblemGroup` (vor 2 Tagen) <Dmitry Gridin>
* 297a443fe46 - i18n: fix name/displayedName for `ModuleInfo` (vor 2 Tagen) <Dmitry Gridin>
* 84f9dcd48a2 - (tag: build-1.4.0-dev-5112) [Gradle, JS] KT-37207 Add test case with non module directory dependency (vor 2 Tagen) <Ilya Goncharov>
* f1133defa33 - [Gradle, JS] KT-37207 Possibility to add dependency on not module dir (vor 2 Tagen) <Ilya Goncharov>
* f0c900c027f - [Gradle, JS] KT-37207 Add test on file-only dependency (vor 2 Tagen) <Ilya Goncharov>
* c72e4a0091d - [Gradle, JS] KT-37207 Support file-only npm dependency in extension (vor 2 Tagen) <Ilya Goncharov>
* f6ef96a34cf - [Gradle, JS] KT-37207 Leave constructor NpmDependency once (vor 2 Tagen) <Ilya Goncharov>
* 459577e6465 - [Gradle, JS] KT-37207 Add constructor fot NpmDependency with only file (vor 2 Tagen) <Ilya Goncharov>
* 7fc74ff7bdf - [Gradle, JS] KT-37207 Correct path to dependency directory (vor 2 Tagen) <Ilya Goncharov>
* 6b035bcdc28 - [Gradle, JS] KT-37207 Move File prefix to NpmDependency.kt (vor 2 Tagen) <Ilya Goncharov>
* 4d107751d7a - [Gradle, JS] KT-37207 Fix of test (vor 2 Tagen) <Ilya Goncharov>
* 8cefa095283 - [Gradle, JS] KT-37207 Add possibility to add npm dependency to directory (vor 2 Tagen) <Ilya Goncharov>
* ee941a3e778 - [Gradle, JS] KT-37207 Add test (vor 2 Tagen) <Ilya Goncharov>