### PR TITLE
Avoid duplicated selectors when Kotlin class inherits from muliple ba…

### DIFF
--- a/backend.native/tests/interop/objc/tests/KT38234_override.h
+++ b/backend.native/tests/interop/objc/tests/KT38234_override.h
@@ -1,0 +1,9 @@
+#import <Foundation/NSObject.h>
+
+@protocol P1
+-(int)foo;
+@end;
+
+@interface Base : NSObject <P1>
+-(int)callFoo;
+@end;

--- a/backend.native/tests/interop/objc/tests/KT38234_override.h
+++ b/backend.native/tests/interop/objc/tests/KT38234_override.h
@@ -1,9 +1,9 @@
 #import <Foundation/NSObject.h>
 
-@protocol P1
+@protocol KT38234_P1
 -(int)foo;
 @end;
 
-@interface Base : NSObject <P1>
+@interface KT38234_Base : NSObject <KT38234_P1>
 -(int)callFoo;
 @end;

--- a/backend.native/tests/interop/objc/tests/KT38234_override.kt
+++ b/backend.native/tests/interop/objc/tests/KT38234_override.kt
@@ -1,0 +1,10 @@
+import kotlin.test.*
+import objcTests.*
+
+class KT38234Impl : P1Protocol, Base() {
+    override fun foo(): Int = 566
+}
+
+@Test fun testKT38234() {
+    assertEquals(566, KT38234Impl().callFoo())
+}

--- a/backend.native/tests/interop/objc/tests/KT38234_override.kt
+++ b/backend.native/tests/interop/objc/tests/KT38234_override.kt
@@ -1,10 +1,10 @@
 import kotlin.test.*
 import objcTests.*
 
-class KT38234Impl : P1Protocol, Base() {
+class KT38234_Impl : KT38234_P1Protocol, KT38234_Base() {
     override fun foo(): Int = 566
 }
 
 @Test fun testKT38234() {
-    assertEquals(566, KT38234Impl().callFoo())
+    assertEquals(566, KT38234_Impl().callFoo())
 }

--- a/backend.native/tests/interop/objc/tests/KT38234_override.m
+++ b/backend.native/tests/interop/objc/tests/KT38234_override.m
@@ -1,0 +1,10 @@
+#include "KT38234_override.h"
+
+@implementation Base
+-(int)foo {
+    return 1;
+}
+-(int)callFoo {
+    return [self foo];
+}
+@end;

--- a/backend.native/tests/interop/objc/tests/KT38234_override.m
+++ b/backend.native/tests/interop/objc/tests/KT38234_override.m
@@ -1,6 +1,6 @@
 #include "KT38234_override.h"
 
-@implementation Base
+@implementation KT38234_Base
 -(int)foo {
     return 1;
 }


### PR DESCRIPTION
…ses (protocols) [KT-38234]

Issue: RuntimeAssert in AddMethods (ObjCInterop.mm) when kotlin class overrides the same
selector from multiple bases, e.g. from the base objc class and a protocol(s).