### PR TITLE
[kotlin compiler][update] 1.4.0-dev-7753

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/TopDownAnalyzerFacadeForKonan.kt
@@ -49,7 +49,9 @@ internal object TopDownAnalyzerFacadeForKonan {
                 projectContext.storageManager,
                 module.builtIns,
                 config.languageVersionSettings,
-                config.friendModuleFiles)
+                config.friendModuleFiles,
+                module
+        )
 
         val additionalPackages = mutableListOf<PackageFragmentProvider>()
         if (!module.isNativeStdlib()) {
@@ -106,7 +108,8 @@ private class ResolvedDependencies(
     storageManager: StorageManager,
     builtIns: KotlinBuiltIns,
     specifics: LanguageVersionSettings,
-    friendModuleFiles: Set<File>
+    friendModuleFiles: Set<File>,
+    currentModuleDescriptor: ModuleDescriptorImpl
 ) {
 
     val moduleDescriptors: KotlinResolvedModuleDescriptors
@@ -123,7 +126,7 @@ private class ResolvedDependencies(
         }
 
         this.moduleDescriptors = NativeFactories.DefaultResolvedDescriptorsFactory.createResolved(
-                resolvedLibraries, storageManager, builtIns, specifics, customAction)
+                resolvedLibraries, storageManager, builtIns, specifics, customAction, listOf(currentModuleDescriptor))
 
         this.friends = collectedFriends.toSet()
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -204,7 +204,7 @@ internal val psiToIrPhase = konanUnitPhase(
                     }.reversed()
                 }
 
-                for (dependency in sortDependencies(dependencies)) {
+                for (dependency in sortDependencies(dependencies).filter { it != moduleDescriptor }) {
                     val kotlinLibrary = dependency.getCapability(KlibModuleOrigin.CAPABILITY)?.let {
                         (it as? DeserializedKlibModuleOrigin)?.library
                     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -86,7 +86,10 @@ internal class KonanIrLinker(
             assert(moduleDescriptor.kotlinLibrary.isInteropLibrary())
         }
 
-        private val descriptorByIdSignatureFinder = DescriptorByIdSignatureFinder(moduleDescriptor, KonanManglerDesc)
+        private val descriptorByIdSignatureFinder = DescriptorByIdSignatureFinder(
+                moduleDescriptor, KonanManglerDesc,
+                DescriptorByIdSignatureFinder.LookupMode.MODULE_ONLY
+        )
         private fun IdSignature.isInteropSignature(): Boolean = IdSignature.Flags.IS_NATIVE_INTEROP_LIBRARY.test()
 
         override fun contains(idSig: IdSignature): Boolean {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-5097
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-5097,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-7380,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-7380
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-7380,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-7380
-kotlinStdlibTestsVersion=1.4.0-dev-7380
-testKotlinCompilerVersion=1.4.0-dev-7380
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-7753,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-7753
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-7753,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-7753
+kotlinStdlibTestsVersion=1.4.0-dev-7753
+testKotlinCompilerVersion=1.4.0-dev-7753
 konanVersion=1.4.0-M3
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -2129,7 +2129,7 @@ public actual inline fun <T> Array<T>.plusElement(element: T): Array<T> {
  * @sample samples.collections.Arrays.Sorting.sortArray
  */
 public actual fun IntArray.sort(): Unit {
-    if (size > 1) sortArray(this)
+    if (size > 1) sortArray(this, 0, size)
 }
 
 /**
@@ -2138,7 +2138,7 @@ public actual fun IntArray.sort(): Unit {
  * @sample samples.collections.Arrays.Sorting.sortArray
  */
 public actual fun LongArray.sort(): Unit {
-    if (size > 1) sortArray(this)
+    if (size > 1) sortArray(this, 0, size)
 }
 
 /**
@@ -2147,7 +2147,7 @@ public actual fun LongArray.sort(): Unit {
  * @sample samples.collections.Arrays.Sorting.sortArray
  */
 public actual fun ByteArray.sort(): Unit {
-    if (size > 1) sortArray(this)
+    if (size > 1) sortArray(this, 0, size)
 }
 
 /**
@@ -2156,7 +2156,7 @@ public actual fun ByteArray.sort(): Unit {
  * @sample samples.collections.Arrays.Sorting.sortArray
  */
 public actual fun ShortArray.sort(): Unit {
-    if (size > 1) sortArray(this)
+    if (size > 1) sortArray(this, 0, size)
 }
 
 /**
@@ -2165,7 +2165,7 @@ public actual fun ShortArray.sort(): Unit {
  * @sample samples.collections.Arrays.Sorting.sortArray
  */
 public actual fun DoubleArray.sort(): Unit {
-    if (size > 1) sortArray(this)
+    if (size > 1) sortArray(this, 0, size)
 }
 
 /**
@@ -2174,7 +2174,7 @@ public actual fun DoubleArray.sort(): Unit {
  * @sample samples.collections.Arrays.Sorting.sortArray
  */
 public actual fun FloatArray.sort(): Unit {
-    if (size > 1) sortArray(this)
+    if (size > 1) sortArray(this, 0, size)
 }
 
 /**
@@ -2183,7 +2183,7 @@ public actual fun FloatArray.sort(): Unit {
  * @sample samples.collections.Arrays.Sorting.sortArray
  */
 public actual fun CharArray.sort(): Unit {
-    if (size > 1) sortArray(this)
+    if (size > 1) sortArray(this, 0, size)
 }
 
 /**
@@ -2194,7 +2194,105 @@ public actual fun CharArray.sort(): Unit {
  * @sample samples.collections.Arrays.Sorting.sortArrayOfComparable
  */
 public actual fun <T : Comparable<T>> Array<out T>.sort(): Unit {
-    if (size > 1) sortArray(this)
+    if (size > 1) sortArray(this, 0, size)
+}
+
+/**
+ * Sorts a range in the array in-place.
+ * 
+ * The sort is _stable_. It means that equal elements preserve their order relative to each other after sorting.
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArrayOfComparable
+ */
+@SinceKotlin("1.4")
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun <T : Comparable<T>> Array<out T>.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
+    sortArray(this, fromIndex, toIndex)
+}
+
+/**
+ * Sorts a range in the array in-place.
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
+ */
+@SinceKotlin("1.4")
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun ByteArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
+    sortArray(this, fromIndex, toIndex)
+}
+
+/**
+ * Sorts a range in the array in-place.
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
+ */
+@SinceKotlin("1.4")
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun ShortArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
+    sortArray(this, fromIndex, toIndex)
+}
+
+/**
+ * Sorts a range in the array in-place.
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
+ */
+@SinceKotlin("1.4")
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun IntArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
+    sortArray(this, fromIndex, toIndex)
+}
+
+/**
+ * Sorts a range in the array in-place.
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
+ */
+@SinceKotlin("1.4")
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun LongArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
+    sortArray(this, fromIndex, toIndex)
+}
+
+/**
+ * Sorts a range in the array in-place.
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
+ */
+@SinceKotlin("1.4")
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun FloatArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
+    sortArray(this, fromIndex, toIndex)
+}
+
+/**
+ * Sorts a range in the array in-place.
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
+ */
+@SinceKotlin("1.4")
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun DoubleArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
+    sortArray(this, fromIndex, toIndex)
+}
+
+/**
+ * Sorts a range in the array in-place.
+ * 
+ * @sample samples.collections.Arrays.Sorting.sortRangeOfArray
+ */
+@SinceKotlin("1.4")
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun CharArray.sort(fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
+    sortArray(this, fromIndex, toIndex)
 }
 
 /**
@@ -2211,7 +2309,9 @@ public actual fun <T> Array<out T>.sortWith(comparator: Comparator<in T>): Unit 
  * 
  * The sort is _stable_. It means that equal elements preserve their order relative to each other after sorting.
  */
-public fun <T> Array<out T>.sortWith(comparator: Comparator<in T>, fromIndex: Int = 0, toIndex: Int = size): Unit {
+@Suppress("ACTUAL_FUNCTION_WITH_DEFAULT_ARGUMENTS")
+public actual fun <T> Array<out T>.sortWith(comparator: Comparator<in T>, fromIndex: Int = 0, toIndex: Int = size): Unit {
+    AbstractList.checkRangeIndexes(fromIndex, toIndex, size)
     sortArrayWith(this, fromIndex, toIndex, comparator)
 }
 

--- a/runtime/src/main/kotlin/kotlin/collections/ArraySorting.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArraySorting.kt
@@ -362,7 +362,7 @@ private fun quickSort(
 // Interfaces   =============================================================================
 /**
  * Sorts the subarray specified by [fromIndex] (inclusive) and [toIndex] (exclusive) parameters
- * using the qsort algorithm with the given [comparator].
+ * using the merge sort algorithm with the given [comparator].
  */
 internal fun <T> sortArrayWith(
         array: Array<out T>, fromIndex: Int = 0, toIndex: Int = array.size, comparator: Comparator<T>) {
@@ -372,21 +372,21 @@ internal fun <T> sortArrayWith(
 
 /**
  * Sorts a subarray of [Comparable] elements specified by [fromIndex] (inclusive) and
- * [toIndex] (exclusive) parameters using the qsort algorithm.
+ * [toIndex] (exclusive) parameters using the merge sort algorithm.
  */
-internal fun <T: Comparable<T>> sortArray(array: Array<out T>) {
+internal fun <T: Comparable<T>> sortArray(array: Array<out T>, fromIndex: Int, toIndex: Int) {
     @Suppress("UNCHECKED_CAST")
-    mergeSort(array as Array<T>, 0, array.size - 1)
+    mergeSort(array as Array<T>, fromIndex, toIndex - 1)
 }
 
 /**
  * Sorts the given array using qsort algorithm.
  */
-internal fun sortArray(array: ByteArray)    = quickSort(array, 0, array.size - 1)
-internal fun sortArray(array: ShortArray)   = quickSort(array, 0, array.size - 1)
-internal fun sortArray(array: IntArray)     = quickSort(array, 0, array.size - 1)
-internal fun sortArray(array: LongArray)    = quickSort(array, 0, array.size - 1)
-internal fun sortArray(array: CharArray)    = quickSort(array, 0, array.size - 1)
-internal fun sortArray(array: FloatArray)   = quickSort(array, 0, array.size - 1)
-internal fun sortArray(array: DoubleArray)  = quickSort(array, 0, array.size - 1)
-internal fun sortArray(array: BooleanArray) = quickSort(array, 0, array.size - 1)
+internal fun sortArray(array: ByteArray, fromIndex: Int, toIndex: Int)    = quickSort(array, fromIndex, toIndex - 1)
+internal fun sortArray(array: ShortArray, fromIndex: Int, toIndex: Int)   = quickSort(array, fromIndex, toIndex - 1)
+internal fun sortArray(array: IntArray, fromIndex: Int, toIndex: Int)     = quickSort(array, fromIndex, toIndex - 1)
+internal fun sortArray(array: LongArray, fromIndex: Int, toIndex: Int)    = quickSort(array, fromIndex, toIndex - 1)
+internal fun sortArray(array: CharArray, fromIndex: Int, toIndex: Int)    = quickSort(array, fromIndex, toIndex - 1)
+internal fun sortArray(array: FloatArray, fromIndex: Int, toIndex: Int)   = quickSort(array, fromIndex, toIndex - 1)
+internal fun sortArray(array: DoubleArray, fromIndex: Int, toIndex: Int)  = quickSort(array, fromIndex, toIndex - 1)
+internal fun sortArray(array: BooleanArray, fromIndex: Int, toIndex: Int) = quickSort(array, fromIndex, toIndex - 1)

--- a/runtime/src/main/kotlin/kotlin/collections/ArraySorting.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArraySorting.kt
@@ -11,7 +11,7 @@ private fun <T: Comparable<T>> mergeSort(array: Array<T>, start: Int, endInclusi
     val buffer = arrayOfNulls<Any?>(array.size) as Array<T>
     val result = mergeSort(array, buffer, start, endInclusive)
     if (result !== array) {
-        result.forEachIndexed { i, v -> array[i] = v }
+        for (i in start..endInclusive) array[i] = result[i]
     }
 }
 
@@ -64,7 +64,7 @@ private fun <T> mergeSort(array: Array<T>, start: Int, endInclusive: Int, compar
     val buffer = arrayOfNulls<Any?>(array.size) as Array<T>
     val result = mergeSort(array, buffer, start, endInclusive, comparator)
     if (result !== array) {
-        result.forEachIndexed { i, v -> array[i] = v }
+        for (i in start..endInclusive) array[i] = result[i]
     }
 }
 
@@ -364,10 +364,11 @@ private fun quickSort(
  * Sorts the subarray specified by [fromIndex] (inclusive) and [toIndex] (exclusive) parameters
  * using the merge sort algorithm with the given [comparator].
  */
-internal fun <T> sortArrayWith(
-        array: Array<out T>, fromIndex: Int = 0, toIndex: Int = array.size, comparator: Comparator<T>) {
-    @Suppress("UNCHECKED_CAST")
-    mergeSort(array as Array<T>, fromIndex, toIndex - 1, comparator)
+internal fun <T> sortArrayWith(array: Array<out T>, fromIndex: Int, toIndex: Int, comparator: Comparator<T>) {
+    if (fromIndex < toIndex - 1) {
+        @Suppress("UNCHECKED_CAST")
+        mergeSort(array as Array<T>, fromIndex, toIndex - 1, comparator)
+    }
 }
 
 /**
@@ -375,8 +376,10 @@ internal fun <T> sortArrayWith(
  * [toIndex] (exclusive) parameters using the merge sort algorithm.
  */
 internal fun <T: Comparable<T>> sortArray(array: Array<out T>, fromIndex: Int, toIndex: Int) {
-    @Suppress("UNCHECKED_CAST")
-    mergeSort(array as Array<T>, fromIndex, toIndex - 1)
+    if (fromIndex < toIndex - 1) {
+        @Suppress("UNCHECKED_CAST")
+        mergeSort(array as Array<T>, fromIndex, toIndex - 1)
+    }
 }
 
 /**


### PR DESCRIPTION
* 11390d9de33 - (tag: build-1.4.0-dev-7753) Add test for obsolete issue (vor 11 Stunden) <Mikhail Zarechenskiy>
* 27384d29d42 - (tag: build-1.4.0-dev-7752) Move inspection checks in EDT thread (vor 12 Stunden) <Andrey Uskov>
* d2a10cbb2d8 - Merge changes in ExternalSystemTestCase into KotlinGradleTests (vor 12 Stunden) <Andrey Uskov>
* 45481b214a9 - (tag: build-1.4.0-dev-7751) Use kotlin.Throws in NativeThrowsChecker (vor 13 Stunden) <Denis Zharkov>
* d0f4631192d - Resolve ambiguity between kotlin.Throws and kotlin.native.Throws (vor 13 Stunden) <Denis Zharkov>
* d3f541a7156 - Overcome ambiguity between kotlin.Throws and kotlin.jvm.Throws (vor 13 Stunden) <Denis Zharkov>
* 534ff58d9cf - Minor. Introduce constant JVM_THROWS_ANNOTATION_FQ_NAME (vor 13 Stunden) <Denis Zharkov>
* 1565fc0211d - (tag: build-1.4.0-dev-7731) Call expression changes in property initializer are OCB (vor 2 Tagen) <Vladimir Dolzhenko>
* 1cc58518c01 - Compatify KotlinCodeBlockModificationListener p.2 (vor 2 Tagen) <Vladimir Dolzhenko>
* 5a36da90b67 - Compatify KotlinCodeBlockModificationListener p.1 (vor 2 Tagen) <Vladimir Dolzhenko>
* 38622d8d926 - (tag: build-1.4.0-dev-7710) (CoroutineDebugger) SkipCoroutineStackFrameProxy logic added (vor 3 Tagen) <Vladimir Ilmov>
* 887165a23b5 - (tag: build-1.4.0-dev-7708) JVM_IR: avoid copying when optimizing ?:/?. (vor 3 Tagen) <pyos>
* 23076920640 - (tag: build-1.4.0-dev-7701) Remove String.format with non-null locale (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* f356ff36b41 - (tag: build-1.4.0-dev-7700) Update group id for refactoring fus collector in 201 bunch (vor 3 Tagen) <Anton Yalyshev>
* 1e69e89f41b - (tag: build-1.4.0-dev-7698) update `misc.xml` (vor 3 Tagen) <Dmitry Gridin>
* 96238cbe1f5 - (tag: build-1.4.0-dev-7695) [FIR] Support diagnostic QUALIFIED_SUPERTYPE_EXTENDED_BY_OTHER_SUPERTYPE (vor 3 Tagen) <Nick>
* 7a928dfed22 - (tag: build-1.4.0-dev-7694) [Gradle, JS] Build gradle node module with only package.json content (vor 3 Tagen) <Ilya Goncharov>
* c64a80d132d - [Gradle, JS] Move suppress gson null issue for particular fields (vor 3 Tagen) <Ilya Goncharov>
* c91089be593 - (tag: build-1.4.0-dev-7688) AddJvmNameAnnotationFix: fix case with top-level functions (vor 3 Tagen) <Dmitry Gridin>
* f494b4ce11b - Add 'Add JvmName annotation' quick fix for CONFLICTING_JVM_DECLARATIONS (vor 3 Tagen) <Toshiaki Kameyama>
* 9bc51be2873 - (tag: build-1.4.0-dev-7679) i18n, MoveKotlinTopLevelDeclarationsDialog: replace `RefactoringBundle` with `KotlinBundle` (vor 3 Tagen) <Dmitry Gridin>
* b07f89864e5 - (tag: build-1.4.0-dev-7677) Allow dependencies to see internals from main module as well (vor 3 Tagen) <Dmitry Savvinov>
* af09cb0e573 - fix testLanguageSettingsApplied (vor 3 Tagen) <Sergey Igushkin>
* 60c49d26e3a - Add Gradle integration tests running the IDE HMPP highlighting tests (vor 3 Tagen) <Sergey Igushkin>
* 4b0da0688ae - Fix expect discrimination with actual typealias in deserialization (vor 3 Tagen) <Sergey Igushkin>
* d4a0844a771 - Support additional module descriptor dependencies in klib descriptors (vor 3 Tagen) <Sergey Igushkin>
* a9dd1943832 - Fix wrong assumption in getHostSpecificSourceSets (KMM-225) (vor 3 Tagen) <Sergey Igushkin>
* 67f4b7e2b03 - Add a dependency from all klib-originated modules to the main module (vor 3 Tagen) <Sergey Igushkin>
* 8979b98fc09 - (tag: build-1.4.0-dev-7674) Dropping components cleanup (vor 3 Tagen) <Vladimir Dolzhenko>
* d2a26e90494 - Fix memory leakage via Library in KotlinMavenImporter (vor 3 Tagen) <Vladimir Dolzhenko>
* 4908d7a78c6 - Convert KotlinImporterComponent into a module service (vor 3 Tagen) <Vladimir Dolzhenko>
* c2c8d81b49e - Convert MavenImportListener into an application service (vor 3 Tagen) <Vladimir Dolzhenko>
* 6e5b288500c - Compatify maven.xml p.1 (vor 3 Tagen) <Vladimir Dolzhenko>
* 951215e6061 - Convert ScratchFileModuleInfoProvider into a startup activity (vor 3 Tagen) <Vladimir Dolzhenko>
* 346cc40f442 - Convert KotlinCompilerManager into a startup activity (vor 3 Tagen) <Vladimir Dolzhenko>
* 4f99ac406a9 - Kotlinify KotlinCompilerManager p.2 (vor 3 Tagen) <Vladimir Dolzhenko>
* bbd4116b670 - Kotlinify KotlinCompilerManager p.1 (vor 3 Tagen) <Vladimir Dolzhenko>
* d3585f1d24d - Convert JvmPluginStartupComponent into a startup activity (vor 3 Tagen) <Vladimir Dolzhenko>
* fa2fb667e6e - Kotlinify JvmPluginStartupComponent p.2 (vor 3 Tagen) <Vladimir Dolzhenko>
* fe3cf88e45c - Kotlinify JvmPluginStartupComponent p.1 (vor 3 Tagen) <Vladimir Dolzhenko>
* d6b4836ae02 - Convert KlibLoadingMetadataCache into an application service (vor 3 Tagen) <Vladimir Dolzhenko>
* 4535584f163 - Convert KotlinUpdatePluginComponent into a startup activity (vor 3 Tagen) <Vladimir Dolzhenko>
* 60dc2f96744 - (tag: build-1.4.0-dev-7672) i18n, MoveKotlinNestedClassesToUpperLevelDialog: add missing bundles for 201 (vor 3 Tagen) <Dmitry Gridin>
* 6524e2b764f - i18n, debugger: add missing bundles for 201 (vor 3 Tagen) <Dmitry Gridin>
* 403cdedf2e9 - (tag: build-1.4.0-dev-7659) Remove unnecessary dependencies of 'fir2ir:jvm-backend' (vor 4 Tagen) <Alexander Udalov>
* 2815bb88c27 - Remove unnecessary dependency of 'fir2ir' on 'ir.backend.common' (vor 4 Tagen) <Alexander Udalov>
* 0c3c8b64ce8 - (tag: build-1.4.0-dev-7652) Optimization for faster search of references to top-level members (vor 4 Tagen) <Valentin Kipyatkov>
* ec057a6c001 - Minor change after review (vor 4 Tagen) <Valentin Kipyatkov>
* 56b20b0f310 - Data Flow from Here: do not include named argument references (vor 4 Tagen) <Valentin Kipyatkov>
* 7c81d93db01 - Data Flow to Here: process data-class copy-method calls (vor 4 Tagen) <Valentin Kipyatkov>
* 7f8b3b6a79c - (tag: build-1.4.0-dev-7649) Minor: rename function (vor 4 Tagen) <Natalia Selezneva>
* 574f57e604d - Minor: extract class to separate file (vor 4 Tagen) <Natalia Selezneva>
* 25dc8b77662 - Minor: rename files (vor 4 Tagen) <Natalia Selezneva>
* 294df3a7e90 - 201: Implement floating notification update (vor 4 Tagen) <Natalia Selezneva>
* 2fba813a532 - Rework the notification for scripts out of project (vor 4 Tagen) <Natalia Selezneva>
* 85141b753b9 - Show notification that gradle project is needed to be imported to get code insight for kotlin scripts (vor 4 Tagen) <Natalia Selezneva>
* 69d86a2972e - Fix getting default sdk for scripts after refactoring (vor 4 Tagen) <Natalia Selezneva>
* 73760effeec - Refactor GradleScriptingSupport to support multiple gradle projects linked to one idea project (vor 4 Tagen) <Sergey Rostov>
* 34df3066b39 - Fix messages for script configuration loading (vor 4 Tagen) <Natalia Selezneva>
* f3687dcd009 - Extract utils methods for getting gradle project settings (vor 4 Tagen) <Natalia Selezneva>
* f5f69ccc1b2 - Fix getting gradle version for new project (vor 4 Tagen) <Natalia Selezneva>
* 3904e0f97c0 - Fix indexing for force load configuration action (vor 4 Tagen) <Natalia Selezneva>
* c52e5d180ab - Fix compilation for AS35 (vor 4 Tagen) <Natalia Selezneva>
* b472e915e63 - Minor: rename files (vor 4 Tagen) <Natalia Selezneva>
* 217696fad56 - Minor: rename class (vor 4 Tagen) <Natalia Selezneva>
* 3008010d733 - Minor: extract class (vor 4 Tagen) <Natalia Selezneva>
* 59bdf67aa22 - Refactoring: extract separate manager to update script configurations of gradle scripts (vor 4 Tagen) <Natalia Selezneva>
* c6609e9a970 - Temporary remove flacky assert from GradleKtsImportTest (vor 4 Tagen) <Natalia Selezneva>
* da76fff83c0 - Remove unused parts (vor 4 Tagen) <Natalia Selezneva>
* 7ecaf35647f - Fix javaHome storing KotlinDslScriptModels (vor 4 Tagen) <Natalia Selezneva>
* a35523b6d0f - Implement global notification for configurations update of gradle scripts (vor 4 Tagen) <Natalia Selezneva>
* e300b30de14 - Do not use hard coded string literals in UI (vor 4 Tagen) <Natalia Selezneva>
* 1b7f72020ef - GradleScriptListener should be applicable for all gradle scripts (vor 4 Tagen) <Natalia Selezneva>
* 426c0c9ff0e - 201: Run partial import in IDEA 2020.1 to get script configurations (vor 4 Tagen) <Natalia Selezneva>
* 10aeead925d - Run gradle import instead of usage of scripting API during configurations update (vor 4 Tagen) <Natalia Selezneva>
* 97e5ff858d9 - Add ability to postpone script configuration loading (vor 4 Tagen) <Natalia Selezneva>
* 7f5715f5da5 - 201: KotlinDslScriptsModel: use ProjectModelContributor to process models (vor 4 Tagen) <Natalia Selezneva>
* 9e4c1ee4e8a - (tag: build-1.4.0-dev-7642) [Gradle, JS] Add explanation comment on compiler type in KotlinJsCompilerTypeHolder (vor 4 Tagen) <Ilya Goncharov>
* 565874b3a0d - (tag: build-1.4.0-dev-7641) Pass along type in IfNullExpressionFusionLowering (vor 4 Tagen) <Georgy Bronnikov>
* f95ff049c63 - (tag: build-1.4.0-dev-7640) [Gradle, JS] Test check several ways to configure compiler type (vor 4 Tagen) <Ilya Goncharov>
* 9a3bf54d9d9 - [Gradle, JS] Add compiler type values on extension type (vor 4 Tagen) <Ilya Goncharov>
* 025d1ca64de - (tag: build-1.4.0-dev-7637) psi2ir: rework representation of bound adapted function references (vor 4 Tagen) <Alexander Udalov>
* 22bf23025af - Minor, workaround IDE exception KT-38521 (vor 4 Tagen) <Alexander Udalov>
* 73a6dc6d1ea - (tag: build-1.4.0-dev-7631) Fix dependency for idea-fir module on 191 IDEA. (vor 4 Tagen) <Konstantin Tskhovrebov>
* f87f32c5a89 - (tag: build-1.4.0-dev-7630) [Gradle, JS] root package json must run after simple package jsons (vor 4 Tagen) <Ilya Goncharov>
* 39e1635c411 - [FIR2IR] Pre-cache original function type parameters for fake overrides (vor 4 Tagen) <Jinseong Jeon>
* bc96e425858 - (tag: build-1.4.0-dev-7625) Produce deterministic klib files. (vor 4 Tagen) <Martin Petrov>
* 923986d6a0c - (tag: build-1.4.0-dev-7624) [Gradle, JS] Replace close on prepare (vor 4 Tagen) <Ilya Goncharov>
* 7fa0faf48cd - [Gradle, JS] Fix registering yarn extension before node plugin (vor 4 Tagen) <Ilya Goncharov>
* bded8443f12 - [Gradle, JS] Root package json must run after all package json (vor 4 Tagen) <Ilya Goncharov>
* b0efd1d7cee - [Gradle, JS] Commonize root package json to prepared files for extensibility via other npm package managers (vor 4 Tagen) <Ilya Goncharov>
* 2f8649a337c - [Gradle, JS] up-to-date check on npm install, not on root package.json (vor 4 Tagen) <Ilya Goncharov>
* 742e27d7f59 - [Gradle, JS] Rearrange (vor 4 Tagen) <Ilya Goncharov>
* e412224572c - [Gradle, JS] Resolve -> install (vor 4 Tagen) <Ilya Goncharov>
* 0af6454e44e - [Gradle, JS] Add new state for npm resolution (vor 4 Tagen) <Ilya Goncharov>
* 9174e184d38 - [Gradle, JS] Rename Installed on prepared (vor 4 Tagen) <Ilya Goncharov>
* 578a33767b8 - [Gradle, JS] Npm resolution plugins work in resolve phase too (vor 4 Tagen) <Ilya Goncharov>
* 910f60b7314 - [Gradle, JS] Not run task if root package.json doesn't exist (vor 4 Tagen) <Ilya Goncharov>
* 86573c6dd18 - [Gradle, JS] Divide creating root package and install tasks (vor 4 Tagen) <Ilya Goncharov>
* 3ad597ca5c7 - (tag: build-1.4.0-dev-7622) Introduce MSE and EME APIs to Kotlin/JS stdlib (vor 4 Tagen) <Alexey Trilis>
* 456469eb3b3 - (tag: build-1.4.0-dev-7617) JVM: fix remapping of `new T` inside regenerated copies of `T` (vor 4 Tagen) <pyos>
* 3f8ffb5ea70 - (tag: build-1.4.0-dev-7613) KT-24750 Blank line after class header formatter should use user setting (vor 4 Tagen) <Sinan Kozak>
* e6f527f1d02 - (tag: build-1.4.0-dev-7610) Update tests: disable tests run gutters for Object. (vor 4 Tagen) <Konstantin Tskhovrebov>
* 57b4a54766c - (tag: build-1.4.0-dev-7607) [FIR] Calculate effective visibility inside anonymous object properly (vor 4 Tagen) <Mikhail Glukhikh>
* bb73681b629 - [FIR] Avoid integer literal types in lambda analysis (vor 4 Tagen) <Mikhail Glukhikh>
* 28051080611 - (tag: build-1.4.0-dev-7606) [FIR2IR] Slightly refactor ConversionUtils (vor 4 Tagen) <Mikhail Glukhikh>
* 09f9e767ede - [FIR2IR] Slightly refactor DataClassMembersGenerator (vor 4 Tagen) <Mikhail Glukhikh>
* 07add635eb2 - FIR2IR: generate synthetic members for data class only if needed (vor 4 Tagen) <Jinseong Jeon>
* acced52384c - (tag: build-1.4.0-dev-7599) (CoroutineDebugger) Tests added for no creation stack frame information (vor 4 Tagen) <Vladimir Ilmov>
* 57214aa4531 - (CoroutineDebugger) Exception if no creationStackTrace available (vor 4 Tagen) <Vladimir Ilmov>
* 8616864e6b8 - Revert "Drop unnecessary dependency from embeddable compiler to daemon" (vor 4 Tagen) <Ilya Chernikov>
* b74652aa5bf - [FIR] Use ieee754equals for floating-point equality operations (vor 4 Tagen) <Mark Punzalan>
* d66281d11f4 - (tag: build-1.4.0-dev-7588) FIR: Fix test data for spec test after c4b7ac994b9f5a3098f106cf85ebbdd06b1afe24 (vor 4 Tagen) <Denis Zharkov>
* 1a90866ce1d - (tag: build-1.4.0-dev-7582) FIR: handle member scope for anonymous objects (vor 4 Tagen) <Ilya Kirillov>
* fdfb5447308 - FIR: use Kotlin String constructors instead of java.lang ones (vor 4 Tagen) <Ilya Kirillov>
* 9b943e3a5a1 - FIR: fix Long primitive type JVM signature (vor 4 Tagen) <Ilya Kirillov>
* f9ebce331c6 - (tag: build-1.4.0-dev-7575) remove execOperation for compiler workers (vor 4 Tagen) <nataliya.valtman>
* 5af76a07d4d - (tag: build-1.4.0-dev-7568) Fix CharArray sort in JS IR-backend (vor 5 Tagen) <Abduqodiri Qurbonzoda>
* 284d4136030 - (tag: build-1.4.0-dev-7566) Fix daemon test task name (vor 5 Tagen) <Ilya Chernikov>
* b439dd62c56 - (tag: build-1.4.0-dev-7562) Allow to force snapshot build (vor 5 Tagen) <Nikolay Krasko>
* 9b0e37f6277 - (tag: build-1.4.0-dev-7553) (CoroutineDebugger) Minor issued fixed, log level adjusted for missing classes in JVM. (vor 5 Tagen) <Vladimir Ilmov>
* eec3263518a - (tag: build-1.4.0-dev-7547, minamoto/kotlin/kotlin-native-build) [psi2ir] Properly link corresponding property symbols. (vor 5 Tagen) <Mads Ager>
* 8bc360fa0cc - Properly link properties and their getter/setters. (vor 5 Tagen) <Mads Ager>
* ac11bc67109 - (tag: build-1.4.0-dev-7542) [Gradle, JS] Remove copypaste in js compiler argument (vor 5 Tagen) <Ilya Goncharov>
* 8e282e8aad9 - [Gradle, JS] Change byArgument on byArgumentOrNull (vor 5 Tagen) <Ilya Goncharov>
* 47c27726b98 - [Gradle, JS] Fix test (vor 5 Tagen) <Ilya Goncharov>
* c7f7f2bcbb6 - [Gradle, JS] Add string sompiler setting in js plugin (vor 5 Tagen) <Ilya Goncharov>
* dfb8fea2c7e - (tag: build-1.4.0-dev-7540) Fix project structure after moving daemon tests to separate project (vor 5 Tagen) <Ilya Chernikov>
* 0b227c1d66f - (tag: build-1.4.0-dev-7539) Explicitly disable suspend-conversion while work in BE isn't ready (vor 5 Tagen) <Mikhail Zarechenskiy>
* cb975bde7cc - Add test for questionable chained fun -> suspend conversion (vor 5 Tagen) <Mikhail Zarechenskiy>
* ac642cf1759 - Support suspend conversion in callable reference adaptation (vor 5 Tagen) <Mikhail Zarechenskiy>
* 537a59d6ca7 - Introduce basic suspend conversion in FE (vor 5 Tagen) <Mikhail Zarechenskiy>
* 9e04ebdacef - Minor: fix typo (vor 5 Tagen) <Mikhail Zarechenskiy>
* de25d13f1a0 - (tag: build-1.4.0-dev-7531) JS: fix JsName renamer (KT-36484 fixed) (vor 5 Tagen) <Anton Bannykh>
* 7d917634d0b - (tag: build-1.4.0-dev-7526) Remove object name and type in project view (vor 5 Tagen) <Igor Yakovlev>
* 72303fd2ad3 - Fixed possible NPE in LightClasses (vor 5 Tagen) <Igor Yakovlev>
* 8a7aac728d3 - Fix invalid signature for UL method (vor 5 Tagen) <Igor Yakovlev>
* ed3ae785fb6 - Fix invalid signature for generic UL method (vor 5 Tagen) <Igor Yakovlev>
* 6f40ad7de22 - (tag: build-1.4.0-dev-7521) Add test for not evaluated snippet (vor 5 Tagen) <Ilya Muradyan>
* ea1a6fbee7a - Add history consistency check (vor 5 Tagen) <Ilya Muradyan>
* e5ca572b91f - Forward diagnostics to the evaluation result (vor 5 Tagen) <Ilya Muradyan>
* 962a767e542 - (tag: build-1.4.0-dev-7516) Set jvm target for scratch files (vor 5 Tagen) <Natalia Selezneva>
* b5be2abb1aa - Set jvm target for REPL from the context module (vor 5 Tagen) <Ilya Chernikov>
* 87159b5428c - (tag: build-1.4.0-dev-7512, origin/rr/gradle/matveev/proivde-fq-name-for-klibs) [Gradle] Use : as a separator for group and name in klib unique names (vor 5 Tagen) <Ilya Matveev>
* 0d9364c1dd6 - [Gradle, native] Make tests tolerate to stacktrace format changes (vor 5 Tagen) <Ilya Matveev>
* a3a6c3f0d53 - [Gradle, native] Improve logging in CacheBuilder (vor 5 Tagen) <Ilya Matveev>
* edf2b18f4f2 - [Gradle, Native/JS] Specify FQ module name for klibs (vor 5 Tagen) <Ilya Matveev>
* e4f4b4eef03 - [JS IR] Support setting custom module name (= unique name) (vor 5 Tagen) <Ilya Matveev>
* d7558112ec4 - Update K/N: 1.4-M3-dev-15378 (vor 5 Tagen) <Ilya Matveev>
* 3bb32941a05 - (tag: build-1.4.0-dev-7497) IR: bugfix in KotlinNothingValueExceptionLowering (vor 6 Tagen) <Georgy Bronnikov>
* 1fb325d56e2 - (tag: build-1.4.0-dev-7490) Fix generateTests task (vor 6 Tagen) <Ilya Chernikov>
* ec64869d39f - (tag: build-1.4.0-dev-7486) Extract daemon tests to separate module (vor 6 Tagen) <Ilya Chernikov>
* 86d47b496b9 - Drop unnecessary dependency from embeddable compiler to daemon (vor 6 Tagen) <Ilya Chernikov>
* c2eaa3d955e - Fix ThreadDeath exception on stopping daemon thread (vor 6 Tagen) <Ilya Chernikov>
* 2bd6714e393 - (tag: build-1.4.0-dev-7485) (CoroutineDebugger) Unneccesary log record removed. (vor 6 Tagen) <Vladimir Ilmov>
* 887d6eb1972 - (tag: build-1.4.0-dev-7479) Fix writeIvyXml to be independent from system charset (#3319) (vor 6 Tagen) <Ilya Muradyan>
* 0ed0152ee0d - (tag: build-1.4.0-dev-7477) [Linker] Add option to control scope of DescriptorByIdSignatureFinder (vor 6 Tagen) <Sergey Bogolepov>
* 318d4d17ba3 - (tag: build-1.4.0-dev-7466) KT-38337 Fix inline class value coercion in delegated members (vor 6 Tagen) <Dmitry Petrov>
* 29f19c78f2b - (tag: build-1.4.0-dev-7464) Add missing fir-common dependency to kotlin plugin jar (vor 6 Tagen) <Ilya Kirillov>
* d83a35d898d - (tag: build-1.4.0-dev-7463) Minor. Update test data to support Corretto JVM 11 (vor 6 Tagen) <Mikhail Bogdanov>
* 38bfcc7ac65 - (tag: build-1.4.0-dev-7459) (CoroutineDebugger) Unstable tests muted (vor 6 Tagen) <Vladimir Ilmov>
* 73f5e48518a - (CoroutineDebugger) Minor fixes, kotlinx.coroutines version fix (vor 6 Tagen) <Vladimir Ilmov>
* 0ce8ca7bcd5 - (CoroutineDebugger) negative frames removed from coroutine stack (vor 6 Tagen) <Vladimir Ilmov>
* be2185ec01c - (CoroutineDebugger) kotlinx.coroutines.core:1.3.5 support / dynamicProxy(interface) classes (vor 6 Tagen) <Vladimir Ilmov>
* c018cf0ce53 - (CoroutineDebugger) kotlinx.coroutines compatibility version fix (vor 6 Tagen) <Vladimir Ilmov>
* c96d30a8cea - (CoroutineDebugger) Added setting to disable coroutine agent (vor 6 Tagen) <Vladimir Ilmov>
* 68c6e9e2d6f - (CoroutineDebugger) kotlinx-coroutines-core:1.3.5 support (vor 6 Tagen) <Vladimir Ilmov>
* 6f42ed7248a - (CoroutineDebugger) PreflightFrame support in tests via CoroutineAsync (vor 6 Tagen) <Vladimir Ilmov>
* 276cf36d6b1 - (CoroutineDebugger) Fixed CombinedContext information, default group renamed to empty dispatcher (vor 6 Tagen) <Vladimir Ilmov>
* 677ca2b9ae9 - (CoroutineDebugger) unused classes removed / code cleanup (vor 6 Tagen) <Vladimir Ilmov>
* 3cd0eb0fca3 - (CoroutineDebugger) Stack printing logic extracted to the single place (vor 6 Tagen) <Vladimir Ilmov>
* 153056b4fda - (CoroutineDebugger) Added check if agent is not available in target jvm (vor 6 Tagen) <Vladimir Ilmov>
* 38ec388429b - (CoroutineDebugger) Group coroutines by dispatcher (vor 6 Tagen) <Vladimir Ilmov>
* 7aa9b81604a - (tag: build-1.4.0-dev-7456) FIR: Add analysis-tests/ReadMe.md (vor 6 Tagen) <Denis Zharkov>
* 64eeedd21a9 - FIR: Minor. Add some minor fixes and clarifications to CallableId (vor 6 Tagen) <Denis Zharkov>
* 8aea75d8b96 - FIR: Add spec tests to "Fast FIR" run configuration (vor 6 Tagen) <Denis Zharkov>
* 3bb6aa6f28c - Mark as FIR_IDENTICAL passing spec tests (vor 6 Tagen) <Denis Zharkov>
* 82b2825b7ac - FIR: Ignore flaky spec tests (vor 6 Tagen) <Denis Zharkov>
* b375e021e5f - FIR: Ignore failing spec test (vor 6 Tagen) <Denis Zharkov>
* 4c4f220fd02 - FIR: Ignore failing spec tests (vor 6 Tagen) <Denis Zharkov>
* c4d72d6906c - FIR: Ignore failing spec test (vor 6 Tagen) <Denis Zharkov>
* 26f0b044fc9 - FIR: Ignore failing spec test (vor 6 Tagen) <Denis Zharkov>
* 39d42318949 - FIR: Adjust testData for spec tests: discrepancy in DEBUG_INFO_CALL format (vor 6 Tagen) <Denis Zharkov>
* bddea7d1638 - FIR: Adjust testData for spec tests: local scopes in overload resolution (vor 6 Tagen) <Denis Zharkov>
* 706ccb2cf9b - FIR: Adjust testData for spec tests: invoke on nullable receiver (vor 6 Tagen) <Denis Zharkov>
* f0d35a24784 - FIR: Adjust testData for spec tests: operator priority (vor 6 Tagen) <Denis Zharkov>
* 5c7c4b4cb6e - FIR: Adjust testData for spec tests: infix priority (vor 6 Tagen) <Denis Zharkov>
* 54546eb8900 - FIR: Adjust testData for spec tests: unsupported DEBUG_INFO_CALL format (vor 6 Tagen) <Denis Zharkov>
* f8791549f3b - FIR: Adjust testData for spec tests: enum "values" priority (vor 6 Tagen) <Denis Zharkov>
* 2ced7162685 - FIR: Adjust testData for spec tests: controversial infix calls (vor 6 Tagen) <Denis Zharkov>
* 12ceaf24e2a - FIR: Adjust testData for spec tests: resolution ambiguity (vor 6 Tagen) <Denis Zharkov>
* 76bb45b46f4 - FIR: Adjust testData for spec tests: other small things (vor 6 Tagen) <Denis Zharkov>
* 7c8e2724e19 - FIR: Adjust testData for spec tests: type-system (vor 6 Tagen) <Denis Zharkov>
* 2f0f5528801 - FIR: Adjust testData for spec tests: annotations (vor 6 Tagen) <Denis Zharkov>
* 798fe9b7d11 - FIR: Adjust testData for spec tests: statements (vor 6 Tagen) <Denis Zharkov>
* 0df63548968 - FIR: Adjust testData for spec tests: conditional-expressions (vor 6 Tagen) <Denis Zharkov>
* 00bf1858cc4 - FIR: Adjust testData for spec tests: declarations (vor 6 Tagen) <Denis Zharkov>
* ee75347bb06 - FIR: Adjust testData for spec tests: expressions (vor 6 Tagen) <Denis Zharkov>
* 06bae1e52fc - FIR: Adjust testData for spec tests: when-expression (vor 6 Tagen) <Denis Zharkov>
* 0d34299b7a3 - FIR: Adjust testData for spec tests: dfa (vor 6 Tagen) <Denis Zharkov>
* 86e1aadd317 - FIR: Adjust testData for spec tests: contracts (vor 6 Tagen) <Denis Zharkov>
* 243f9bb758d - FIR: Adjust testData for spec tests: constant-literals (vor 6 Tagen) <Denis Zharkov>
* 04076ea7485 - Add FIR version of spec diagnostic tests (vor 6 Tagen) <Denis Zharkov>
* 3cb2b0cab15 - Ignore irrelevant diagnostics in overload-set related spec tests (vor 6 Tagen) <Denis Zharkov>
* 0aed7375e6b - Ignore irrelevant diagnostics in overload-set related spec tests (vor 6 Tagen) <Denis Zharkov>
* 26cb0ba1446 - Prepare spec tests for FIR version (vor 6 Tagen) <Denis Zharkov>
* 13efabc764d - FIR: Add reflection JPS module of test-spec (vor 6 Tagen) <Denis Zharkov>
* 1d891561cf3 - Fix spec tests metadata (vor 6 Tagen) <Denis Zharkov>
* 9be2fc9b126 - Sort excluded dirs in generated spec tests (vor 6 Tagen) <Denis Zharkov>
* 477e8bbcd48 - FIR: Add test case for qualifier-based call resolution (vor 6 Tagen) <Denis Zharkov>
* 6fdbc38cf10 - FIR: Fix label/receiver for lambda within infix calls (vor 6 Tagen) <Denis Zharkov>
* 65e444a39cc - FIR: Properly support local functions in DEBUG_INFO_CALL (vor 6 Tagen) <Denis Zharkov>
* fa3b3e7a9a0 - FIR: Fix false positive INAPPLICABLE_INFIX_MODIFIER (vor 6 Tagen) <Denis Zharkov>
* 27b860682be - FIR: Support DEBUG_INFO_EXPRESSION_TYPE (vor 6 Tagen) <Denis Zharkov>
* 6cd1ae9c82a - Prepare AbstractFirOldFrontendDiagnosticsTest to RawFirBuilders failures (vor 6 Tagen) <Denis Zharkov>
* 7612f37c85d - FIR: Prohibit calling singletons' constructors (vor 6 Tagen) <Denis Zharkov>
* b62400124a4 - FIR: Support DEBUG_INFO_CALL calls in tests (vor 6 Tagen) <Denis Zharkov>
* 22dc837e26e - (tag: build-1.4.0-dev-7452) IDE. Allow expect declarations in completion in shared native modules (vor 6 Tagen) <Dmitriy Dolovov>
* d6472aa700b - (tag: build-1.4.0-dev-7446) Reverse range and sortDescending range #KT-36955 (vor 7 Tagen) <Abduqodiri Qurbonzoda>
* 05cb0e89941 - (tag: build-1.4.0-dev-7436) KNVE: support in JVM_IR and JS_IR (vor 7 Tagen) <Dmitry Petrov>
* b06780988df - KNVE: add doc comment and mark as PublishedApi (vor 7 Tagen) <Dmitry Petrov>
* 8d06744a6a4 - (tag: build-1.4.0-dev-7428) Set local build version to 1.4.255-SNAPSHOT (vor 7 Tagen) <Vyacheslav Gerasimov>
* 4b819aa0286 - (tag: build-1.4.0-dev-7427) Remove incorrect comment from old FE diagnostic test (vor 7 Tagen) <Mikhail Glukhikh>
* 790a517fa34 - [FIR TEST] Add bad test data (submitted KT-38400) (vor 7 Tagen) <Mikhail Glukhikh>
* c4b7ac994b9 - [FIR] Support diagnostic ABSTRACT_SUPER_CALL (vor 7 Tagen) <Nick>
* 8960829c01b - (tag: build-1.4.0-dev-7426) [FIR] Cast error on the element name instead of the whole body (vor 7 Tagen) <rapturemain>
* 4c639a840d9 - [FIR] Apply bad test data (protected eff. visibility related, KT-38401) (vor 7 Tagen) <Mikhail Glukhikh>
* 6d63de01acb - [FIR] Fix effective visibility calculation & relevant test data (vor 7 Tagen) <rapturemain>
* d811f6f4a6e - [FIR] Support for EXPOSED_PARAMETER_TYPE (vor 7 Tagen) <rapturemain>
* 216eea6a208 - [FIR] Fix EXPOSED_RECEIVER_TYPE (vor 7 Tagen) <rapturemain>
* 2e8f73adbac - [FIR] Change errors location from Errors.java to FirErrors.kt (vor 7 Tagen) <rapturemain>
* 4e577caa99c - [FIR] Support for EXPOSED_FUNCTION_RETURN_TYPE (vor 7 Tagen) <rapturemain>
* 0f16c88dd2e - [FIR] Support for FIR_EXPOSED_RECEIVER_TYPE (vor 7 Tagen) <rapturemain>
* 15d4891c92f - [FIR} Test data for EXPOSED_PROPERTY_TYPE (vor 7 Tagen) <rapturemain>
* 02c90c65760 - [FIR] Support for EXPOSED_PROPERTY_TYPE (vor 7 Tagen) <rapturemain>
* cc86767a23c - [FIR] Support for EXPOSED_TYPEALIAS_EXPANDED_TYPE (vor 7 Tagen) <rapturemain>
* 42de83c21a2 - (tag: build-1.4.0-dev-7419) FIR: fix lambda labeling in light tree builder (vor 7 Tagen) <Mikhail Glukhikh>
* 29114fe7b56 - FIR: leave 'isSuspend' in functional & resolved type references only (vor 7 Tagen) <Mikhail Glukhikh>
* 96d8b0bea37 - FIR: make KFunctionX derived from KFunction (vor 7 Tagen) <Mikhail Glukhikh>
* 4bb6410ce3b - [FIR TEST] Temporary ignore overrideDefaultArgument test (KT-38416) (vor 7 Tagen) <Mikhail Glukhikh>
* fe02c2bab31 - FIR: return Unit from empty lambda (vor 7 Tagen) <Mikhail Glukhikh>
* c5dea02074d - FIR: handle suspend functions in SAM resolution properly (vor 7 Tagen) <Mikhail Glukhikh>
* aada7bfe510 - FIR: handle suspend functions in callable reference resolve properly (vor 7 Tagen) <Mikhail Glukhikh>
* c26adf53dd2 - FIR: resolve suspend lambda properly (vor 7 Tagen) <Jinseong Jeon>
* 88f81b9b715 - FIR: record 'suspend' function modifier in type references (vor 7 Tagen) <Jinseong Jeon>
* bf97391c51a - (tag: build-1.4.0-dev-7417) Wizard: enable new wizard by default in registry key (vor 7 Tagen) <Ilya Kirillov>
* f13d31c7bde - (tag: build-1.4.0-dev-7409) Cleanup process in LauncherScriptTest (vor 7 Tagen) <Ilmir Usmanov>
* 2d64ded3c74 - (tag: build-1.4.0-dev-7406) i18n: fix text in `AbstractKotlinInlineDialog` (vor 7 Tagen) <Dmitry Gridin>
* d8b4ff9eabb - (tag: build-1.4.0-dev-7393) Post KotlinNativeABICompatibilityChecker startup activity conversion clean up (vor 7 Tagen) <Vladimir Dolzhenko>
* 3d4c5b00910 - (tag: build-1.4.0-dev-7392) Fix NPE in LookupCancelService$Reminiscence (vor 7 Tagen) <Vladimir Dolzhenko>
* 061bc9af074 - Avoid using containingKtFile in PerFileAnalysisCache (vor 7 Tagen) <Vladimir Dolzhenko>
* a53a12b68a8 - Do not search TODOs in non KT and non physical files (vor 7 Tagen) <Vladimir Dolzhenko>
* 67fec903f6a - Read file content under readAction in ToFromOriginalFileMapper (vor 7 Tagen) <Vladimir Dolzhenko>
* 8ea7fc1d47f - Add file content on analysis failure (vor 7 Tagen) <Vladimir Dolzhenko>
* 7bbe1ba8c2d - Improve error reporting on KotlinSliceUsage#copy (vor 7 Tagen) <Vladimir Dolzhenko>
* 3ad7e74ecb5 - (tag: build-1.4.0-dev-7391) AbstractPerformanceTypingIndentationTest: fix compilation for 191 (vor 7 Tagen) <Dmitry Gridin>
* b91cf132598 - (tag: build-1.4.0-dev-7390) [NI] Fix expicit super receiver check (vor 7 Tagen) <Pavel Kirpichenkov>
* af147017b40 - (tag: build-1.4.0-dev-7383) Fix REPL completion after "final" expressions (vor 7 Tagen) <Ilya Muradyan>
* befa1e114c5 - (tag: build-1.4.0-dev-7381) Add tests for obsolete issues (vor 7 Tagen) <Mikhail Zarechenskiy>