### PR TITLE
[devirtualization] Removed redundant code with associated objects + test

### DIFF
--- a/backend.native/tests/objcexport/expectedLazy.h
+++ b/backend.native/tests/objcexport/expectedLazy.h
@@ -205,6 +205,12 @@ __attribute__((swift_name("GH4002Argument")))
 @end;
 
 __attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("Kt35940Kt")))
+@interface KtKt35940Kt : KtBase
++ (NSString *)testKt35940 __attribute__((swift_name("testKt35940()")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
 __attribute__((swift_name("LibraryKt")))
 @interface KtLibraryKt : KtBase
 + (NSString *)readDataFromLibraryClassInput:(KtA *)input __attribute__((swift_name("readDataFromLibraryClass(input:)")));

--- a/backend.native/tests/objcexport/kt35940.kt
+++ b/backend.native/tests/objcexport/kt35940.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package kt35940
+
+import kotlin.reflect.*
+
+@OptIn(ExperimentalAssociatedObjects::class)
+@AssociatedObjectKey
+@Retention(AnnotationRetention.BINARY)
+annotation class Associated(val kClass: KClass<*>)
+
+private interface I1 {
+    val s: String
+}
+
+private class I1Impl : I1 {
+    override val s = "zzz"
+}
+
+private class C(var i1: I1?)
+
+private interface I2 {
+    fun bar(c: C)
+}
+
+private object I2Impl : I2 {
+    override fun bar(c: C) {
+        c.i1 = I1Impl()
+    }
+}
+
+@Associated(I2Impl::class)
+private class I2ImplHolder
+
+@OptIn(ExperimentalAssociatedObjects::class)
+fun testKt35940(): String {
+    val i2 = I2ImplHolder::class.findAssociatedObject<Associated>()!! as I2
+    val c = C(null)
+    i2.bar(c)
+    return c.i1!!.s
+}

--- a/backend.native/tests/objcexport/kt35940.swift
+++ b/backend.native/tests/objcexport/kt35940.swift
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+import Kt
+
+private func test1() throws {
+    try assertEquals(actual: Kt35940Kt.testKt35940(), expected: "zzz")
+}
+
+class Kt35940Tests : SimpleTestProvider {
+    override init() {
+        super.init()
+
+        test("Test1", test1)
+    }
+}


### PR DESCRIPTION
It turned out that it is not needed to explicitly add all associated objects to instantiating classes
since their constructors have been already added to the root set and all constructors have additional parameter (<this>) and its type will be added to instantiating classes since it is final for all objects.