### PR TITLE
[Interop][Metadata] Omit unsupported declaration

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrDriver.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrDriver.kt
@@ -129,7 +129,7 @@ class StubIrDriver(
             GenerationMode.SOURCE_CODE -> {
                 emitSourceCode(outKtFile(), builderResult, bridgeBuilderResult)
             }
-            GenerationMode.METADATA -> emitMetadata(builderResult, moduleName, bridgeBuilderResult.kotlinFile)
+            GenerationMode.METADATA -> emitMetadata(builderResult, moduleName, bridgeBuilderResult)
         }
     }
 
@@ -142,8 +142,9 @@ class StubIrDriver(
         return Result.SourceCode
     }
 
-    private fun emitMetadata(builderResult: StubIrBuilderResult, moduleName: String, scope: KotlinScope) =
-            Result.Metadata(StubIrMetadataEmitter(context, builderResult, moduleName, scope).emit())
+    private fun emitMetadata(
+            builderResult: StubIrBuilderResult, moduleName: String, bridgeBuilderResult: BridgeBuilderResult
+    ) = Result.Metadata(StubIrMetadataEmitter(context, builderResult, moduleName, bridgeBuilderResult).emit())
 
     private fun emitCFile(context: StubIrContext, cFile: Appendable, entryPoint: String?, nativeBridges: NativeBridges) {
         val out = { it: String -> cFile.appendln(it) }


### PR DESCRIPTION
We need to check the result of bridge generation in `metadata` mode as we did in `sourcecode` mode because of cases like:
```
typedef int MyInt;
MyInt g7;
#define g7 bad macro
```
Test will be added separately after https://github.com/JetBrains/kotlin-native/pull/4134.