### PR TITLE
[Coverage] Disable tests

### DIFF
--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/Utils.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/Utils.kt
@@ -58,7 +58,7 @@ val Project.globalTestArgs: List<String>
     }
 
 val Project.testTargetSupportsCodeCoverage: Boolean
-    get() = this.testTarget.supportsCodeCoverage()
+    get() = false // Disable until tests are fixed
 
 //endregion
 


### PR DESCRIPTION
llvm-profdata fails with `Unsupported instrumentation profile format version`.
Disabling for now because code coverage is not enabled for end-users.