### PR TITLE
Fix external tests: DFS methods

### DIFF
--- a/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -502,7 +502,7 @@ fun runTest() {
                             .distinct()
                             .collect(Collectors.toMap({ it.name }, UnaryOperator.identity() ))
 
-                    List<TestModule> orderedModules = DFS.topologicalOrder(modules.values()) { module ->
+                    List<TestModule> orderedModules = DFS.INSTANCE.topologicalOrder(modules.values()) { module ->
                         module.dependencies.collect { modules[it] }.findAll { it != null }
                     }
                     def libsFlags = []


### PR DESCRIPTION
DFS is a Kotlin object. To invoke methods from Groovy it is required to use INSTANCE  property.
Otherwise tests fail with:
`groovy.lang.MissingMethodException: No signature of method: static org.jetbrains.kotlin.utils.DFS.topologicalOrder() is applicable for argument types:`