### PR TITLE
[kotlin compiler][update] 1.4.0-dev-5483 

### DIFF
--- a/backend.native/tests/stdlib_external/utils.kt
+++ b/backend.native/tests/stdlib_external/utils.kt
@@ -24,3 +24,6 @@ internal actual inline fun testOnNonJvm6And7(f: () -> Unit) {
 
 actual fun testOnJvm(action: () -> Unit) {}
 actual fun testOnJs(action: () -> Unit) {}
+
+
+public actual val isFloat32RangeEnforced: Boolean get() = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-5097
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5097,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5257,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-5257
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5257,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-5257
-kotlinStdlibTestsVersion=1.4.0-dev-5257
-testKotlinCompilerVersion=1.4.0-dev-5257
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5483,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-5483
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5483,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-5483
+kotlinStdlibTestsVersion=1.4.0-dev-5483
+testKotlinCompilerVersion=1.4.0-dev-5483
 konanVersion=1.4.0-M2
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/Primitives.kt
+++ b/runtime/src/main/kotlin/kotlin/Primitives.kt
@@ -1158,18 +1158,31 @@ public final class Float private constructor() : Number(), Comparable<Float> {
          * A constant holding the positive infinity value of Float.
          */
         @Suppress("DIVISION_BY_ZERO")
-        public val POSITIVE_INFINITY: Float = 1.0f / 0.0f
+        public const val POSITIVE_INFINITY: Float = 1.0f / 0.0f
 
         /**
          * A constant holding the negative infinity value of Float.
          */
         @Suppress("DIVISION_BY_ZERO")
-        public val NEGATIVE_INFINITY: Float = -1.0f / 0.0f
+        public const val NEGATIVE_INFINITY: Float = -1.0f / 0.0f
 
         /**
          * A constant holding the "not a number" value of Float.
          */
-        public val NaN: Float = kotlinx.cinterop.bitsToFloat(0x7fc00000)
+        @Suppress("DIVISION_BY_ZERO")
+        public const val NaN: Float = -(0.0f / 0.0f)
+
+        /**
+         * The number of bytes used to represent an instance of Float in a binary form.
+         */
+        @SinceKotlin("1.4")
+        public const val SIZE_BYTES: Int = 4
+
+        /**
+         * The number of bits used to represent an instance of Float in a binary form.
+         */
+        @SinceKotlin("1.4")
+        public const val SIZE_BITS: Int = 32
     }
 
     /**
@@ -1415,18 +1428,31 @@ public final class Double private constructor() : Number(), Comparable<Double> {
          * A constant holding the positive infinity value of Double.
          */
         @Suppress("DIVISION_BY_ZERO")
-        public val POSITIVE_INFINITY: Double = 1.0 / 0.0
+        public const val POSITIVE_INFINITY: Double = 1.0 / 0.0
 
         /**
          * A constant holding the negative infinity value of Double.
          */
         @Suppress("DIVISION_BY_ZERO")
-        public val NEGATIVE_INFINITY: Double = -1.0 / 0.0
+        public const val NEGATIVE_INFINITY: Double = -1.0 / 0.0
 
         /**
          * A constant holding the "not a number" value of Double.
          */
-        public val NaN: Double = kotlinx.cinterop.bitsToDouble(0x7ff8000000000000L)
+        @Suppress("DIVISION_BY_ZERO")
+        public const val NaN: Double = -(0.0 / 0.0)
+
+        /**
+         * The number of bytes used to represent an instance of Double in a binary form.
+         */
+        @SinceKotlin("1.4")
+        public const val SIZE_BYTES: Int = 8
+
+        /**
+         * The number of bits used to represent an instance of Double in a binary form.
+         */
+        @SinceKotlin("1.4")
+        public const val SIZE_BITS: Int = 64
     }
 
     /**


### PR DESCRIPTION
* f451cb93da7 - (tag: build-1.4.0-dev-5483) Fix collectors name to match it to the whitelist (vor 15 Stunden) <Anton Yalyshev>
* 947e181b902 - Remove refactorings logging as now it's done in the platform collector (vor 15 Stunden) <Anton Yalyshev>
* aa12d4cd0cd - (tag: build-1.4.0-dev-5481) [Gradle, JS] Karma configuration. Remove launcher duplication (vor 28 Stunden) <Victor Turansky>
* e73a5738854 - (tag: build-1.4.0-dev-5480) Fetch analysis results if it is available (vor 2 Tagen) <Vladimir Dolzhenko>
* 3742fe48714 - (tag: build-1.4.0-dev-5476) i18n: fix some tests (vor 2 Tagen) <Dmitry Gridin>
* dc51a268aa0 - (tag: build-1.4.0-dev-5474) ReplaceWithAnnotationAnalyzer: should throw `ControlFlowException` (vor 2 Tagen) <Dmitry Gridin>
* d5ace43614d - (tag: build-1.4.0-dev-5470) KT-37986 Force boxing of inline class returned from function reference (vor 2 Tagen) <Dmitry Petrov>
* 5ed845d0b41 - (tag: build-1.4.0-dev-5462) JVM_IR: reuse same bodies for suspend funs and $$forInline versions (vor 3 Tagen) <pyos>
* 8945d5a0df7 - JVM_IR: remove $$forInline checks from ExpressionCodegen (vor 3 Tagen) <pyos>
* de1fa40c7ea - (tag: build-1.4.0-dev-5461) CodeInliner: fix KNPE (vor 3 Tagen) <Dmitry Gridin>
* 12379cb91cf - (tag: build-1.4.0-dev-5459) [Gradle, JS] Bump NPM versions (vor 3 Tagen) <Ilya Goncharov>
* 187ab5f393e - [Gradle, JS] KT-37984 Add additional Chrome and Firefox based browsers (vor 3 Tagen) <Ilya Goncharov>
* 50e6f6e07ea - (tag: build-1.4.0-dev-5455) [Gradle, JS] Remove hard test (vor 3 Tagen) <Ilya Goncharov>
* 8194652793a - (tag: build-1.4.0-dev-5450) Allow placing Suppress on a type parameter (vor 3 Tagen) <Ilya Gorbunov>
* fcada0a5e32 - Make use of contracts of time measurement functions (vor 3 Tagen) <Ilya Gorbunov>
* d71410bfb52 - (tag: build-1.4.0-dev-5449) Update version of properties-maven-plugin to 1.0.0 (vor 3 Tagen) <Nikolay Krasko>
* b89a7325b2c - Remove https://dl.bintray.com/kotlin/kotlin-eap repository from gradle tests (vor 3 Tagen) <Nikolay Krasko>
* 01e10324f05 - Eliminate 1.3.60-eap-76 usages from tests (vor 3 Tagen) <Nikolay Krasko>
* a422a124079 - (tag: build-1.4.0-dev-5446) Minor: update testData (vor 3 Tagen) <Dmitry Petrov>
* 7938a992dd7 - (tag: build-1.4.0-dev-5445, tag: build-1.4.0-dev-5444) i18n: make text from intention lazy (vor 3 Tagen) <Dmitry Gridin>
* 25dfc6dd636 - (tag: build-1.4.0-dev-5443) i18n: make text from intention lazy (vor 3 Tagen) <Dmitry Gridin>
* d8ca21d728c - (tag: build-1.4.0-dev-5442) Add `KotlinContextFeatureProvider` to the plugin.xml for 201 platform (vor 3 Tagen) <Roman Golyshev>
* 75283c74ac6 - (tag: build-1.4.0-dev-5441) [FIR] Generate type arguments for variable assignments (vor 3 Tagen) <Mikhail Glukhikh>
* d7460d47de1 - [FIR] Generate dispatch & extension receivers for variable assignments (vor 3 Tagen) <Mikhail Glukhikh>
* 774fc32f3e9 - (tag: build-1.4.0-dev-5438) JVM IR: support optimized callable reference superclasses (vor 3 Tagen) <Alexander Udalov>
* bb1a12e28eb - JVM IR: use correct owner for callable references in optimized multifile classes (vor 3 Tagen) <Alexander Udalov>
* 78467792d55 - JVM IR: rename CallableReferenceLowering -> FunctionReferenceLowering (vor 3 Tagen) <Alexander Udalov>
* 238488d4fb5 - (tag: build-1.4.0-dev-5427) [FIR] Fix collection subgraphs to drop from delegate calls (vor 3 Tagen) <Dmitriy Novozhilov>
* b21da3910a9 - (tag: build-1.4.0-dev-5420) [FIR] Set type arguments also in provideDelegate property reference (vor 3 Tagen) <Mikhail Glukhikh>
* 8bf4ec66a95 - [FIR] Fix receiver type order in delegate property reference (vor 3 Tagen) <Mikhail Glukhikh>
* f374c36cd25 - [FIR2IR] Generate property extension receiver references properly (vor 3 Tagen) <Mikhail Glukhikh>
* 4234438d8da - [FIR] Generate thisRef more correctly for extension property (vor 3 Tagen) <Mikhail Glukhikh>
* f3f7bf70f63 - [FIR] Set delegate field receiver properly (vor 3 Tagen) <Mikhail Glukhikh>
* 036b6c63f6c - [FIR] During resolve, set correctly property reference type in delegate (vor 3 Tagen) <Mikhail Glukhikh>
* 58e00400f13 - [FIR2IR] Support PROPERTY_REFERENCE_FROM_DELEGATE origin (vor 3 Tagen) <Mikhail Glukhikh>
* 5f8fadb2207 - [FIR2IR] Remove GET_PROPERTY origin from delegate field reads (vor 3 Tagen) <Mikhail Glukhikh>
* 94749855b99 - (tag: build-1.4.0-dev-5417) FIR: fix visibility extension for fake override. (vor 3 Tagen) <Jinseong Jeon>
* 0054c22ef24 - (tag: build-1.4.0-dev-5413) Use correct return type for serializers (vor 3 Tagen) <Leonid Startsev>
* 75c4607e574 - (tag: build-1.4.0-dev-5411) Rename of KotlinQuickDocumentationProvider to KotlinDocumentationProvider (vor 3 Tagen) <Igor Yakovlev>
* a71fd0e6d9c - Support for showing rendered doc comments in editor (vor 3 Tagen) <Igor Yakovlev>
* d620802a186 - (tag: build-1.4.0-dev-5404) [FIR] Add `equals` and `hashCode` to `ConeCapturedType` (vor 3 Tagen) <Dmitriy Novozhilov>
* 7dd91df10b2 - [FIR] Don't analyze with DFA already analyzed classes (vor 3 Tagen) <Dmitriy Novozhilov>
* 0b2536199b3 - [FIR] Don't analyze delegated constructor calls twice (vor 3 Tagen) <Dmitriy Novozhilov>
* 20d0e8647df - [FIR] Pass data flow to init blocks of local classes (vor 3 Tagen) <Dmitriy Novozhilov>
* 16b5b2dcefb - [FIR] Add symbol to FirAnonymousInitializer (vor 3 Tagen) <Dmitriy Novozhilov>
* bcd2e5ed2c2 - [FIR] Add control flow graph to inplace lambdas (vor 3 Tagen) <Dmitriy Novozhilov>
* 1d39270b3ea - [FIR] Don't pass data flow to property accessors of non local classes (vor 3 Tagen) <Dmitriy Novozhilov>
* bb8d7437418 - [FIR-TEST] Throw RuntimeException instead of AssertionError in FirResolveBench (vor 3 Tagen) <Dmitriy Novozhilov>
* 1d1b8d3290a - [FIR-TEST] Update cfg dumps according to previous commits (vor 3 Tagen) <Dmitriy Novozhilov>
* 6faf364a46d - [FIR] Update cfg renderer (vor 3 Tagen) <Dmitriy Novozhilov>
* d1422dbf9f4 - [FIR] Don't pass analyzed lambda to data flow analyzer (vor 3 Tagen) <Dmitriy Novozhilov>
* 68b5e4d13f6 - [FIR] Choose right cfg owner for postponed lambdas (vor 3 Tagen) <Dmitriy Novozhilov>
* 9fa0a2cc77e - [FIR] Drop subgraphs of lambda arguments of delegate calls (vor 3 Tagen) <Dmitriy Novozhilov>
* 14db88cccb0 - [FIR] Fix double resolution of default property accessors (vor 3 Tagen) <Dmitriy Novozhilov>
* 9bdd5e47ac9 - [FIR] Fix equality for cfg nodes (vor 3 Tagen) <Dmitriy Novozhilov>
* b90c8eb8ed6 - [FIR] Analyze annotations of local class before class itself (vor 3 Tagen) <Dmitriy Novozhilov>
* 1177a568152 - [FIR] Don't resolve annotations twice (vor 3 Tagen) <Dmitriy Novozhilov>
* 28738971bcd - [FIR] Add `transformAnnotations` for fir nodes (vor 3 Tagen) <Dmitriy Novozhilov>
* 3190793b62f - [FIR] Add incoming edges to local class's property initializers (vor 3 Tagen) <Dmitriy Novozhilov>
* c223ae03ba4 - [FIR] Don't analyze local classes twice (vor 3 Tagen) <Dmitriy Novozhilov>
* 119d5b3740a - [FIR] Add incoming edge for all members of local class, not only implicit ones (vor 3 Tagen) <Dmitriy Novozhilov>
* 43e9cbbbf58 - [FIR] Add parent graph to CFG (vor 3 Tagen) <Dmitriy Novozhilov>
* 6be554e7653 - [FIR] Rename `ControlFlowGraph.owner` to `declaration` (vor 3 Tagen) <Dmitriy Novozhilov>
* 8cb6e8f8afd - [FIR] Add control flow graph for class initialization (vor 3 Tagen) <Dmitriy Novozhilov>
* ad9e6517c7f - [FIR] Add cfg nodes for classes (vor 3 Tagen) <Dmitriy Novozhilov>
* 74d86d82c62 - [FIR] Add control flow graph to FirAnonymousInitializer (vor 3 Tagen) <Dmitriy Novozhilov>
* 8d3ee4f3048 - [FIR] Add cfg reference to classes (vor 3 Tagen) <Dmitriy Novozhilov>
* c1c0df962f3 - (tag: build-1.4.0-dev-5403) [Gradle, JS] Add browser to test js composite build (vor 3 Tagen) <Ilya Goncharov>
* a5026d60db3 - [Gradle, JS] Configure test executable only once (vor 3 Tagen) <Ilya Goncharov>
* c26c8fdb89f - [Gradle, JS] Added binaries names to store (vor 3 Tagen) <Ilya Goncharov>
* 6b325484917 - [Gradle, JS] JvmOverloads for Groovy DSL (vor 3 Tagen) <Ilya Goncharov>
* d4ece2b23b8 - [Gradle, JS] Fix ktor version in web mpp wizard (vor 3 Tagen) <Ilya Goncharov>
* 1b294ce5a5a - [Gradle, JS] Fix DSL for project wizards (vor 3 Tagen) <Ilya Goncharov>
* b3e67382432 - [Gradle, JS] Fix binaries.executable for Groovy dsl (vor 3 Tagen) <Ilya Goncharov>
* 1f6b7dd88db - (tag: build-1.4.0-dev-5397) "Redundant suspend modifier": fix false negative with only recursive call (vor 3 Tagen) <Toshiaki Kameyama>
* e3871a99618 - Wizard: fix project editor width on the second step (vor 3 Tagen) <Ilya Kirillov>
* 126cd38360e - (tag: build-1.4.0-dev-5392) Fix testdata of RemoveSingleLambdaParameter quickfix (vor 4 Tagen) <Ilya Kirillov>
* cc0cb30b534 - "Remove single lambda parameter declaration": do not suggest when lambda is directly under 'if/when' (vor 4 Tagen) <Toshiaki Kameyama>
* 352a860e468 - (tag: build-1.4.0-dev-5385) Add system classloader as a parent of ReplClassLoader. (vor 4 Tagen) <Pierre-Luc Carmel Biron>
* cec747349e4 - (tag: build-1.4.0-dev-5382) Fix PSI tests for correct parsing them by the ANTLR grammar (vor 4 Tagen) <Victor Petukhov>
* 5786578f382 - (tag: build-1.4.0-dev-5373) Fix NPE in ProjectRootsUtilKt.isKotlinBinary (vor 4 Tagen) <Matthew Gharrity>
* e6769670565 - (tag: build-1.4.0-dev-5372) Unmute two FIR black box test (related to JDK version) (vor 4 Tagen) <Mikhail Glukhikh>
* a75408b1ed5 - (tag: build-1.4.0-dev-5364) JVM_IR: use non-nullable types as SAM super types (vor 4 Tagen) <pyos>
* 164f25937f6 - (tag: build-1.4.0-dev-5353) NI: take into account an extension function annotation during CST calculation (vor 4 Tagen) <Victor Petukhov>
* f8d72f5dd92 - NI: improve lambdas completion – look at all postponed arguments during resolution lambdas by additional conditions (vor 4 Tagen) <Victor Petukhov>
* 3baeb634555 - (tag: build-1.4.0-dev-5352) Update K/N: 1.4-M2-dev-15123 (vor 4 Tagen) <Ilya Matveev>
* a96b359a093 - (tag: build-1.4.0-dev-5345) "Remove braces from 'if' statement": do not suggest when lambda is directly under 'if' (vor 4 Tagen) <Toshiaki Kameyama>
* 30366148bf8 - Convert to block body: adjust line indent (vor 4 Tagen) <Toshiaki Kameyama>
* 1bc72f0b323 - (tag: build-1.4.0-dev-5342) "Surround with lambda" quickfix: suggest for suspend function (vor 4 Tagen) <Toshiaki Kameyama>
* 44c34ab8c37 - [FIR2IR] Don't create fake overrides for private property accessors (vor 4 Tagen) <Jinseong Jeon>
* 3e6b38a921a - [FIR] Fix type reference for 1st arg of GetClassCall (vor 4 Tagen) <Jinseong Jeon>
* 4a5643856eb - (tag: build-1.4.0-dev-5339) FIR: Extract fir.resolve.calls.tower package (vor 4 Tagen) <Denis Zharkov>
* 177abe9f876 - FIR: Add fixes after review (vor 4 Tagen) <Denis Zharkov>
* 426609a133e - FIR: Fix resolution for HideMembers level (vor 4 Tagen) <Denis Zharkov>
* 6cc6b9efcb8 - FIR: Fix overload resolution for some invoke cases (vor 4 Tagen) <Denis Zharkov>
* bcd79c1e2e6 - FIR: Drop unused TowerGroup.Weakened (vor 4 Tagen) <Denis Zharkov>
* 328740f8e12 - FIR: Minor. Use copy in CallInfo (vor 4 Tagen) <Denis Zharkov>
* 7fc06558496 - FIR: Refactor CandidateCollector (vor 4 Tagen) <Denis Zharkov>
* b52dd8e6808 - FIR: Extract processLevelForRegularInvoke (vor 4 Tagen) <Denis Zharkov>
* 19e0cf570c1 - FIR: Cleanup MemberScopeTowerLevel (vor 4 Tagen) <Denis Zharkov>
* 9abe669443b - FIR: Fix resolution for invokes on class qualifiers (vor 4 Tagen) <Denis Zharkov>
* 10531d2874a - FIR: Refactor createExplicitReceiverForInvoke (vor 4 Tagen) <Denis Zharkov>
* b83ffe83faf - FIR: Minor. Add comments (vor 4 Tagen) <Denis Zharkov>
* 90d82e201eb - FIR: Get rid of lateinit property in CandidateFactoriesAndCollectors (vor 4 Tagen) <Denis Zharkov>
* 80c64207f7f - FIR: Rename CallResolutionContext -> CandidateFactoriesAndCollectors (vor 4 Tagen) <Denis Zharkov>
* 4053978609f - FIR: Refactor FirTowerResolverSession and LevelHandler (vor 4 Tagen) <Denis Zharkov>
* 31c6cf31066 - FIR: Clean up code in LevelHandler (vor 4 Tagen) <Denis Zharkov>
* 063795f280c - FIR: Minor. Move createExplicitReceiverForInvoke out of the class (vor 4 Tagen) <Denis Zharkov>
* 3e32f21e7e0 - FIR: Replace extension receiver with explicit parameter (vor 4 Tagen) <Denis Zharkov>
* b97ce3d6efe - FIR: Extract function in TowerLevelHandler (vor 4 Tagen) <Denis Zharkov>
* 36d3abad517 - FIR: Get rid of relation from LevelHandler to FirTowerResolver (vor 4 Tagen) <Denis Zharkov>
* 123bcdb0adf - FIR: Move some responsibilities of TowerResolveManager to FirTowerResolverSession (vor 4 Tagen) <Denis Zharkov>
* a39dbe8eec3 - FIR: Declare `manager` as a property inside FirTowerResolverSession (vor 4 Tagen) <Denis Zharkov>
* f8227e4cb91 - FIR: Extract FirTowerResolverSession (vor 4 Tagen) <Denis Zharkov>
* 60cbc5fa399 - FIR: Extract LevelHandler and CallResolutionContext from TowerManager (vor 4 Tagen) <Denis Zharkov>
* 08ee76b103a - FIR: Introduce FirTowerResolver.implicitReceiversUsableAsValues (vor 4 Tagen) <Denis Zharkov>
* e936c03839b - FIR: Extract processScopeForExplicitReceiver (vor 4 Tagen) <Denis Zharkov>
* 9cd8432c92a - FIR: Minor. Formatting (vor 4 Tagen) <Denis Zharkov>
* 2e631052f67 - FIR: Drop redundant main function (vor 4 Tagen) <Denis Zharkov>
* 5c61211e652 - FIR: Extract LevelHandler.processInvokeReceiversCandidates (vor 4 Tagen) <Denis Zharkov>
* a5c3e4bfd44 - FIR: Extract some parts from FirTowerResolver and cleanup (vor 4 Tagen) <Denis Zharkov>
* 7843f7d3f07 - FIR: Minor. Reuse processExtensionsThatHideMembers (vor 4 Tagen) <Denis Zharkov>
* aeb3354a5b5 - FIR: Extract ReceiverValue.toMemberScopeTowerLevel (vor 4 Tagen) <Denis Zharkov>
* e2ca1f2af49 - FIR: Extract FirScope.toScopeTowerLevel (vor 4 Tagen) <Denis Zharkov>
* bea9d20557a - FIR: Split FirTowerResolver.runResolverForNoReceiver (vor 4 Tagen) <Denis Zharkov>
* 07d80aa11c6 - (tag: build-1.4.0-dev-5337) [Gradle, JS] KT-36784 Enable composite builds only for IR compiler (vor 4 Tagen) <Ilya Goncharov>
* 43efac69a9b - [Gradle, JS] KT-36784 Move test only to IR (vor 4 Tagen) <Ilya Goncharov>
* c11c3dffe7f - [Gradle, JS] KT-36784 Provide args for kotlinNpmInstall (vor 4 Tagen) <Ilya Goncharov>
* fe40056abee - [Gradle, JS] KT-36784 Remove hasNodeModulesDependentTasks (vor 4 Tagen) <Ilya Goncharov>
* 9806ac992e4 - [Gradle, JS] KT-36784 Fix tests on composite (vor 4 Tagen) <Ilya Goncharov>
* a27ae5dd7bb - [Gradle, JS] KT-36784 Fix absolute paths on relative in package.json (vor 4 Tagen) <Ilya Goncharov>
* ffc22f4190e - (tag: build-1.4.0-dev-5333) [FIR] Unmute two passing black box tests (vor 4 Tagen) <Mikhail Glukhikh>
* 055a1921cce - (tag: build-1.4.0-dev-5332) Update kotlin-build-gradle-plugin to 0.0.17 (vor 4 Tagen) <Ilya Gorbunov>
* 8bc8a8cf79a - Publish kotlin-build-gradle-plugin sources (vor 4 Tagen) <Ilya Gorbunov>
* fde33252cf5 - Present boolean property without value is considered true (vor 4 Tagen) <Ilya Gorbunov>
* 1727fcf1a8a - Make some build properties extensions in buildSrc (vor 4 Tagen) <Ilya Gorbunov>
* c046f431d9f - Rename KotlinBuildProperties.get private function to getOrNull (vor 4 Tagen) <Ilya Gorbunov>
* 2e20fab05fd - Add bootstrap.teamcity.url parameter to specify bootstrap teamcity server (vor 4 Tagen) <Ilya Gorbunov>
* 453e91daf2e - (tag: build-1.4.0-dev-5325) Advance bootstrap to 1.4.0-dev-5258 (vor 4 Tagen) <Ilya Gorbunov>
* 01b463993be - Use SinceKotlin in primitive companion objects for documentation purpose (vor 4 Tagen) <Ilya Gorbunov>
* a225842f9b4 - Test that known Floats can fit in FloatArray without over/underflow (vor 4 Tagen) <Ilya Gorbunov>
* d88d2cb0580 - Test new Double/Float constants (vor 4 Tagen) <Ilya Gorbunov>
* 3e6ab65ccc4 - (tag: build-1.4.0-dev-5324) Wizard: place kotlin.code.style to gradle.properties file instead of local.properties (vor 4 Tagen) <Ilya Kirillov>
* db2c2cc8d96 - Wizard: fix generated project path & name (vor 4 Tagen) <Ilya Kirillov>
* 00e5e96fe38 - Wizard: fix write action scope in IdeaJpsWizardService (vor 4 Tagen) <Ilya Kirillov>
* 24b8495e00c - (tag: build-1.4.0-dev-5323) KT-30419 Box inline classes in return types of covariant overrides (vor 5 Tagen) <Dmitry Petrov>
* e44f12d7b04 - (tag: build-1.4.0-dev-5313) Minor, unmute passing FIR black box tests (vor 5 Tagen) <Alexander Udalov>
* 10df7ee31a1 - (tag: build-1.4.0-dev-5312) Get rid of getInstanceIfNotDisposed (vor 5 Tagen) <Vladimir Dolzhenko>
* 55a98fc5df1 - (tag: build-1.4.0-dev-5308) Include kotlin-test-annotations-common into core libs list (vor 5 Tagen) <Ilya Gorbunov>
* 5e1e9876fda - (tag: build-1.4.0-dev-5303, origin/spec-tests) IDE: Don't use direct refs on IdePlatformKindResolution EP instances (vor 5 Tagen) <Dmitriy Dolovov>
* a2e2213d310 - Keep KonanTarget.predefinedTargets as Map<String, KonanTarget> (vor 5 Tagen) <Dmitriy Dolovov>
* 132464fa4fa - Minor. Rename KotlinLibrary.readSafe() -> KotlinLibrary.safeRead() (vor 5 Tagen) <Dmitriy Dolovov>
* b199403c579 - (tag: build-1.4.0-dev-5298) 201: Revert adding RUN_SLOW_ASSERTIONS enabling in KtUsefulTestCase (vor 5 Tagen) <Nikolay Krasko>
* 34a64d9171d - (tag: build-1.4.0-dev-5291) Making var arg kParameters default to empty array no argument given (vor 5 Tagen) <Mathias Quintero>
* b1dbacf45fc - (tag: build-1.4.0-dev-5290) [Spec tests] Fix test-info parser for relevant places (vor 5 Tagen) <anastasiia.spaseeva>
* 9f684bfd658 - [Spec tests] Add tests for call-with-specified-type-parameters (vor 5 Tagen) <anastasiia.spaseeva>
* 3269a7e6934 - (tag: build-1.4.0-dev-5286) Change behavior of equals/hashCode on adapted function references (vor 5 Tagen) <Alexander Udalov>
* c344b85d4e9 - (tag: build-1.4.0-dev-5278) Convert parameter <-> receiver intention: do not add label to 'this' if not needed (vor 5 Tagen) <Toshiaki Kameyama>
* 34e9e899f8b - (tag: build-1.4.0-dev-5277) FIR: move FirModifierList to module 'fir:checkers' (vor 5 Tagen) <Alexander Udalov>
* 3263e85beea - (tag: build-1.4.0-dev-5275) Introduce "Remove fun modifier" quick fix for FUN_INTERFACE_WRONG_COUNT_OF_ABSTRACT_MEMBERS error (vor 5 Tagen) <Toshiaki Kameyama>
* bfd6eeda606 - (tag: build-1.4.0-dev-5274) Fix compilation with JPS (vor 5 Tagen) <Dmitriy Dolovov>
* e455e926aad - (tag: build-1.4.0-dev-5271) Implement members: fix it works correctly if primary constructor has implemented member (vor 5 Tagen) <Toshiaki Kameyama>
* 5eabc1117f7 - (tag: build-1.4.0-dev-5258) Generate constant expression initializers for special fp values in kapt (vor 5 Tagen) <Ilya Gorbunov>
* 427750ba03a - Update builtins test data (vor 5 Tagen) <Ilya Gorbunov>
* f3fc1197ae2 - Add SIZE_BITS and SIZE_BYTES constants to Double and Float (vor 5 Tagen) <Ilya Gorbunov>
* 1c939112798 - Make Double and Float known values constant (vor 5 Tagen) <Ilya Gorbunov>