### PR TITLE
[kotlin compiler][update] 1.4.0-dev-9010

### DIFF
--- a/backend.native/tests/runtime/collections/hash_map0.kt
+++ b/backend.native/tests/runtime/collections/hash_map0.kt
@@ -155,7 +155,7 @@ fun testEquals() {
     assertFalse(m == mapOf("a" to "1", "b" to "2", "c" to "5"))
     assertFalse(m == mapOf("a" to "1", "b" to "2"))
     assertEquals(m.keys, expected.keys)
-    assertEquals(m.values, expected.values)
+    assertEquals(m.values.toList(), expected.values.toList())
     assertEquals(m.entries, expected.entries)
 }
 
@@ -165,7 +165,6 @@ fun testHashCode() {
     assertEquals(expected.hashCode(), m.hashCode())
     assertEquals(expected.entries.hashCode(), m.entries.hashCode())
     assertEquals(expected.keys.hashCode(), m.keys.hashCode())
-    assertEquals(listOf("1", "2", "3").hashCode(), m.values.hashCode())
 }
 
 fun testToString() {
@@ -184,9 +183,9 @@ fun testPutEntry() {
     assertTrue(m.entries.contains(e))
     assertTrue(m.entries.remove(e))
     assertTrue(mapOf("b" to "2", "c" to "3") == m)
-    assertTrue(m.entries.add(e))
+    assertEquals(null, m.put(e.key, e.value))
     assertTrue(expected == m)
-    assertFalse(m.entries.add(e))
+    assertEquals(e.value, m.put(e.key, e.value))
     assertTrue(expected == m)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-8620
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8620,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8722,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-8722
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8722,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-8722
-kotlinStdlibTestsVersion=1.4.0-dev-8722
-testKotlinCompilerVersion=1.4.0-dev-8722
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9010,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.0-dev-9010
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9010,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.0-dev-9010
+kotlinStdlibTestsVersion=1.4.0-dev-9010
+testKotlinCompilerVersion=1.4.0-dev-9010
 konanVersion=1.4.0-M3
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayList.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayList.kt
@@ -9,50 +9,44 @@ actual class ArrayList<E> private constructor(
         private var array: Array<E>,
         private var offset: Int,
         private var length: Int,
-        private val backing: ArrayList<E>?
-) : MutableList<E>, RandomAccess, AbstractMutableCollection<E>() {
+        private var isReadOnly: Boolean,
+        private val backing: ArrayList<E>?,
+        private val root: ArrayList<E>?
+) : MutableList<E>, RandomAccess, AbstractMutableList<E>() {
 
     actual constructor() : this(10)
 
     actual constructor(initialCapacity: Int) : this(
-            arrayOfUninitializedElements(initialCapacity), 0, 0, null)
+            arrayOfUninitializedElements(initialCapacity), 0, 0, false, null, null)
 
     actual constructor(elements: Collection<E>) : this(elements.size) {
         addAll(elements)
     }
 
-    override actual val size : Int
+    @PublishedApi
+    internal fun build(): List<E> {
+        if (backing != null) throw IllegalStateException() // just in case somebody casts subList to ArrayList
+        checkIsMutable()
+        isReadOnly = true
+        return this
+    }
+
+    override actual val size: Int
         get() = length
 
     override actual fun isEmpty(): Boolean = length == 0
 
     override actual fun get(index: Int): E {
-        checkIndex(index)
+        checkElementIndex(index)
         return array[offset + index]
     }
 
     override actual operator fun set(index: Int, element: E): E {
-        checkIndex(index)
+        checkIsMutable()
+        checkElementIndex(index)
         val old = array[offset + index]
         array[offset + index] = element
         return old
-    }
-
-    override actual fun contains(element: E): Boolean {
-        var i = 0
-        while (i < length) {
-            if (array[offset + i] == element) return true
-            i++
-        }
-        return false
-    }
-
-    override actual fun containsAll(elements: Collection<E>): Boolean {
-        val it = elements.iterator()
-        while (it.hasNext()) {
-            if (!contains(it.next()))return false
-        }
-        return true
     }
 
     override actual fun indexOf(element: E): Int {
@@ -77,60 +71,68 @@ actual class ArrayList<E> private constructor(
     override actual fun listIterator(): MutableListIterator<E> = Itr(this, 0)
 
     override actual fun listIterator(index: Int): MutableListIterator<E> {
-        checkInsertIndex(index)
+        checkPositionIndex(index)
         return Itr(this, index)
     }
 
     override actual fun add(element: E): Boolean {
+        checkIsMutable()
         addAtInternal(offset + length, element)
         return true
     }
 
     override actual fun add(index: Int, element: E) {
-        checkInsertIndex(index)
+        checkIsMutable()
+        checkPositionIndex(index)
         addAtInternal(offset + index, element)
     }
 
     override actual fun addAll(elements: Collection<E>): Boolean {
+        checkIsMutable()
         val n = elements.size
         addAllInternal(offset + length, elements, n)
         return n > 0
     }
 
     override actual fun addAll(index: Int, elements: Collection<E>): Boolean {
-        checkInsertIndex(index)
+        checkIsMutable()
+        checkPositionIndex(index)
         val n = elements.size
         addAllInternal(offset + index, elements, n)
         return n > 0
     }
 
     override actual fun clear() {
+        checkIsMutable()
         removeRangeInternal(offset, length)
     }
 
     override actual fun removeAt(index: Int): E {
-        checkIndex(index)
+        checkIsMutable()
+        checkElementIndex(index)
         return removeAtInternal(offset + index)
     }
 
     override actual fun remove(element: E): Boolean {
+        checkIsMutable()
         val i = indexOf(element)
         if (i >= 0) removeAt(i)
         return i >= 0
     }
 
     override actual fun removeAll(elements: Collection<E>): Boolean {
+        checkIsMutable()
         return retainOrRemoveAllInternal(offset, length, elements, false) > 0
     }
 
     override actual fun retainAll(elements: Collection<E>): Boolean {
+        checkIsMutable()
         return retainOrRemoveAllInternal(offset, length, elements, true) > 0
     }
 
     override actual fun subList(fromIndex: Int, toIndex: Int): MutableList<E> {
-        checkInsertIndex(fromIndex)
-        checkInsertIndexFrom(toIndex, fromIndex)
-        return ArrayList(array, offset + fromIndex, toIndex - fromIndex, this)
+        checkRangeIndexes(fromIndex, toIndex)
+        return ArrayList(array, offset + fromIndex, toIndex - fromIndex, isReadOnly, this, root ?: this)
     }
 
     actual fun trimToSize() {
@@ -139,12 +141,11 @@ actual class ArrayList<E> private constructor(
             array = array.copyOfUninitializedElements(length)
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     final actual fun ensureCapacity(minCapacity: Int) {
         if (backing != null) throw IllegalStateException() // just in case somebody casts subList to ArrayList
         if (minCapacity > array.size) {
-            var newSize = array.size * 3 / 2
-            if (minCapacity > newSize)
-                newSize = minCapacity
+            val newSize = ArrayDeque.newCapacity(array.size, minCapacity)
             array = array.copyOfUninitializedElements(newSize)
         }
     }
@@ -155,47 +156,46 @@ actual class ArrayList<E> private constructor(
     }
 
     override fun hashCode(): Int {
-        var result = 1
-        var i = 0
-        while (i < length) {
-            val nextElement = array[offset + i]
-            val nextHash = if (nextElement != null) nextElement.hashCode() else 0
-            result = result * 31 + nextHash
-            i++
-        }
-        return result
+        return array.subarrayContentHashCode(offset, length)
     }
 
     override fun toString(): String {
-        return this.array.subarrayContentToString(offset, length)
+        return array.subarrayContentToString(offset, length)
     }
 
     // ---------------------------- private ----------------------------
+
+    private fun checkElementIndex(index: Int) {
+        if (index < 0 || index >= length) {
+            throw IndexOutOfBoundsException("index: $index, size: $length")
+        }
+    }
+
+    private fun checkPositionIndex(index: Int) {
+        if (index < 0 || index > length) {
+            throw IndexOutOfBoundsException("index: $index, size: $length")
+        }
+    }
+
+    private fun checkRangeIndexes(fromIndex: Int, toIndex: Int) {
+        if (fromIndex < 0 || toIndex > length) {
+            throw IndexOutOfBoundsException("fromIndex: $fromIndex, toIndex: $toIndex, size: $length")
+        }
+        if (fromIndex > toIndex) {
+            throw IllegalArgumentException("fromIndex: $fromIndex > toIndex: $toIndex")
+        }
+    }
+
+    private fun checkIsMutable() {
+        if (isReadOnly || root != null && root.isReadOnly) throw UnsupportedOperationException()
+    }
 
     private fun ensureExtraCapacity(n: Int) {
         ensureCapacity(length + n)
     }
 
-    private fun checkIndex(index: Int) {
-        if (index < 0 || index >= length) throw IndexOutOfBoundsException()
-    }
-
-    private fun checkInsertIndex(index: Int) {
-        if (index < 0 || index > length) throw IndexOutOfBoundsException()
-    }
-
-    private fun checkInsertIndexFrom(index: Int, fromIndex: Int) {
-        if (index < fromIndex || index > length) throw IndexOutOfBoundsException()
-    }
-
     private fun contentEquals(other: List<*>): Boolean {
-        if (length != other.size) return false
-        var i = 0
-        while (i < length) {
-            if (array[offset + i] != other[i]) return false
-            i++
-        }
-        return true
+        return array.subarrayContentEquals(offset, length, other)
     }
 
     private fun insertAtInternal(i: Int, n: Int) {
@@ -309,8 +309,8 @@ actual class ArrayList<E> private constructor(
         }
 
         override fun set(element: E) {
-            list.checkIndex(lastIndex)
-            list.array[list.offset + lastIndex] = element
+            check(lastIndex != -1) { "Call next() or previous() before replacing element from the iterator." }
+            list.set(lastIndex, element)
         }
 
         override fun add(element: E) {
@@ -325,4 +325,25 @@ actual class ArrayList<E> private constructor(
             lastIndex = -1
         }
     }
+}
+
+private fun <T> Array<T>.subarrayContentHashCode(offset: Int, length: Int): Int {
+    var result = 1
+    var i = 0
+    while (i < length) {
+        val nextElement = this[offset + i]
+        result = result * 31 + nextElement.hashCode()
+        i++
+    }
+    return result
+}
+
+private fun <T> Array<T>.subarrayContentEquals(offset: Int, length: Int, other: List<*>): Boolean {
+    if (length != other.size) return false
+    var i = 0
+    while (i < length) {
+        if (this[offset + i] != other[i]) return false
+        i++
+    }
+    return true
 }

--- a/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/ArrayUtil.kt
@@ -16,6 +16,7 @@ import kotlin.native.internal.ExportForCppRuntime
 @PublishedApi
 internal fun <E> arrayOfUninitializedElements(size: Int): Array<E> {
     // TODO: special case for size == 0?
+    require(size >= 0) { "capacity must be non-negative." }
     @Suppress("TYPE_PARAMETER_AS_REIFIED")
     return Array<E>(size)
 }

--- a/runtime/src/main/kotlin/kotlin/collections/Collections.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Collections.kt
@@ -41,6 +41,23 @@ public interface MutableIterable<out T> : Iterable<T> {
 }
 
 
+@PublishedApi
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+@kotlin.internal.InlineOnly
+internal actual inline fun <E> buildListInternal(builderAction: MutableList<E>.() -> Unit): List<E> {
+    return ArrayList<E>().apply(builderAction).build()
+}
+
+@PublishedApi
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+@kotlin.internal.InlineOnly
+internal actual inline fun <E> buildListInternal(capacity: Int, builderAction: MutableList<E>.() -> Unit): List<E> {
+    return ArrayList<E>(capacity).apply(builderAction).build()
+}
+
+
 /**
  * Replaces each element in the list with a result of a transformation specified.
  */

--- a/runtime/src/main/kotlin/kotlin/collections/HashMap.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/HashMap.kt
@@ -21,9 +21,11 @@ actual class HashMap<K, V> private constructor(
     override actual val size: Int
         get() = _size
 
-    private var keysView: HashSet<K>? = null
+    private var keysView: HashMapKeys<K>? = null
     private var valuesView: HashMapValues<V>? = null
     private var entriesView: HashMapEntrySet<K, V>? = null
+
+    private var isReadOnly: Boolean = false
 
     // ---------------------------- functions ----------------------------
 
@@ -44,14 +46,16 @@ actual class HashMap<K, V> private constructor(
     // This implementation doesn't use a loadFactor, this constructor is used for compatibility with common stdlib
     actual constructor(initialCapacity: Int, loadFactor: Float) : this(initialCapacity)
 
+    @PublishedApi
+    internal fun build(): Map<K, V> {
+        checkIsMutable()
+        isReadOnly = true
+        return this
+    }
+
     override actual fun isEmpty(): Boolean = _size == 0
     override actual fun containsKey(key: K): Boolean = findKey(key) >= 0
     override actual fun containsValue(value: V): Boolean = findValue(value) >= 0
-
-
-    operator fun set(key: K, value: V): Unit {
-        put(key, value)
-    }
 
     override actual operator fun get(key: K): V? {
         val index = findKey(key)
@@ -60,6 +64,7 @@ actual class HashMap<K, V> private constructor(
     }
 
     override actual fun put(key: K, value: V): V? {
+        checkIsMutable()
         val index = addKey(key)
         val valuesArray = allocateValuesArray()
         if (index < 0) {
@@ -73,11 +78,12 @@ actual class HashMap<K, V> private constructor(
     }
 
     override actual fun putAll(from: Map<out K, V>) {
+        checkIsMutable()
         putAllEntries(from.entries)
     }
 
     override actual fun remove(key: K): V? {
-        val index = removeKey(key)
+        val index = removeKey(key)  // mutability gets checked here
         if (index < 0) return null
         val valuesArray = valuesArray!!
         val oldValue = valuesArray[index]
@@ -86,6 +92,7 @@ actual class HashMap<K, V> private constructor(
     }
 
     override actual fun clear() {
+        checkIsMutable()
         // O(length) implementation for hashArray cleanup
         for (i in 0..length - 1) {
             val hash = presenceArray[i]
@@ -103,7 +110,7 @@ actual class HashMap<K, V> private constructor(
     override actual val keys: MutableSet<K> get() {
         val cur = keysView
         return if (cur == null) {
-            val new = HashSet(this)
+            val new = HashMapKeys(this)
             if (!isFrozen)
                 keysView = new
             new
@@ -133,7 +140,7 @@ actual class HashMap<K, V> private constructor(
     override fun equals(other: Any?): Boolean {
         return other === this ||
                 (other is Map<*, *>) &&
-                        contentEquals(other)
+                contentEquals(other)
     }
 
     override fun hashCode(): Int {
@@ -164,6 +171,10 @@ actual class HashMap<K, V> private constructor(
     private val capacity: Int get() = keysArray.size
     private val hashSize: Int get() = hashArray.size
 
+    internal fun checkIsMutable() {
+        if (isReadOnly) throw UnsupportedOperationException()
+    }
+
     private fun ensureExtraCapacity(n: Int) {
         ensureCapacity(length + n)
     }
@@ -174,7 +185,7 @@ actual class HashMap<K, V> private constructor(
             if (capacity > newSize) newSize = capacity
             keysArray = keysArray.copyOfUninitializedElements(newSize)
             valuesArray = valuesArray?.copyOfUninitializedElements(newSize)
-            presenceArray = presenceArray.copyOfUninitializedElements(newSize)
+            presenceArray = presenceArray.copyOf(newSize)
             val newHashSize = computeHashSize(newSize)
             if (newHashSize > hashSize) rehash(newHashSize)
         } else if (length + capacity - _size > this.capacity) {
@@ -265,6 +276,7 @@ actual class HashMap<K, V> private constructor(
     }
 
     internal fun addKey(key: K): Int {
+        checkIsMutable()
         retry@ while (true) {
             var hash = hash(key)
             // put is allowed to grow maxProbeDistance with some limits (resize hash on reaching limits)
@@ -298,6 +310,7 @@ actual class HashMap<K, V> private constructor(
     }
 
     internal fun removeKey(key: K): Int {
+        checkIsMutable()
         val index = findKey(key)
         if (index < 0) return TOMBSTONE
         removeKeyAt(index)
@@ -402,7 +415,7 @@ actual class HashMap<K, V> private constructor(
         return true
     }
 
-    internal fun putEntry(entry: Map.Entry<K, V>): Boolean {
+    private fun putEntry(entry: Map.Entry<K, V>): Boolean {
         val index = addKey(entry.key)
         val valuesArray = allocateValuesArray()
         if (index >= 0) {
@@ -417,7 +430,7 @@ actual class HashMap<K, V> private constructor(
         return false
     }
 
-    internal fun putAllEntries(from: Collection<Map.Entry<K, V>>): Boolean {
+    private fun putAllEntries(from: Collection<Map.Entry<K, V>>): Boolean {
         if (from.isEmpty()) return false
         ensureExtraCapacity(from.size)
         val it = from.iterator()
@@ -430,6 +443,7 @@ actual class HashMap<K, V> private constructor(
     }
 
     internal fun removeEntry(entry: Map.Entry<K, V>): Boolean {
+        checkIsMutable()
         val index = findKey(entry.key)
         if (index < 0) return false
         if (valuesArray!![index] != entry.value) return false
@@ -437,69 +451,12 @@ actual class HashMap<K, V> private constructor(
         return true
     }
 
-    internal fun removeAllEntries(elements: Collection<Map.Entry<K, V>>): Boolean {
-        if (elements.isEmpty()) return false
-        val it = entriesIterator()
-        var updated = false
-        while (it.hasNext()) {
-            if (elements.contains(it.next())) {
-                it.remove()
-                updated = true
-            }
-        }
-        return updated
-    }
-
-    internal fun retainAllEntries(elements: Collection<Map.Entry<K, V>>): Boolean {
-        val it = entriesIterator()
-        var updated = false
-        while (it.hasNext()) {
-            if (!elements.contains(it.next())) {
-                it.remove()
-                updated = true
-            }
-        }
-        return updated
-    }
-
-    internal fun containsAllValues(elements: Collection<V>): Boolean {
-        val it = elements.iterator()
-        while (it.hasNext()) {
-            if (!containsValue(it.next()))
-                return false
-        }
-        return true
-    }
-
     internal fun removeValue(element: V): Boolean {
+        checkIsMutable()
         val index = findValue(element)
         if (index < 0) return false
         removeKeyAt(index)
         return true
-    }
-
-    internal fun removeAllValues(elements: Collection<V>): Boolean {
-        val it = valuesIterator()
-        var updated = false
-        while (it.hasNext()) {
-            if (elements.contains(it.next())) {
-                it.remove()
-                updated = true
-            }
-        }
-        return updated
-    }
-
-    internal fun retainAllValues(elements: Collection<V>): Boolean {
-        val it = valuesIterator()
-        var updated = false
-        while (it.hasNext()) {
-            if (!elements.contains(it.next())) {
-                it.remove()
-                updated = true
-            }
-        }
-        return updated
     }
 
     internal fun keysIterator() = KeysItr(this)
@@ -508,16 +465,16 @@ actual class HashMap<K, V> private constructor(
 
     @kotlin.native.internal.CanBePrecreated
     private companion object {
-        const val MAGIC =  -1640531527 // 2654435769L.toInt(), golden ratio
-        const val INITIAL_CAPACITY = 8
-        const val INITIAL_MAX_PROBE_DISTANCE = 2
-        const val TOMBSTONE = -1
+        private const val MAGIC = -1640531527 // 2654435769L.toInt(), golden ratio
+        private const val INITIAL_CAPACITY = 8
+        private const val INITIAL_MAX_PROBE_DISTANCE = 2
+        private const val TOMBSTONE = -1
 
         @OptIn(ExperimentalStdlibApi::class)
-        fun computeHashSize(capacity: Int): Int = (capacity.coerceAtLeast(1) * 3).takeHighestOneBit()
+        private fun computeHashSize(capacity: Int): Int = (capacity.coerceAtLeast(1) * 3).takeHighestOneBit()
 
         @OptIn(ExperimentalStdlibApi::class)
-        fun computeShift(hashSize: Int): Int = hashSize.countLeadingZeroBits() + 1
+        private fun computeShift(hashSize: Int): Int = hashSize.countLeadingZeroBits() + 1
     }
 
     internal open class Itr<K, V>(
@@ -538,6 +495,7 @@ actual class HashMap<K, V> private constructor(
         fun hasNext(): Boolean = index < map.length
 
         fun remove() {
+            map.checkIsMutable()
             map.removeKeyAt(lastIndex)
             lastIndex = -1
         }
@@ -605,6 +563,7 @@ actual class HashMap<K, V> private constructor(
             get() = map.valuesArray!![index]
 
         override fun setValue(newValue: V): V {
+            map.checkIsMutable()
             val valuesArray = map.allocateValuesArray()
             val oldValue = valuesArray[index]
             valuesArray[index] = newValue
@@ -622,82 +581,78 @@ actual class HashMap<K, V> private constructor(
     }
 }
 
+internal class HashMapKeys<E> internal constructor(
+        private val backing: HashMap<E, *>
+) : MutableSet<E>, kotlin.native.internal.KonanSet<E>, AbstractMutableSet<E>() {
+
+    override val size: Int get() = backing.size
+    override fun isEmpty(): Boolean = backing.isEmpty()
+    override fun contains(element: E): Boolean = backing.containsKey(element)
+    override fun getElement(element: E): E? = backing.getKey(element)
+    override fun clear() = backing.clear()
+    override fun add(element: E): Boolean = throw UnsupportedOperationException()
+    override fun addAll(elements: Collection<E>): Boolean = throw UnsupportedOperationException()
+    override fun remove(element: E): Boolean = backing.removeKey(element) >= 0
+    override fun iterator(): MutableIterator<E> = backing.keysIterator()
+
+    override fun removeAll(elements: Collection<E>): Boolean {
+        backing.checkIsMutable()
+        return super.removeAll(elements)
+    }
+
+    override fun retainAll(elements: Collection<E>): Boolean {
+        backing.checkIsMutable()
+        return super.retainAll(elements)
+    }
+}
+
 internal class HashMapValues<V> internal constructor(
         val backing: HashMap<*, V>
-) : MutableCollection<V> {
+) : MutableCollection<V>, AbstractMutableCollection<V>() {
 
     override val size: Int get() = backing.size
     override fun isEmpty(): Boolean = backing.isEmpty()
     override fun contains(element: V): Boolean = backing.containsValue(element)
-    override fun containsAll(elements: Collection<V>): Boolean = backing.containsAllValues(elements)
     override fun add(element: V): Boolean = throw UnsupportedOperationException()
     override fun addAll(elements: Collection<V>): Boolean = throw UnsupportedOperationException()
     override fun clear() = backing.clear()
     override fun iterator(): MutableIterator<V> = backing.valuesIterator()
     override fun remove(element: V): Boolean = backing.removeValue(element)
-    override fun removeAll(elements: Collection<V>): Boolean = backing.removeAllValues(elements)
-    override fun retainAll(elements: Collection<V>): Boolean = backing.retainAllValues(elements)
 
-    override fun equals(other: Any?): Boolean =
-            other === this ||
-                    other is Collection<*> &&
-                            contentEquals(other)
-
-    override fun hashCode(): Int {
-        var result = 1
-        val it = iterator()
-        while (it.hasNext()) {
-            result = result * 31 + it.next().hashCode()
-        }
-        return result
+    override fun removeAll(elements: Collection<V>): Boolean {
+        backing.checkIsMutable()
+        return super.removeAll(elements)
     }
 
-    override fun toString(): String = collectionToString()
-
-    // ---------------------------- private ----------------------------
-
-    private fun contentEquals(other: Collection<*>): Boolean {
-        @Suppress("UNCHECKED_CAST") // todo: figure out something better
-        return size == other.size && backing.containsAllValues(other as Collection<V>)
+    override fun retainAll(elements: Collection<V>): Boolean {
+        backing.checkIsMutable()
+        return super.retainAll(elements)
     }
 }
 
 internal class HashMapEntrySet<K, V> internal constructor(
         val backing: HashMap<K, V>
-) : MutableSet<MutableMap.MutableEntry<K, V>>, kotlin.native.internal.KonanSet<MutableMap.MutableEntry<K, V>> {
+) : MutableSet<MutableMap.MutableEntry<K, V>>, kotlin.native.internal.KonanSet<MutableMap.MutableEntry<K, V>>, AbstractMutableSet<MutableMap.MutableEntry<K, V>>() {
 
     override val size: Int get() = backing.size
     override fun isEmpty(): Boolean = backing.isEmpty()
     override fun contains(element: MutableMap.MutableEntry<K, V>): Boolean = backing.containsEntry(element)
     override fun getElement(element: MutableMap.MutableEntry<K, V>): MutableMap.MutableEntry<K, V>? = backing.getEntry(element)
     override fun clear() = backing.clear()
-    override fun add(element: MutableMap.MutableEntry<K, V>): Boolean = backing.putEntry(element)
+    override fun add(element: MutableMap.MutableEntry<K, V>): Boolean = throw UnsupportedOperationException()
+    override fun addAll(elements: Collection<MutableMap.MutableEntry<K, V>>): Boolean = throw UnsupportedOperationException()
     override fun remove(element: MutableMap.MutableEntry<K, V>): Boolean = backing.removeEntry(element)
     override fun iterator(): MutableIterator<MutableMap.MutableEntry<K, V>> = backing.entriesIterator()
     override fun containsAll(elements: Collection<MutableMap.MutableEntry<K, V>>): Boolean = backing.containsAllEntries(elements)
-    override fun addAll(elements: Collection<MutableMap.MutableEntry<K, V>>): Boolean = backing.putAllEntries(elements)
-    override fun removeAll(elements: Collection<MutableMap.MutableEntry<K, V>>): Boolean = backing.removeAllEntries(elements)
-    override fun retainAll(elements: Collection<MutableMap.MutableEntry<K, V>>): Boolean = backing.retainAllEntries(elements)
 
-    override fun equals(other: Any?): Boolean =
-            other === this || other is Set<*> && contentEquals(other)
-
-    override fun hashCode(): Int {
-        var result = 0
-        val it = iterator()
-        while (it.hasNext()) {
-            result += it.next().hashCode()
-        }
-        return result
+    override fun removeAll(elements: Collection<MutableMap.MutableEntry<K, V>>): Boolean {
+        backing.checkIsMutable()
+        return super.removeAll(elements)
     }
 
-    override fun toString(): String = collectionToString()
-
-    // ---------------------------- private ----------------------------
-
-    private fun contentEquals(other: Set<*>): Boolean {
-        @Suppress("UNCHECKED_CAST") // todo: get rid of unchecked cast here somehow
-        return size == other.size && backing.containsAllEntries(other as Collection<Map.Entry<*, *>>)
+    override fun retainAll(elements: Collection<MutableMap.MutableEntry<K, V>>): Boolean {
+        backing.checkIsMutable()
+        return super.retainAll(elements)
     }
 }
 

--- a/runtime/src/main/kotlin/kotlin/collections/HashSet.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/HashSet.kt
@@ -6,8 +6,8 @@
 package kotlin.collections
 
 actual class HashSet<E> internal constructor(
-        val backing: HashMap<E, *>
-) : MutableSet<E>, AbstractMutableCollection<E>(), kotlin.native.internal.KonanSet<E> {
+        private val backing: HashMap<E, *>
+) : MutableSet<E>, kotlin.native.internal.KonanSet<E>, AbstractMutableSet<E>() {
 
     actual constructor() : this(HashMap<E, Nothing>())
 
@@ -20,6 +20,12 @@ actual class HashSet<E> internal constructor(
     // This implementation doesn't use a loadFactor
     actual constructor(initialCapacity: Int, loadFactor: Float) : this(initialCapacity)
 
+    @PublishedApi
+    internal fun build(): Set<E> {
+        backing.build()
+        return this
+    }
+
     override actual val size: Int get() = backing.size
     override actual fun isEmpty(): Boolean = backing.isEmpty()
     override actual fun contains(element: E): Boolean = backing.containsKey(element)
@@ -29,46 +35,20 @@ actual class HashSet<E> internal constructor(
     override actual fun remove(element: E): Boolean = backing.removeKey(element) >= 0
     override actual fun iterator(): MutableIterator<E> = backing.keysIterator()
 
-    override actual fun containsAll(elements: Collection<E>): Boolean {
-        val it = elements.iterator()
-        while (it.hasNext()) {
-            if (!contains(it.next()))
-                return false
-        }
-        return true
-    }
-
     override actual fun addAll(elements: Collection<E>): Boolean {
-        val it = elements.iterator()
-        var updated = false
-        while (it.hasNext()) {
-            if (add(it.next()))
-                updated = true
-        }
-        return updated
+        backing.checkIsMutable()
+        return super.addAll(elements)
     }
 
-    override fun equals(other: Any?): Boolean {
-        return other === this ||
-                (other is Set<*>) &&
-                        contentEquals(
-                                @Suppress("UNCHECKED_CAST") (other as Set<E>))
+    override actual fun removeAll(elements: Collection<E>): Boolean {
+        backing.checkIsMutable()
+        return super.removeAll(elements)
     }
 
-    override fun hashCode(): Int {
-        var result = 0
-        val it = iterator()
-        while (it.hasNext()) {
-            result += it.next().hashCode()
-        }
-        return result
+    override actual fun retainAll(elements: Collection<E>): Boolean {
+        backing.checkIsMutable()
+        return super.retainAll(elements)
     }
-
-    override fun toString(): String = collectionToString()
-
-    // ---------------------------- private ----------------------------
-
-    private fun contentEquals(other: Set<E>): Boolean = size == other.size && containsAll(other)
 }
 
 // This hash set keeps insertion order.

--- a/runtime/src/main/kotlin/kotlin/collections/Maps.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Maps.kt
@@ -5,6 +5,23 @@
 
 package kotlin.collections
 
+@PublishedApi
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+@kotlin.internal.InlineOnly
+internal actual inline fun <K, V> buildMapInternal(builderAction: MutableMap<K, V>.() -> Unit): Map<K, V> {
+    return HashMap<K, V>().apply(builderAction).build()
+}
+
+@PublishedApi
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+@kotlin.internal.InlineOnly
+internal actual inline fun <K, V> buildMapInternal(capacity: Int, builderAction: MutableMap<K, V>.() -> Unit): Map<K, V> {
+    return HashMap<K, V>(capacity).apply(builderAction).build()
+}
+
+
 // creates a singleton copy of map, if there is specialization available in target platform, otherwise returns itself
 @Suppress("NOTHING_TO_INLINE")
 internal inline actual fun <K, V> Map<K, V>.toSingletonMapOrSelf(): Map<K, V> = toSingletonMap()
@@ -19,14 +36,3 @@ internal actual fun <K, V> Map<out K, V>.toSingletonMap(): Map<K, V>
  */
 @PublishedApi
 internal actual fun mapCapacity(expectedSize: Int) = expectedSize
-
-/**
- * Checks a collection builder function capacity argument.
- * Does nothing, capacity is validated in List/Set/Map constructor
- */
-@SinceKotlin("1.3")
-@ExperimentalStdlibApi
-@PublishedApi
-internal actual fun checkBuilderCapacity(capacity: Int) {
-    require(capacity >= 0) { "capacity must be non-negative." }
-}

--- a/runtime/src/main/kotlin/kotlin/collections/Set.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Set.kt
@@ -50,9 +50,3 @@ public interface MutableSet<E> : Set<E>, MutableCollection<E> {
     override fun retainAll(elements: Collection<E>): Boolean
     override fun clear(): Unit
 }
-
-// TODO: Add SingletonSet class
-/**
- * Returns an immutable set containing only the specified object [element].
- */
-public fun <T> setOf(element: T): Set<T> = hashSetOf(element)

--- a/runtime/src/main/kotlin/kotlin/collections/Sets.kt
+++ b/runtime/src/main/kotlin/kotlin/collections/Sets.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package kotlin.collections
+
+// TODO: Add SingletonSet class
+/**
+ * Returns an immutable set containing only the specified object [element].
+ */
+public fun <T> setOf(element: T): Set<T> = hashSetOf(element)
+
+@PublishedApi
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+@kotlin.internal.InlineOnly
+internal actual inline fun <E> buildSetInternal(builderAction: MutableSet<E>.() -> Unit): Set<E> {
+    return HashSet<E>().apply(builderAction).build()
+}
+
+@PublishedApi
+@SinceKotlin("1.3")
+@ExperimentalStdlibApi
+@kotlin.internal.InlineOnly
+internal actual inline fun <E> buildSetInternal(capacity: Int, builderAction: MutableSet<E>.() -> Unit): Set<E> {
+    return HashSet<E>(capacity).apply(builderAction).build()
+}


### PR DESCRIPTION
* 574b917061d - (tag: build-1.4.0-dev-9010, origin/rr/ic/compiler-deps) Remove new kotlin daemon from dist (vor 17 Stunden) <Ilya Chernikov>
* 3dd79ffea68 - Update coroutines-core version to 1.3.7 (vor 17 Stunden) <Ilya Chernikov>
* 9d98c908815 - Drop coroutines from compiler jar, add appropriate plugin dependency (vor 17 Stunden) <Ilya Chernikov>
* 343e519f7f3 - (tag: build-1.4.0-dev-9005) [FIR-PLUGIN] Update testdata according removed class generation stage (vor 19 Stunden) <Dmitriy Novozhilov>
* e340dacb9a6 - [FIR-PLUGIN] Add check to test that jar with annotations exists (vor 19 Stunden) <Dmitriy Novozhilov>
* d49c198a7f6 - [FIR] Correctly initialize extensions in all sessions (vor 19 Stunden) <Dmitriy Novozhilov>
* 96da6d35c5a - [FIR] Add processor for transforming statuses with plugins (vor 19 Stunden) <Dmitriy Novozhilov>
* 8d686226c71 - [FIR] Introduce FirResolveProcessors (vor 19 Stunden) <Dmitriy Novozhilov>
* 96802dde04c - [FIR-PLUGIN] Fix compilation (vor 19 Stunden) <Dmitriy Novozhilov>
* 3de12f9b090 - [FIR] Completely remove old extensions service (vor 19 Stunden) <Dmitriy Novozhilov>
* 9a8d520b851 - [FIR] Remove first version of class generation transformer (vor 19 Stunden) <Dmitriy Novozhilov>
* 3e3387fb697 - [FIR] Remove extension status transformation from status resolve (vor 19 Stunden) <Dmitriy Novozhilov>
* 006232dfb25 - [FIR] Fix FirPluginAnnotationsResolveTransformer (vor 19 Stunden) <Dmitriy Novozhilov>
* 206a6461958 - [FIR] Use caches for predicate matching (vor 19 Stunden) <Dmitriy Novozhilov>
* 594a854b4ed - [FIR] Reimplement FirExtensionService (vor 19 Stunden) <Dmitriy Novozhilov>
* 846db641be9 - [FIR] Make ArrayMap iterable (vor 19 Stunden) <Dmitriy Novozhilov>
* 5c12b3df952 - [FIR] Introduce FirPredicateBasedProvider (vor 19 Stunden) <Dmitriy Novozhilov>
* 0b000154240 - [FIR] Deprecate FirExtensionsService (vor 19 Stunden) <Dmitriy Novozhilov>
* f3d4fa715e9 - [FIR] Introduce DeclarationPredicates for matching declarations for extensions (vor 19 Stunden) <Dmitriy Novozhilov>
* 74353d8bc9f - [FIR] Introduce `FirAnnotatedDeclaration` (vor 19 Stunden) <Dmitriy Novozhilov>
* 799253256cb - [FIR-PLUGIN] Add additional checker to prototype plugin (vor 19 Stunden) <Dmitriy Novozhilov>
* f764baad829 - [FIR] Add extension with additional checkers (vor 19 Stunden) <Dmitriy Novozhilov>
* 04a1027b39f - [FIR] Add empty instances of `DeclarationCheckers` and `ExpressionCheckers` (vor 19 Stunden) <Dmitriy Novozhilov>
* c0a57ae55c5 - [FIR] Move expression checkers from package `call` to `expression` (vor 19 Stunden) <Dmitriy Novozhilov>
* 6d6ed1e7558 - [FIR] Create session component with registered checkers (vor 19 Stunden) <Dmitriy Novozhilov>
* b61b4e4a978 - (tag: build-1.4.0-dev-9002) Use proper `distributionSha256Sum` for android tests (vor 21 Stunden) <Mikhail Bogdanov>
* bfad00e8c97 - (tag: build-1.4.0-dev-8982) Mute android-related gradle import tests (vor 2 Tagen) <Andrey Uskov>
* 22c4d30a89d - (tag: build-1.4.0-dev-8981) Correct docs of ThreadLocal and SharedImmutable annotations (vor 2 Tagen) <Ilya Gorbunov>
* dae7a239980 - Clarify docs of CharSequence.split(Pattern, limit) (vor 2 Tagen) <Ilya Gorbunov>
* f3145454f28 - (tag: build-1.4.0-dev-8966) Decommonize collection builder implementations (vor 2 Tagen) <Abduqodiri Qurbonzoda>
* 379c6944a20 - (tag: build-1.4.0-dev-8958) NI: extract diagnostics from partially resolved call instead of separately handling it including running all checks (vor 3 Tagen) <Victor Petukhov>
* eaa16714f6f - (tag: build-1.4.0-dev-8950, origin/rr/gradle/matveev/partially-fix-KT-32476) [Gradle, native] Allow disabling warning about incorrect dependencies (vor 3 Tagen) <Ilya Matveev>
* c9adf226978 - (tag: build-1.4.0-dev-8944) [JS] Remove binding context from NameSuggestion instance (vor 3 Tagen) <Svyatoslav Kuzmich>
* 104352b313d - (tag: build-1.4.0-dev-8927) [Gradle, JS] Remove browser tests from gradle integration tests (vor 3 Tagen) <Ilya Goncharov>
* 6e3d3831c27 - (tag: build-1.4.0-dev-8918) [JS] JsExport diagnostics and legacy support (vor 3 Tagen) <Svyatoslav Kuzmich>
* 4076bf40a9d - (tag: build-1.4.0-dev-8914, tag: build-1.4.0-dev-8913) [Commonizer] Add Gradle property to pass JVM args (vor 3 Tagen) <Dmitriy Dolovov>
* 2a1e014d51d - Minor. Add jetbrains to project dictionary (vor 3 Tagen) <Dmitriy Dolovov>
* c736a1e5b07 - (tag: build-1.4.0-dev-8910) [Spec tests] Update testsMap for when-expression section (vor 3 Tagen) <anastasiia.spaseeva>
* d9160a26e9a - [Spec tests] Add property `helpers` to testMaps (vor 3 Tagen) <anastasiia.spaseeva>
* cbba52e43c6 - [Spec tests] Make collectInfoFromTests for both spec and implementation tests (vor 3 Tagen) <anastasiia.spaseeva>
* 270972ca1c9 - [Spec tests] Make main link nullable for case if implementation tests don't have this one (vor 3 Tagen) <anastasiia.spaseeva>
* 3a46b5a45ad - [Spec tests] Add path element at testMaps for main links also (vor 3 Tagen) <anastasiia.spaseeva>
* d94c212a604 - [Spec tests] Add linkType element to testMaps (vor 3 Tagen) <anastasiia.spaseeva>
* 3a31150df45 - [Spec tests] Metadata refactoring: remove duplicated links in testMaps (vor 3 Tagen) <anastasiia.spaseeva>
* d32aca87d11 - [Spec tests] Change metadata structure of implementation and spec tests (vor 3 Tagen) <anastasiia.spaseeva>
* 80cd26c9df9 - (tag: build-1.4.0-dev-8897) [FIR] Support several annotation class diagnostics (vor 4 Tagen) <Mikhail Likholetov>
* c112d37ac1a - (tag: build-1.4.0-dev-8896) Consolidate resolving in the new lib, deprecate it in script-util (vor 4 Tagen) <Ilya Chernikov>
* 7d426226f9d - Switch example to the new maven resolving API (vor 4 Tagen) <Ilya Chernikov>
* f363134fbc3 - Do not continue compilation if collected dependencies contain error (vor 4 Tagen) <Ilya Chernikov>
* d92e4d28f54 - Provide a method to update script definitions after loading into IDE (vor 4 Tagen) <Ilya Chernikov>
* 4b032a14af3 - Refactor host configuration handling and script definition creation (vor 4 Tagen) <Ilya Chernikov>
* 255ad474068 - Use copied key to extract default jdkHome from host configuration (vor 4 Tagen) <Ilya Chernikov>
* 20bbcd5d5ac - Implement copied key with ability to take default from source config (vor 4 Tagen) <Ilya Chernikov>
* 3c9207a2cd9 - (tag: build-1.4.0-dev-8895) [Gradle, JS] Add test on local project dependency (vor 4 Tagen) <Ilya Goncharov>
* 985623eac51 - [Gradle, JS] Fix hmpp on only js (vor 4 Tagen) <Ilya Goncharov>
* bed7b23d6c5 - [Gradle, JS] Fix naming of test and test data (vor 4 Tagen) <Ilya Goncharov>
* d089bbe14ac - [Gradle, JS] Fix for JsIrTarget in mixed mode (vor 4 Tagen) <Ilya Goncharov>
* 79984b6e04b - [Gradle, JS] Add test on hmpp with both js (vor 4 Tagen) <Ilya Goncharov>
* a6812e5d6ad - [Gradle, JS] Add fake common usage context for single js plugin publish (vor 4 Tagen) <Ilya Goncharov>
* 4f747072f4e - [Gradle, JS] Define fake configuration for single js plugin to publish as common (vor 4 Tagen) <Ilya Goncharov>
* 22f5d3b1345 - [Gradle, JS] Add isMpp property (vor 4 Tagen) <Ilya Goncharov>
* 0b33e9430ba - (tag: build-1.4.0-dev-8891) [NI] Report unstable smart cast directly instead of using SmartCastManager (vor 4 Tagen) <Pavel Kirpichenkov>
* b808d5f381f - (tag: build-1.4.0-dev-8888) TrailingCommaInspection: cleanup code (vor 4 Tagen) <Dmitry Gridin>
* ee141ae57b1 - TrailingCommaInspection: add dependency to settings (vor 4 Tagen) <Dmitry Gridin>
* 8d77ec83c65 - (tag: build-1.4.0-dev-8884) [Gradle, native] Don't set system properties when the compiler runs in daemon (vor 4 Tagen) <Ilya Matveev>
* f88722ae763 - Update K/N: 1.4-M3-dev-15627 (vor 4 Tagen) <Ilya Matveev>
* a83b0bef968 - (tag: build-1.4.0-dev-8881, origin/rr/fedochet/KT-38841/fixing-intention-preview) KT-38841 Do not call `preparePsiElementForWrite` if not needed (vor 4 Tagen) <Roman Golyshev>
* b89878a5097 - (tag: build-1.4.0-dev-8878) Update testData for KAPT tests for new inline class ABI (vor 4 Tagen) <Dmitry Petrov>
* 7a947e8008d - (tag: build-1.4.0-dev-8863) FIR: fix default constructor visibility for enum entry. (vor 4 Tagen) <Jinseong Jeon>
* 0d3301b6951 - FIR: resolve local class in anonymous initializer. (vor 4 Tagen) <Jinseong Jeon>
* 2ff5b253ae7 - (tag: build-1.4.0-dev-8856) [NI] Fix suspend conversions for subtypes of functional types (vor 5 Tagen) <Mikhail Zarechenskiy>
* 3903814c9c3 - (tag: build-1.4.0-dev-8854) Revert "KT-38841 Remove redundant `preparePsiElementForWrite` call" (vor 5 Tagen) <Roman Golyshev>
* 12db3d6e835 - (tag: build-1.4.0-dev-8852) NI: remove separation of variable fixation order by constraint kind (vor 5 Tagen) <Victor Petukhov>
* 874fa5b998c - (tag: build-1.4.0-dev-8848, tag: build-1.4.0-dev-8832) Bootstrap: 1.4.0-dev-8798 (vor 5 Tagen) <Dmitry Petrov>
* 165b62da63b - (tag: build-1.4.0-dev-8829) KT-38841 Remove redundant `preparePsiElementForWrite` call (vor 5 Tagen) <Roman Golyshev>
* 933440dc63b - (tag: build-1.4.0-dev-8824) JVM IR: Fix mangling of @JvmStatic internal function in companion objects (vor 5 Tagen) <Steven Schäfer>
* 2d0445ebaa1 - (tag: build-1.4.0-dev-8818) Add klib extension to ARCHIVE fileType (vor 5 Tagen) <Vladimir Dolzhenko>
* fceaf657292 - (tag: build-1.4.0-dev-8812) [NI] Don't compute conversions for definitely not SAM parameter (vor 5 Tagen) <Mikhail Zarechenskiy>
* 8bdc4d34f72 - [NI] Commonize type-conversions (SAM/Suspend) (vor 5 Tagen) <Mikhail Zarechenskiy>
* f702da5c51b - [NI] Small refactoring around type conversions (vor 5 Tagen) <Mikhail Zarechenskiy>
* d3d162f9c8a - Refactoring: start commonization of type-conversions (vor 5 Tagen) <Mikhail Zarechenskiy>
* cce9646c7de - Refactoring: extract method about SAM conversions out (vor 5 Tagen) <Mikhail Zarechenskiy>
* 372f378edcb - [NI] Support nested transactions inside constraint system (vor 5 Tagen) <Mikhail Zarechenskiy>
* 4f26ac9a045 - (tag: build-1.4.0-dev-8807) Fix "Koltin" typos throughout codebase (#3383) (vor 5 Tagen) <Kevin Most>
* 38fd9c3d1a9 - (tag: build-1.4.0-dev-8802) Fix KT-39063 by not adding extendsFrom with metadata configurations (vor 5 Tagen) <Sergey Igushkin>
* 6fcdab23cc2 - (tag: build-1.4.0-dev-8798) Bootstrap: 1.4.0-dev-8774 (vor 5 Tagen) <Dmitry Petrov>
* 88efac00b31 - (tag: build-1.4.0-dev-8794) Disable klib fileType in lue of KLibFileTypeFactory (vor 5 Tagen) <Vladimir Dolzhenko>
* 081d6c1dffd - (tag: build-1.4.0-dev-8789) Useless call on collection: propose 'Replace with toList()' instead of 'Remove useless call' if receiver is array type (vor 5 Tagen) <Toshiaki Kameyama>
* 994897cee98 - (tag: build-1.4.0-dev-8786) Fix textdata after reverting a commit about CompilerMessageLocation (vor 5 Tagen) <Ilya Chernikov>
* d825428718c - (tag: build-1.4.0-dev-8782) New J2K : move resolve resolve out of EDT in shorten references processing (vor 5 Tagen) <Ilya Kirillov>
* dc57d307f3b - (tag: build-1.4.0-dev-8780) [FIR] Clean data flow context before body resolve of file (vor 5 Tagen) <Dmitriy Novozhilov>
* 8df635a4e0e - [FIR] Add cleanup of tower data for imports (vor 5 Tagen) <Dmitriy Novozhilov>
* b05546dd64b - [FIR] Add check for session consistency in body resolve transformer (vor 5 Tagen) <Dmitriy Novozhilov>
* 371757309e0 - [FIR] Don't recreate transformer in FirBodyResolveTransformerAdapter (vor 5 Tagen) <Dmitriy Novozhilov>
* 4e07f8180b7 - [FIR] Don't recreate transformer in FirImplicitTypeBodyResolveTransformerAdapter (vor 5 Tagen) <Dmitriy Novozhilov>
* c4407d6d638 - [FIR] Don't recreate transformer in FirContractResolveTransformerAdapter (vor 5 Tagen) <Dmitriy Novozhilov>
* c1080989b63 - [FIR] Suppress pointless unchecked casts in FirStatusResolveTransformer (vor 5 Tagen) <Dmitriy Novozhilov>
* 329af659967 - [FIR] Get rid of `FirStatusResolveTransformerAdapter` (vor 5 Tagen) <Dmitriy Novozhilov>
* 93992d1d759 - [FIR] Get rid of `FirTypeResolveTransformerAdapter` (vor 5 Tagen) <Dmitriy Novozhilov>
* ca4deec10e2 - [FIR] Don't recreate transformers in `FirSupertypeResolverTransformer` (vor 5 Tagen) <Dmitriy Novozhilov>
* dc30bf5d09f - [FIR] Don't recreate transformers in `FirPluginAnnotationsResolveTransformer` (vor 5 Tagen) <Dmitriy Novozhilov>
* 05443695030 - [FIR] Add `transformImports` to FirFile (vor 5 Tagen) <Dmitriy Novozhilov>
* f60c8eac71d - [FIR] Don't rewrite session in FirImportResolveTransformer (vor 5 Tagen) <Dmitriy Novozhilov>
* 67a259a9036 - [FIR] Get rid of `FirSymbolProvider.getInstance(session)`` (vor 5 Tagen) <Dmitriy Novozhilov>
* 24c8a659ee5 - [FIR] Add FirSession as parameter for FirTotalResolveTransformer (vor 5 Tagen) <Dmitriy Novozhilov>
* c165b8d55c9 - (tag: build-1.4.0-dev-8774) JVM: Update IR bytecode text and signature tests (vor 5 Tagen) <Dmitry Petrov>
* 16e7a42aea8 - JVM: Fix line numbers in test (vor 5 Tagen) <Dmitry Petrov>
* e625bb375f6 - Temporarily mute unsigned tests in JVM_IR and FIR (vor 5 Tagen) <Dmitry Petrov>
* de4ebe4395e - Prohibit @JvnName on functions mangled because of return type (vor 5 Tagen) <Dmitry Petrov>
* fcf8a91a38e - Update kotlin-stdlib-runtime-merged.txt (vor 5 Tagen) <Dmitry Petrov>
* cf70c83ab75 - JVM: Update tests (vor 5 Tagen) <Dmitry Petrov>
* 2f82c5b6afc - JVM: Fix default parameter values handling (vor 5 Tagen) <Dmitry Petrov>
* dc9f64fc9da - JVM: Fix reflection tests for new IC ABI (vor 5 Tagen) <Dmitry Petrov>
* b5bd3604b1b - JVM: Mangle functions returning inline class values (vor 5 Tagen) <Dmitry Petrov>
* 9beb36ca2b6 - (tag: build-1.4.0-dev-8773) Code style: add option for blank lines before declarations (vor 5 Tagen) <Dmitry Gridin>
* 499a02ebe33 - (tag: build-1.4.0-dev-8771) AddThrowsAnnotationIntention: improve for mpp (vor 5 Tagen) <Dmitry Gridin>
* 8b4660031ff - multiPlatformSetup: cleanup code (vor 5 Tagen) <Dmitry Gridin>
* 7b079a5f1c1 - (tag: build-1.4.0-dev-8770) Deprecated symbol usages: fix test (vor 5 Tagen) <Dmitry Gridin>
* 1ba4d7d99b4 - Update foreign references when renaming a Kotlin file (vor 10 Tagen) <Vyacheslav Karpukhin>
* ba993ba0fe4 - Provide an extension point that allows plugins to handle renaming of references in other languages (vor 4 Wochen) <Vyacheslav Karpukhin>
* 16b4342d92c - (tag: build-1.4.0-dev-8750) Add minor test for SMAP (vor 6 Tagen) <Mikhail Bogdanov>
* 73e91af7923 - (tag: build-1.4.0-dev-8749) IDEA: test the plugin's ability to parse correct JSR-045 data (vor 6 Tagen) <pyos>
* c51c5375049 - JVM: use precise line bounds when regenerating objects with no SMAPs (vor 6 Tagen) <pyos>
* 7222a732c18 - JVM: treat empty SMAP instances as "skip all line numbers" (vor 6 Tagen) <pyos>
* 86b28b95ca8 - JVM: keep call site markers when inlining lambdas into objects (vor 6 Tagen) <pyos>
* 5feadd56efb - JVM: parse KotlinDebug when regenerating anonymous objects (vor 6 Tagen) <pyos>
* 1fe7ef6521c - JVM: separate the two kinds of source mappers (vor 6 Tagen) <pyos>
* 143d8d1520a - (tag: build-1.4.0-dev-8748) Minor: fix issue reference (vor 6 Tagen) <Ilya Gorbunov>
* d37c412f764 - Suppress a couple more warnings (vor 6 Tagen) <Ilya Gorbunov>
* bf21e1282a5 - Suppress most of unused parameter warnings (vor 6 Tagen) <Ilya Gorbunov>
* dd46d5ca5af - Add sample for Map.flatMap (vor 6 Tagen) <Dmitry Borodin>
* 1a0b59da49d - (tag: build-1.4.0-dev-8747) KT-20357 Add sortedBy() sample (#3283) (vor 6 Tagen) <Dmitry Borodin>
* 0d71758112d - (tag: build-1.4.0-dev-8742) Build: Add miscCompilerTest task (vor 6 Tagen) <Vyacheslav Gerasimov>
* eff5f3a2428 - (tag: build-1.4.0-dev-8731) NI: do type checking for anonymous functions not inside a call (vor 6 Tagen) <Victor Petukhov>
* 425ce8c3ab7 - (tag: build-1.4.0-dev-8726) [FIR] Use flexible type lower bound when approximating type for IntegerLiteral. (vor 6 Tagen) <Mark Punzalan>
* d5141674a3b - [FIR] Update GenerateRangesCodegenTestData for newly-enabled FIR tests. (vor 6 Tagen) <Mark Punzalan>
* 89d706972c2 - [FIR] Use vararg element type when generating argument mapping. (vor 6 Tagen) <Mark Punzalan>
* 98d3855fd8f - (tag: build-1.4.0-dev-8723) KotlinDslModels: project can be null in ExternalSystemTaskNotificationListener.onStart (vor 6 Tagen) <Natalia Selezneva>
* 879fe9b493b - Fix order of ExternalSystemListeners (vor 6 Tagen) <Natalia Selezneva>
* 1a1bcefb2a7 - Add debug logger to ScriptTemplatesFromDependenciesProvider (vor 6 Tagen) <Natalia Selezneva>
* 16b7232b4fd - Minor: do not associate with the same extensions multiple times in ScriptDefinitionsManager (vor 6 Tagen) <Natalia Selezneva>
* 8d22429abc2 - Do not show notification before all definitions are loaded (vor 6 Tagen) <Natalia Selezneva>
* 1513429613c - Load script definitions in IDE on project opening (vor 6 Tagen) <Natalia Selezneva>
* 942c8aaafc6 - Introduce index for folders with script definitions templates (vor 6 Tagen) <Natalia Selezneva>