### PR TITLE
Fix measuring compile time in benchmarks plugin. Plugin creates tasks…

### DIFF
--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/BenchmarkingPlugin.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/BenchmarkingPlugin.kt
@@ -220,8 +220,8 @@ abstract class BenchmarkingPlugin: Plugin<Project> {
             it.doLast {
                 val applicationName = benchmark.applicationName
                 val benchContents = buildDir.resolve(nativeBenchResults).readText()
-                val nativeCompileTime = if (benchmark.compileTasks.isEmpty()) getNativeCompileTime(applicationName)
-                else getNativeCompileTime(applicationName, benchmark.compileTasks)
+                val nativeCompileTime = if (benchmark.compileTasks.isEmpty()) getNativeCompileTime(project, applicationName)
+                else getNativeCompileTime(project, applicationName, benchmark.compileTasks)
 
                 val properties = commonBenchmarkProperties + mapOf(
                         "type" to "native",

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/CompileBenchmarkingPlugin.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/CompileBenchmarkingPlugin.kt
@@ -85,6 +85,7 @@ open class CompileBenchmarkingPlugin : Plugin<Project> {
 
             doLast {
                 val nativeCompileTime = getCompileBenchmarkTime(
+                    project,
                     applicationName,
                     buildSteps.names,
                     repeatNumber,

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/KotlinNativeBenchmarkingPlugin.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/KotlinNativeBenchmarkingPlugin.kt
@@ -43,7 +43,7 @@ open class KotlinNativeBenchmarkingPlugin: BenchmarkingPlugin() {
             it.doLast {
                 val applicationName = benchmark.applicationName
                 val jarPath = (tasks.getByName("jvmJar") as Jar).archiveFile.get().asFile
-                val jvmCompileTime = getJvmCompileTime(applicationName)
+                val jvmCompileTime = getJvmCompileTime(project, applicationName)
                 val benchContents = buildDir.resolve(jvmBenchResults).readText()
 
                 val properties: Map<String, Any> = commonBenchmarkProperties + mapOf(

--- a/performance/framework/build.gradle
+++ b/performance/framework/build.gradle
@@ -91,7 +91,7 @@ task konanJsonReport {
             def frameworkPath = kotlin.macosX64("macos").binaries.
                     getFramework(frameworkName, kotlin.macosX64("macos").binaries.DEBUG).outputFile.absolutePath
             def nativeExecutable = new File("$frameworkPath/$frameworkName").canonicalPath
-            def nativeCompileTime = MPPTools.getNativeCompileTime(applicationName, ['compileKotlinMacos',
+            def nativeCompileTime = MPPTools.getNativeCompileTime(project, applicationName, ['compileKotlinMacos',
                                                                                     'linkBenchmarksAnalyzerDebugFrameworkMacos',
                                                                                     'cinteropLibcurlMacos'])
             def properties = getCommonProperties() + ['type'           : 'native',


### PR DESCRIPTION
… with same names for each subproject