### PR TITLE
Fix race in cyclic collector

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -883,9 +883,7 @@ task worker_bound_reference0(type: KonanLocalTest) {
 }
 
 task worker_bound_reference1(type: KonanLocalTest) {
-    // enabled = (project.testTarget != 'wasm32') // Workers need pthreads.
-    // TODO: These tests are flaky. Fix them.
-    enabled = false
+    enabled = (project.testTarget != 'wasm32') // Workers need pthreads.
     source = "runtime/concurrent/worker_bound_reference1.kt"
 }
 


### PR DESCRIPTION
Prevent cyclic collector from observing newly allocated atomic root with RC = 0.
