### PR TITLE
Fix `lazy {}` memory leak regression caused by #3862

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1039,6 +1039,10 @@ standaloneTest("lazy2") {
     source = "runtime/workers/lazy2.kt"
 }
 
+standaloneTest("lazy3") {
+    source = "runtime/workers/lazy3.kt"
+}
+
 task enumIdentity(type: KonanLocalTest) {
     enabled = (project.testTarget != 'wasm32') // Workers need pthreads.
     goldValue = "true\n"

--- a/backend.native/tests/runtime/workers/lazy3.kt
+++ b/backend.native/tests/runtime/workers/lazy3.kt
@@ -1,0 +1,54 @@
+import kotlin.native.concurrent.*
+import kotlin.native.ref.*
+import kotlin.test.*
+
+fun main() {
+    test1()
+    test2()
+}
+
+fun test1() {
+    ensureGetsCollectedFrozenAndNotFrozen { LazyCapturesThis() }
+    ensureGetsCollectedFrozenAndNotFrozen {
+        val l = LazyCapturesThis()
+        l.bar
+        l
+    }
+    ensureGetsCollected {
+        val l = LazyCapturesThis().freeze()
+        l.bar
+        l
+    }
+}
+
+class LazyCapturesThis {
+    fun foo() = 42
+    val bar by lazy { foo() }
+}
+
+fun test2() {
+    ensureGetsCollectedFrozenAndNotFrozen { Throwable() }
+    ensureGetsCollectedFrozenAndNotFrozen {
+        val throwable = Throwable()
+        throwable.getStackTrace()
+        throwable
+    }
+    ensureGetsCollected {
+        val throwable = Throwable().freeze()
+        throwable.getStackTrace()
+        throwable
+    }
+}
+
+fun ensureGetsCollectedFrozenAndNotFrozen(create: () -> Any) {
+    ensureGetsCollected { create().freeze() }
+    ensureGetsCollected(create)
+}
+
+fun ensureGetsCollected(create: () -> Any) {
+    val ref = makeWeakRef(create)
+    kotlin.native.internal.GC.collect()
+    assertNull(ref.get())
+}
+
+fun makeWeakRef(create: () -> Any) = WeakReference(create())


### PR DESCRIPTION
This PR is exact copy of https://github.com/JetBrains/kotlin-native/pull/3944, which was added only to 1.3.7x.
After https://github.com/JetBrains/kotlin-native/pull/4142 the same fix is required for master branch too.