### PR TITLE
Changes to support unsigned progressions in ForLoopsLowering.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -76,7 +76,7 @@ To update the blackbox compiler tests set TeamCity build number in `gradle.prope
 
 * **-Pprefix** allows one to choose external test directories to run. Only tests from directories with given prefix will be executed.
 
-        ./gradlew -Pprefix=external_codegen_box_cast run_external
+        ./gradlew -Pprefix=build_external_compiler_codegen_box_cast run_external
 
 * **-Ptest_flags** passes flags to the compiler used to compile tests
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -63,10 +63,10 @@ internal class KonanSymbols(
 
     private fun unsignedClass(unsignedType: UnsignedType): IrClassSymbol = classById(unsignedType.classId)
 
-    val uByte = unsignedClass(UnsignedType.UBYTE)
-    val uShort = unsignedClass(UnsignedType.USHORT)
-    val uInt = unsignedClass(UnsignedType.UINT)
-    val uLong = unsignedClass(UnsignedType.ULONG)
+    override val uByte = unsignedClass(UnsignedType.UBYTE)
+    override val uShort = unsignedClass(UnsignedType.USHORT)
+    override val uInt = unsignedClass(UnsignedType.UINT)
+    override val uLong = unsignedClass(UnsignedType.ULONG)
 
     val signedIntegerClasses = setOf(byte, short, int, long)
     val unsignedIntegerClasses = setOf(uByte, uShort, uInt, uLong)


### PR DESCRIPTION
See: https://github.com/JetBrains/kotlin/pull/3274

Also corrected example for test prefix in HACKING.md.