### PR TITLE
Provide an -Xmanifest-targets flag, allowing to specify manifest targets explicitly

### DIFF
--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -141,6 +141,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                     (arguments.produce ?: "program").toUpperCase())
                 put(PRODUCE, outputKind)
                 put(METADATA_KLIB, arguments.metadataKlib)
+                arguments.manifestTargets?.let { put(MANIFEST_TARGETS, it.asList()) }
 
                 arguments.libraryVersion ?. let { put(LIBRARY_VERSION, it) }
 

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -265,6 +265,13 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     @Argument(value = "-Xmetadata-klib", description = "Produce a klib that only contains the declarations metadata")
     var metadataKlib: Boolean = false
 
+    @Argument(
+            value = "-Xmanifest-targets",
+            valueDescription = "<target1,target2,...>",
+            description = "Override list of targets which will be written in manifest"
+    )
+    var manifestTargets: Array<String>? = null
+
     override fun configureAnalysisFlags(collector: MessageCollector): MutableMap<AnalysisFlag<*>, Any> =
             super.configureAnalysisFlags(collector).also {
                 val useExperimental = it[AnalysisFlags.useExperimental] as List<*>

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/CompilerOutput.kt
@@ -146,6 +146,7 @@ internal fun produceOutput(context: Context) {
                 irVersion = irVersion
             )
             val target = context.config.target
+            val targetsNamesForManifest = context.config.manifestTargets ?: listOf(target.visibleName)
             val nopack = config.getBoolean(KonanConfigKeys.NOPACK)
             val manifestProperties = context.config.manifestProperties
 
@@ -157,6 +158,7 @@ internal fun produceOutput(context: Context) {
                     context.serializedIr,
                     versions,
                     target,
+                    targetsNamesForManifest,
                     output,
                     libraryName,
                     nopack,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfig.kt
@@ -67,6 +67,8 @@ class KonanConfig(val project: Project, val configuration: CompilerConfiguration
 
     internal val metadataKlib get() = configuration.get(KonanConfigKeys.METADATA_KLIB)!!
 
+    internal val manifestTargets get() = configuration.get(KonanConfigKeys.MANIFEST_TARGETS)
+
     internal val produceStaticFramework get() = configuration.getBoolean(KonanConfigKeys.STATIC_FRAMEWORK)
 
     internal val purgeUserLibs: Boolean

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -68,6 +68,8 @@ class KonanConfigKeys {
                 = CompilerConfigurationKey.create("generate metadata")
         val METADATA_KLIB: CompilerConfigurationKey<Boolean>
                 = CompilerConfigurationKey.create("metadata klib")
+        val MANIFEST_TARGETS: CompilerConfigurationKey<List<String>?>
+                = CompilerConfigurationKey.create("manifest targets")
         val MODULE_KIND: CompilerConfigurationKey<ModuleKind> 
                 = CompilerConfigurationKey.create("module kind")
         val MODULE_NAME: CompilerConfigurationKey<String?> 

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryWriterImpl.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/impl/KonanLibraryWriterImpl.kt
@@ -31,10 +31,11 @@ class KonanLibraryWriterImpl(
         builtInsPlatform: BuiltInsPlatform,
         nopack: Boolean = false,
         shortName: String? = null,
+        targetNamesToWritetInManifest: List<String> = listOf(target.visibleName),
 
         val layout: KonanLibraryLayoutForWriter = KonanLibraryLayoutForWriter(libDir, target),
 
-        base: BaseWriter = BaseWriterImpl(layout, moduleName, versions, builtInsPlatform, listOf(target.visibleName), nopack, shortName),
+        base: BaseWriter = BaseWriterImpl(layout, moduleName, versions, builtInsPlatform, targetNamesToWritetInManifest, nopack, shortName),
         bitcode: BitcodeWriter = BitcodeWriterImpl(layout),
         metadata: MetadataWriter = MetadataWriterImpl(layout),
         ir: IrWriter = IrMonoliticWriterImpl(layout)
@@ -49,6 +50,7 @@ fun buildLibrary(
     ir: SerializedIrModule?,
     versions: KotlinLibraryVersioning,
     target: KonanTarget,
+    targetNamesToWriteInManifest: List<String>,
     output: String,
     moduleName: String,
     nopack: Boolean,
@@ -64,7 +66,8 @@ fun buildLibrary(
             target,
             BuiltInsPlatform.NATIVE,
             nopack,
-            shortName
+            shortName,
+            targetNamesToWriteInManifest
     )
 
     library.addMetadata(metadata)


### PR DESCRIPTION
This is needed for https://youtrack.jetbrains.com/issue/KT-38658. This commit only exposes a CLI-argument,
which later will be used by Gradle tooling