### PR TITLE
Use latest Gradle plugin and bootstrap compiler in the shared project

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -27,6 +27,7 @@ val rootBuildDirectory by extra(file(".."))
 apply(from="../gradle/loadRootProperties.gradle")
 
 val kotlinVersion: String by extra
+val buildKotlinVersion: String by extra
 val konanVersion: String by extra
 val kotlinCompilerRepo: String by extra
 val buildKotlinCompilerRepo: String by extra
@@ -68,6 +69,8 @@ tasks.jar {
 }
 
 dependencies {
+    kotlinCompilerClasspath("org.jetbrains.kotlin:kotlin-compiler-embeddable:$buildKotlinVersion")
+
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     api("org.jetbrains.kotlin:kotlin-native-utils:$kotlinVersion")

--- a/shared/settings.gradle.kts
+++ b/shared/settings.gradle.kts
@@ -3,18 +3,18 @@ pluginManagement {
         rootDir.resolve("../gradle.properties").reader().use(::load)
     }
 
-    val buildKotlinCompilerRepo: String by rootProperties
-    val buildKotlinVersion: String by rootProperties
+    val kotlinCompilerRepo: String by rootProperties
+    val kotlinVersion: String by rootProperties
 
     repositories {
-        maven(buildKotlinCompilerRepo)
+        maven(kotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
     }
 
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "kotlin") {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$buildKotlinVersion")
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
             }
         }
     }


### PR DESCRIPTION
This patch sets the following versions in the shared project:
 - for Gradle plugin - kotlinVersion
 - for Kotlin compiler - buildKotlinVersion
The same approach is used in all other K/N subprojects.