### PR TITLE
[runtime] Terminate on IncorrectDereferenceException from ObjC weak p…

### DIFF
--- a/runtime/src/main/cpp/Memory.h
+++ b/runtime/src/main/cpp/Memory.h
@@ -601,6 +601,7 @@ class ObjHolder {
    ObjHeader* obj_;
 };
 
+//! TODO Follow the Rule of Zero to prevent dangling on unintented copy ctor
 class ExceptionObjHolder {
  public:
    explicit ExceptionObjHolder(const ObjHeader* obj) {

--- a/runtime/src/main/cpp/Natives.h
+++ b/runtime/src/main/cpp/Natives.h
@@ -19,6 +19,7 @@
 
 #include "Types.h"
 #include "Exceptions.h"
+#include "Memory.h"
 
 constexpr size_t alignUp(size_t size, size_t alignment) {
   return (size + alignment - 1) & ~(alignment - 1);

--- a/runtime/src/main/cpp/ObjCExportErrors.mm
+++ b/runtime/src/main/cpp/ObjCExportErrors.mm
@@ -46,7 +46,7 @@ extern "C" RUNTIME_NORETURN void Kotlin_ObjCExport_trapOnUndeclaredException(KRe
 static char kotlinExceptionOriginChar;
 
 static bool isExceptionOfType(KRef exception, const TypeInfo** types) {
-  for (int i = 0; types[i] != nullptr; ++i) {
+  if (types) for (int i = 0; types[i] != nullptr; ++i) {
     // TODO: use fast instance check when possible.
     if (IsInstance(exception, types[i])) return true;
   }

--- a/runtime/src/main/cpp/SourceInfo.h
+++ b/runtime/src/main/cpp/SourceInfo.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef RUNTIME_SOURCEINFO_H
+#define RUNTIME_SOURCEINFO_H
+
 struct SourceInfo {
     const char* fileName;
     int lineNumber;
@@ -29,3 +32,5 @@ struct SourceInfo Kotlin_getSourceInfo(void* addr);
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif // RUNTIME_SOURCEINFO_H

--- a/runtime/src/release/cpp/SourceInfo.cpp
+++ b/runtime/src/release/cpp/SourceInfo.cpp
@@ -16,6 +16,6 @@
 
 #include "SourceInfo.h"
 
-extern "C" struct SourceInfo Kotlin_getSourceInfo(void* addr) {
+struct SourceInfo Kotlin_getSourceInfo(void* addr) {
   return (SourceInfo) { .fileName = nullptr, .lineNumber = -1, .column = -1 };
 }


### PR DESCRIPTION
…roperty

Root cause: ObjC runtime gets a os_unfair_lock when accessing weak property.
If exception is thrown from _tryRetainImp this lock left unlocked,
so it will hang on `__ulock_wait` on the next access.
Interim workaround: terminate instead of exception propagating.