### PR TITLE
[CInterop] Fix global property mangling

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrExtensions.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrExtensions.kt
@@ -87,3 +87,14 @@ fun ConstantStub.determineConstantAnnotationClassifier(): Classifier = when (thi
         else -> error("Real constant with unexpected size of $size.")
     }
 }.let { Classifier.topLevel(cinteropInternalPackage, "ConstantValue").nested(it) }
+
+/**
+ * Returns the original name of the given type.
+ */
+val StubType.underlyingTypeFqName: String
+    get() = when (this) {
+        is ClassifierStubType -> classifier.fqName
+        is AbbreviatedType -> underlyingType.underlyingTypeFqName
+        is FunctionalType -> classifier.fqName
+        is TypeParameterType -> name
+    }

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrMetadataEmitter.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrMetadataEmitter.kt
@@ -98,11 +98,11 @@ internal class ModuleMetadataEmitter(
     private fun isTopLevelContainer(container: StubContainer?): Boolean =
             container == null
 
-    private fun getPropertyNameInScope(originalName: String, container: StubContainer?): String =
+    private fun getPropertyNameInScope(property: PropertyStub, container: StubContainer?): String =
         if (isTopLevelContainer(container)) {
-            getTopLevelPropertyDeclarationName(bridgeBuilderResult.kotlinFile, originalName)
+            getTopLevelPropertyDeclarationName(bridgeBuilderResult.kotlinFile, property)
         } else {
-            originalName
+            property.name
         }
 
     private val visitor = object : StubIrVisitor<VisitingContext, Any?> {
@@ -170,7 +170,7 @@ internal class ModuleMetadataEmitter(
                 data.withMappingExtensions {
                     val kind = element.bridgeSupportedKind
                     if (kind != null) {
-                        val name = getPropertyNameInScope(element.name, data.container)
+                        val name = getPropertyNameInScope(element, data.container)
                         KmProperty(element.flags, name, kind.getterFlags, kind.setterFlags).also { km ->
                             element.annotations.mapTo(km.annotations) { it.map() }
                             km.uniqId = data.uniqIds.uniqIdForProperty(element)

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrTextEmitter.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrTextEmitter.kt
@@ -30,7 +30,7 @@ class StubIrTextEmitter(
         get() = context.configuration.pkgName
 
     private val StubContainer.isTopLevelContainer: Boolean
-        get() = this == builderResult.stubs
+        get() = this == builderResult.stubs || this in builderResult.stubs.simpleContainers
 
     /**
      * The output currently used by the generator.
@@ -286,7 +286,7 @@ class StubIrTextEmitter(
         val modality = "$override${renderMemberModality(element.modality, owner)}"
         val receiver = if (element.receiverType != null) "${renderStubType(element.receiverType)}." else ""
         val name = if (owner?.isTopLevelContainer == true) {
-            getTopLevelPropertyDeclarationName(kotlinFile, element.name).asSimpleName()
+            getTopLevelPropertyDeclarationName(kotlinFile, element).asSimpleName()
         } else {
             element.name.asSimpleName()
         }


### PR DESCRIPTION
Do not mangle properties with the same name but with different receivers.