### PR TITLE
[debug] Forbade getting llvm for external non-exported functions + test

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1919,7 +1919,12 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
     private fun IrFunction.scope(startLine:Int): DIScopeOpaqueRef? {
         if (!context.shouldContainLocationDebugInfo())
             return null
-        val functionLlvmValue = codegen.llvmFunctionOrNull(this)
+        val functionLlvmValue =
+                // TODO: May be tie up inline lambdas to their outer function?
+                if (codegen.isExternal(this) && !KonanBinaryInterface.isExported(this))
+                    null
+                else
+                    codegen.llvmFunctionOrNull(this)
         return if (!isReifiedInline && functionLlvmValue != null) {
             context.debugInfo.subprograms.getOrPut(functionLlvmValue) {
                 memScoped {

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3340,6 +3340,11 @@ linkTest("inline_lateinitProperty_linkTest") {
     lib = "codegen/inline/lateinitProperty_linkTest_lib.kt"
 }
 
+linkTest("inline_inlineCtor_linkTest") {
+    source = "codegen/inline/inlineCtor_linkTest_main.kt"
+    lib = "codegen/inline/inlineCtor_linkTest_lib.kt"
+}
+
 def generateWithSpaceDefFile() {
     def mapOption = "--Map \"${buildDir}/cutom map.map\""
     if (isAppleTarget(project)) {

--- a/backend.native/tests/codegen/inline/inlineCtor_linkTest_lib.kt
+++ b/backend.native/tests/codegen/inline/inlineCtor_linkTest_lib.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package a
+
+fun foo(n: Int, block: (Int) -> Int): Int {
+    val arr = IntArray(n) { block(it) }
+    var sum = 0
+    for (x in arr) sum += x
+    return sum
+}

--- a/backend.native/tests/codegen/inline/inlineCtor_linkTest_main.kt
+++ b/backend.native/tests/codegen/inline/inlineCtor_linkTest_main.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+import a.*
+import kotlin.test.*
+
+fun main() {
+    assertEquals(42, foo(7) { it * 2 })
+}


### PR DESCRIPTION
This could happen for inline lambdas