### PR TITLE
Remove kotlin-stdlib compilation during configuration phase in composite build 

### DIFF
--- a/Interop/Indexer/build.gradle
+++ b/Interop/Indexer/build.gradle
@@ -20,7 +20,6 @@ buildscript {
     apply from: "$rootBuildDirectory/gradle/kotlinGradlePlugin.gradle"
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
     }
 }

--- a/Interop/Runtime/build.gradle
+++ b/Interop/Runtime/build.gradle
@@ -23,7 +23,6 @@ buildscript {
     apply from: "$rootBuildDirectory/gradle/kotlinGradlePlugin.gradle"
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
     }
 }

--- a/build-tools/build.gradle.kts
+++ b/build-tools/build.gradle.kts
@@ -46,8 +46,7 @@ dependencies {
     compileOnly(gradleApi())
 
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+
     implementation("com.ullink.slack:simpleslackapi:1.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0-1.4.0-dev-5730") {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib")
@@ -63,6 +62,14 @@ dependencies {
     // Located in <repo root>/shared and always provided by the composite build.
     api("org.jetbrains.kotlin:kotlin-native-shared:$konanVersion")
     implementation("com.github.jengelman.gradle.plugins:shadow:5.1.0")
+
+    constraints {
+        configurations.forEach { conf ->
+            add(conf.name, "org.jetbrains.kotlin:kotlin-stdlib") { version { strictly(kotlinVersion) } }
+            add(conf.name, "org.jetbrains.kotlin:kotlin-reflect") { version { strictly(kotlinVersion) } }
+            add(conf.name, "org.jetbrains.kotlin:kotlin-stdlib-common") { version { strictly(kotlinVersion) } }
+        }
+    }
 }
 
 sourceSets["main"].withConvention(KotlinSourceSet::class) {
@@ -101,4 +108,9 @@ kotlinCompilerPluginClasspath.resolutionStrategy.eachDependency {
     if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-serialization") {
         useVersion(buildKotlinVersion)
     }
+}
+
+val kotlinCompilerClasspath by configurations.getting
+kotlinCompilerClasspath.resolutionStrategy {
+    failOnVersionConflict()
 }

--- a/endorsedLibraries/build.gradle
+++ b/endorsedLibraries/build.gradle
@@ -8,7 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-native-gradle-plugin:$gradlePluginVersion"
+        classpath("org.jetbrains.kotlin:kotlin-native-gradle-plugin:$gradlePluginVersion") {
+            transitive = false
+        }
     }
 }
 

--- a/endorsedLibraries/kotlinx.cli/build.gradle
+++ b/endorsedLibraries/kotlinx.cli/build.gradle
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.konan.target.HostManager
-import org.jetbrains.kotlin.konan.util.PlatformLibsInfo
 
 buildscript {
     repositories {
@@ -12,6 +11,12 @@ buildscript {
     }
 
     dependencies {
+        constraints {
+            classpath('org.jetbrains.kotlin:kotlin-reflect') { version { strictly kotlinVersion } }
+            classpath('org.jetbrains.kotlin:kotlin-stdlib-common') { version { strictly kotlinVersion } }
+            classpath('org.jetbrains.kotlin:kotlin-stdlib') { version { strictly kotlinVersion } }
+        }
+
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/gradle/kotlinGradlePlugin.gradle
+++ b/gradle/kotlinGradlePlugin.gradle
@@ -19,8 +19,15 @@ project.buildscript.repositories {
 }
 
 project.buildscript.dependencies {
+    constraints {
+        classpath('org.jetbrains.kotlin:kotlin-reflect') { version { strictly kotlinVersion } }
+        classpath('org.jetbrains.kotlin:kotlin-stdlib-common') { version { strictly kotlinVersion } }
+        classpath('org.jetbrains.kotlin:kotlin-stdlib') { version { strictly kotlinVersion } }
+    }
+
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 }
+
 configurations {
     kotlinCompilerClasspath
 }

--- a/libclangext/build.gradle
+++ b/libclangext/build.gradle
@@ -22,10 +22,10 @@ buildscript {
     apply from: "$rootBuildDirectory/gradle/kotlinGradlePlugin.gradle"
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
     }
 }
+
 import org.jetbrains.kotlin.konan.target.ClangArgs
 import org.jetbrains.kotlin.PlatformInfo
 ext.isEnabled = PlatformInfo.isMac()

--- a/llvmCoverageMappingC/build.gradle
+++ b/llvmCoverageMappingC/build.gradle
@@ -23,7 +23,6 @@ buildscript {
   apply from: "$rootBuildDirectory/gradle/kotlinGradlePlugin.gradle"
 
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     classpath "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
   }
 }

--- a/llvmDebugInfoC/build.gradle
+++ b/llvmDebugInfoC/build.gradle
@@ -23,7 +23,6 @@ buildscript {
   apply from: "$rootBuildDirectory/gradle/kotlinGradlePlugin.gradle"
 
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     classpath "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
   }
 }

--- a/platformLibs/build.gradle
+++ b/platformLibs/build.gradle
@@ -22,6 +22,12 @@ buildscript {
     }
 
     dependencies {
+        constraints {
+            classpath('org.jetbrains.kotlin:kotlin-reflect') { version { strictly kotlinVersion } }
+            classpath('org.jetbrains.kotlin:kotlin-stdlib-common') { version { strictly kotlinVersion } }
+            classpath('org.jetbrains.kotlin:kotlin-stdlib') { version { strictly kotlinVersion } }
+        }
+
         classpath "org.jetbrains.kotlin:kotlin-native-gradle-plugin:$gradlePluginVersion"
         classpath "org.jetbrains.kotlin:kotlin-native-build-tools:$konanVersion"
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -67,9 +67,21 @@ tasks.jar {
     archiveFileName.set("shared.jar")
 }
 
+configurations.all {
+    resolutionStrategy {
+        failOnVersionConflict()
+    }
+}
+
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    api("org.jetbrains.kotlin:kotlin-native-utils:$kotlinVersion")
-    api("org.jetbrains.kotlin:kotlin-util-klib:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-native-utils:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-util-klib:$kotlinVersion")
+
+    constraints {
+        configurations.forEach { conf ->
+            add(conf.name, "org.jetbrains.kotlin:kotlin-stdlib") { version { strictly(kotlinVersion) } }
+            add(conf.name, "org.jetbrains.kotlin:kotlin-reflect") { version { strictly(kotlinVersion) } }
+            add(conf.name, "org.jetbrains.kotlin:kotlin-stdlib-common") { version { strictly(kotlinVersion) } }
+        }
+    }
 }

--- a/tools/kotlin-native-gradle-plugin/build.gradle
+++ b/tools/kotlin-native-gradle-plugin/build.gradle
@@ -66,8 +66,14 @@ configurations {
     testImplementation.extendsFrom bundleDependencies
 }
 
+configurations.all {
+    resolutionStrategy {
+        failOnVersionConflict()
+    }
+}
+
 dependencies {
-    shadow "org.jetbrains.kotlin:kotlin-stdlib:1.3.0"
+    shadow "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     // Bundle the serialization plugin into the final jar because we shade classes of the kotlin plugin
     // while the serialization one extends them.
@@ -85,6 +91,14 @@ dependencies {
     testImplementation "org.tools4j:tools4j-spockito:1.6"
     testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude module: 'groovy-all'
+    }
+
+    constraints {
+        configurations.all { conf ->
+            add(conf.name, "org.jetbrains.kotlin:kotlin-stdlib") { version { strictly(kotlinVersion) }}
+            add(conf.name, "org.jetbrains.kotlin:kotlin-reflect") { version { strictly(kotlinVersion) }}
+            add(conf.name, "org.jetbrains.kotlin:kotlin-stdlib-common") { version { strictly(kotlinVersion) }}
+        }
     }
 }
 


### PR DESCRIPTION
Unfortunately, there's still `org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0-dev-7380 
 :kotlin:include:kotlin-stdlib-common-sources` substitution in `shared` project which I have found impossible to prevent (https://scans.gradle.com/s/7t2e4wfnwyzgo/dependencies?toggled=W1sxMV0sWzExLDJdLFsxMSwxXSxbMTEsMixbMzldXSxbMTEsMixbMzksMzZdXV0)

Relevant build scan: https://scans.gradle.com/s/7t2e4wfnwyzgo

Changes in Kotlin repository: https://github.com/JetBrains/kotlin/compare/rr/nk_/kti-192

https://youtrack.jetbrains.com/issue/KTI-192