### PR TITLE
Update compiler for 1.4.0: 1.4-M3-eap-7

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.*
 import org.jetbrains.kotlin.ir.descriptors.IrAbstractFunctionFactory
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.linkage.IrProvider
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -233,6 +233,7 @@ internal val psiToIrPhase = konanUnitPhase(
                 generatorContext,
                 environment.getSourceFiles(),
                 irProviders,
+                pluginExtensions,
                 // TODO: This is a hack to allow platform libs to build in reasonable time.
                 // referenceExpectsForUsedActuals() appears to be quadratic in time because of
                 // how ExpectedActualResolver is implemented.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-9619
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9619,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9642,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-9642
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9642,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-9642
-kotlinStdlibTestsVersion=1.4.0-dev-9642
-testKotlinCompilerVersion=1.4.0-dev-9642
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4-M3-eap-7,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4-M3-eap-7
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4-M3-eap-7,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4-M3-eap-7
+kotlinStdlibTestsVersion=1.4-M3-eap-7
+testKotlinCompilerVersion=1.4-M3-eap-7
 konanVersion=1.4.0-M3
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -27,6 +27,7 @@ val rootBuildDirectory by extra(file(".."))
 apply(from="../gradle/loadRootProperties.gradle")
 
 val kotlinVersion: String by extra
+val buildKotlinVersion: String by extra
 val konanVersion: String by extra
 val kotlinCompilerRepo: String by extra
 val buildKotlinCompilerRepo: String by extra
@@ -68,6 +69,8 @@ tasks.jar {
 }
 
 dependencies {
+    kotlinCompilerClasspath("org.jetbrains.kotlin:kotlin-compiler-embeddable:$buildKotlinVersion")
+
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     api("org.jetbrains.kotlin:kotlin-native-utils:$kotlinVersion")

--- a/shared/settings.gradle.kts
+++ b/shared/settings.gradle.kts
@@ -3,18 +3,18 @@ pluginManagement {
         rootDir.resolve("../gradle.properties").reader().use(::load)
     }
 
-    val buildKotlinCompilerRepo: String by rootProperties
-    val buildKotlinVersion: String by rootProperties
+    val kotlinCompilerRepo: String by rootProperties
+    val kotlinVersion: String by rootProperties
 
     repositories {
-        maven(buildKotlinCompilerRepo)
+        maven(kotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
     }
 
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "kotlin") {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$buildKotlinVersion")
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
             }
         }
     }

--- a/shared/settings.gradle.kts
+++ b/shared/settings.gradle.kts
@@ -3,18 +3,18 @@ pluginManagement {
         rootDir.resolve("../gradle.properties").reader().use(::load)
     }
 
-    val kotlinCompilerRepo: String by rootProperties
-    val kotlinVersion: String by rootProperties
+    val buildKotlinCompilerRepo: String by rootProperties
+    val buildKotlinVersion: String by rootProperties
 
     repositories {
-        maven(kotlinCompilerRepo)
+        maven(buildKotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
     }
 
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "kotlin") {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$buildKotlinVersion")
             }
         }
     }


### PR DESCRIPTION
* a394de00c58 [JS IR] Greenify failing (in 1.4.0 branch) tests  
* d29251f5070 [PLUGIN API] Implement custom linkage for plugin extensions 
* e61f5956cb8 [PLUGIN API] Add extension point to customize linkage process 
* 740bbaeb8c4 [IR] Move `IrProvider` and 'IrDeserializer' into separate package 
* 6851607a04b JVM IR: do not generate DefaultImpls delegate for collection fake overrides  
* 5b5684cd5dc [Gradle, JS] Fix test after changing type of IR link task on mode  
* a6a94277574 [Gradle, JS] Webpack on file providers for task configuration avoidance 
* 52dace2970f [Gradle, JS] Make destinationDir as var 
* 3716d2c4e77 [Gradle, JS] Use RegularFile to not explicit dependsOn 
* 4f96393f149 [Gradle, JS] Add dependency on dce task 
* 6995eb87df7 [Gradle, JS] JsBinaryType to KotlinJsBinaryType 
* f94653fd495 [Gradle, JS] KotlinJsType to KotlinJsMode 
* 007b3d97d6c [Gradle, JS] Move common part of webpack configuration to separate fun 
* b8918eab5d7 [Gradle, JS] Add resolveFromModulesFirst to build tasks 
* aaa2747a4ef [Gradle, JS] Use property for webpack entry 
* 5c40432b4ea [Gradle, JS] Add dce to development 
* 6fe1c56c32b [Gradle, JS] Use API form Gradle 5.0 
* 130eeff06e7 [Gradle, JS] Add index.html to Kotlin DSL wizard 
* 385498aa789 [Gradle, JS] Fix grammar in methods for JS import 
* 6ec97cc85f2 [Gradle, JS] Fix grammar on comment 
* 328db2f0bfe Remove compatibility hack 
* 357203fb11c Build: Remove identifying info from build scans 
* f8693209abd Use system-specific user cache directory in main-kts
* 1e9ee7014b0 Improve hashing of script files 
* f128e5222ae [JVM_IR] Fix line number information for try-catch.  
* 5efbe6ae15e PSI2IR: SAM conversion in varargs  
* 16f175612e0 KT-31908 Handle SAM conversion on vararg elements 
* 343af60cb4d Add intention to expand boolean expression 
* f005091dfb3 Fix performance test stats reporting  
* afd544cbabf Introduce "Redundant 'asSequence' call" inspections  
* e2c34554459 Document NaN propagation in top-level minOf/maxOf functions  
* d19f9ee0c5a Simplify min/max implementation 
* b4ba00ca366 Document and test NaN propagation of maxOf/minOf 
* 7b68de38e1f Introduce minOf/maxOf, minOfWith/maxOfWith and their OrNull variants 
* 6a24becd1d7 Introduce sumOf with various selector types 
* bdd53ee9cda Introduce new overloads of flatMap and flatMapTo 
* 562788ceb95 stdlib-gen: allow template function sequences 
* 79afc4f72bd stdlib-gen: avoid placing exact duplicates of annotations 
* 4ae6665b946 Advance bootstrap to 1.4.0-dev-9619 
* 0ffa0b2bd77 [FIR] Fix effective visibility handling for local members  
* cb345a4c199 [FIR mangler] Search for type parameters also in overridden declarations 
* 8c422fbfc72 [FIR2IR] Use signature composer to read external callables 
* 9ea69b4b3ce Introduce first version of FirJvmKotlinMangler & its parts 
* a239604c24e Rename & make public: Collection.collect -> collectForMangler 
* ecb48b7ed94 [FIR2IR] Support callables in signature composer 
* 563981808d3 Build: Move dependencies cleanup to corresponding task action  
* f8b423046e3 Build: Don't build idea sources for teamcity builds 
* 05d160b1306 Revert "IR linked: introduce IrElement.isExpectMember instead of descriptor use"  
* 72dd2ef4486 [FIR] Fix CFG building for secondary constructor with delegation 
* b40709649dc [FIR TEST] Add more detailed CFG inconsistency message 
* 718f0240a1c [FIR TEST] Add problematic CFG test 
* a476d1dbc49 String prototypes polyfills on Object.defineProperty  
* 9431fc46933 Polyfill for Arrays should be declared with Object.defineProperty 
* 83e17cbf092 [Gradle, JS] Use name of target, not name of preset  
* b68715441f7 [Gradle, JS] Remove redundant fixing names 
* 44f16eac2ec Fixed resolution of dependencies on js libraries compiled in both mode 