### PR TITLE
[kotlin compiler][update] 1.4.20-dev-226 

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.*
 import org.jetbrains.kotlin.ir.descriptors.IrAbstractFunctionFactory
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+import org.jetbrains.kotlin.ir.linkage.IrProvider
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -234,6 +234,7 @@ internal val psiToIrPhase = konanUnitPhase(
                 generatorContext,
                 environment.getSourceFiles(),
                 irProviders,
+                pluginExtensions,
                 // TODO: This is a hack to allow platform libs to build in reasonable time.
                 // referenceExpectsForUsedActuals() appears to be quadratic in time because of
                 // how ExpectedActualResolver is implemented.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-9619
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9619,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9642,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.0-dev-9642
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9642,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.0-dev-9642
-kotlinStdlibTestsVersion=1.4.0-dev-9642
-testKotlinCompilerVersion=1.4.0-dev-9642
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-226,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-226
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-226,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-226
+kotlinStdlibTestsVersion=1.4.20-dev-226
+testKotlinCompilerVersion=1.4.20-dev-226
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/text/Strings.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Strings.kt
@@ -223,6 +223,7 @@ public actual fun CharSequence.repeat(n: Int): String {
 /**
  * Converts the characters in the specified array to a string.
  */
+@Deprecated("Use CharArray.concatToString() instead", ReplaceWith("chars.concatToString()"))
 public actual fun String(chars: CharArray): String = chars.concatToString()
 
 /**
@@ -231,6 +232,7 @@ public actual fun String(chars: CharArray): String = chars.concatToString()
  * @throws IndexOutOfBoundsException if either [offset] or [length] are less than zero
  * or `offset + length` is out of [chars] array bounds.
  */
+@Deprecated("Use CharArray.concatToString(startIndex, endIndex) instead", ReplaceWith("chars.concatToString(offset, offset + length)"))
 public actual fun String(chars: CharArray, offset: Int, length: Int): String {
     if (offset < 0 || length < 0 || offset + length > chars.size)
         throw ArrayIndexOutOfBoundsException()

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -27,6 +27,7 @@ val rootBuildDirectory by extra(file(".."))
 apply(from="../gradle/loadRootProperties.gradle")
 
 val kotlinVersion: String by extra
+val buildKotlinVersion: String by extra
 val konanVersion: String by extra
 val kotlinCompilerRepo: String by extra
 val buildKotlinCompilerRepo: String by extra
@@ -68,6 +69,8 @@ tasks.jar {
 }
 
 dependencies {
+    kotlinCompilerClasspath("org.jetbrains.kotlin:kotlin-compiler-embeddable:$buildKotlinVersion")
+
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     api("org.jetbrains.kotlin:kotlin-native-utils:$kotlinVersion")

--- a/shared/settings.gradle.kts
+++ b/shared/settings.gradle.kts
@@ -3,18 +3,18 @@ pluginManagement {
         rootDir.resolve("../gradle.properties").reader().use(::load)
     }
 
-    val buildKotlinCompilerRepo: String by rootProperties
-    val buildKotlinVersion: String by rootProperties
+    val kotlinCompilerRepo: String by rootProperties
+    val kotlinVersion: String by rootProperties
 
     repositories {
-        maven(buildKotlinCompilerRepo)
+        maven(kotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
     }
 
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "kotlin") {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$buildKotlinVersion")
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
             }
         }
     }

--- a/shared/settings.gradle.kts
+++ b/shared/settings.gradle.kts
@@ -3,18 +3,18 @@ pluginManagement {
         rootDir.resolve("../gradle.properties").reader().use(::load)
     }
 
-    val kotlinCompilerRepo: String by rootProperties
-    val kotlinVersion: String by rootProperties
+    val buildKotlinCompilerRepo: String by rootProperties
+    val buildKotlinVersion: String by rootProperties
 
     repositories {
-        maven(kotlinCompilerRepo)
+        maven(buildKotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
     }
 
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "kotlin") {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$buildKotlinVersion")
             }
         }
     }


### PR DESCRIPTION
* 6a2fed33d37 - (tag: build-1.4.20-dev-226) Deprecate old CharArray to String conversion api #KT-31343 (vor 8 Stunden) <Abduqodiri Qurbonzoda>
* 19855c5bd57 - (tag: build-1.4.20-dev-224) Tweaked performance-tests stats output (vor 12 Stunden) <Vladimir Dolzhenko>
* 8216e5cd72f - (tag: build-1.4.20-dev-220) Avoid persisting default anchor configuration (vor 14 Stunden) <Pavel Kirpichenkov>
* b8cbfcbe7e4 - (tag: build-1.4.20-dev-213) Revert "Add temporary fixMeExtensions to pass test on extensions check" (vor 25 Stunden) <Yunir Salimzyanov>
* 571cab305c1 - Cleanup as35 patchset logic (KTI-267) (vor 25 Stunden) <Yunir Salimzyanov>
* dce19b0aceb - Cleanup 191 patchset logic (KTI-267) (vor 25 Stunden) <Yunir Salimzyanov>
* 820353ee0e3 - (tag: build-1.4.20-dev-211) Promote scanReduce deprecation level to error (vor 26 Stunden) <Abduqodiri Qurbonzoda>
* 4e820edd1fa - Promote randomOrNull, reduceOrNull, scan to stable (vor 26 Stunden) <Abduqodiri Qurbonzoda>
* 094dbf4c2da - Remove experimental status from Array.associateWith (vor 26 Stunden) <Abduqodiri Qurbonzoda>
* db0788c68fc - (tag: build-1.4.20-dev-209) (LightClass) KotlinShortNamesCacheTest fix for methods, referenced from companions and classes (vor 35 Stunden) <Vladimir Ilmov>
* 8f00344191e - (UnusedSymbolInspection) optimized path for data-classes (vor 35 Stunden) <Vladimir Ilmov>
* 0f73cdeccbe - (tag: build-1.4.20-dev-208) Add ability to skip stats for performance tests if there is a custom stats name (vor 2 Tagen) <Vladimir Dolzhenko>
* bd2a0563add - (tag: build-1.4.20-dev-204) JS: fix explicit cross-module SAM constructor calls (vor 2 Tagen) <Anton Bannykh>
* 489290263f0 - (tag: build-1.4.20-dev-195) Add info about the end of range in scripting REPL compiler messages (vor 3 Tagen) <Ilya Muradyan>
* 5e33612238c - Extract interface from CompilerMessageLocation to ease extension (vor 3 Tagen) <Ilya Chernikov>
* f1906bc9669 - (tag: build-1.4.20-dev-194) Minor. Update test (vor 3 Tagen) <Ilmir Usmanov>
* f0006f24058 - (tag: build-1.4.20-dev-193) Minor. Add regression test (vor 3 Tagen) <Ilmir Usmanov>
* a3c881da59e - (tag: build-1.4.20-dev-189) KT-38027 Support Code Vision feature in Kotlin // experimental status (vor 3 Tagen) <Andrei Klunnyi>
* b08f501aac5 - KT-38027 Support Code Vision feature in Kotlin (vor 3 Tagen) <Andrei Klunnyi>
* 4c8f9e4e066 - (tag: build-1.4.20-dev-186) KT-39311 Fix `fix.change.package.family` bundle message (vor 3 Tagen) <Roman Golyshev>
* 46caf27e701 - (tag: build-1.4.20-dev-183) Add "Remove annotation" quickfix for `@Throws override` mismatch (vor 3 Tagen) <Svyatoslav Scherbina>
* 6461c1b4f1f - Add "Remove annotation" quickfix for empty `@Throws` (vor 3 Tagen) <Svyatoslav Scherbina>
* b7a08494ae4 - Add quickfix for adding CancellableException to `@Throws suspend fun` (vor 3 Tagen) <Svyatoslav Scherbina>
* 290a8241079 - Add basic support for Native in idea/testdata/multiModuleQuickFix (vor 3 Tagen) <Svyatoslav Scherbina>
* 46297645a43 - (tag: build-1.4.20-dev-179) Promote String <-> utf8 and CharArray conversions to stable (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* ab02381a833 - (tag: build-1.4.20-dev-177, tag: build-1.4.20-dev-173) [FIR] Make overriding generic callables independent of TP bounds order (vor 3 Tagen) <simon.ogorodnik>
* 2287435740d - [FIR] KT-39033: Fix generic property override detection (vor 3 Tagen) <simon.ogorodnik>
* e4a1c8dcef6 - (tag: build-1.4.20-dev-172) Anonymous function to lambda: add lambda parameter if type parameter is used, even if parameter is unused (vor 3 Tagen) <Toshiaki Kameyama>
* 311b2d7969b - (tag: build-1.4.20-dev-171) [PLUGIN API] Make context provide information about target platform (vor 3 Tagen) <Roman Artemev>
* 89c87f941fc - (tag: build-1.4.20-dev-170) FIR: consider the absence of type arguments when constructing GetClassCall type (vor 3 Tagen) <Jinseong Jeon>
* a086d9f7df1 - (tag: build-1.4.20-dev-166) Update forgotten FIR test (vor 3 Tagen) <Mikhail Zarechenskiy>
* 6c5806f971b - Add test for obsolete issue (vor 3 Tagen) <Mikhail Zarechenskiy>
* f9b3daabd1f - (tag: build-1.4.20-dev-162) Change testData for `ShortenRefsTestGenerated` to not use `sql` package (vor 3 Tagen) <Roman Golyshev>
* 7d662bf5d14 - Change testData for `IntentionsTestGenerated` to avoid using `javax` and `sql` packages (vor 3 Tagen) <Roman Golyshev>
* 22b558110d9 - (tag: build-1.4.20-dev-161) Don't apply Unit-conversion for expressions that return Nothing type (vor 3 Tagen) <Mikhail Zarechenskiy>
* 3634cbe3cb6 - (tag: build-1.4.20-dev-153) (LightClasses) resolve of annotations fast-path (vor 3 Tagen) <Vladimir Ilmov>
* 991f12bd738 - (LightClasses) while looking for accessors we expect them to be taken from single class (vor 3 Tagen) <Vladimir Ilmov>
* c0144d2161a - (LightClasses) minor improvement in annotation order check (vor 3 Tagen) <Vladimir Ilmov>
* 4e7901b8071 - (tag: build-1.4.20-dev-151) Bootstrap: 1.4.20-dev-117 (vor 3 Tagen) <Dmitry Petrov>
* fb812301b27 - (tag: build-1.4.20-dev-150) Add test to preserve behaviour (vor 3 Tagen) <Mikhail Zarechenskiy>
* e72401c5f4f - (tag: build-1.4.20-dev-146) Don't allow coercing receivers from signed to unsigned constants (vor 3 Tagen) <Mikhail Zarechenskiy>
* bfa648972f7 - Introduce call checker for `Unit`-conversions (vor 3 Tagen) <Mikhail Zarechenskiy>
* 6b0a803d142 - Allow suspend-conversion for callable references as part of adaptation (vor 3 Tagen) <Mikhail Zarechenskiy>
* 6b58be377ef - Fix chained conversions for subtypes of functional types (vor 3 Tagen) <Mikhail Zarechenskiy>
* 71cbe976886 - Introduce `Unit`-conversions for simple arguments (vor 3 Tagen) <Mikhail Zarechenskiy>
* f08a45f2d4e - Refactoring: rename files to avoid "util" suffixes (vor 3 Tagen) <Mikhail Zarechenskiy>
* a4af833d55e - Narrow down the range for compatibility warning to callee expression (vor 3 Tagen) <Mikhail Zarechenskiy>
* 4bd622c1c56 - Refactoring: rename method to make it more specific (vor 3 Tagen) <Mikhail Zarechenskiy>
* 718f23b34fc - Compatibility warning for references to companion via name (KT-13934) (vor 3 Tagen) <Mikhail Zarechenskiy>
* 3fdf048e51e - (tag: build-1.4.20-dev-144) Regenerate Serialization* tests (vor 3 Tagen) <Dmitry Gridin>
* 8ca5d3b6f9b - (tag: build-1.4.20-dev-140) Update library to source analysis mode configuration (vor 3 Tagen) <Pavel Kirpichenkov>
* 8ed4424e3e5 - Clean up API of AbstractResolverForProject (vor 3 Tagen) <Pavel Kirpichenkov>
* 80a310540ea - (tag: build-1.4.20-dev-134) [Gradle, JS]Remove failed on variant aware resolution tests on kotlin2js (vor 3 Tagen) <Ilya Goncharov>
* ee3beea3270 - (tag: build-1.4.20-dev-131) [FIR] Cache files with plugin annotations (vor 3 Tagen) <Dmitriy Novozhilov>
* 6c5181d8ceb - [FIR-PLUGIN] Add status transformer for default visibility (vor 3 Tagen) <Dmitriy Novozhilov>
* 1f80f35ce64 - [FIR] Don't cache importing scopes while resolving plugin's annotations (vor 3 Tagen) <Dmitriy Novozhilov>
* 1ffe438fa13 - [FIR-PLUGIN] Update AllOpenStatusTransformer according to previous commit (vor 3 Tagen) <Dmitriy Novozhilov>
* 514cbc77fc8 - [FIR] Add owners to `FirStatusTransformerExtension.transformStatus` (vor 3 Tagen) <Dmitriy Novozhilov>
* b79d6aced4e - [FIR] Add resolve phase for resolving arguments of plugin's annotations (vor 3 Tagen) <Dmitriy Novozhilov>
* 73b738b7ff9 - [FIR] Replace `resolved` flag with resolve status enum for annotation calls (vor 3 Tagen) <Dmitriy Novozhilov>
* 4f1b7b38b22 - (tag: build-1.4.20-dev-123) (Resolve) lightweight resolve annotations (vor 3 Tagen) <Vladimir Ilmov>
* 46ab338ea6a - (tag: build-1.4.20-dev-122) "Convert anonymous function to lambda expression" intention: add necessary lambda type parameter (vor 4 Tagen) <Toshiaki Kameyama>
* d27c7ce86f6 - (tag: build-1.4.20-dev-117) Bootstrap: 1.4.20-dev-65 (vor 4 Tagen) <Dmitry Petrov>
* 8cc5f2abfb1 - (tag: build-1.4.20-dev-116) Forbid val field initialization inside EXACLTY_ONCE lambda (vor 4 Tagen) <Ilmir Usmanov>
* 6d6a2280575 - (tag: build-1.4.20-dev-113) Android import: binary-compatible setting of the BuildType attribute (vor 4 Tagen) <Vyacheslav Karpukhin>
* 39a3f5e7d94 - Android import: better value source for BuildTypeAttr (vor 4 Tagen) <Vyacheslav Karpukhin>
* 1f638f52d51 - Android import: setting BuildType attribute for kotlin android compilations (vor 4 Tagen) <Vyacheslav Karpukhin>
* e4e70f1b5b8 - (tag: build-1.4.20-dev-108) VariantAwareDependenciesIT.kt: remove compile/runtime/... configurations (vor 4 Tagen) <Sergey Igushkin>
* 3291cf7a6e1 - (tag: build-1.4.20-dev-101) JVM IR: Mark lateinit fields as NotNull (vor 4 Tagen) <Steven Schäfer>
* 52b29b53bc0 - (tag: build-1.4.20-dev-95) Fixup BuildCacheRelocationIT: Gradle 5.6.1 -> 5.6.4 (AGP requirement) (vor 4 Tagen) <Sergey Igushkin>
* 6ad37eb7a8b - (tag: build-1.4.20-dev-92) Unmute two more FIR BB tests (vor 4 Tagen) <Mikhail Glukhikh>
* 802beb49a65 - (tag: build-1.4.20-dev-91) Use TypeSubstitutor to get the substituted underlying type for inline classes, instead of MemberScope. (vor 4 Tagen) <Mark Punzalan>
* 88b130308d6 - (tag: build-1.4.20-dev-88) Revert accidental test data change introduced in 0d6e3093 (vor 4 Tagen) <Mikhail Glukhikh>
* 0ce47f2f12d - [FIR TEST] Mute 2 BB tests broken by 0d6e3093 (vor 4 Tagen) <Mikhail Glukhikh>
* 5647a935a23 - (tag: build-1.4.20-dev-84) JVM IR: do not generate DefaultImpls delegate for collection fake overrides (vor 4 Tagen) <Alexander Udalov>
* 47c25982b62 - (tag: build-1.4.20-dev-82) (ResolveElementCache) KtAnnotationEntry resolveToDescriptor added (vor 4 Tagen) <Vladimir Ilmov>
* c5aa35e016a - (tag: build-1.4.20-dev-80) [Gradle, JS] All regular text printed to DEBUG (vor 4 Tagen) <Ilya Goncharov>
* 97e4d23d759 - [Gradle, JS] Filter warning with source maps (vor 4 Tagen) <Ilya Goncharov>
* 69b9a2e98a9 - [Gradle, JS] Remove trailing commas from webpack config (vor 4 Tagen) <Ilya Goncharov>
* 4bbead6200d - [Gradle, JS] Remove custom source-map-loader (vor 4 Tagen) <Ilya Goncharov>
* a94d2211e45 - (tag: build-1.4.20-dev-77) Cleanup `getLineCount` (vor 4 Tagen) <Nikita Bobko>
* 603bae398f7 - (tag: build-1.4.20-dev-71) Fix BuildCacheIT and BuildCacheRelocationIT (vor 4 Tagen) <Sergey Igushkin>
* 71a45e56d7b - (tag: build-1.4.20-dev-69) Don't apply copyright notice to Kotlin Ultimate (vor 4 Tagen) <Florian Kistner>
* de25359a905 - (tag: build-1.4.20-dev-65, origin/as41/master) Fix stdlib compilation after updated @JvmName check (vor 4 Tagen) <Dmitry Petrov>
* 202bbdf8dd5 - Forward compatibility hacks for Result.{success, failure} (vor 4 Tagen) <Dmitry Petrov>
* 8a4521864ea - (tag: build-1.4.20-dev-63) Wizard: use cache redirector on project importing tests (vor 4 Tagen) <Ilya Kirillov>
* cce5a9a1ca5 - Wizard: download latest dev version for tests from bintray (vor 4 Tagen) <Ilya Kirillov>
* 1ea72ec3780 - (tag: build-1.4.20-dev-57) Fix test data in FIR diagnostic test (merge with local eff. visibility) (vor 4 Tagen) <Mikhail Glukhikh>
* 74e4a817cbb - (tag: build-1.4.20-dev-55) [Gradle, JS] Fix test after changing type of IR link task on mode (vor 4 Tagen) <Ilya Goncharov>
* 0d6e3093726 - (tag: build-1.4.20-dev-54) FIR: construct type with actual type arguments during GetClassCall transformation (vor 4 Tagen) <Jinseong Jeon>
* 4f8ad6bdcb7 - (tag: build-1.4.20-dev-50) Remove compatibility hack (vor 4 Tagen) <Mikhail Bogdanov>
* c023a02884f - (tag: build-1.4.20-dev-44) Create SortedMap with Comparator and items (vor 4 Tagen) <Valeriy.Vyrva>
* e3fb74b6561 - (tag: build-1.4.20-dev-36) Promote KClass.cast/safeCast, KAnnotatedElement.hasAnnotation() to stable (vor 5 Tagen) <Abduqodiri Qurbonzoda>
* a4b9e8fdc62 - (tag: build-1.4.20-dev-35) Minor: mute test in JS_IR (vor 5 Tagen) <Dmitry Petrov>
* 0db02926f53 - (tag: build-1.4.20-dev-33) JVM_IR: remove descriptors from MethodSignatureMapper (vor 5 Tagen) <Georgy Bronnikov>
* 77c20066a8f - JVM_IR: implement getJvmModuleNameForDeserialized in MethodSignatureMapper (vor 5 Tagen) <Georgy Bronnikov>
* 80afe42d17c - JVM_IR: implement getJvmNameIfSpecial in MethodSignatureMapper (vor 5 Tagen) <Georgy Bronnikov>
* 986b13c3a1c - (tag: build-1.4.20-dev-20) Optimize synchronization for resolution anchors (vor 5 Tagen) <Pavel Kirpichenkov>
* 175fe163af9 - Add cancelation check when building anchor mappings (vor 5 Tagen) <Pavel Kirpichenkov>
* 7fff8f82e2e - Changes after review (vor 5 Tagen) <Pavel Kirpichenkov>
* db1210fc671 - Introduce components for library-to-source resolution in IDE (vor 5 Tagen) <Pavel Kirpichenkov>
* 0b2c9ff77ac - (tag: build-1.4.20-dev-19) IDE plugin dependencies: publish kotlin-main-kts artifact (vor 5 Tagen) <Yan Zhulanow>
* 822c14814bb - (tag: build-1.4.20-dev-18) Revert "Completely rewrite reifiedIntTypeAnalysis, making it more streamline" (vor 5 Tagen) <Ilmir Usmanov>
* 148f49d54ad - (tag: build-1.4.20-dev-17) UselessCallOnCollectionInspection: fix false positive when lambda last statement is function call that returns generic type (vor 5 Tagen) <Toshiaki Kameyama>
* 3c8ef5749f3 - (tag: build-1.4.20-dev-11, origin/rr/4u7/wip) Build: Remove identifying info from build scans (vor 5 Tagen) <Vyacheslav Gerasimov>
* f7ed3139ab1 - (origin/rr/gradle/igushkin/fix-kt-39304-unused-source-sets-failure) Fix unused source sets missing in compilationsBySourceSets (KT-39304) (vor 6 Tagen) <Sergey Igushkin>
* a18bfad53a9 - Add stdlib API test + remove some extra IR stdlib API's (vor 5 Tagen) <Anton Bannykh>
* 1ed43246137 - Completely rewrite reifiedIntTypeAnalysis, making it more streamline (vor 5 Tagen) <Ilmir Usmanov>
* 0e908b720d0 - Replace SourceInterpreter with specific one in tail-call optimization (vor 5 Tagen) <Ilmir Usmanov>
* 3fa9ea9bc08 - Remove unreachable instructions (vor 5 Tagen) <Ilmir Usmanov>
* ea60b83f169 - Fix merging two sources with same type (vor 5 Tagen) <Ilmir Usmanov>
* cd0e218a073 - Rewrite RedundantLocalsEliminationMethodTransformer (vor 5 Tagen) <Ilmir Usmanov>
* f247ea7c27d - Replace SourceInterpreter with a specific one in coroutines inlining (vor 5 Tagen) <Ilmir Usmanov>
* 99a1ef04604 - Minor: mute test in JS_IR (vor 5 Tagen) <Dmitry Petrov>
* 426f164e023 - [Gradle, JS] Webpack on file providers for task configuration avoidance (vor 5 Tagen) <Ilya Goncharov>
* 01f3e4b0833 - [Gradle, JS] Make destinationDir as var (vor 5 Tagen) <Ilya Goncharov>
* 402dfd5da72 - [Gradle, JS] Use RegularFile to not explicit dependsOn (vor 5 Tagen) <Ilya Goncharov>
* e27bd04ba20 - [Gradle, JS] Add dependency on dce task (vor 5 Tagen) <Ilya Goncharov>
* d3260bca27f - [Gradle, JS] JsBinaryType to KotlinJsBinaryType (vor 5 Tagen) <Ilya Goncharov>
* d27ad99daa7 - [Gradle, JS] KotlinJsType to KotlinJsMode (vor 5 Tagen) <Ilya Goncharov>
* a5e46568eea - [Gradle, JS] Move common part of webpack configuration to separate fun (vor 5 Tagen) <Ilya Goncharov>
* ef63d6f84c0 - [Gradle, JS] Add resolveFromModulesFirst to build tasks (vor 5 Tagen) <Ilya Goncharov>
* d4d8495840b - [Gradle, JS] Use property for webpack entry (vor 5 Tagen) <Ilya Goncharov>
* 65db6bb2a5a - [Gradle, JS] Add dce to development (vor 5 Tagen) <Ilya Goncharov>
* 9d8eb65a5ef - [Gradle, JS] Use API form Gradle 5.0 (vor 5 Tagen) <Ilya Goncharov>
* ba43ee84107 - Handle error type in SamType (vor 5 Tagen) <Dmitry Petrov>
* b0445496bbe - [JS] Autogenerate and mute missing test (vor 5 Tagen) <Svyatoslav Kuzmich>
* af13ae1ef29 - [JS] Add klib to kostlin-stdlib-js.jar distribution (vor 5 Tagen) <Svyatoslav Kuzmich>
* ebae6332aa5 - Fix invalid resources placement (vor 5 Tagen) <Igor Yakovlev>
* f2d0d8b422a - [FIR-PLUGIN] Add test for supertype modification extension (vor 5 Tagen) <Dmitriy Novozhilov>
* dae2acca88e - [FIR] Remove useless hack for builtins from supertype resolution (vor 5 Tagen) <Dmitriy Novozhilov>
* 9fa4ff750bf - [FIR] Fix ArrayMapImpl.iterator() (vor 5 Tagen) <Dmitriy Novozhilov>
* 15d85bdc053 - [FIR] Add extension for adding new supertypes (vor 5 Tagen) <Dmitriy Novozhilov>
* 0c18cb054d9 - [FIR-PLUGIN] Add tests for generating declarations from plugin (vor 5 Tagen) <Dmitriy Novozhilov>
* eceeacdf610 - [FIR] Change nested class generation extension to generate top-level classes also (vor 5 Tagen) <Dmitriy Novozhilov>
* 9cc13c8324f - [FIR-PLUGIN] Add dummy implementation for nested class generator extension (vor 5 Tagen) <Dmitriy Novozhilov>
* 8acdb39bdd1 - [FIR-PLUGIN] Add dummy implementation for member generator extension (vor 5 Tagen) <Dmitriy Novozhilov>
* 1b120c189ee - [FIR] Record generated classes in FirProvider (vor 5 Tagen) <Dmitriy Novozhilov>
* ed55e84afa4 - [FIR] Distinct declarations found by FirPredicateBasedProvider (vor 5 Tagen) <Dmitriy Novozhilov>
* 87f0f123a80 - [FIR] Add extension for generating new members for existing classes (vor 5 Tagen) <Dmitriy Novozhilov>
* bd194686dfe - [Gradle, JS] Add index.html to Kotlin DSL wizard (vor 5 Tagen) <Ilya Goncharov>
* 6cb0190fad6 - FoldInitializerAndIfToElvis: should not add new line for multiline initializer (vor 5 Tagen) <Toshiaki Kameyama>
* 5eae262264e - [PLUGIN API] Implement custom linkage for plugin extensions (vor 5 Tagen) <Roman Artemev>
* a401374ed4d - [PLUGIN API] Add extension point to customize linkage process (vor 5 Tagen) <Roman Artemev>
* f9c2c846f79 - [IR] Move `IrProvider` and 'IrDeserializer' into separate package (vor 5 Tagen) <Roman Artemev>
* 71da941c8b4 - Use system-specific user cache directory in main-kts (vor 5 Tagen) <Henrik Tunedal>
* 8f80cf56645 - Improve hashing of script files (vor 5 Tagen) <Henrik Tunedal>
* 890da492fb0 - [Gradle, JS] Fix grammar in methods for JS import (vor 5 Tagen) <Ilya Goncharov>
* bc4d7e00207 - [Gradle, JS] Fix grammar on comment (vor 5 Tagen) <Ilya Goncharov>
* e9e850ad8f3 - [JS IR] Fix findInterfaceImplementation (vor 5 Tagen) <Svyatoslav Kuzmich>
* 19219c37b66 - FIR: Fix test data for KT-13650 related test (vor 5 Tagen) <Denis Zharkov>
* 7a22827af49 - FIR: Unify all references to FIR nodes from non-parents (vor 5 Tagen) <Denis Zharkov>
* 4a4dce1766a - FIR: Use more refined names instead of "safe" (vor 5 Tagen) <Denis Zharkov>
* 6507656496c - FIR: Remove FirQualifiedAccessWithoutCallee.safe from generated code (vor 5 Tagen) <Denis Zharkov>
* 291afd84486 - FIR: Remove FirQualifiedAcces.safe in non-generated code (vor 5 Tagen) <Denis Zharkov>
* 55a4c40970d - FIR: Fix diagnostics test data after safe-call refactoring (vor 5 Tagen) <Denis Zharkov>
* 723b275d99d - FIR: Fix rendered fir and DFA graph test data after safe-calls refactoring (vor 5 Tagen) <Denis Zharkov>
* 409e90e7de3 - FIR: Fix codegen test data after safe-call refactoring (vor 5 Tagen) <Denis Zharkov>
* 080565e4820 - FIR: Support safe-calls new format in DFA (vor 5 Tagen) <Denis Zharkov>
* ec746e17c97 - FIR: Get rid of RealVariable.originalType (vor 5 Tagen) <Denis Zharkov>
* b0b7cf40428 - FIR: Support safe-calls new format in FIR2IR (vor 5 Tagen) <Denis Zharkov>
* 7ba1371466a - FIR: Support safe-calls new format in body resolution (vor 5 Tagen) <Denis Zharkov>
* 755b8468777 - FIR: Support safe-calls in renderers (vor 5 Tagen) <Denis Zharkov>
* 9f793f1486b - FIR: Support safe-calls new format in FIR builders (vor 5 Tagen) <Denis Zharkov>
* cb1c3f87f07 - FIR: Prepare tree structure for safe-call refactoring (vor 5 Tagen) <Denis Zharkov>
* 14a41d91f6c - FIR: Extract foldFlow from joinFlow/unionFlow in PersistentLogicSystem (vor 5 Tagen) <Denis Zharkov>
* a3d6c428101 - FIR: Reuse some common parts in PersistentLogicSystem (vor 5 Tagen) <Denis Zharkov>
* 233cf13bdc6 - FIR: Minor. Remove when branch that is just the same as "else" (vor 5 Tagen) <Denis Zharkov>
* 93f39d5df95 - FIR: Minor. Refactor processLevelForPropertyWithInvoke (vor 5 Tagen) <Denis Zharkov>
* be4d3783a40 - FIR: Fix type resolution for anonymous objects (vor 5 Tagen) <Denis Zharkov>
* 4d484dd971e - FIR: Support java array in type argument (vor 5 Tagen) <Denis Zharkov>
* 164b4dd4399 - [FIR-TEST] Update testdata according to #KT-39340 (vor 5 Tagen) <Dmitriy Novozhilov>
* f8fdb0dc7ef - [JS] Add `;` after functions in .d.ts (vor 5 Tagen) <Svyatoslav Kuzmich>
* 2ca751a9fc1 - [JS] Prevent default class constructors in d.ts files. (vor 5 Tagen) <Svyatoslav Kuzmich>
* 695d383ed1f - [JS] Support secondary constructors in JsExport (vor 5 Tagen) <Svyatoslav Kuzmich>
* f128e5222ae - (tag: build-1.4.0-dev-9724, origin/rrr/1.4.0/1.4.0_start) [JVM_IR] Fix line number information for try-catch. (vor 5 Tagen) <Mads Ager>
* 5efbe6ae15e - (tag: build-1.4.0-dev-9703, origin/rr/spaseeva/spec-tests) PSI2IR: SAM conversion in varargs (vor 6 Tagen) <Dmitry Petrov>
* 16f175612e0 - KT-31908 Handle SAM conversion on vararg elements (vor 6 Tagen) <Dmitry Petrov>
* 343af60cb4d - Add intention to expand boolean expression (vor 6 Tagen) <Toshiaki Kameyama>
* f005091dfb3 - (tag: build-1.4.0-dev-9700) Fix performance test stats reporting (vor 6 Tagen) <Vladimir Dolzhenko>
* afd544cbabf - (tag: build-1.4.0-dev-9699) Introduce "Redundant 'asSequence' call" inspections (vor 6 Tagen) <Toshiaki Kameyama>
* e2c34554459 - (tag: build-1.4.0-dev-9689) Document NaN propagation in top-level minOf/maxOf functions (vor 6 Tagen) <Ilya Gorbunov>
* d19f9ee0c5a - Simplify min/max implementation (vor 6 Tagen) <Ilya Gorbunov>
* b4ba00ca366 - Document and test NaN propagation of maxOf/minOf (vor 6 Tagen) <Ilya Gorbunov>
* 7b68de38e1f - Introduce minOf/maxOf, minOfWith/maxOfWith and their OrNull variants (vor 6 Tagen) <Ilya Gorbunov>
* 6a24becd1d7 - Introduce sumOf with various selector types (vor 6 Tagen) <Ilya Gorbunov>
* bdd53ee9cda - Introduce new overloads of flatMap and flatMapTo (vor 6 Tagen) <Ilya Gorbunov>
* 562788ceb95 - stdlib-gen: allow template function sequences (vor 6 Tagen) <Ilya Gorbunov>
* 79afc4f72bd - stdlib-gen: avoid placing exact duplicates of annotations (vor 6 Tagen) <Ilya Gorbunov>
* 4ae6665b946 - Advance bootstrap to 1.4.0-dev-9619 (vor 6 Tagen) <Ilya Gorbunov>
* 0ffa0b2bd77 - (tag: build-1.4.0-dev-9686) [FIR] Fix effective visibility handling for local members (vor 6 Tagen) <Mikhail Glukhikh>
* cb345a4c199 - [FIR mangler] Search for type parameters also in overridden declarations (vor 6 Tagen) <Mikhail Glukhikh>
* 8c422fbfc72 - [FIR2IR] Use signature composer to read external callables (vor 6 Tagen) <Mikhail Glukhikh>
* 9ea69b4b3ce - Introduce first version of FirJvmKotlinMangler & its parts (vor 6 Tagen) <Mikhail Glukhikh>
* a239604c24e - Rename & make public: Collection.collect -> collectForMangler (vor 6 Tagen) <Mikhail Glukhikh>
* ecb48b7ed94 - [FIR2IR] Support callables in signature composer (vor 6 Tagen) <Mikhail Glukhikh>
* 563981808d3 - (tag: build-1.4.0-dev-9671) Build: Move dependencies cleanup to corresponding task action (vor 6 Tagen) <Vyacheslav Gerasimov>
* f8b423046e3 - Build: Don't build idea sources for teamcity builds (vor 6 Tagen) <Vyacheslav Gerasimov>
* 05d160b1306 - (tag: build-1.4.0-dev-9664) Revert "IR linked: introduce IrElement.isExpectMember instead of descriptor use" (vor 6 Tagen) <Mikhail Glukhikh>
* 72dd2ef4486 - [FIR] Fix CFG building for secondary constructor with delegation (vor 6 Tagen) <Mikhail Glukhikh>
* b40709649dc - [FIR TEST] Add more detailed CFG inconsistency message (vor 6 Tagen) <Mikhail Glukhikh>
* 718f0240a1c - [FIR TEST] Add problematic CFG test (vor 6 Tagen) <Mikhail Glukhikh>
* a476d1dbc49 - (tag: build-1.4.0-dev-9653) String prototypes polyfills on Object.defineProperty (vor 6 Tagen) <Ilya Goncharov>
* 9431fc46933 - Polyfill for Arrays should be declared with Object.defineProperty (vor 6 Tagen) <Ilya Goncharov>
* 83e17cbf092 - (tag: build-1.4.0-dev-9651, origin/rr/gradle/ilgonmic/KT-39213) [Gradle, JS] Use name of target, not name of preset (vor 6 Tagen) <Ilya Goncharov>
* b68715441f7 - [Gradle, JS] Remove redundant fixing names (vor 6 Tagen) <Ilya Goncharov>
* 44f16eac2ec - Fixed resolution of dependencies on js libraries compiled in both mode (vor 6 Tagen) <Andrey Uskov>