### PR TITLE
[kotlin compiler][update] 1.4.0-dev-8620

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -76,7 +76,7 @@ To update the blackbox compiler tests set TeamCity build number in `gradle.prope
 
 * **-Pprefix** allows one to choose external test directories to run. Only tests from directories with given prefix will be executed.
 
-        ./gradlew -Pprefix=external_codegen_box_cast run_external
+        ./gradlew -Pprefix=build_external_compiler_codegen_box_cast run_external
 
 * **-Ptest_flags** passes flags to the compiler used to compile tests
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -63,10 +63,10 @@ internal class KonanSymbols(
 
     private fun unsignedClass(unsignedType: UnsignedType): IrClassSymbol = classById(unsignedType.classId)
 
-    val uByte = unsignedClass(UnsignedType.UBYTE)
-    val uShort = unsignedClass(UnsignedType.USHORT)
-    val uInt = unsignedClass(UnsignedType.UINT)
-    val uLong = unsignedClass(UnsignedType.ULONG)
+    override val uByte = unsignedClass(UnsignedType.UBYTE)
+    override val uShort = unsignedClass(UnsignedType.USHORT)
+    override val uInt = unsignedClass(UnsignedType.UINT)
+    override val uLong = unsignedClass(UnsignedType.ULONG)
 
     val signedIntegerClasses = setOf(byte, short, int, long)
     val unsignedIntegerClasses = setOf(uByte, uShort, uInt, uLong)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
@@ -42,10 +43,11 @@ internal class KonanIr(context: Context, irModule: IrModuleFragment): Ir<Context
 
 internal class KonanSymbols(
         context: Context,
+        irBuiltIns: IrBuiltIns,
         private val symbolTable: SymbolTable,
         lazySymbolTable: ReferenceSymbolTable,
         val functionIrClassFactory: BuiltInFictitiousFunctionIrClassFactory
-): Symbols<Context>(context, symbolTable) {
+): Symbols<Context>(context, irBuiltIns, symbolTable) {
 
     val entryPoint = findMainEntryPoint(context)?.let { symbolTable.referenceSimpleFunction(it) }
 

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/CollisionDetector.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/CollisionDetector.kt
@@ -43,6 +43,7 @@ open class CollisionDetector : DefaultTask() {
                     zip.entries().asSequence().filterNot {
                         it.isDirectory ||
                         it.name.equals("META-INF/MANIFEST.MF", ignoreCase = true) ||
+                        it.name.equals("META-INF/versions/9/module-info.class", ignoreCase = true) ||
                         it.name.startsWith("META-INF/services/", ignoreCase = true)
                     }.forEach {
                         val outputPath = it.name

--- a/build.gradle
+++ b/build.gradle
@@ -332,6 +332,7 @@ task shadowJar(type: ShadowJar) {
     archiveBaseName.set("kotlin-native")
     // Exclude trove4j because of license agreement.
     exclude "*trove4j*"
+    exclude("META-INF/versions/9/module-info.class")
     configurations = [project.configurations.distPack]
     archiveClassifier.set(null)
     transform(CollisionTransformer.class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,15 +15,15 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.4.0-dev-7380
-buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-7380,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.4.0-dev-8620
+buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8620,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8300,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-8300
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8300,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-8300
-kotlinStdlibTestsVersion=1.4.0-dev-8300
-testKotlinCompilerVersion=1.4.0-dev-8300
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8620,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-8620
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8620,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-8620
+kotlinStdlibTestsVersion=1.4.0-dev-8620
+testKotlinCompilerVersion=1.4.0-dev-8620
 konanVersion=1.4.0-M3
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 01992b581ef - (tag: build-1.4.0-dev-8620) Dropped KotlinNativeFileTypeFactory from native-common.xml (vor 21 Stunden) <Vladimir Dolzhenko>
* 005e62526b9 - (tag: build-1.4.0-dev-8616) Build: Add distributionSha256Sum to gradle-wrapper.properties (vor 30 Stunden) <Vyacheslav Gerasimov>
* 7afadb9b5e6 - (tag: build-1.4.0-dev-8608) Init default profile for perf tests (vor 2 Tagen) <Vladimir Dolzhenko>
* fb6ef38370a - (tag: build-1.4.0-dev-8588) Revert "Add info about the end of range in scripting REPL compiler messages" (vor 3 Tagen) <Ilya Chernikov>
* 3793e485b6e - (tag: build-1.4.0-dev-8585) Check for common klibs builtins_platform properly (vor 3 Tagen) <Dmitry Savvinov>
* c6f38ebfbfd - (tag: build-1.4.0-dev-8580) JS IR: enable scope expansion strategy for JS IR KLIB incremental generation (vor 3 Tagen) <Anton Bannykh>
* 59ca626487c - Make JPS-based wizards available only for new_module use case (vor 3 Tagen) <Anton Yalyshev>
* f0ff4b066eb - Remove old Gradle-based new_project_wizards from the Kotlin group (vor 3 Tagen) <Anton Yalyshev>
* 82d81d5223a - Change Signature: move lambda outside of parentheses if the arguments are reordered so that the lambda goes last (vor 3 Tagen) <Toshiaki Kameyama>
* 912fd556e5d - Fix commonizer: merge klib manifest dependencies during commonization. (vor 3 Tagen) <Konstantin Tskhovrebov>
* 32e0ce87799 - Disable default platform libs for konanc metadata compilation. (vor 3 Tagen) <Konstantin Tskhovrebov>
* 17ad0a97d81 - Add commonized dependencies to metadata compilation. (vor 3 Tagen) <Konstantin Tskhovrebov>
* beb59b3075e - Refactor: add Project.getMetadataCompilationForSourceSet extension. (vor 3 Tagen) <Konstantin Tskhovrebov>
* 5bbb4599930 - (tag: build-1.4.0-dev-8568) FIR: Refactor FirTowerResolverSession.enumerateTowerLevels (vor 3 Tagen) <Denis Zharkov>
* 475671563bd - FIR: Get rid of obsolete local scopes optimizations (vor 3 Tagen) <Denis Zharkov>
* e7a67c7a16d - FIR: Extract StandardClassIds.KClass (vor 3 Tagen) <Denis Zharkov>
* b691b13d8e3 - FIR: Add separate local scopes for blocks (vor 3 Tagen) <Denis Zharkov>
* b084399b58a - FIR: Cleanup local scope tracking (vor 3 Tagen) <Denis Zharkov>
* e7e84b18cd2 - FIR: Do not retrieve symbol for type construction (vor 3 Tagen) <Denis Zharkov>
* 25bee057e01 - FIR: Do not retrieve file for callable until it's needed (vor 3 Tagen) <Denis Zharkov>
* 295f7d7500c - FIR: Do not add trivial constraints (vor 3 Tagen) <Denis Zharkov>
* 27aa0040be1 - FIR: Cache supetypes scopes when building callable scopes for qualifier (vor 3 Tagen) <Denis Zharkov>
* 774c5b55c36 - FIR: Avoid creating empty nested classes scopes (vor 3 Tagen) <Denis Zharkov>
* cd149957ee5 - FIR: Filter out irrelevant local scopes during resolution (vor 3 Tagen) <Denis Zharkov>
* beb9a72e9d8 - FIR: Optimize constructor of FirTowerResolverSession (vor 3 Tagen) <Denis Zharkov>
* 2e91bf7e50c - FIR: Minor. Clarify name for addNonLocalTowerDataElements (vor 3 Tagen) <Denis Zharkov>
* 288db4fb1c7 - Revert "FIR: make both ImplicitReceiverStack.get implementations consistent" (vor 3 Tagen) <Denis Zharkov>
* 808355d817e - FIR: Fix test data for secondary constructor delegation calls (vor 3 Tagen) <Denis Zharkov>
* f71a56e7427 - FIR: Fix test data after rewritten scope structure (vor 3 Tagen) <Denis Zharkov>
* f64c12efac9 - FIR: Drop MutableImplicitReceiverStack and its implementation (vor 3 Tagen) <Denis Zharkov>
* 35e3942afbd - FIR: Drop unused ImplicitDispatchReceiverKind (vor 3 Tagen) <Denis Zharkov>
* 0ef16287519 - FIR: Refactor scope structure on body resolve stage (vor 3 Tagen) <Denis Zharkov>
* cee38e08005 - FIR: Implement FirScopeProvider.getStaticScope (vor 3 Tagen) <Denis Zharkov>
* 5268802d5d4 - FIR: Minor. Move "storeFunction" call to transformSimpleFunction (vor 3 Tagen) <Denis Zharkov>
* 3d6eedc9628 - FIR: Do not store nested local classes to local scopes (vor 3 Tagen) <Denis Zharkov>
* 07be2ae5c70 - FIR: Use containers structure in FirContractResolveTransformer (vor 3 Tagen) <Denis Zharkov>
* a67e9966b89 - FIR: Adapt DataFlowAnalyzer to PersistentReceiverStackImpl (vor 3 Tagen) <Denis Zharkov>
* 687a58843fe - FIR: Rewrite visibility checking (vor 3 Tagen) <Denis Zharkov>
* 825cdd38412 - FIR: Move PersistentImplicitReceiverStack to resolve module (vor 3 Tagen) <Denis Zharkov>
* e8232fe471a - FIR: Remove unused TowerGroupKind.Static (vor 3 Tagen) <Denis Zharkov>
* 56c793ffc6c - FIR: Minor. Extract FirDeclarationsResolveTransformer::doTransformRegularClass (vor 3 Tagen) <Denis Zharkov>
* 7489b9f636c - FIR: Minor. Inline processMembersForExplicitReceiver (vor 3 Tagen) <Denis Zharkov>
* fee639258c4 - FIR: Simplify file imports scope tracking (vor 3 Tagen) <Denis Zharkov>
* 8a51bb7810d - FIR: Minor. Unbound FirTowerResolverSession from FirLocalScope (vor 3 Tagen) <Denis Zharkov>
* 8363671cab0 - FIR: Inline constructor parameter at FirTowerResolverSession (vor 3 Tagen) <Denis Zharkov>
* 75c42395049 - Add "*.png binary" to .gitattributes (vor 3 Tagen) <Denis Zharkov>
* 1d39ac1d3e6 - Move statement: do not move when function last parameter is on same line as right parenthesis (vor 3 Tagen) <Toshiaki Kameyama>
* 615636ed55e - (tag: build-1.4.0-dev-8562) FIR2IR: apply SAM conversion to arguments of functional type. (vor 3 Tagen) <Jinseong Jeon>
* 599c5dd474e - (tag: build-1.4.0-dev-8560) Collect unique subtypes from incremental compilation cache (vor 3 Tagen) <Vladimir Dolzhenko>
* 2f3ff102044 - formatting clean up (vor 3 Tagen) <Vladimir Dolzhenko>
* e101f88b50c - (tag: build-1.4.0-dev-8534) [FIR] Add lines per second metric (vor 4 Tagen) <simon.ogorodnik>
* 8a595ad1654 - (tag: build-1.4.0-dev-8532) Move statement: Add or remove empty lines correctly (vor 4 Tagen) <Toshiaki Kameyama>
* 73dec25eb10 - (tag: build-1.4.0-dev-8531) NI: intersect DFI types before capturing (vor 4 Tagen) <Victor Petukhov>
* 5a7ceec9856 - (tag: build-1.4.0-dev-8529) Color settings: use "Static field" instead of "Instance field" for "Enum entry" language defaults (vor 4 Tagen) <Toshiaki Kameyama>
* 0e67e8e747a - (tag: build-1.4.0-dev-8528) Advance bootstrap to 1.4.0-dev-8447 (vor 4 Tagen) <Ilya Gorbunov>
* 34bdd95e50f - (tag: build-1.4.0-dev-8520) [JS SCRIPT] Enable js script test along with other script tests (vor 4 Tagen) <Roman Artemev>
* 9d9930f748e - [JS SCRIPT] Fix test dependencies (vor 4 Tagen) <Roman Artemev>
* 0e21dd15ba0 - [JS SCRIPT] Fix script test data (vor 4 Tagen) <Roman Artemev>
* 31af1e6ca7c - [JS SCRIPT] Fix ScriptDependencyCompiler (vor 4 Tagen) <Roman Artemev>
* 52a93f189ea - [JS SCRIPT] Fix IrBuiltIns to make it stable if symbols already defined (vor 4 Tagen) <Roman Artemev>
* 8f71bdbf014 - [JS SCRIPT] Fix IrScript visit order (vor 4 Tagen) <Roman Artemev>
* f792c5c9361 - [JS SCRIPT] Fix default arguments in script (vor 4 Tagen) <Roman Artemev>
* 996137576e2 - [JS SCRIPT] Fix script lowering (vor 4 Tagen) <Roman Artemev>
* e573efb3a59 - [JS SCRIPT] Handle IrScript in mangler correctly (vor 4 Tagen) <Roman Artemev>
* 785fa7dd1c7 - (tag: build-1.4.0-dev-8519) [Gradle, Import] Ignore incompatible test runs for Native targets. (vor 4 Tagen) <Yaroslav Chernyshev>
* e2857a910b4 - (tag: build-1.4.0-dev-8516) Minor: show existing modules in absent error in gradle tests (vor 4 Tagen) <Nikolay Krasko>
* 189a9dbc022 - 201: Mute tests with changed module names after idea update (KT-37125) (vor 4 Tagen) <Nikolay Krasko>
* 82551e91a4e - (tag: build-1.4.0-dev-8509) Add KClass.isFun modifier to reflection (vor 4 Tagen) <Alexander Udalov>
* 86b5c63891a - (tag: build-1.4.0-dev-8505) JS IR: fix origin for callable references with bound reciever (vor 4 Tagen) <Anton Bannykh>
* bdca4b45bdc - JS: inliner supports extra argument caused by suspend conversions (vor 4 Tagen) <Anton Bannykh>
* ed8efafa9b3 - (tag: build-1.4.0-dev-8504) Generate InnerClasses attribute for nested classes in annotation arguments (vor 4 Tagen) <Alexander Udalov>
* cdac6157a92 - (tag: build-1.4.0-dev-8502) [FIR2IR] Force loading Java SAM from external classes (vor 4 Tagen) <Mikhail Glukhikh>
* 89a6ecd77d4 - (tag: build-1.4.0-dev-8499) [FIR] Update argument mapping while transforming integer operator. (vor 4 Tagen) <Jinseong Jeon>
* 858731cac8a - [FIR] add support for varargs in delegated constructor calls (vor 4 Tagen) <Juan Chen>
* 3652ac93548 - [FIR2IR] Mute 2 failing BB tests (vor 4 Tagen) <Mikhail Glukhikh>
* d8398bb0abb - [FIR2IR] Handle external declaration parents more accurately (vor 4 Tagen) <Mikhail Glukhikh>
* 6beee004a39 - [FIR2IR] Take callables from scope in external declaration generator (vor 4 Tagen) <Mikhail Glukhikh>
* 12c0cbee945 - [FIR2IR] Don't enter same class twice while override searching (vor 4 Tagen) <Mikhail Glukhikh>
* 00fcb6cb021 - [FIR2IR] Minor refactoring of populateOverriddenSymbols (vor 4 Tagen) <Mikhail Glukhikh>
* e7e80be34a1 - [FIR2IR] Populate overridden symbols even for !isOverride (vor 4 Tagen) <Mikhail Glukhikh>
* ac1e96500a0 - (tag: build-1.4.0-dev-8497) [Commonizer] Added README.md (vor 4 Tagen) <Dmitriy Dolovov>
* 08588001be5 - (tag: build-1.4.0-dev-8490) Redundant suspend modifier: do not report when the function has 'actual' modifier (vor 4 Tagen) <Toshiaki Kameyama>
* 188bcf0e7bc - (tag: build-1.4.0-dev-8480) stdlib-js-ir: do not copy source directories from the same project (vor 4 Tagen) <Ilya Gorbunov>
* 46b0784508c - Disable kotlinMetadata compilation for js-ir-minimal-for-test (vor 4 Tagen) <Ilya Gorbunov>
* bcf277d885a - (tag: build-1.4.0-dev-8475) Add comments for generators about data/inline class (in psi2ir and fir2ir) and annotations (fir2ir). (vor 4 Tagen) <Jinseong Jeon>
* e844c59e7e2 - FIR2IR: filter correct use-site target for value parameter annotations. (vor 4 Tagen) <Jinseong Jeon>
* 76e679a6cad - FIR2IR: refactor annotation generations. (vor 4 Tagen) <Jinseong Jeon>
* 931ba4892a9 - FIR2IR: split property annotations according to use-site targets. (vor 4 Tagen) <Jinseong Jeon>
* 9bc8fdcb3c4 - (tag: build-1.4.0-dev-8463) JVM IR: Validate corresponding properties (vor 5 Tagen) <Steven Schäfer>
* 13f15a702b0 - JVM IR: Remove corresponding property hacks from MethodSignatureMapper (vor 5 Tagen) <Steven Schäfer>
* 497df0922af - JVM IR: Fix corresponding properties in inline classes (vor 5 Tagen) <Steven Schäfer>
* c41e71b1c5f - JVM IR: Merge PropertiesToFieldsLowering and JvmPropertiesLowering (vor 5 Tagen) <Steven Schäfer>
* d5c2707c2c5 - JVM IR: Fix corresponding properties in JvmStaticAnnotationLowering (vor 5 Tagen) <Steven Schäfer>
* 24b28f80cb5 - JVM IR: Fix corresponding properties in BridgeLowering (vor 5 Tagen) <Steven Schäfer>
* 4a2b5df9faf - JVM IR: Fix corresponding properties for default impls redirections (vor 5 Tagen) <Steven Schäfer>
* 1fafbb8d72c - Minor: Remove duplicate IrSetField builder (vor 5 Tagen) <Steven Schäfer>
* 86683e94fc0 - (tag: build-1.4.0-dev-8448) [FIR] Fix cfg crash with multiple postponed arguments (vor 5 Tagen) <simon.ogorodnik>
* 5b63dad1c3a - (tag: build-1.4.0-dev-8447) JS IR: fix incremental compilation for stdlib (vor 5 Tagen) <Anton Bannykh>
* a95f205c1a2 - (tag: build-1.4.0-dev-8446) Binary compatibility validator is now an external tool (vor 5 Tagen) <Ilya Gorbunov>
* ceb03ce739a - (tag: build-1.4.0-dev-8434, tag: build-1.4.0-dev-8431) Disable KotlinNativeRunConfigurationProducer if not found Gradle plugin. (vor 5 Tagen) <Konstantin Tskhovrebov>
* af114e32119 - (tag: build-1.4.0-dev-8426) (CoroutineDebugger) 192/193 compatibility fix (vor 5 Tagen) <Vladimir Ilmov>
* b5f31a3d761 - (tag: build-1.4.0-dev-8424) JS IR: make CodeCleaner more conservative (vor 5 Tagen) <Anton Bannykh>
* 8809abdbacc - (tag: build-1.4.0-dev-8416) JVM_IR: do not handle Nothing in suspend tail call bridges (vor 5 Tagen) <pyos>
* 0acaedef92d - Fix attribute clash between STATIC_INLINE_CLASS_REPLACEMENT and original (vor 5 Tagen) <Ilmir Usmanov>
* d2a691d157e - (tag: build-1.4.0-dev-8412) Minor, ignore failing box tests for light analysis (vor 5 Tagen) <Alexander Udalov>
* 99856afc31a - ForLoopsLowering: Use `@file:OptIn(ExperimentalUnsignedTypes::class)` instead of annotating declarations. (vor 5 Tagen) <Mark Punzalan>
* b5b361bb091 - Add tests for nullable loop variable in for-loop over unsigned progression. (vor 5 Tagen) <Mark Punzalan>
* b85da8411df - ForLoopsLowering: Convert ProgressionType from enum to sealed class and move more logic into the class. (vor 5 Tagen) <Mark Punzalan>
* 177967258bb - ForLoopsLowering: Eliminate construction/boxing/unboxing of UInt/ULong. (vor 5 Tagen) <Mark Punzalan>
* e1120f49d8e - ForLoopsLowering: Reduce unnecessary temporary variables. (vor 5 Tagen) <Mark Punzalan>
* eaddd02e9b2 - Mute/unmute failing/passing unsigned progression tests for FIR. (vor 5 Tagen) <Mark Punzalan>
* f249e7f5e9a - ForLoopsLowering: Add additional bytecode text tests for optimization of unsigned progressions. (vor 5 Tagen) <Mark Punzalan>
* 0e6af517d72 - Generate tests for unsigned progressions using GenerateSteppedRangesCodegenTestData. (vor 5 Tagen) <Mark Punzalan>
* 03ef3724f49 - ForLoopsLowering: Add support for unsigned progressions. (vor 5 Tagen) <Mark Punzalan>
* 9fdb1ff4f82 - (tag: build-1.4.0-dev-8410) Call `visit` method on `ClassWriter` in IC caching in proper order (vor 5 Tagen) <Mikhael Bogdanov>
* df8031945b0 - (tag: build-1.4.0-dev-8404) Allow UL class for KtEnumEntry declaration (vor 5 Tagen) <Igor Yakovlev>
* 762f38a394e - (tag: build-1.4.0-dev-8403) KT-38832 Add additional check to RemoveCurlyBracesFromTemplateInspection (vor 5 Tagen) <Roman Golyshev>
* 150708069ca - KT-38831 Use safe casts in ReplaceWithOperatorAssignmentInspection (vor 5 Tagen) <Roman Golyshev>
* 225d3546046 - KT-38829 Add additional check to RemoveRedundantBackticksQuickFix (vor 5 Tagen) <Roman Golyshev>
* 6034fcdc465 - (tag: build-1.4.0-dev-8401) FIR2IR: apply SAM conversion to arguments if needed (vor 5 Tagen) <Jinseong Jeon>
* 0ce16b9d8c5 - (tag: build-1.4.0-dev-8399) Support non-reified type parameters in typeOf in JVM and JVM_IR (vor 5 Tagen) <Alexander Udalov>
* 6fb40878c4b - Minor, do not report "no reflection" error on KTypeParameter (vor 5 Tagen) <Alexander Udalov>
* 37cf7316bc4 - Do not calculate maxStack size manually when generating typeOf (vor 5 Tagen) <Alexander Udalov>
* 82603f38530 - Move some codegen utilities to callableReferenceUtil.kt (vor 5 Tagen) <Alexander Udalov>
* 4fe8754ba1b - Minor, extract generation of typeOf out of inlineIntrinsics.kt (vor 5 Tagen) <Alexander Udalov>
* ea413cefb48 - Remove TypeOfChecker for JVM frontend (vor 5 Tagen) <Alexander Udalov>
* 0c0f4ef3db1 - (tag: build-1.4.0-dev-8398) FIR CFG: handle 'Dead' properly in edge kind merging (vor 5 Tagen) <Mikhail Glukhikh>
* 41f241f6087 - FIR CFG: merge DFA + CFA edge in Simple edge (vor 5 Tagen) <Mikhail Glukhikh>
* 32cfee50e04 - FIR CFG: remove duplicating lambda enter -> exit connection (vor 5 Tagen) <Mikhail Glukhikh>
* 5ef37148ea2 - (tag: build-1.4.0-dev-8396) Add flag for proper array convention with default args calls (vor 5 Tagen) <Mikhael Bogdanov>
* adc770b6042 - Process default arguments in array convention calls (vor 5 Tagen) <Mikhail Bogdanov>
* 31348323967 - (tag: build-1.4.0-dev-8392) Call missed `visit` method on `ClassWriter` in IC caching (vor 5 Tagen) <Mikhail Bogdanov>
* 4daac140088 - (tag: build-1.4.0-dev-8382) Revert due to massive flaky tests (vor 6 Tagen) <Sergey Rostov>
* 5228da2ebc8 - (tag: build-1.4.0-dev-8375) (CoroutineDebugger) 192/as36 compilation fix (vor 6 Tagen) <Vladimir Ilmov>
* 4597fff18a7 - (tag: build-1.4.0-dev-8373) Prohibit OptionalExpectation on nested annotation classes (vor 6 Tagen) <Alexander Udalov>
* 012ffa29934 - Support new scheme of compilation of OptionalExpectation annotations (vor 6 Tagen) <Alexander Udalov>
* 63e355d979b - (tag: build-1.4.0-dev-8369) Scripting IDE cache: unblocking concurrent update (vor 6 Tagen) <Sergey Rostov>
* 30e5748fec6 - (tag: build-1.4.0-dev-8368) FIR: set proper visibility of property accessors. (vor 6 Tagen) <Jinseong Jeon>
* 5d724a8cbc6 - (tag: build-1.4.0-dev-8352) Fix samples package import (vor 6 Tagen) <Ilya Gorbunov>
* 84c6c365dbc - (tag: build-1.4.0-dev-8351) Wizard: Reorder build phases in iOS template (fix KT-38810) (vor 6 Tagen) <Kirill Shmakov>
* cc7b8cc558d - Wizard: Add KMM-related property in iOS template gradle.properties (vor 6 Tagen) <Kirill Shmakov>
* 84a582c6189 - (tag: build-1.4.0-dev-8348) Fix escaping const string literals in UL (vor 6 Tagen) <Igor Yakovlev>
* 9f8044ff1bd - Fix ultraKtLightClassForFacade compiler backend call (vor 6 Tagen) <Igor Yakovlev>
* 62c24c95b52 - Add support for UltraLightScripts (vor 6 Tagen) <Igor Yakovlev>
* 6a2461f2c64 - (tag: build-1.4.0-dev-8347) [FIR] Refactor boolean flags related to constructors: !no -> include (vor 6 Tagen) <Mikhail Glukhikh>
* db694dd7ab3 - [FIR] Extract ConstructorScopeTowerLevel (vor 6 Tagen) <Mikhail Glukhikh>
* 22e72644603 - [FIR] Use all implicit receivers for del. constructors, not just one (vor 6 Tagen) <Mikhail Glukhikh>
* 535b4434a8e - [FIR TEST] Add extra test for inner classes inside hierarchy (vor 6 Tagen) <Mikhail Glukhikh>
* f48ff2679ef - [FIR] Branch delegating constructor call resolve by isInner from start (vor 6 Tagen) <Mikhail Glukhikh>
* 28c0dac36f6 - [FIR] Set FirJavaClass.isInner properly (vor 6 Tagen) <Mikhail Glukhikh>
* 3aca40538b3 - [FIR TEST] Fix error in exposedSupertype test (vor 6 Tagen) <Mikhail Glukhikh>
* 457fb09e3ad - [FIR] Use tower to resolve delegated constructors, set dispatch receiver (vor 6 Tagen) <Mikhail Glukhikh>
* 0b8c497d2eb - (tag: build-1.4.0-dev-8346) [Import] Downgrade jvmTarget & move Models and ModelBuilderServices (vor 6 Tagen) <Yaroslav Chernyshev>
* 385ddba2d91 - (tag: build-1.4.0-dev-8345) (CoroutineDebugger) Keep coroutine info list reference from collection (vor 6 Tagen) <Vladimir Ilmov>
* 5a5c1c34202 - (CoroutineDebugger) Local variables should have precedence over restored. (vor 6 Tagen) <Vladimir Ilmov>
* f19f49711cf - (tag: build-1.4.0-dev-8344) Scripting: minor changes (vor 6 Tagen) <Sergey Rostov>
* 800fcc511a4 - JPS: ignore removed java files (vor 6 Tagen) <Sergey Rostov>
* 14bd6fe7817 - scripting ucache: update synchronously in unit test mode (vor 6 Tagen) <Sergey Rostov>
* ac70234342f - 201: proper implementation for AsyncFileChangeListenerHelper.kt (vor 6 Tagen) <Sergey Rostov>
* 9aa5f0c31a3 - Scripting unified cache: update sdks synchronously on changes (vor 6 Tagen) <Sergey Rostov>
* 9e968855861 - GradleBuildRoot: don't store references to virtual files (vor 6 Tagen) <Sergey Rostov>
* 35765fe6e68 - remove stale GradleScriptInputsWatcher references (vor 6 Tagen) <Sergey Rostov>
* ed6e3697358 - minor: ScriptingSupport.Provider -> ScriptingSupport, KDoc (vor 6 Tagen) <Sergey Rostov>
* 33d79f91357 - GradleScriptOutOfProjectTest: roots are already registered as legacy (vor 6 Tagen) <Sergey Rostov>
* fc59e286102 - Fix lastIndexOfOrNull (vor 6 Tagen) <Sergey Rostov>
* a4c7981424a - Scripting, minor: updateScriptDefinitions -> updateScriptDefinitionReferences (vor 6 Tagen) <Sergey Rostov>
* 0e5b9813633 - ScriptClassRootsCache, sdk: use toSystemIndependentName (vor 6 Tagen) <Sergey Rostov>
* 0404f4fd570 - gradle.kts, minor: remove unused code (vor 6 Tagen) <Sergey Rostov>
* 4575a8cade0 - GradleScriptListenerTest: add gradle-wrapper.properties to specify gradle version explicitly (vor 6 Tagen) <Sergey Rostov>
* fa679129d15 - ScriptClassRootsUpdater, updateSynchronously: cancel before waiting for lock (vor 6 Tagen) <Sergey Rostov>
* 75e8f15b5ed - ScriptClassRootsUpdater: fix clearing scheduledUpdate and check cancelled in sync (vor 6 Tagen) <Sergey Rostov>
* a498171400a - gradle.kts: remove LastModifiedFiles fs data when removing gradle root (vor 6 Tagen) <Sergey Rostov>
* 06e43027cf3 - gradle.kts, minor: move isInAffectedGradleProjectFiles inside GradleBuildRootsManager (vor 6 Tagen) <Sergey Rostov>
* b2729f977a9 - GradleScriptListenerTest: link gradle project (vor 6 Tagen) <Sergey Rostov>
* c0e9092f94b - GradleBuildRootsManager: fix onProjectsLinked (vor 6 Tagen) <Sergey Rostov>
* 9302a620c2c - GradleLegacyScriptListener: call from GradleScriptListener (vor 6 Tagen) <Sergey Rostov>
* 80991f7c560 - gradle.kts: use toSystemIndependentName for paths coming from Gradle (vor 6 Tagen) <Sergey Rostov>
* 4e07e4c8fe4 - ScriptClassRootsUpdater: run synchronously in unit test mode (vor 6 Tagen) <Sergey Rostov>
* c6be0a8213b - UnusedSymbolInspection: load script configurations from cache (vor 6 Tagen) <Sergey Rostov>
* b199531f0ed - gradle.kts, scheduleLastModifiedFilesSave: fix race condition (vor 6 Tagen) <Sergey Rostov>
* 5962bd79550 - gradle.kts, minor: areRelatedFilesUpToDate -> areRelatedFilesChangedBefore (vor 6 Tagen) <Sergey Rostov>
* cb318a63ad7 - GradleScriptListener: update lastModifiedFiles on document change (vor 6 Tagen) <Sergey Rostov>
* 9b0a2f63a98 - GradleBuildRoot: fix loading lastModifiedFiles (vor 6 Tagen) <Sergey Rostov>
* 34bc52f3d4b - LastModifiedFiles: fix in case of sequential changes in same file (vor 6 Tagen) <Sergey Rostov>
* cde53285c62 - .gradle.kts, listener: support multiple gradle projects linked to one IntelliJ project (vor 6 Tagen) <Sergey Rostov>
* 258064d82de - gradle.kts: docs (vor 6 Tagen) <Sergey Rostov>
* 64682ad5500 - ScriptConfigurationManager: take OutsidersPsiFileSupport into account (vor 6 Tagen) <Sergey Rostov>
* e7c19ab3ef7 - Scripts, minor: get rid of ScriptingSupportHelper (vor 6 Tagen) <Sergey Rostov>
* b42d5eda0a4 - gradle.kts: merge data on failed gradle sync, fix updates scheduling in corner cases (vor 6 Tagen) <Sergey Rostov>
* e972203a2a8 - gradle.kts: solve the linked gradle builds hell (vor 6 Tagen) <Sergey Rostov>
* 6fe3365dd31 - gradle.kts, imported gradle build root: fix equality (vor 6 Tagen) <Sergey Rostov>
* 0ff95ee5168 - ScriptConfigurationManager, outsider files: search in roots cache too (vor 6 Tagen) <Sergey Rostov>
* 751d167f66b - ScriptConfigurationManager: rebuild cache synchronously from default loader (vor 6 Tagen) <Sergey Rostov>
* ab51292da80 - gradle.kts: cache definitions (vor 6 Tagen) <Sergey Rostov>
* fc7be92c42b - gradle.kts: remove useless gradle build root kinds (vor 6 Tagen) <Sergey Rostov>
* 802c03b9343 - Script configuration: fix getting javaHome (vor 6 Tagen) <Sergey Rostov>
* b04fabf1e83 - CompositeScriptConfigurationManager: unified caching (vor 6 Tagen) <Sergey Rostov>
* 8f8902a85fd - GradleScriptConfigurationLoader: KDocs (vor 6 Tagen) <Sergey Rostov>
* 11d05c1abda - (tag: build-1.4.0-dev-8342) NI: propagate `isNullabilityConstraint` flag into constraint injector and inherit it (vor 6 Tagen) <Victor Petukhov>
* 19e352a1b53 - (tag: build-1.4.0-dev-8335) [ANDROID] Simplify parcelize ir plugin code (vor 6 Tagen) <Roman Artemev>
* c20aa297f1f - [ANDROID] Fix Parcelize reslove extension plugin (vor 6 Tagen) <Roman Artemev>
* 6bdd473effd - [JVM IR] Fix plugin API for JVM IR (vor 6 Tagen) <Roman Artemev>
* a794052f861 - [IR] Mark Value Parameters which have default argument (vor 6 Tagen) <Roman Artemev>
* 7737c765400 - [PLUGIN API] Do postprocess after symbol resolve (vor 6 Tagen) <Roman Artemev>
* 92befaac5d4 - [IR] Remove IrExtensionGenerator (vor 6 Tagen) <Roman Artemev>
* 9f990947806 - [IR] Clean up linker interface (vor 6 Tagen) <Roman Artemev>
* 1e9c9ef7e0a - [IR] Clean up linker code (vor 6 Tagen) <Roman Artemev>
* 1949b11bb2e - [KTX.SERIALIZATION] Refactor plugin once again (vor 6 Tagen) <Roman Artemev>
* d41bbbae0de - [IR] Deprecate some API (vor 6 Tagen) <Roman Artemev>
* 2f0840388d0 - [IR] Fix context (vor 6 Tagen) <Roman Artemev>
* 559b654a4fc - [IR] Provide new plugin API to access declaration via FqName in the safe way (vor 6 Tagen) <Roman Artemev>
* 8335ce8665a - [IR] Fix to make K/N work (vor 6 Tagen) <Roman Artemev>
* aac46498457 - [JS IR] Remove usage of `LazyIr` from JS (vor 6 Tagen) <Roman Artemev>
* 3d24665c0d6 - [IR] Use `ReferenceSymbolTable` in `BuiltinSymbolsBase` (vor 6 Tagen) <Roman Artemev>
* 3c50b473334 - [IR] Add new API into IrBuiltIns to access functional interfaces (vor 6 Tagen) <Roman Artemev>
* a477aa7289b - [KLIB] Pass IrFunctionFactory from outside (vor 6 Tagen) <Roman Artemev>
* 318568636e1 - [IR] Pass IrBuiltIns to `BuiltinSymbolsBase` (vor 6 Tagen) <Roman Artemev>
* da661e4db7c - [IR BE] Remove usage of KotlinType from ir loop optimization (vor 6 Tagen) <Roman Artemev>
* c38ba45c1b6 - [JVM IR] Fix jvm linker (vor 6 Tagen) <Roman Artemev>
* 5ea309d5781 - [PSi2IR] Generate synthetic declaration during psi2ir (vor 6 Tagen) <Roman Artemev>
* 66543131c25 - [IR] Add `referenceScript` to `SymbolTable` (vor 6 Tagen) <Roman Artemev>
* 003ba1c8f5d - (tag: build-1.4.0-dev-8323) [NI] CST: add preemptive recursion detection (vor 6 Tagen) <Pavel Kirpichenkov>
* 7cde9b43551 - (tag: build-1.4.0-dev-8304, kotlin/minamoto/debug-info/subprograms-with-missed-scopes) Add tests for analyze return type in REPL IDE services (vor 7 Tagen) <Ilya Muradyan>
* 8a1b44cc2b9 - Add snippet result type to analysis output of REPL IDE services (vor 7 Tagen) <Ilya Muradyan>
* c496b932185 - [minor] refactor repl API file layout (vor 7 Tagen) <Ilya Chernikov>