### PR TITLE
Fix spelling of "destroyed" in WeakReference docs

### DIFF
--- a/runtime/src/main/kotlin/kotlin/native/ref/Weak.kt
+++ b/runtime/src/main/kotlin/kotlin/native/ref/Weak.kt
@@ -7,7 +7,7 @@ package kotlin.native.ref
 
 /**
  * Class WeakReference encapsulates weak reference to an object, which could be used to either
- * retrieve a strong reference to an object, or return null, if object was already destoyed by
+ * retrieve a strong reference to an object, or return null, if object was already destroyed by
  * the memory manager.
  */
 public class WeakReference<T : Any> {


### PR DESCRIPTION
This commit adds a missing "r" to the word "destroyed" in the class
documentation for WeakReference.