### PR TITLE
Exclude tests

### DIFF
--- a/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -533,7 +533,8 @@ fun runTest() {
             def settings = languageSettings.first()
             if (settings.contains('-ProperIeee754Comparisons') ||  // K/N supports only proper IEEE754 comparisons
                     settings.contains('-ReleaseCoroutines') ||     // only release coroutines
-                    settings.contains('-DataClassInheritance')) {  // old behavior is not supported
+                    settings.contains('-DataClassInheritance') ||  // old behavior is not supported
+                    settings.contains('-ProhibitAssigningSingleElementsToVarargsInNamedForm')) { // Prohibit these assignments
                 return false
             }
         }


### PR DESCRIPTION
Do not execute tests for -ProhibitAssigningSingleElementsToVarargsInNamedForm.
These assignments is prohibited, compiler issues an error. See `compiler/testData/codegen/box/vararg/singleAssignmentToVarargsInFunction.kt`. This test with `-` fails.