### PR TITLE
Advance buildKotlinVersion to 1.4.0-dev-9619

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.4.0-dev-8620
-buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-8620,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.4.0-dev-9619
+buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9619,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9010,branch:default:any,pinned:true/artifacts/content/maven
 kotlinVersion=1.4.0-dev-9010

--- a/shared/settings.gradle.kts
+++ b/shared/settings.gradle.kts
@@ -3,18 +3,18 @@ pluginManagement {
         rootDir.resolve("../gradle.properties").reader().use(::load)
     }
 
-    val kotlinCompilerRepo: String by rootProperties
-    val kotlinVersion: String by rootProperties
+    val buildKotlinCompilerRepo: String by rootProperties
+    val buildKotlinVersion: String by rootProperties
 
     repositories {
-        maven(kotlinCompilerRepo)
+        maven(buildKotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
     }
 
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "kotlin") {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$buildKotlinVersion")
             }
         }
     }


### PR DESCRIPTION
Use it to build shared tools.
Earlier, kotlinVersion was used, which caused shared and main project being built with different versions of the compiler.

The new version is required because of new `flatMap` overloads in stdlib, which can be resolved only with a compiler that supports such overloads.