### PR TITLE
[kotlin compiler][update] 1.4.20-dev-554

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
+import org.jetbrains.kotlin.backend.common.ir.addFakeOverridesViaIncorrectHeuristic
 import org.jetbrains.kotlin.backend.common.ir.addSimpleDelegatingConstructor
 import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
@@ -115,7 +115,7 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
         )
 
         implObject.superTypes += context.irBuiltIns.anyType
-        implObject.addFakeOverrides()
+        implObject.addFakeOverridesViaIncorrectHeuristic()
 
         val itemGetterSymbol = symbols.array.functions.single { it.descriptor.name == Name.identifier("get") }
         val enumEntriesMap = enumClass.declarations

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlin.backend.konan.cgen
 
-import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
+import org.jetbrains.kotlin.backend.common.ir.addFakeOverridesViaIncorrectHeuristic
 import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
 import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
 import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
@@ -1318,7 +1318,7 @@ private class ObjCBlockPointerValuePassing(
             +irReturn(callBlock(blockPointer, arguments))
         }
 
-        irClass.addFakeOverrides()
+        irClass.addFakeOverridesViaIncorrectHeuristic()
 
         stubs.addKotlin(irClass)
         return constructor

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
@@ -246,7 +246,7 @@ internal class CallableReferenceLowering(val context: Context): FileLoweringPass
             }
 
             functionReferenceClass.superTypes += superTypes
-            functionReferenceClass.addFakeOverrides()
+            functionReferenceClass.addFakeOverridesViaIncorrectHeuristic()
 
             return BuiltFunctionReference(functionReferenceClass, constructor)
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSingleAbstractMethodLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSingleAbstractMethodLowering.kt
@@ -5,14 +5,20 @@
 
 package org.jetbrains.kotlin.backend.konan.lower
 
+import org.jetbrains.kotlin.backend.common.ScopeWithIr
 import org.jetbrains.kotlin.backend.common.lower.SingleAbstractMethodLowering
 import org.jetbrains.kotlin.backend.konan.Context
+import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.render
 
 internal class NativeSingleAbstractMethodLowering(context: Context) : SingleAbstractMethodLowering(context) {
+    override fun getWrapperVisibility(expression: IrTypeOperatorCall, scopes: List<ScopeWithIr>) =
+            Visibilities.PRIVATE
+
     override fun getSuperTypeForWrapper(typeOperand: IrType): IrType {
         return typeOperand.classOrNull?.defaultType ?: error("Unsupported SAM conversion: ${typeOperand.render()}")
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -5,10 +5,7 @@
 
 package org.jetbrains.kotlin.backend.konan.lower
 
-import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
-import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
-import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
-import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
+import org.jetbrains.kotlin.backend.common.ir.*
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.reportWarning
 import org.jetbrains.kotlin.backend.konan.Context
@@ -35,6 +32,7 @@ import org.jetbrains.kotlin.ir.symbols.impl.IrConstructorSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.util.addChild
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.load.kotlin.PackagePartClassUtils
@@ -529,7 +527,7 @@ internal class TestProcessor (val context: Context) {
             companionGetter?.let { declarations += it }
 
             superTypes += symbols.baseClassSuite.typeWith(listOf(testClassType, testCompanionType))
-            addFakeOverrides()
+            addFakeOverridesViaIncorrectHeuristic()
         }
     }
     //endregion

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -180,7 +180,7 @@ internal class KonanIrLinker(
 
         private fun resolveDescriptor(idSig: IdSignature): ClassDescriptor =
             with(idSig as IdSignature.PublicSignature) {
-                val classId = ClassId(packageFqn, declarationFqn, false)
+                val classId = ClassId(packageFqName(), FqName(declarationFqName), false)
                 moduleDescriptor.findClassAcrossModuleDependencies(classId) ?: error("No declaration found with $idSig")
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-9619
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9619,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-226,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-226
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-226,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-226
-kotlinStdlibTestsVersion=1.4.20-dev-226
-testKotlinCompilerVersion=1.4.20-dev-226
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-554,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-554
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-554,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-554
+kotlinStdlibTestsVersion=1.4.20-dev-554
+testKotlinCompilerVersion=1.4.20-dev-554
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 063c973eaae - (HEAD -> master, tag: build-1.4.20-dev-554, origin/rr/4u7/fix-gradle-tests, origin/master, origin/HEAD) Build: Rename empty marker jar to avoid collision with main jar (vor 10 Stunden) <Vyacheslav Gerasimov>
* 852dcedb860 - (tag: build-1.4.20-dev-548) Build: Remove marker task dependencies from gradle integration tests (vor 13 Stunden) <Vyacheslav Gerasimov>
* 5689a2c67ab - (tag: build-1.4.20-dev-547) Build: Fix kotlin-jsr223-daemon-local-eval-example test runtime (vor 14 Stunden) <Vyacheslav Gerasimov>
* 38416e7e309 - Build: Fix kotlin-compiler-embeddable test runtime (vor 14 Stunden) <Vyacheslav Gerasimov>
* ef48c38eb48 - Build: Fix kotlin.kotlin-scripting-jsr223-tes test runtime (vor 14 Stunden) <Vyacheslav Gerasimov>
* 07e18654d93 - Build: Fix tests compilation in kotlin.idea.idea-frontend-fir (vor 14 Stunden) <Vyacheslav Gerasimov>
* 3e3afac4070 - Build: Fix pom runtime scope for kotlin-klib-commonizer (vor 14 Stunden) <Vyacheslav Gerasimov>
* a5e9e1e9beb - Build: Specify Locale.ROOT for humanReadableName generation (vor 14 Stunden) <Vyacheslav Gerasimov>
* 567aabeced3 - Build: Fix kotlin-reflect publication (vor 14 Stunden) <Vyacheslav Gerasimov>
* b0c9b884855 - Build: Disable sha512 checksums generated by maven-publish (vor 14 Stunden) <Vyacheslav Gerasimov>
* f9ec4f7d5c2 - Build: Generate human readable project name from gradle project id (vor 14 Stunden) <Vyacheslav Gerasimov>
* b4df4e55253 - Build: Fix variant resolution ambiguity (vor 14 Stunden) <Vyacheslav Gerasimov>
* eeb2f7d3d11 - Build: Migrate plugin markers to maven-publish publication (vor 14 Stunden) <Vyacheslav Gerasimov>
* da6c2ddb2f9 - Build: Migrate stdlib & kotlin-test to maven-publish publication (vor 14 Stunden) <Vyacheslav Gerasimov>
* f4e8c213098 - Build: Introduce new software component for publishing (vor 14 Stunden) <Vyacheslav Gerasimov>
* e3111730ace - Build: Extract publishing logic to the KotlinBuildPublishingPlugin (vor 14 Stunden) <Vyacheslav Gerasimov>
* 40dfb2a4386 - Build: Add additional configuration lambda to the `publish` helper (vor 14 Stunden) <Vyacheslav Gerasimov>
* e3f1ddefd0a - Build: Add modularJar helper (vor 14 Stunden) <Vyacheslav Gerasimov>
* 4925ca2c9ab - Build: Fix receiver for configure* helpers in commonConfiguration.gradle (vor 14 Stunden) <Vyacheslav Gerasimov>
* 9faf088c96e - Build: Disable automated publishing setup for kotlin-gradle-plugin (vor 14 Stunden) <Vyacheslav Gerasimov>
* 4aa3040550b - Build: Use runtimeOnly instead of deprecated runtime (vor 14 Stunden) <Vyacheslav Gerasimov>
* 8737168d416 - Build: Use maven-publish in configurePublishing helper (vor 14 Stunden) <Vyacheslav Gerasimov>
* 94b4f4a91a8 - Build: Remove configureJvmProject helper for groovy script (vor 14 Stunden) <Vyacheslav Gerasimov>
* c2589c7d6d7 - Build: Rename javadocJar for groovy to configureJavadocJar (vor 14 Stunden) <Vyacheslav Gerasimov>
* d711086be2f - Build: Publish Kotlin artifacts with maven-publish plugin (vor 14 Stunden) <Vyacheslav Gerasimov>
* b85b733e427 - Build: Remove explicit legacy maven plugin application (vor 14 Stunden) <Vyacheslav Gerasimov>
* 410c5f3e692 - Build: Remove artifact configuration out of lazy lambda (vor 14 Stunden) <Vyacheslav Gerasimov>
* b43ff7fbf9d - (tag: build-1.4.20-dev-537) Don't show KDoc references in Call Hierarchy (vor 2 Tagen) <Nikita Bobko>
* a79efd0768f - filter out references in javadoc to fix IDEA-185139 A method's call hierarchy shows also references (vor 2 Tagen) <Alexey Kudravtsev>
* 89aa15c419f - (tag: build-1.4.20-dev-533) JVM_IR: implement isCompiledToJvm8OrHigher on IrClass (vor 2 Tagen) <Georgy Bronnikov>
* 8037baf3078 - IR: add SourceElement reference to IrClass (vor 2 Tagen) <Georgy Bronnikov>
* 811e8d0f24c - JVM_IR: remove one usage of descriptors from AnnotationCodegen (vor 2 Tagen) <Georgy Bronnikov>
* 58a9c0c9969 - JVM_IR: remove descriptor usage from IrTypeMapper (vor 2 Tagen) <Georgy Bronnikov>
* c875c30f2c9 - (tag: build-1.4.20-dev-523) Add changelog for 1.4-M2 (vor 3 Tagen) <Lilia>
* 2bf31ae3c30 - (tag: build-1.4.20-dev-503) IR: minor reformat of IdSignature (vor 4 Tagen) <Alexander Udalov>
* d8aee421acf - IR: don't store isPublic as field in IdSignature (vor 4 Tagen) <Alexander Udalov>
* 3154eca218d - IR: use String instead of FqName in IdSignature.PublicSignature (vor 4 Tagen) <Alexander Udalov>
* d24e136ba8c - Minor, make IdSignature.PublicSignature not a data class (vor 4 Tagen) <Alexander Udalov>
* 8b37a094fe4 - (tag: build-1.4.20-dev-502) Added a test on possible name clash for SAM wrappers (vor 4 Tagen) <Igor Chevdar>
* 66bbd3e1020 - [IR] Improved tuning of SAM wrapper visibility (vor 4 Tagen) <Igor Chevdar>
* 1b1e579cbf7 - (tag: build-1.4.20-dev-501) 201: Uast: fixing `KotlinUastGenerationTest` by using system-independent inline unaware `asRecursiveLogString` (vor 4 Tagen) <Nicolay Mitropolsky>
* b8597b48f18 - (tag: build-1.4.20-dev-498) Fix removed negation in 9b77c2d (vor 4 Tagen) <Yunir Salimzyanov>
* 01b61425001 - (tag: build-1.4.20-dev-497) Revert changes from 6e67e1e78d6 in Gradle integration tests (vor 4 Tagen) <Alexander Udalov>
* 5d827d9b5c4 - (tag: build-1.4.20-dev-489) AS41: Disable all tests in idea-gradle and idea-gradle-native (KTI-281) (vor 4 Tagen) <Nikolay Krasko>
* 032d017c4f8 - (tag: build-1.4.20-dev-488) Revert "Add tests for setup native run gutters." (vor 4 Tagen) <Konstantin Tskhovrebov>
* d528d24f83e - (tag: build-1.4.20-dev-487) Optimize AllUnderImportScope (vor 4 Tagen) <Ilya Chernikov>
* 484d026d2f1 - Optimize resolution scope queries from the synthetic scopes (vor 4 Tagen) <Ilya Chernikov>
* a0efd1e3231 - Optimize scopes handling inside ChainedMemberScope (vor 4 Tagen) <Ilya Chernikov>
* 3da6ff7ec3b - Optimize scopes handling inside LexicalChainedScope (vor 4 Tagen) <Ilya Chernikov>
* bf97323301b - Optimize data handling inside scopes (vor 4 Tagen) <Ilya Chernikov>
* c720fa57939 - Optimize LazyScopeAdapter internals (vor 4 Tagen) <Ilya Chernikov>
* c2ede13d5a6 - Fix importing scopes problem for scripting REPL (vor 4 Tagen) <Ilya Muradyan>
* b74692e96b2 - Add missing definitelyDoesNotContainName methods (vor 4 Tagen) <Ilya Muradyan>
* 262e21fcbc4 - Add overload to comply with the contract (vor 4 Tagen) <Ilya Muradyan>
* 6da22414dc2 - [minor] Fix typo in comment (vor 4 Tagen) <Ilya Muradyan>
* 4d2caa8e76f - (tag: build-1.4.20-dev-485) KT-33211 Quickfix "add parameter" for method references should infer functional type instead of KFunction (#2664) (vor 4 Tagen) <Toshiaki Kameyama>
* 6e67e1e78d6 - (tag: build-1.4.20-dev-473) Replace appendln with appendLine in project (vor 4 Tagen) <Alexander Udalov>
* d1c88798dfe - (tag: build-1.4.20-dev-470) Load script definitions only from production source root and libraries (vor 4 Tagen) <Natalia Selezneva>
* 2d5b50531df - (tag: build-1.4.20-dev-463) FIR IDE: fix AbstractFirLazyResolveTest (vor 4 Tagen) <Ilya Kirillov>
* 46907f861a8 - (tag: build-1.4.20-dev-461) Extend Selection: don't select lambda parameters if lambda is multiple lines (#2586) (vor 4 Tagen) <Toshiaki Kameyama>
* 232be94738a - (tag: build-1.4.20-dev-460) Smart enter: support get() clause (#2630) (vor 4 Tagen) <Toshiaki Kameyama>
* cbbdec58989 - (tag: build-1.4.20-dev-459) Change Signature: enable on primary constructor keyword (#2482) (vor 4 Tagen) <Toshiaki Kameyama>
* 957a9277908 - KT-15846 'Change lambda expression return type' quick fix does nothing (#3182) (vor 4 Tagen) <Toshiaki Kameyama>
* 5ab05e6e479 - (tag: build-1.4.20-dev-456) FIR: Fix incorrect resolution to synthetic property by implicit receiver (vor 4 Tagen) <Denis Zharkov>
* 293f78efe87 - FIR: Correct capturing for type-alias bases arguments (vor 4 Tagen) <Denis Zharkov>
* bea37569e68 - FIR: Fix processOverriddenFunctions implementations (vor 4 Tagen) <Denis Zharkov>
* 28627e97540 - FIR: Minor. Clarify naming for unwrapping overrides (vor 4 Tagen) <Denis Zharkov>
* 89cbe9bf93c - FIR: Pull down FirScope.processOverriddenFunctions (vor 4 Tagen) <Denis Zharkov>
* 6178cb7206d - FIR: Get rid of last usages of FirScope.processOverriddenFunctions (vor 4 Tagen) <Denis Zharkov>
* 72b09ff3237 - FIR: Rename FirSuperTypeScope and reuse it for type parameter type (vor 4 Tagen) <Denis Zharkov>
* 0bd2a745428 - FIR: Add FirTypeScope (vor 4 Tagen) <Denis Zharkov>
* 38922a84f17 - FIR: Do not create synthetic properties for non-Java accessors (vor 4 Tagen) <Denis Zharkov>
* 6a1f921a5cb - FIR: Introduce FirScope.processOverriddenFunctions (vor 4 Tagen) <Denis Zharkov>
* 8447f512b4e - Minor. Drop unused FirSyntheticPropertiesScope.synthetic (vor 4 Tagen) <Denis Zharkov>
* ab2a2b3a875 - (tag: build-1.4.20-dev-454) FIR2IR: eager conversion of annotations in Library class and members (vor 4 Tagen) <Jinseong Jeon>
* fd32e918d59 - FIR deserializer: signature-aware annotation loading for property accessors (vor 4 Tagen) <Jinseong Jeon>
* 2d55b8db072 - FIR deserializer: build property accessors if non-default ones exist (vor 4 Tagen) <Jinseong Jeon>
* 369c08214bb - (tag: build-1.4.20-dev-453) Add quick isCheapEnoughToSearch check to AddFunctionParametersFix (vor 4 Tagen) <Vladimir Dolzhenko>
* a63f83ab15e - (tag: build-1.4.20-dev-435, origin/rr/ddol/commonizer-lift-up-declarations) Get rid of usages of internal LibraryImpl class (vor 5 Tagen) <Nikita Bobko>
* 801c97f4564 - Use ModuleOrderEntry instead of ModuleOrderEntryImpl (vor 5 Tagen) <Alex Plate>
* bc20464badf - (tag: build-1.4.20-dev-434, tag: build-1.4.20-dev-427) 202: Restrict compatibility for 201 plugin (vor 5 Tagen) <Nikolay Krasko>
* 76d819f66df - Drop typo and fix fir package imports in GenerateTests.kt.192 (vor 5 Tagen) <Vladimir Dolzhenko>
* e45e4917188 - (tag: build-1.4.20-dev-423) Add options param to external dependencies resolver API (vor 5 Tagen) <Mathias Quintero>
* 83087291df1 - Add API to get locations of collected script annotations (vor 5 Tagen) <Mathias Quintero>
* 1539128c3f6 - (tag: build-1.4.20-dev-418) Delete module kotlin-build-common included twice (#3459) (vor 5 Tagen) <Andrey>
* 3921a0ed701 - (tag: build-1.4.20-dev-414) Add test for obsolete issue (vor 5 Tagen) <Mikhail Zarechenskiy>
* d61e40e49be - Add tests for setup native run gutters. (vor 5 Tagen) <Konstantin Tskhovrebov>
* 39e1f03cd10 - Fix for 192: enable native run gutters only if gradle plugin exists. (vor 5 Tagen) <Konstantin Tskhovrebov>
* 25f0e38c73d - (tag: build-1.4.20-dev-410) [inliner] parent fix after copy (vor 5 Tagen) <Vasily Levchenko>
* 163bd341729 - (tag: build-1.4.20-dev-408) Fixed GenerateTests.kt.192 compilation (vor 5 Tagen) <Vladimir Dolzhenko>
* 18914ac9a57 - (tag: build-1.4.20-dev-404) [Gradle, JS] Fix name of publication in both mode (vor 5 Tagen) <Ilya Goncharov>
* 60d62148e84 - [Gradle, JS] Fix isMain in js targets (vor 5 Tagen) <Ilya Goncharov>
* b72f7c3021d - [Gradle, JS] Remove Native Only isMainCompilation only (vor 5 Tagen) <Ilya Goncharov>
* 2d068a42f49 - [Gradle, JS] Use common isMain for KotlinCompilation (vor 5 Tagen) <Ilya Goncharov>
* 24568058e12 - (tag: build-1.4.20-dev-402) Minor. Remove unused code (vor 5 Tagen) <Dmitriy Dolovov>
* 84a46444905 - (tag: build-1.4.20-dev-396) [Commonizer] Speed-up serialization of commonized member scopes (vor 5 Tagen) <Dmitriy Dolovov>
* 974e01ec703 - (tag: build-1.4.20-dev-390) Fix bunch files after moving plugin.xml (vor 5 Tagen) <Nikolay Krasko>
* 6babc733201 - AS41: Fix problems with initialization of Android plugin in tests (vor 5 Tagen) <Nikolay Krasko>
* 7190b3400fa - (tag: build-1.4.20-dev-388) 202: Fix compilation in DefaultDiagnosticReporter (vor 5 Tagen) <Nikolay Krasko>
* ff7576f8e41 - 202: Fix compilation (vor 5 Tagen) <Nikita Bobko>
* eb67c4519d0 - 202: Fix compilation because of CoreJarVirtualFile (vor 5 Tagen) <Nikita Bobko>
* 256bd8d5948 - 202: Disable check for broken plugins in tests (vor 5 Tagen) <Nikolay Krasko>
* 143cad78bfc - 202: Add fastutil dependency to compiler for to make proguard work (vor 5 Tagen) <Nikolay Krasko>
* cc709a2ef94 - 202: Update dependencies (vor 5 Tagen) <Nikolay Krasko>
* 84855328564 - 202: Update to the latest EAP (vor 5 Tagen) <Nikolay Krasko>
* fdbdc5aac75 - (tag: build-1.4.20-dev-382) [Gradle, JS] Fix error message for both executable (vor 5 Tagen) <Ilya Goncharov>
* 83144d59be7 - (tag: build-1.4.20-dev-380) Fix tests (vor 5 Tagen) <Pavel Kirpichenkov>
* dc34d355bc9 - (tag: build-1.4.20-dev-371) [JVM_IR] Generate line numbers and nops for init blocks. (vor 5 Tagen) <Mads Ager>
* 85e2392fef2 - (tag: build-1.4.20-dev-363) Fix merging two reference values (vor 6 Tagen) <Ilmir Usmanov>
* 5567033b334 - Revert "Revert "Completely rewrite reifiedIntTypeAnalysis, making it more streamline"" (vor 6 Tagen) <Ilmir Usmanov>
* e801fad4d41 - (tag: build-1.4.20-dev-362) Minor, unmute test on fun interface inheritance for FIR (vor 6 Tagen) <Alexander Udalov>
* e3a23aed333 - Minor, remove unneeded check in ClosureCodegen (vor 6 Tagen) <Alexander Udalov>
* 93e9d3e57d7 - (tag: build-1.4.20-dev-347) Delay check for possibly deferred return type for reference candidate (vor 6 Tagen) <Mikhail Zarechenskiy>
* 21f7cd5d8f8 - (tag: build-1.4.20-dev-341) Add test for check expect/actual gutters at same module. (vor 6 Tagen) <Konstantin Tskhovrebov>
* a6161c6f221 - Fix expect/actual gutters for declarations in the same module. (vor 6 Tagen) <Konstantin Tskhovrebov>
* 3b422377d20 - (tag: build-1.4.20-dev-337, tag: build-1.4.20-dev-335) FIR IDE: move validation contract to analysis session base class (vor 6 Tagen) <Ilya Kirillov>
* fb8acf8c1e2 - FIR IDE: add tests for call resolve (vor 6 Tagen) <Ilya Kirillov>
* 8ac0466ec2c - FIR IDE: resolve constructors to correct CallInfo (vor 6 Tagen) <Ilya Kirillov>
* 87a65c0e4bb - FIR IDE: throw PCE in highlighter & reference resolver if on EDT thread (vor 6 Tagen) <Ilya Kirillov>
* 19043537c1a - FIR IDE: make API functions that returns types return non-null value (vor 6 Tagen) <Ilya Kirillov>
* ee22d0b9380 - FIR IDE: introduce TypeInfo as a wrapper for types in high level API (vor 6 Tagen) <Ilya Kirillov>
* 115327b9679 - FIR IDE: add validation contract to analysis session (vor 6 Tagen) <Ilya Kirillov>
* 71b916ae8f1 - FIR IDE: rename AnalysisSessionFirImpl -> FirAnalysisSession (vor 6 Tagen) <Ilya Kirillov>
* 52a422350b2 - FIR IDE: always invalidate PSI -> FIR caches on any change (vor 6 Tagen) <Ilya Kirillov>
* c3f547ec775 - FIR IDE: add missing runtime dependencies (vor 6 Tagen) <Ilya Kirillov>
* 7ac48f441d4 - FIR IDE: remove enabled/disable FirResolution by registry (vor 6 Tagen) <Ilya Kirillov>
* 19d721d2625 - FIR IDE: mute not passing tests (vor 6 Tagen) <Ilya Kirillov>
* d317ee11976 - FIR IDE: move highlighting to fir ide module (vor 6 Tagen) <Ilya Kirillov>
* a62c0e8163b - FIR IDE: introduce fir lower level module (vor 6 Tagen) <Ilya Kirillov>
* c1a62e2f05d - Fix import optimizer test after reference classes rename (vor 6 Tagen) <Ilya Kirillov>
* 858b0531340 - FIR IDE: do not run fir tests in non FIR IDE plugin (vor 6 Tagen) <Ilya Kirillov>
* dbfa43a60af - FIR IDE: remove unneeded dependencies of idea-fir & idea-frontend-fir modules (vor 6 Tagen) <Ilya Kirillov>
* 1b8ea311723 - FIR IDE: ignore not passing highlighting tests (vor 6 Tagen) <Ilya Kirillov>
* 65b22ebfa97 - FIR IDE: improve search of containing declaration for getOrBuildFir (vor 6 Tagen) <Ilya Kirillov>
* 918e4ef7d0d - FIR IDE: remove checker/duplicateJvmSignature tests for FIR as duplicate signature is not implemented for fir ide yet (vor 6 Tagen) <Ilya Kirillov>
* 00a271dd940 - FIR IDE: Remove IGNORE_FIR from passing tests (vor 6 Tagen) <Ilya Kirillov>
* c6ae916b24b - FIR IDE: Fix tests in idea-fir (vor 6 Tagen) <Ilya Kirillov>
* ba7e953760c - FIR IDE: Introduce plugin.xml for fir ide (vor 6 Tagen) <Ilya Kirillov>
* 72175fc40ea - Fix idea.xml (vor 6 Tagen) <Ilya Kirillov>
* bd12b373537 - FIR IDE: Move ApplicationUtils to frontend independent module (vor 6 Tagen) <Ilya Kirillov>
* a4f8c6734c2 - FIR IDE: Introduce ide-frontend-independent.xml extensions (vor 6 Tagen) <Ilya Kirillov>
* 66d44162e9b - FIR IDE: Move common caches related stuff from plugin-common.xml to caches.xml (vor 6 Tagen) <Ilya Kirillov>
* 3ca317e0ce4 - FIR IDE: Split resources to three folders which is needed for FIR plugin (vor 6 Tagen) <Ilya Kirillov>
* 2290c32a830 - FIR IDE: Move idea related stuff from plugin-common.xml to idea.xml (vor 6 Tagen) <Ilya Kirillov>
* 3e253750134 - FIR IDE: Move jps related stuff from plugin-common.xml to jps.xml (vor 6 Tagen) <Ilya Kirillov>
* 2c0e14ba92c - FIR IDE: Move index related stuff from plugin-common.xml to indexes.xml (vor 6 Tagen) <Ilya Kirillov>
* e06f2974990 - FIR IDE: Move inspections from plugin-common.xml to inspections.xml (vor 6 Tagen) <Ilya Kirillov>
* d46088548d3 - FIR IDE: Implement FIR reference resolve for some kinds of references (vor 6 Tagen) <Ilya Kirillov>
* 30eab6c8a3e - FIR IDE: Implement search of psi elements for deserialized Kotlin declarations (vor 6 Tagen) <Ilya Kirillov>
* a8b94b1ccae - FIR IDE: Move some declarations highlighting to before resolve highlighting pass (vor 6 Tagen) <Ilya Kirillov>
* f37e3137059 - FIR IDE: Begin implementing semantic highlighting via FIR (vor 6 Tagen) <Ilya Kirillov>
* 507fc34c22a - FIR: fix incorrect psi for named & spread arguments in FIR builder (vor 6 Tagen) <Ilya Kirillov>
* 6a4fa8de9d3 - FIR IDE: Move base part of highlighting to frontend-independent-module (vor 6 Tagen) <Ilya Kirillov>
* 77550186ade - FIR IDE: Move KDoc Reference & mainReference to frontend-independent module (vor 6 Tagen) <Ilya Kirillov>
* 45ef0e1b50d - FIR IDE: Move fir resolving functionality from idea module to idea-frontend-fir (vor 6 Tagen) <Ilya Kirillov>
* 003827a4f2c - FIR IDE: Start IDEA FIR plugin (vor 6 Tagen) <Ilya Kirillov>
* 418903e9ef0 - FIR IDE: Make KtReference class descriptors frontend independent (vor 6 Tagen) <Ilya Kirillov>
* 6adad1055b7 - (tag: build-1.4.20-dev-331, tag: build-1.4.20-dev-322) JVM IR: generate delegates to DefaultImpls for fun interfaces (vor 6 Tagen) <Alexander Udalov>
* fc1217ba077 - Generate delegates to DefaultImpls in fun interface wrappers (vor 6 Tagen) <Alexander Udalov>
* 77e479fda83 - (tag: build-1.4.20-dev-321, origin/aocherepanov) JVM IR: generate InnerClasses attribute for nested classes in annotation arguments (vor 6 Tagen) <Alexander Udalov>
* 2793187bdae - (tag: build-1.4.20-dev-318) Handle IllegalArgumentException in trimMargin intrinsics on JVM (vor 6 Tagen) <Alexander Udalov>
* 261ed463415 - (tag: build-1.4.20-dev-313) IR metadata source: do not require descriptor in property metadata (vor 6 Tagen) <Mikhail Glukhikh>
* 6f0eeecc64b - [FIR2IR] Fix generation of type arguments of delegated constructor calls (vor 6 Tagen) <Mikhail Glukhikh>
* 5c6f40b34ad - IR metadata source: extract & use declaration name (vor 6 Tagen) <Mikhail Glukhikh>
* b2c78e490e4 - [FIR2IR] Remove some descriptor-around calls (vor 6 Tagen) <Mikhail Glukhikh>
* 69d5635aae0 - (tag: build-1.4.20-dev-312) [minor] Fix textdata after reapplying commit w\ CompilerMessageLocation (vor 6 Tagen) <Ilya Chernikov>
* 802272a5793 - (tag: build-1.4.20-dev-311) Enable `ContractsOnCallsWithImplicitReceiver` in 1.4 (vor 6 Tagen) <Dmitriy Novozhilov>
* 64785256664 - (tag: build-1.4.20-dev-309) Fixed GenerateCompilerTestsAgainstKlib.kt compilation (vor 6 Tagen) <Vladimir Dolzhenko>
* 3817f7f044f - (tag: build-1.4.20-dev-305) Fixed GenerateKotlinpTests compilation (vor 6 Tagen) <Vladimir Dolzhenko>
* 9936468a5e4 - (tag: build-1.4.20-dev-298) [Commonizer] Update stats collector to report lifted up declarations (vor 6 Tagen) <Dmitriy Dolovov>
* 611946a7c79 - [Commonizer] Drop useless annotation tests (vor 6 Tagen) <Dmitriy Dolovov>
* 596363ea23e - [Commonizer] Refactor/simplify marker interfaces (vor 6 Tagen) <Dmitriy Dolovov>
* f3b400975e4 - [Commonizer] Drop useless "allowPrivate" flag in VisibilityCommonizer (vor 6 Tagen) <Dmitriy Dolovov>
* d9bfe11ca1e - [Commonizer] Source-based tests on lifting up identical type aliases (vor 6 Tagen) <Dmitriy Dolovov>
* e5885e92776 - [Commonizer] Unit tests on lifting up identical type aliases (vor 6 Tagen) <Dmitriy Dolovov>
* d3c6dc362e4 - [Commonizer] Lift up identical type aliases (vor 6 Tagen) <Dmitriy Dolovov>
* e37a485aaa3 - [Commonizer] Process expect/actual cross-module dependencies in source-based tests (vor 6 Tagen) <Dmitriy Dolovov>
* c8ba3fa8ed5 - [Commonizer] Clean-up in AbstractCommonizationFromSourcesTest (vor 6 Tagen) <Dmitriy Dolovov>
* 5076f981a66 - Minor. Add "kotlinx" and "cinterop" to project dictionary (vor 6 Tagen) <Dmitriy Dolovov>
* e51c7a79c78 - [Commonizer] Minor. Fixed typo (vor 6 Tagen) <Dmitriy Dolovov>
* 3654da8a630 - [Commonizer] Minor. Improve error reporting (vor 6 Tagen) <Dmitriy Dolovov>
* be9e25a2e56 - [Commonizer] Move fqNameWithTypeParameters extension val into CirType (vor 6 Tagen) <Dmitriy Dolovov>
* 719d5da641e - [Commonizer] Move some extension functions into CirFunctionOrProperty (vor 6 Tagen) <Dmitriy Dolovov>
* da9e0d3c029 - [Commonizer] Simplify detection if property is lifted up (vor 6 Tagen) <Dmitriy Dolovov>
* 50165397c70 - (tag: build-1.4.20-dev-291) (CoroutineDebugger) flaky test coroutine-debug library changed to 1.3.4 (vor 6 Tagen) <Vladimir Ilmov>
* 9319c4c96e3 - (tag: build-1.4.20-dev-286) DryRun mode for GenerateTests is added (vor 7 Tagen) <Vladimir Dolzhenko>
* cd9273028b2 - (tag: build-1.4.20-dev-283) Profiling and repeat support for JVM CLI Compiler (vor 7 Tagen) <simon.ogorodnik>
* ce1ef6c1598 - (tag: build-1.4.20-dev-272) Fixing a bug with private accessors in IR fake override construction (vor 7 Tagen) <Alexander Gorshenev>
* 89e5e106574 - (tag: build-1.4.20-dev-266) [FIR2IR] Drop effectively unused FirMetadataSource.File.descriptors (vor 7 Tagen) <Mikhail Glukhikh>
* 6eab6a96cb6 - [FIR2IR] Support type aliases properly (vor 7 Tagen) <Mikhail Glukhikh>
* 6485869659b - (tag: build-1.4.20-dev-258) AbstractKotlinCodeVisionProviderTest has no test methods actually (vor 7 Tagen) <Andrei Klunnyi>
* c3802891fce - (tag: build-1.4.20-dev-251, tag: build-1.4.20-dev-241) Hide commonizer import error message for unsupported kotlin plugin. (vor 7 Tagen) <Konstantin Tskhovrebov>
* 8677d630033 - (tag: build-1.4.20-dev-239) [FIR2IR] Re-use FakeOverrideGenerator for external classes (vor 7 Tagen) <Mikhail Glukhikh>
* ba1172b3ad0 - FIR2IR: distinguish substitution case when adding external fake overrides (vor 7 Tagen) <Jinseong Jeon>
* 538535c3b77 - [FIR2IR] Introduce & use declaration-based SymbolTable.enter(leave)Scope (vor 7 Tagen) <Mikhail Glukhikh>
* e593c7270f7 - [FIR2IR] Use specific symbols for enum entries (vor 7 Tagen) <Mikhail Glukhikh>
* 0770a6f8489 - [FIR2IR] Drop yet-unused local declaration symbols (vor 7 Tagen) <Mikhail Glukhikh>
* 35678803037 - [FIR] Consider enum entry nested classes as local (vor 7 Tagen) <Mikhail Glukhikh>
* 8a456f578d4 - [FIR mangler] Handle parent type aliases properly (vor 7 Tagen) <Mikhail Glukhikh>
* 5603afbd200 - FirClassSubstitutionScope: handle fake override local eff. visibility (vor 7 Tagen) <Mikhail Glukhikh>
* 21498359e45 - FirClassSubstitutionScope: extract 'configureAnnotationsAndParameters' (vor 7 Tagen) <Mikhail Glukhikh>
* 7bd872b264c - [FIR2IR] Restore container source related logic (vor 7 Tagen) <Mikhail Glukhikh>
* 0c41fcba6a4 - [FIR2IR] Use signature composer only for non-local declarations (vor 7 Tagen) <Mikhail Glukhikh>
* 55b7cf0dda1 - [FIR2IR] Extract declareIr<SomeDeclaration> (vor 7 Tagen) <Mikhail Glukhikh>
* 6d8b0f55669 - [FIR2IR] Provide correct callable ids for fake overrides (vor 7 Tagen) <Mikhail Glukhikh>
* dc660e72e54 - [IR] Don't store descriptor in IR function to allow lazy initialization (vor 7 Tagen) <Mikhail Glukhikh>
* de2980e9e5b - [FIR2IR] Use specific symbols for class declarations (vor 7 Tagen) <Mikhail Glukhikh>
* 85801ea62c3 - [FIR2IR] Use specific symbols for callable declarations (vor 7 Tagen) <Mikhail Glukhikh>
* c7041c0f1a6 - [FIR2IR] Add signature to all symbols (vor 7 Tagen) <Mikhail Glukhikh>
* d4cb6b68c4b - [FIR2IR] Introduce own symbol implementations (vor 7 Tagen) <Mikhail Glukhikh>
* 529c73d58d3 - [FIR2IR] Introduce abstract bindable symbol (vor 7 Tagen) <Mikhail Glukhikh>
* 9719391c82c - (tag: build-1.4.20-dev-233, tag: build-1.4.20-dev-232, origin/rr/vladimiri/work) (PerformanceTest) improvements in profiler snapshots (vor 7 Tagen) <Vladimir Ilmov>
* 0d2552b0b64 - (tag: build-1.4.20-dev-231) FIR: record and serialize the modifier "fun" for functional interface (vor 7 Tagen) <Jinseong Jeon>