### PR TITLE
Exclude module-info descriptor from standard library artifacts

### DIFF
--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/CollisionDetector.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/CollisionDetector.kt
@@ -43,6 +43,7 @@ open class CollisionDetector : DefaultTask() {
                     zip.entries().asSequence().filterNot {
                         it.isDirectory ||
                         it.name.equals("META-INF/MANIFEST.MF", ignoreCase = true) ||
+                        it.name.equals("META-INF/versions/9/module-info.class", ignoreCase = true) ||
                         it.name.startsWith("META-INF/services/", ignoreCase = true)
                     }.forEach {
                         val outputPath = it.name

--- a/build.gradle
+++ b/build.gradle
@@ -328,6 +328,7 @@ task shadowJar(type: ShadowJar) {
     mergeServiceFiles()
     destinationDirectory.set(file("$distDir/konan/lib"))
     archiveBaseName.set("kotlin-native")
+    exclude("META-INF/versions/9/module-info.class")
     configurations = [project.configurations.distPack]
     archiveClassifier.set(null)
     transform(CollisionTransformer.class) {


### PR DESCRIPTION
There's a conflict between kotlin-stdlib and kotlin-reflect, and
that descriptor is anyway not needed when running merged jar
on a classpath.