### PR TITLE
[runtime] Add assert for illegal alignment

### DIFF
--- a/runtime/src/main/cpp/Natives.cpp
+++ b/runtime/src/main/cpp/Natives.cpp
@@ -52,6 +52,8 @@ void* Kotlin_interop_malloc(KLong size, KInt align) {
   if (size > SIZE_MAX) {
     return nullptr;
   }
+  RuntimeAssert(align > 0, "Unsupported alignment");
+  RuntimeAssert((align & (align - 1)) == 0, "Alignment must be power of two");
 
   void* result = konan::calloc_aligned(1, size, align);
   if ((reinterpret_cast<uintptr_t>(result) & (align - 1)) != 0) {


### PR DESCRIPTION
Without that check next assert will wrongly pass e.g. for align=65