### PR TITLE
[kotlin compiler][update] 1.4.0-dev-8300

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-7380
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-7380,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8041,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-8041
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8041,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-8041
-kotlinStdlibTestsVersion=1.4.0-dev-8041
-testKotlinCompilerVersion=1.4.0-dev-8041
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8300,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-8300
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8300,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-8300
+kotlinStdlibTestsVersion=1.4.0-dev-8300
+testKotlinCompilerVersion=1.4.0-dev-8300
 konanVersion=1.4.0-M3
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* a47bab24663 - (tag: build-1.4.0-dev-8300) [FIR] Fix build scripts for plugin prototype (vor 14 Stunden) <Dmitriy Novozhilov>
* 0c7b04a4956 - (tag: build-1.4.0-dev-8294) Document fromIndex and toIndex parameters #KT-38388 (vor 2 Tagen) <Abduqodiri Qurbonzoda>
* 3c1b41c0200 - (tag: build-1.4.0-dev-8291) Move statement: move into lambda correctly (vor 2 Tagen) <Toshiaki Kameyama>
* 19824201e27 - Move statement: do not move into lambda beyond 'if/when/try/for/while' (vor 2 Tagen) <Toshiaki Kameyama>
* ee5ecb232ab - (tag: build-1.4.0-dev-8290) Long test execution on 201: remove repeating calls to startup activities (KTI-185) (vor 2 Tagen) <Nikolay Krasko>
* fd584e6f132 - (tag: build-1.4.0-dev-8289) FIR2IR: fix offsets for calls. (vor 2 Tagen) <Jinseong Jeon>
* b49dc46e6c9 - (tag: build-1.4.0-dev-8283) NI: improve reporting errors about mismatch number of anonymous function parameters (vor 2 Tagen) <Victor Petukhov>
* 585e98a8358 - NI: support inferring lambda receiver type by explicit receiver of anonymous function (which is another postponed argument) (vor 2 Tagen) <Victor Petukhov>
* a590fe3d656 - (tag: build-1.4.0-dev-8276) Wizard: Use simpler debug information settings (vor 3 Tagen) <Kirill Shmakov>
* 67fdc5db3bd - (tag: build-1.4.0-dev-8275) Update to 201.7223.91 (KT-38561) (vor 3 Tagen) <Nikolay Krasko>
* d6d331de2a6 - (tag: build-1.4.0-dev-8270) Minor. Fix test (vor 3 Tagen) <Ilmir Usmanov>
* e92adf3d4ef - (tag: build-1.4.0-dev-8268) [Commonizer] Don't preserve annotations on types (vor 3 Tagen) <Dmitriy Dolovov>
* 5bb5d7f892e - [Commonizer] Limited annotation commonization. Tests (vor 3 Tagen) <Dmitriy Dolovov>
* 600daaa320a - [Commonizer] Reformat tests (vor 3 Tagen) <Dmitriy Dolovov>
* 413e6552ef3 - [Commonizer] Simplify creation of individual commonizers (vor 3 Tagen) <Dmitriy Dolovov>
* 735387b6853 - [Commonizer] Limited annotation commonization (@Deprecated for functions) (vor 3 Tagen) <Dmitriy Dolovov>
* be04fbd5bbd - [Commonizer] More accurate verification of annotations in tests (vor 3 Tagen) <Dmitriy Dolovov>
* ae570e4acfb - [Commonizer] Don't filter out @Deprecated non-top-level functions (vor 3 Tagen) <Dmitriy Dolovov>
* 312072d6ce1 - (tag: build-1.4.0-dev-8262) Revert accidental .idea/misc.xml change (vor 3 Tagen) <Svyatoslav Kuzmich>
* 1dd50ba1f2d - (tag: build-1.4.0-dev-8258) [FIR] Use JvmGeneratorExtensions also from CLI (vor 3 Tagen) <Mikhail Glukhikh>
* eac9af521ee - [FIR2IR] differentiate external Java stub origin from external stub (vor 3 Tagen) <Jinseong Jeon>
* b271b6d7a82 - [FIR2IR] Add conversion of value parameter annotations (vor 3 Tagen) <Mikhail Glukhikh>
* 76f6e27e375 - [FIR2IR] Add initial support of collection literals (vor 3 Tagen) <Mikhail Glukhikh>
* f3e2dbf3600 - [FIR2IR] Add conversion of function annotations (vor 3 Tagen) <Mikhail Glukhikh>
* ad00d286312 - (tag: build-1.4.0-dev-8249) TypingIndentation: add large test (vor 3 Tagen) <Dmitry Gridin>
* 36f6ccffde2 - (tag: build-1.4.0-dev-8245) Add test for obsolete issue (vor 3 Tagen) <Mikhail Zarechenskiy>
* 91ef053fbce - IR: keep local scope with counter maps across LDL invocations (vor 3 Tagen) <Alexander Udalov>
* 50506658c09 - (tag: build-1.4.0-dev-8242) fix some tests for as36 (vor 3 Tagen) <Dmitry Gridin>
* ad09eb5416d - (tag: build-1.4.0-dev-8239) [FIR] Add ability to rewrite attributes in FirDeclarationAttributes (vor 3 Tagen) <Dmitriy Novozhilov>
* 239837fd147 - [FIR] Introduce `FirDeclarationAttributes` for `FirDeclaration` (vor 3 Tagen) <Dmitriy Novozhilov>
* b348ae689a4 - [FIR] Introduce different implementations of ArrayMapOwner (vor 3 Tagen) <Dmitriy Novozhilov>
* edd7d5b0b05 - [FIR-TEST] Add tests of compiler plugin prototype to :firAllTest (vor 3 Tagen) <Dmitriy Novozhilov>
* 959ecceaf7b - [FIR-PLUGIN] Move fir plugin prototype out from :compiler module (vor 3 Tagen) <Dmitriy Novozhilov>
* ab7613f6a41 - [FIR-PLUGIN] Rename `FirExtensionPoint` to `FirExtension` (vor 3 Tagen) <Dmitriy Novozhilov>
* 4eb9eb05377 - [FIR] Rename `FirExtensionPoint` to `FirExtension` (vor 3 Tagen) <Dmitriy Novozhilov>
* a1e719a127b - [FIR] Register extensions in CLI (vor 3 Tagen) <Dmitriy Novozhilov>
* 6af3b289a34 - [FIR-PLUGIN] Add plugin key to allopen extensions (vor 3 Tagen) <Dmitriy Novozhilov>
* 78b8a7b3886 - [FIR] Store extensions by plugin key (vor 3 Tagen) <Dmitriy Novozhilov>
* e5365cec87c - [FIR-PLUGIN] Change allopen plugin according to previous commit (vor 3 Tagen) <Dmitriy Novozhilov>
* fac57344a3a - [FIR] Split plugin annotations for two groups. Introduce modes for meta annotations (vor 3 Tagen) <Dmitriy Novozhilov>
* 4022a57a4b6 - [FIR-PLUGIN] Add simple implemetation of class generator extension point (vor 3 Tagen) <Dmitriy Novozhilov>
* 2b24317358f - [FIR-PLUGIN] Add test with meta annotation in plugin (vor 3 Tagen) <Dmitriy Novozhilov>
* 343928b97e2 - [FIR] Add proper extension key to FirExtensionPoint (vor 3 Tagen) <Dmitriy Novozhilov>
* 941e43a226c - [FIR] Fix collecting annotations with meta annotations (vor 3 Tagen) <Dmitriy Novozhilov>
* b52452ef847 - [FIR] Don't resolve annotation to error types on annotation phase (vor 3 Tagen) <Dmitriy Novozhilov>
* 17434c34b4f - [FIR-PLUGIN] Enable lib with annotation in plugin tests (vor 3 Tagen) <Dmitriy Novozhilov>
* 7e5024fb887 - [FIR-PLUGIN] Add lib with annotations for allopen plugin (vor 3 Tagen) <Dmitriy Novozhilov>
* 728e0604ac6 - [FIR] Add prototype of first generation phase (vor 3 Tagen) <Dmitriy Novozhilov>
* b31981619ee - [FIR] Skip annotations resolve phase if no extensions registered (vor 3 Tagen) <Dmitriy Novozhilov>
* 4ed6d7fddb8 - [FIR] Add stage for resolving annotations from plugins (vor 3 Tagen) <Dmitriy Novozhilov>
* f9c37cfa6ce - [FIR] Add `transformAnnotationTypeRef` to FirAnnotationCall (vor 3 Tagen) <Dmitriy Novozhilov>
* ab2177f8a48 - [FIR] Extract `withScopesCleanup` from `FirAbstractBodyResolveTransformer` (vor 3 Tagen) <Dmitriy Novozhilov>
* bb645a7962f - [FIR] Add `transformSuperTypeRefs` to FirClass (vor 3 Tagen) <Dmitriy Novozhilov>
* bad44979703 - [FIR] Add `transformDeclarations` to FirFile (vor 3 Tagen) <Dmitriy Novozhilov>
* 4b580b4e06b - [FIR] Refactor `FirResolvePhase.requiredToLaunch` (vor 3 Tagen) <Dmitriy Novozhilov>
* 3d30ba9c19c - [FIR] Add ability to register user defined annotations for plugins (vor 3 Tagen) <Dmitriy Novozhilov>
* 8ecd3d8efef - [FIR-PLUGIN] Fix allopen plugin due to previous commits (vor 3 Tagen) <Dmitriy Novozhilov>
* ab831179e2f - [FIR] Add different modes for extensions and annotations (vor 3 Tagen) <Dmitriy Novozhilov>
* 8f293acb2e1 - [FIR] Add prototype of declaring plugin annotations (vor 3 Tagen) <Dmitriy Novozhilov>
* d1b709e6323 - [FIR] Extract FirExtensionPointService to separate file (vor 3 Tagen) <Dmitriy Novozhilov>
* 35cce7eedd2 - [FIR] Initialize extension service in all FIR tests (vor 3 Tagen) <Dmitriy Novozhilov>
* cb0a7a5bf76 - [FIR] Rename `FirExtensionRegistrarExtension` to `FirExtensionRegistrar` (vor 3 Tagen) <Dmitriy Novozhilov>
* dd2b7f87f71 - [FIR-PLUGIN] Add prototype of allopen plugin for FIR compiler (vor 3 Tagen) <Dmitriy Novozhilov>
* 9b43c66f801 - [FIR] Add status transformer extension (vor 3 Tagen) <Dmitriy Novozhilov>
* 7f8a8ca0990 - [FIR] Add ability to register extension points in diagnostic tests (vor 3 Tagen) <Dmitriy Novozhilov>
* a37975ab21b - [FIR] Add compiler extension for plugin registration (vor 3 Tagen) <Dmitriy Novozhilov>
* ff4a71386e9 - [FIR] Register extension point component in fir sessions (vor 3 Tagen) <Dmitriy Novozhilov>
* 262d1472f26 - [FIR] Add service for fir extension points (vor 3 Tagen) <Dmitriy Novozhilov>
* 1f4a3b0d1cb - (tag: build-1.4.0-dev-8228) [JVM_IR] Avoid safe-call conversions from Byte? and Short? to Int? for comparisons. (vor 3 Tagen) <Mads Ager>
* 3d5003d4763 - (tag: build-1.4.0-dev-8224) [JS_IR] Use new plugin to build Kotlin/JS stdlib with IR compiler (vor 3 Tagen) <Svyatoslav Kuzmich>
* 14edc26cf18 - (tag: build-1.4.0-dev-8221) Revert due to test failing in 201 (vor 3 Tagen) <Sergey Rostov>
* 05797afaf87 - (tag: build-1.4.0-dev-8214) Replace last SourceInterpreter with specific one in inliner (vor 4 Tagen) <Ilmir Usmanov>
* 2c888444092 - Replace SourceInterpreter with interpreter, which track only (vor 4 Tagen) <Ilmir Usmanov>
* 3173113cb36 - Use BasicInterpreter instead of SourceInterpreter in LocalReturnsTransformer (vor 4 Tagen) <Ilmir Usmanov>
* 841e588c879 - (tag: build-1.4.0-dev-8210) AsyncFileChangeListenerHelper: 191 and 201 (vor 4 Tagen) <Sergey Rostov>
* fbaf639784b - (tag: build-1.4.0-dev-8209) AsyncFileChangeListenerHelper: 191 and 201 (vor 4 Tagen) <Sergey Rostov>
* c76c9836148 - (tag: build-1.4.0-dev-8208) minor: ScriptingSupport.Provider -> ScriptingSupport, KDoc (vor 4 Tagen) <Sergey Rostov>
* 541e6dc1197 - GradleScriptOutOfProjectTest: roots are already registered as legacy (vor 4 Tagen) <Sergey Rostov>
* e099ee3af82 - Fix lastIndexOfOrNull (vor 4 Tagen) <Sergey Rostov>
* 5474d557956 - Scripting, minor: updateScriptDefinitions -> updateScriptDefinitionReferences (vor 4 Tagen) <Sergey Rostov>
* 0d6c7f2b41e - ScriptClassRootsCache, sdk: use toSystemIndependentName (vor 4 Tagen) <Sergey Rostov>
* f1789e910b6 - gradle.kts, minor: remove unused code (vor 4 Tagen) <Sergey Rostov>
* 3e6f8278854 - GradleScriptListenerTest: add gradle-wrapper.properties to specify gradle version explicitly (vor 4 Tagen) <Sergey Rostov>
* 7de0bc9cdc1 - ScriptClassRootsUpdater, updateSynchronously: cancel before waiting for lock (vor 4 Tagen) <Sergey Rostov>
* bc0255890d0 - ScriptClassRootsUpdater: fix clearing scheduledUpdate and check cancelled in sync (vor 4 Tagen) <Sergey Rostov>
* 6c3a6f8bc22 - gradle.kts: remove LastModifiedFiles fs data when removing gradle root (vor 4 Tagen) <Sergey Rostov>
* f196085e417 - gradle.kts, minor: move isInAffectedGradleProjectFiles inside GradleBuildRootsManager (vor 4 Tagen) <Sergey Rostov>
* c764ebfbac4 - GradleScriptListenerTest: link gradle project (vor 4 Tagen) <Sergey Rostov>
* 9e18df87dcf - GradleBuildRootsManager: fix onProjectsLinked (vor 4 Tagen) <Sergey Rostov>
* 15c6c9f530f - GradleLegacyScriptListener: call from GradleScriptListener (vor 4 Tagen) <Sergey Rostov>
* 3a98ed96a2d - gradle.kts: use toSystemIndependentName for paths coming from Gradle (vor 4 Tagen) <Sergey Rostov>
* c79858e965f - ScriptClassRootsUpdater: run synchronously in unit test mode (vor 4 Tagen) <Sergey Rostov>
* d8692a78ba1 - UnusedSymbolInspection: load script configurations from cache (vor 4 Tagen) <Sergey Rostov>
* b8866078d2b - gradle.kts, scheduleLastModifiedFilesSave: fix race condition (vor 4 Tagen) <Sergey Rostov>
* b089f4dd2ed - gradle.kts, minor: areRelatedFilesUpToDate -> areRelatedFilesChangedBefore (vor 4 Tagen) <Sergey Rostov>
* f5ac45ea08e - GradleScriptListener: update lastModifiedFiles on document change (vor 4 Tagen) <Sergey Rostov>
* d626184ceeb - GradleBuildRoot: fix loading lastModifiedFiles (vor 4 Tagen) <Sergey Rostov>
* 3ba7c52fe86 - LastModifiedFiles: fix in case of sequential changes in same file (vor 4 Tagen) <Sergey Rostov>
* 39c6efd40f3 - .gradle.kts, listener: support multiple gradle projects linked to one IntelliJ project (vor 4 Tagen) <Sergey Rostov>
* 02940f9f173 - gradle.kts: docs (vor 4 Tagen) <Sergey Rostov>
* 0e7cf60b04f - ScriptConfigurationManager: take OutsidersPsiFileSupport into account (vor 4 Tagen) <Sergey Rostov>
* 316c7ce60fa - Scripts, minor: get rid of ScriptingSupportHelper (vor 4 Tagen) <Sergey Rostov>
* 0cadcec27c6 - gradle.kts: merge data on failed gradle sync, fix updates scheduling in corner cases (vor 4 Tagen) <Sergey Rostov>
* b7e1cd7489d - gradle.kts: solve the linked gradle builds hell (vor 4 Tagen) <Sergey Rostov>
* 6213c6187da - gradle.kts, imported gradle build root: fix equality (vor 4 Tagen) <Sergey Rostov>
* 7942b4a0d23 - ScriptConfigurationManager, outsider files: search in roots cache too (vor 4 Tagen) <Sergey Rostov>
* eb672c02fad - ScriptConfigurationManager: rebuild cache synchronously from default loader (vor 4 Tagen) <Sergey Rostov>
* e6528a26e9b - gradle.kts: cache definitions (vor 4 Tagen) <Sergey Rostov>
* 4de13816498 - gradle.kts: remove useless gradle build root kinds (vor 4 Tagen) <Sergey Rostov>
* aca17716197 - Script configuration: fix getting javaHome (vor 4 Tagen) <Sergey Rostov>
* 6ad0ed7f403 - CompositeScriptConfigurationManager: unified caching (vor 4 Tagen) <Sergey Rostov>
* 368e6f93df6 - GradleScriptConfigurationLoader: KDocs (vor 4 Tagen) <Sergey Rostov>
* 7e3dfb245bf - (tag: build-1.4.0-dev-8200) Avoid skipping lambda argument processing in case of explicit type param (vor 4 Tagen) <Ilya Chernikov>
* ec98d615209 - (tag: build-1.4.0-dev-8192) Fix TeamCity badge (vor 4 Tagen) <Ilya Goncharov>
* fb9562ca70b - (tag: build-1.4.0-dev-8179) Add `ThrowableRunnable` to fix CCE (vor 4 Tagen) <Dmitry Gridin>
* 988c89602d1 - tests: wrap `tearDown` with `RunAll` (vor 4 Tagen) <Dmitry Gridin>
* f50e2890337 - fix psi tree in `moveFunctionLiteralOutsideParentheses` (vor 4 Tagen) <Dmitry Gridin>
* afb15eb7cfb - BranchedFoldingUtils: fix psi tree after `tryFoldToAssignment` (vor 4 Tagen) <Dmitry Gridin>
* ee0b7426c43 - KotlinFunctionCallUsage: fix psi tree (vor 4 Tagen) <Dmitry Gridin>
* 11a34829700 - tests: apply official code style (vor 4 Tagen) <Dmitry Gridin>
* d8f9643650f - [FIR2IR] Use intersection type approximation for receivers (vor 4 Tagen) <Mikhail Glukhikh>
* 292563451ca - (tag: build-1.4.0-dev-8175) Fix falsely skipped shared-native source sets in HMPP (KT-38746) (vor 4 Tagen) <Sergey Igushkin>
* a0400f59c22 - (tag: build-1.4.0-dev-8173) Add -Xskip-prerelease-check compiler argument (vor 4 Tagen) <Alexander Udalov>
* 37e676a4a6c - (tag: build-1.4.0-dev-8170) Bump Gradle (6.3) and Android-build-tools (3.6.3) versions in new project wizards (vor 4 Tagen) <Anton Yalyshev>
* 821aca984bd - (tag: build-1.4.0-dev-8163) JVM IR: Take superQualifierSymbols into account when lowering inline classes (vor 4 Tagen) <Steven Schäfer>
* 52abc2ae1a6 - (tag: build-1.4.0-dev-8158) [FIR] Fix spec test data according to a new diagnostic (vor 4 Tagen) <Mikhail Glukhikh>
* 38fc4d0f1f9 - FIR: set & use dispatch receiver for q. access with super reference (vor 4 Tagen) <Mikhail Glukhikh>
* b058ca635c9 - FIR: make both ImplicitReceiverStack.get implementations consistent (vor 4 Tagen) <Mikhail Glukhikh>
* cd2f5895a62 - FIR: add minor fix of super reference handling (vor 4 Tagen) <Mikhail Glukhikh>
* 7b01cf7b040 - FIR: handle labeled super reference properly (vor 4 Tagen) <Jinseong Jeon>
* 260683c20ef - (tag: build-1.4.0-dev-8156) NI: Improve postponed arguments analysis (vor 4 Tagen) <Victor Petukhov>
* 50151e0e010 - (tag: build-1.4.0-dev-8149) [Gradle, JS]AbstractNpmDependencyExtension -> DefaultNpmDependencyExtension (vor 4 Tagen) <subroh0508>
* abf942b9280 - [Gradle, JS]Add optionalNpm methods (vor 4 Tagen) <subroh0508>
* 34e8b114750 - [Gradle, JS]Add directoryNpmDependency method (vor 4 Tagen) <subroh0508>
* 121897133e6 - [Gradle, JS]Delete peerNpm method used by file argument (vor 4 Tagen) <subroh0508>
* 231324d119c - [Gradle, JS]Add peerNpm method for peerDependencies to KotlinDependencyHandler (vor 4 Tagen) <subroh0508>
* 3e2feac4ea9 - [Gradle, JS]Add devNpm method for devDependencies to KotlinDependencyHandler (vor 4 Tagen) <subroh0508>
* 726a871c07f - (tag: build-1.4.0-dev-8148) [FIR] Add dependency of `:dist` to `:firAllTest` (vor 4 Tagen) <Dmitriy Novozhilov>
* 41545cd2b48 - [FIR] Initialize origin in all places with creating of declarations (vor 4 Tagen) <Dmitriy Novozhilov>
* e515b1c8234 - [FIR] Add origin field to FirDeclaration (vor 4 Tagen) <Dmitriy Novozhilov>
* 7a369b3a6ae - (tag: build-1.4.0-dev-8135) Mark PureIrGenerationExtension as deprecated to prevent more usages (vor 5 Tagen) <Alexander Udalov>
* 9fc210224d8 - Parcelize: Fix IBinderIInterface test (vor 5 Tagen) <Steven Schäfer>
* 518c7a32b8a - Parcelize: Add a test for efficient Parcelable serialization within the same module (vor 5 Tagen) <Steven Schäfer>
* a4e6dbb0d70 - Parcelize: Add test for TypeParceler scoping behavior (vor 5 Tagen) <Steven Schäfer>
* b35e8e208a0 - Parcelize: Add a test for Parcelize with persistable bundles (vor 5 Tagen) <Steven Schäfer>
* 43bccff135f - Parcelize: Add a test for parcelize of IBinder and IInterface (vor 5 Tagen) <Steven Schäfer>
* 6cf3e0e38e2 - Parcelize: Add a test for exceptions in parcels (KT-31830) (vor 5 Tagen) <Steven Schäfer>
* 21637c828ea - Parcelize: Add a test for Java interop (KT-25807) (vor 5 Tagen) <Steven Schäfer>
* aa0eeba3275 - Parcelize: Add a test for KT-36658 (vor 5 Tagen) <Steven Schäfer>
* 01ea2a641f3 - Parcelize: Add test for KT-26221 (vor 5 Tagen) <Steven Schäfer>
* 1552e554748 - Parcelize: Add an exhaustive test for primitive types (vor 5 Tagen) <Steven Schäfer>
* 1f97486fdd3 - Parcelize: Improve testing infrarstructure (vor 5 Tagen) <Steven Schäfer>
* d62b353ab55 - Parcelize: Fix metadata and remap synthetic descriptor stubs (vor 5 Tagen) <Steven Schäfer>
* 779133e71e1 - Parcelize: Implement support for the JVM IR backend. (vor 5 Tagen) <Steven Schäfer>
* 7cad2be329b - IR: Add an extension point after IR construction (vor 5 Tagen) <Steven Schäfer>
* 6ae7d53a93d - (tag: build-1.4.0-dev-8107) Uast: support `extendsList` for reified types (KT-38173) (vor 5 Tagen) <Nicolay Mitropolsky>
* 43549baf58f - Revert "Uast: forcing `kotlin.uast.force.uinjectionhost=true` always" (vor 5 Tagen) <Nicolay Mitropolsky>
* 00b44c1e68a - Uast: making `KotlinStringTemplateUPolyadicExpression.operands` always non-empty (EA-231393) (vor 5 Tagen) <Nicolay Mitropolsky>
* b7e715045a9 - Uast: skip `KtWhenConditionWithExpression` in UAST (KT-38521) (vor 5 Tagen) <Nicolay Mitropolsky>
* 903f35ce0cd - Uast: don't fall on empty when entries (EA-231339) (vor 5 Tagen) <Nicolay Mitropolsky>
* 3143b15a17f - (tag: build-1.4.0-dev-8105) Generate widening cast for Byte and Short to Int (vor 5 Tagen) <Dmitry Petrov>
* 427973fe48f - (tag: build-1.4.0-dev-8101) FIR serializer: fix typo in finding argument name (vor 5 Tagen) <Mikhail Glukhikh>
* deb8e1f9db8 - IR: cleanup unused implementation in WrappedDescriptors (vor 5 Tagen) <Jinseong Jeon>
* 0c7ed042608 - FIR: make (K)SuspendFunctionX derived from (K)Function (vor 5 Tagen) <Jinseong Jeon>
* 9eee0897403 - FIR: regenerate diagnostic tests (vor 5 Tagen) <Mikhail Glukhikh>
* f7137fe860c - (tag: build-1.4.0-dev-8097) Slightly polish FirAnnotationClassDeclarationChecker (vor 5 Tagen) <Mikhail Glukhikh>
* aa706d322d3 - [FIR] Support several annotation class diagnostics (vor 5 Tagen) <Likholetov Mikhail>
* 1e8dff6a7ca - (tag: build-1.4.0-dev-8076, origin/rr/yunir/KTI-216-Build-configuration-with-muted-tests-state-check) Fix bunch files after removing IDE option (vor 7 Tagen) <Mikhail Zarechenskiy>
* b2ca61e8a55 - (tag: build-1.4.0-dev-8075) Fix compilation, remove import (vor 7 Tagen) <Mikhail Zarechenskiy>
* c01a171d4cd - (tag: build-1.4.0-dev-8074) Revert "Add option to enable new inference only for IDE analysis" (vor 7 Tagen) <Mikhail Zarechenskiy>
* d7dfe9e1e5c - FUS Collector: remove metric about using new inference in IDE (vor 7 Tagen) <Mikhail Zarechenskiy>
* 54f9f130e2b - (tag: build-1.4.0-dev-8072) Do not generate references as adapted with -Xno-optimized-callable-references (vor 7 Tagen) <Alexander Udalov>
* 4f7599076cb - (tag: build-1.4.0-dev-8071, origin/rr/mb/undep) Postpone `JvmDefault` deprecation. Revert "Deprecate @JvmDefault" (vor 7 Tagen) <Mikhail Bogdanov>
* 911dfde0fe6 - (tag: build-1.4.0-dev-8068) Add highlighting perf test with empty profile (vor 7 Tagen) <Vladimir Dolzhenko>
* 32be4c03ca3 - (tag: build-1.4.0-dev-8065) ExtractSuperRefactoring: add `quoteSegmentsIfNeeded()` (vor 7 Tagen) <Dmitry Gridin>
* 86de734f266 - KotlinExtractSuperclassDialog: cleanup code (vor 7 Tagen) <Dmitry Gridin>
* ccfea973903 - CopyKotlinDeclarationsHandler: fix for package with backticks (vor 7 Tagen) <Dmitry Gridin>
* b058dc12df6 - packageUtils: cleanup code (vor 7 Tagen) <Dmitry Gridin>
* ac9ad306814 - SetterBackingFieldAssignmentInspection: fix exception (vor 7 Tagen) <Dmitry Gridin>
* 6f5b3aebe1c - KotlinIntroduceVariableHandler: fix CCE for destruction declaration (vor 7 Tagen) <Dmitry Gridin>
* 8e35b7a29cf - KotlinIntroduceVariableHandler: fix for declarations with expression body (vor 7 Tagen) <Dmitry Gridin>
* d21e383094d - KotlinIntroduceVariableHandler: cleanup code (vor 7 Tagen) <Dmitry Gridin>
* b574917314d - (tag: build-1.4.0-dev-8046) Minor: update FIR2IR testData (vor 10 Tagen) <Dmitry Petrov>
* 6257b32954e - [JVM_IR] Avoid boxing when comparing primitive to object. (vor 10 Tagen) <Mads Ager>
* 7e553363009 - (tag: build-1.4.0-dev-8043) Add yourKit profiler to perfTests (vor 10 Tagen) <Vladimir Dolzhenko>
* a564d471589 - (tag: build-1.4.0-dev-8042) Minor: unmute FIR black box test (vor 10 Tagen) <Dmitry Petrov>
* 1d10776db44 - Minor: update FIR2IR testData (vor 10 Tagen) <Dmitry Petrov>
* db17184cfd0 - [JVM_IR] Avoid some boxing when comparing boxed primitives to primitives. (vor 10 Tagen) <Mads Ager>