### PR TITLE
Change worker_bound_reference0 test to Standalone test

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -880,9 +880,10 @@ task empty_substring(type: KonanLocalTest) {
     source = "runtime/basic/empty_substring.kt"
 }
 
-task worker_bound_reference0(type: KonanLocalTest) {
+standaloneTest("worker_bound_reference0") {
     enabled = (project.testTarget != 'wasm32') // Workers need pthreads.
     source = "runtime/concurrent/worker_bound_reference0.kt"
+    flags = ['-tr']
 }
 
 task worker0(type: KonanLocalTest) {


### PR DESCRIPTION
Being a KonanLocalTest this test is compiled into a single binary that fails on wasm32 due to a workers usage in this test. The test is not being run but others fail during initialization