### PR TITLE
[kotlin compiler][update] 1.4.20-dev-971

### DIFF
--- a/backend.native/build.gradle
+++ b/backend.native/build.gradle
@@ -56,6 +56,7 @@ compileCompilerKotlin {
     // but not for Kotlin.
     dependsOn('generateCompilerProto')
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI"
 }
 
 compileCompilerJava {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -78,7 +78,6 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
                     isFinal = true,
                     isExternal = false,
                     isStatic = false,
-                    isFakeOverride = false
             ).apply {
                 it.bind(this)
                 parent = implObject

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -395,7 +395,6 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
                 isFinal = true,
                 isExternal = false,
                 isStatic = false,
-                isFakeOverride = false
         )
         irField.parent = declaration
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
@@ -97,7 +97,6 @@ internal class PropertyDelegationLowering(val context: Context) : FileLoweringPa
                     isFinal = true,
                     isExternal = false,
                     isStatic = true,
-                    isFakeOverride = false
             ).apply {
                 it.bind(this)
                 parent = irFile

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -53,7 +53,7 @@ object KonanFakeOverrideClassFilter : PlatformFakeOverrideClassFilter {
 
 internal class KonanIrLinker(
         private val currentModule: ModuleDescriptor,
-        override val functionalInteraceFactory: IrAbstractFunctionFactory,
+        override val functionalInterfaceFactory: IrAbstractFunctionFactory,
         logger: LoggingContext,
         builtIns: IrBuiltIns,
         symbolTable: SymbolTable,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -79,7 +79,6 @@ internal fun IrFile.addTopLevelInitializer(expression: IrExpression, context: Ko
             isFinal = true,
             isExternal = false,
             isStatic = true,
-            isFakeOverride = false
     ).apply {
         descriptor.bind(this)
 
@@ -364,7 +363,6 @@ fun createField(
             !isMutable,
             false,
             false,
-            false
     ).apply {
         it.bind(this)
         owner.declarations += this

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-9619
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9619,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-554,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-554
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-554,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-554
-kotlinStdlibTestsVersion=1.4.20-dev-554
-testKotlinCompilerVersion=1.4.20-dev-554
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-971,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-971
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-971,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-971
+kotlinStdlibTestsVersion=1.4.20-dev-971
+testKotlinCompilerVersion=1.4.20-dev-971
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -180,10 +180,10 @@ public actual fun FloatArray.asList(): List<Float> {
     return object : AbstractList<Float>(), RandomAccess {
         override val size: Int get() = this@asList.size
         override fun isEmpty(): Boolean = this@asList.isEmpty()
-        override fun contains(element: Float): Boolean = this@asList.contains(element)
+        override fun contains(element: Float): Boolean = this@asList.any { it.toBits() == element.toBits() }
         override fun get(index: Int): Float = this@asList[index]
-        override fun indexOf(element: Float): Int = this@asList.indexOf(element)
-        override fun lastIndexOf(element: Float): Int = this@asList.lastIndexOf(element)
+        override fun indexOf(element: Float): Int = this@asList.indexOfFirst { it.toBits() == element.toBits() }
+        override fun lastIndexOf(element: Float): Int = this@asList.indexOfLast { it.toBits() == element.toBits() }
     }
 }
 
@@ -194,10 +194,10 @@ public actual fun DoubleArray.asList(): List<Double> {
     return object : AbstractList<Double>(), RandomAccess {
         override val size: Int get() = this@asList.size
         override fun isEmpty(): Boolean = this@asList.isEmpty()
-        override fun contains(element: Double): Boolean = this@asList.contains(element)
+        override fun contains(element: Double): Boolean = this@asList.any { it.toBits() == element.toBits() }
         override fun get(index: Int): Double = this@asList[index]
-        override fun indexOf(element: Double): Int = this@asList.indexOf(element)
-        override fun lastIndexOf(element: Double): Int = this@asList.lastIndexOf(element)
+        override fun indexOf(element: Double): Int = this@asList.indexOfFirst { it.toBits() == element.toBits() }
+        override fun lastIndexOf(element: Double): Int = this@asList.indexOfLast { it.toBits() == element.toBits() }
     }
 }
 

--- a/runtime/src/main/kotlin/kotlin/Comparator.kt
+++ b/runtime/src/main/kotlin/kotlin/Comparator.kt
@@ -5,12 +5,6 @@
 
 package kotlin
 
-actual public interface Comparator<T> {
-    actual fun compare(a: T, b: T): Int
-}
-
-actual public inline fun <T> Comparator(crossinline comparison: (a: T, b: T) -> Int): Comparator<T> {
-    return object: Comparator<T> {
-        override fun compare(a: T, b: T) = comparison(a, b)
-    }
+public actual fun interface Comparator<T> {
+    public actual fun compare(a: T, b: T): Int
 }


### PR DESCRIPTION
* a493b21c7c4 - (tag: build-1.4.20-dev-971) JVM_IR: Deprecation cycle for companion object instance visibility (vor 3 Tagen) <Dmitry Petrov>
* 230f2f5ce03 - (CoroutineDebugger) fix for debugger agent for 1.3.6 version and up (vor 3 Tagen) <Vladimir Ilmov>
* c638043aeeb - (tag: build-1.4.20-dev-965) [Gradle, CocoaPods] Improved CocoaPods Integration features with tests (vor 3 Tagen) <Yaroslav Chernyshev>
* 130987fa1e2 - (tag: build-1.4.20-dev-964) Provide flatMapIndexed operation (vor 3 Tagen) <Ilya Gorbunov>
* db93462bcfe - Initial template for flatMapIndexed operation (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* d9fea52344f - Fix compilation of DukatCompilationResolverPlugin after rebase (vor 3 Tagen) <Sergey Igushkin>
* f7b660b5736 - (minor) Fixes for review KT-MR-1290 (vor 3 Tagen) <Sergey Igushkin>
* 10cae9bc5de - Fixes for task configuration avoidance in Gradle Kotlin/JS support (vor 3 Tagen) <Sergey Igushkin>
* 0b7d8c51cb0 - Move kotlinOptions out of the tasks (vor 3 Tagen) <Sergey Igushkin>
* 19ac036ec59 - Rework ScriptingGradleSubplugin for the new subplugins API (vor 3 Tagen) <Sergey Igushkin>
* cb5aa64a95a - Rework AndroidSubplugin for the new subplugins API (vor 3 Tagen) <Sergey Igushkin>
* 48153c53caa - Rework SamWithReceiverSubplugin for the new subplugins API (vor 3 Tagen) <Sergey Igushkin>
* 120f77416bb - (minor) Suppress a warning about property initialized with ctor param (vor 3 Tagen) <Sergey Igushkin>
* 66a59df7deb - Rework ExampleSubplugin for the new subplugins API (vor 3 Tagen) <Sergey Igushkin>
* a2e4b527473 - Rework SerializationSubplugin for the new subplugins API (vor 3 Tagen) <Sergey Igushkin>
* 98fc4ab2e1e - Rework NoArgSubplugin for the new subplugins API (vor 3 Tagen) <Sergey Igushkin>
* f2bc391bdd3 - Rework AllOpenSubplugin for the new subplugins API (vor 3 Tagen) <Sergey Igushkin>
* e8a303650ce - Rework Gradle subplugins application in Kotlin/Native (vor 3 Tagen) <Sergey Igushkin>
* 06a33763683 - Refactor the Kotlin Android plugin to make it compliant with TCA (vor 3 Tagen) <Sergey Igushkin>
* 4dbc6803ba6 - Refactor the kapt Gradle plugin to use the new plugins API and TCA (vor 3 Tagen) <Sergey Igushkin>
* 96ed30a4496 - Introduce new API for Kotlin compiler support Gradle plugins (vor 3 Tagen) <Sergey Igushkin>
* 0b2d96c1ef5 - Refactor Kotlin classes registration for java-library plugin (vor 3 Tagen) <Sergey Igushkin>
* 58dd0fa3d27 - Use TCA-compliant Gradle APIs in the JS part of the Kotlin Gradle plugin (vor 3 Tagen) <Sergey Igushkin>
* 58e9b3ae0e1 - Use TCA-compliant Gradle APIs in the Kotlin Gradle plugin (vor 3 Tagen) <Sergey Igushkin>
* 84287d77cae - Add Java tasks to relevant compilation APIs (vor 3 Tagen) <Sergey Igushkin>
* 1749cb9129f - (minor) Initialize compilations with the precise target type (vor 3 Tagen) <Sergey Igushkin>
* f4e4baa2530 - Add TaskProvider property for Kotlin compile tasks in compilations (vor 3 Tagen) <Sergey Igushkin>
* 1ebb1160560 - Revert "Invalidate library caches on OOCBM with enabled resolution anchors" (vor 3 Tagen) <Pavel Kirpichenkov>
* f1955c84aaf - FIR: Remove ignoreFrontendIR from GenerateInRangeExpressionTestData (vor 3 Tagen) <Denis Zharkov>
* 6e9efefd2ac - gradle scripts: fix isFirstLoadActual and notification typos (vor 3 Tagen) <Sergey Rostov>
* 9f4569e5a14 - (tag: build-1.4.20-dev-948) gradle scripts: custom notification wording gradle with default scripting support (gradle older then 6.0) (vor 3 Tagen) <Sergey Rostov>
* 37fbc750085 - gradle scripts: "link project" action implementation (vor 3 Tagen) <Sergey Rostov>
* d6fc830c243 - gradle scripts: temporary disable irrelevant actions when script configuration was not received during import (vor 3 Tagen) <Sergey Rostov>
* a7675c16d55 - [FIR] Fix problems with renaming `invocationKind` and field in FirAnonymousFunction (vor 3 Tagen) <Dmitriy Novozhilov>
* 9c8e9793080 - Fix compatibility resolve for references with multiple outer candidates (vor 3 Tagen) <Mikhail Zarechenskiy>
* 58183b774d2 - Fix test data (vor 3 Tagen) <Mikhail Bogdanov>
* 99d844dcfb2 - Deprecate kotlin.browser and kotlin.dom packages and provide (vor 3 Tagen) <Alexey Trilis>
* 16100843b2c - Add classpaths from all plugin classloaders to the console scripts (vor 3 Tagen) <Ilya Chernikov>
* b5ecab31f55 - Load script configuration under read action - avoid possible exception (vor 3 Tagen) <Ilya Chernikov>
* bd8eaad8851 - [FIR-TEST] Update cfg dumps in some tests (vor 3 Tagen) <Dmitriy Novozhilov>
* d01817ce141 - Rename `InvocationKind` to `EventOccurrencesRange` (vor 3 Tagen) <Dmitriy Novozhilov>
* 1dfccf1416d - [FIR] Rename edge kinds of control flow graph (vor 3 Tagen) <Dmitriy Novozhilov>
* f0cc3a32d9a - [FIR-TEST] Update testdata due to KT-39711 (vor 3 Tagen) <Dmitriy Novozhilov>
* 64c9a838626 - [FIR-TEST] Update testdata due to KT-39709 (vor 3 Tagen) <Dmitriy Novozhilov>
* a317c8a803b - [FIR-TEST] Update testdata due to unresolved KT-36056 (vor 3 Tagen) <Dmitriy Novozhilov>
* 26458875d5b - [FIR] Add checker for uninitialized properties (vor 3 Tagen) <Dmitriy Novozhilov>
* 25621d699bf - Add methods for combine InvocationKind's (vor 3 Tagen) <Dmitriy Novozhilov>
* 4078b4b6f94 - [FIR] Prepare ControlFlowAnalysisDiagnosticComponent (vor 3 Tagen) <Dmitriy Novozhilov>
* c9bc5884dd6 - [FIR] Add more utils for traversing control flow graph (vor 3 Tagen) <Dmitriy Novozhilov>
* faa0f07d098 - [FIR] Add utility flags to EdgeKind (vor 3 Tagen) <Dmitriy Novozhilov>
* 5ecbf8b7cd8 - [FIR] Add CFGNodeWithCfgOwner to detect subgraphs in CFA (vor 3 Tagen) <Dmitriy Novozhilov>
* 05ee436db0c - [FIR] Introduce FirControlFlowGraphOwner node (vor 3 Tagen) <Dmitriy Novozhilov>
* 8a81a09fd04 - [FIR] Assume that when without branches is not exhaustive. KT-39621 (vor 3 Tagen) <Dmitriy Novozhilov>
* 4e2e05e6896 - [FIR-TEST] Check control flow graph in old frontend diagnostic tests (vor 3 Tagen) <Dmitriy Novozhilov>
* 12ed8c3bb42 - [FIR-TEST] Update CFG dumps according to new nodes order (vor 3 Tagen) <Dmitriy Novozhilov>
* 4e6542a6465 - [FIR] Add Stub kind for CFG (vor 3 Tagen) <Dmitriy Novozhilov>
* 1a0df97961c - [FIR] Pop and complete graph only after adding last edge to it (vor 3 Tagen) <Dmitriy Novozhilov>
* 3765c5119fd - [FIR] Cache nodes in sorted order in CFG (vor 3 Tagen) <Dmitriy Novozhilov>
* b5cceb8995d - [FIR-TEST] Add validation of control flow graph nodes order (vor 3 Tagen) <Dmitriy Novozhilov>
* 2f8e95dace6 - [FIR-TEST] Add validation for completed graph in diagnostic tests (vor 3 Tagen) <Dmitriy Novozhilov>
* 9f55d4f3cda - [FIR-TEST] Mute test failing due to KT-39614 (vor 3 Tagen) <Dmitriy Novozhilov>
* 87859b0faa0 - [FIR] Introduce new algorithm for building CFG for declarations (vor 3 Tagen) <Dmitriy Novozhilov>
* 950bbfe3a5e - [FIR] Add kind for back edges in CFG (vor 3 Tagen) <Dmitriy Novozhilov>
* 34be9e35695 - [FIR] Add controlFlowGraph references to value parameters (vor 3 Tagen) <Dmitriy Novozhilov>
* 65fae3bb0c8 - [FIR] Fix problem with local classes in anonymous objects (vor 3 Tagen) <Dmitriy Novozhilov>
* 5b64c0cfe2b - [FIR] Add different states for CFG and some assertions for graph modification (vor 3 Tagen) <Dmitriy Novozhilov>
* 1261f62afb9 - [FIR] Extract CFGNode and it's inheritors to separate file (vor 3 Tagen) <Dmitriy Novozhilov>
* 3a4f53682f7 - [FIR] Don't convert non-local functions without name as FirAnonymousFunction (vor 3 Tagen) <Dmitriy Novozhilov>
* 44f6a5adcdc - Filter only valid roots in KotlinScriptDependenciesClassFinder (vor 3 Tagen) <Natalia Selezneva>
* d119298232a - Add registry key to hide new Load Script Configurations action (vor 3 Tagen) <Natalia Selezneva>
* b43014a097d - Do not start gradle import if it is already in progress (vor 3 Tagen) <Natalia Selezneva>
* 66e23c9767f - Floating notification shouldn't be shown during import (vor 3 Tagen) <Natalia Selezneva>
* 59183a8142e - (tag: build-1.4.20-dev-944) [Commonizer] Replace j.u.HashMap by g.t.THashMap to reduce memory usage (vor 3 Tagen) <Dmitriy Dolovov>
* 70ea53315d3 - [Commonizer] Intern duplicated CirContainingClassDetails instances (vor 3 Tagen) <Dmitriy Dolovov>
* 63d549dfa15 - [Commonizer] Intern duplicated CirFunctionModifiers instances (vor 3 Tagen) <Dmitriy Dolovov>
* 68e1acd2cb1 - [Commonizer] More detailed progress logging (vor 3 Tagen) <Dmitriy Dolovov>
* 6410aed1b4a - Minor. Replace computeIfAbsent() by getOrPut() (vor 3 Tagen) <Dmitriy Dolovov>
* 6393667ddad - [Commonizer] Rework preparation of CIR cache in TypeCommonizerTest (vor 3 Tagen) <Dmitriy Dolovov>
* 5cad8a793cd - [Commonizer] Rework CommonizedGroup API to make it more usable (vor 3 Tagen) <Dmitriy Dolovov>
* 63575582c47 - [Commonizer] Reduce memory consumption during approximation phase (vor 3 Tagen) <Dmitriy Dolovov>
* d5ffc7416dd - (tag: build-1.4.20-dev-942) Clean-up and improve sam-with-receiver test with scripts (vor 3 Tagen) <Ilya Chernikov>
* 0ade8140f76 - Add serialization plugin test with main-kts (vor 3 Tagen) <Ilya Chernikov>
* dbb47cf48e9 - Implement non-transitive dependencies resolving in main-kts (vor 3 Tagen) <Ilya Chernikov>
* cd1bf563cd3 - Add error reporting on the options parsing errors in scripting (vor 3 Tagen) <Ilya Chernikov>
* f0bc52222da - Fix annotation construction with array literals (vor 3 Tagen) <Mathias Quintero>
* 8cb4f591149 - Explicitly handle array annotation args in scripting pre-processing (vor 3 Tagen) <Efeturi Money>
* 743abea6901 - (tag: build-1.4.20-dev-935) Don't create default importing scopes for REPL snippets (vor 3 Tagen) <Ilya Muradyan>
* c3cbfe34c4f - Allow not to create default importing scopes (vor 3 Tagen) <Ilya Muradyan>
* 53b31a20ca8 - Refactor REPL IDE services testing configuration and add new tests (vor 3 Tagen) <Ilya Muradyan>
* 94de114894a - Support selective filtering of implicits for extensions resolution in REPL (vor 3 Tagen) <Ilya Muradyan>
* 017f640f26e - Allow skipping extensions resolution for implicit receivers (vor 3 Tagen) <Ilya Muradyan>
* e93bcc55ae1 - (tag: build-1.4.20-dev-933) Revert "Deprecate DefaultImpl methods in compatibility mode" (vor 3 Tagen) <Mikhail Bogdanov>
* 8bc4407be0d - Fix compilation (vor 3 Tagen) <Mikhail Bogdanov>
* 6c9c2a287df - Deprecate DefaultImpl methods in compatibility mode (vor 3 Tagen) <Mikhail Bogdanov>
* 9c0b96af710 - (tag: build-1.4.20-dev-928) Report error on missed specialization in compatibility mode (vor 3 Tagen) <Mikhail Bogdanov>
* a150e7b6e5b - Don't forget about extension parameter in `methodSignatureMapping.kt` (vor 3 Tagen) <Mikhail Bogdanov>
* 929bb0e8d19 - Move common logic from CodegenTestCase to KotlinBaseTest (vor 3 Tagen) <Mikhail Bogdanov>
* 9d48ecfac33 - Make proper check for defaults on delegation to DefaultImpls (vor 3 Tagen) <Mikhail Bogdanov>
* b8f0ad2111e - Generate nullability annotations on this receiver in DefaultImpls. Don't generate nullability annotations in private methods (vor 3 Tagen) <Mikhail Bogdanov>
* 5bdf3d57573 - Don't generate compatibility stubs for @JvmDefaultWithoutCompatibility (vor 3 Tagen) <Mikhail Bogdanov>
* 477cca3c99c - Add JvmDefaultWithoutCompatibility annotation (vor 3 Tagen) <Mikhail Bogdanov>
* a98ad79d86a - (tag: build-1.4.20-dev-924) [FIR-TEST] Add option to run modularized tests with checkers (vor 3 Tagen) <Dmitriy Novozhilov>
* 7a8908a75b8 - [FIR-TEST] Change main module of `[JPS] Fast FIR tests` task (vor 3 Tagen) <Dmitriy Novozhilov>
* a0cccdf75c0 - [JS IR] Make backend work with new shared boxes (vor 3 Tagen) <Roman Artemev>
* 596c3d1af8b - [JS IR] Implement shared box intrinsics translator (vor 3 Tagen) <Roman Artemev>
* 4c878c27a93 - [JS IR] Introduce intrinsics to create shared boxes (vor 3 Tagen) <Roman Artemev>
* 5b48845dfa8 - (tag: build-1.4.20-dev-923) Check for native-shared source-sets properly during facet import (vor 3 Tagen) <Dmitry Savvinov>
* ce553f12117 - (tag: build-1.4.20-dev-920) [Gradle, JS] Add webpackConfig for karma (vor 3 Tagen) <Ilya Goncharov>
* 48a4e08d60a - [Gradle, JS] Disable css support by default (vor 3 Tagen) <Ilya Goncharov>
* efee0dae947 - (tag: build-1.4.20-dev-912) FIR: Simplify JvmBinaryAnnotationDeserializer (vor 3 Tagen) <Denis Zharkov>
* 0bc26426342 - FIR: Add clarification to the workaround for KT-39659 (vor 3 Tagen) <Denis Zharkov>
* 429b2a9705c - FIR: Optimize deserialized annotations loading (vor 3 Tagen) <Denis Zharkov>
* 260e2d0dc39 - FIR: Add dependency for :core:descriptors.runtime to modularized tests (vor 3 Tagen) <Denis Zharkov>
* 6a28558d43c - FIR deserializer: rename a callable kind that represents all "others" (vor 3 Tagen) <Jinseong Jeon>
* 12181e55c03 - FIR deserializer: signature-aware annotation loading for constructors (vor 3 Tagen) <Jinseong Jeon>
* 955c7a1e5b5 - FIR2IR: handle deserialized class reference inside GetClassCall (vor 3 Tagen) <Jinseong Jeon>
* 781bfa20e86 - FIR deserializer: fix conversion of class literal inside annotation array value. (vor 3 Tagen) <Jinseong Jeon>
* b076bec07f5 - FIR deserializer: signature-aware annotation loading for functions (vor 3 Tagen) <Jinseong Jeon>
* 11a680d7d8d - (tag: build-1.4.20-dev-907) Wizard: group project templates into the categories on the first step (vor 3 Tagen) <Ilya Kirillov>
* bfedeed2c1d - Wizard: use new icons in UI (vor 3 Tagen) <Ilya Kirillov>
* 7df0dd50324 - Wizard: fix ui constants (vor 3 Tagen) <Ilya Kirillov>
* 6e5b94f695b - (tag: build-1.4.20-dev-903) Update js public api dump (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* c923b2e1392 - Deprecate contains, indexOf, lastIndexOf functions of Float/DoubleArray #KT-28753 (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* 97c688057da - Compare floating point values asList elements in total order #KT-28753 (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* ba5e643cb21 - (tag: build-1.4.20-dev-902) Redundant qualifier name: fix false positive with same name variable (vor 3 Tagen) <Toshiaki Kameyama>
* bf26d87ee98 - (tag: build-1.4.20-dev-900) Update js public api dump (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* 16b62b8e651 - Introduce minWithOrNull and maxWithOrNull extension functions #KT-38854 (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* 194791a1689 - Introduce minByOrNull and maxByOrNull extension functions #KT-38854 (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* 846a7823ad5 - Introduce minOrNull and maxOrNull extension functions #KT-39064 (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* a8cd8ad8f88 - (tag: build-1.4.20-dev-895) [FIR] Fix testData after changing anonymous object name (vor 4 Tagen) <simon.ogorodnik>
* b100fd526fb - (tag: build-1.4.20-dev-893) (CoroutineDebugger)(Test) local variable removed from generated code (vor 4 Tagen) <Vladimir Ilmov>
* 5724c47bcf5 - (tag: build-1.4.20-dev-889) Build: Fix uri parsing on windows in publication repo configuration (vor 4 Tagen) <Vyacheslav Gerasimov>
* 542f1b8709c - (tag: build-1.4.20-dev-865) Minor. Update tests (vor 4 Tagen) <Ilmir Usmanov>
* 932cf21776c - [Gradle, JS] Allow to change destDir only for separate task and name it destinationDir (vor 4 Tagen) <Ilya Goncharov>
* 7386408e94d - [Gradle, JS] AbstractDukatTask -> DukatTask (vor 4 Tagen) <Ilya Goncharov>
* 49dd8391314 - [Gradle, JS] DukatTask -> IntegratedDukatTask (vor 4 Tagen) <Ilya Goncharov>
* 46be588f278 - [Gradle, JS] Add task for separate usage of Dukat with project npm dependencies (vor 4 Tagen) <Ilya Goncharov>
* 606fad64ad6 - Leave StringBuilder.append/insert with non-nullable String parameter (vor 4 Tagen) <Ilya Gorbunov>
* 91b371789e2 - (tag: build-1.4.20-dev-861) Invalidate library caches on OOCBM with enabled resolution anchors (vor 4 Tagen) <Pavel Kirpichenkov>
* 204871a7aba - (tag: build-1.4.20-dev-859) Update bootstrap to 1.4.20-dev-772 (vor 4 Tagen) <Alexander Udalov>
* 754a74ac4ae - (tag: build-1.4.20-dev-854) [Gradle, native] Allow parallel in-process compiler execution (vor 4 Tagen) <Ilya Matveev>
* 03bb9138ade - [klib] Create ZipFileSystem from a Path instead of an URI (vor 4 Tagen) <Ilya Matveev>
* bf1ad44af95 - (tag: build-1.4.20-dev-853) Run partial import only for specified build root (vor 4 Tagen) <Natalia Selezneva>
* 5fe47ffbecb - Workaround for bug in GradleInstallationManager.resolveGradleVersion() (vor 4 Tagen) <Natalia Selezneva>
* 7a47994498f - Get gradle version and gradle home from corresponding BuildModel after import (vor 4 Tagen) <Natalia Selezneva>
* ece61915de2 - (tag: build-1.4.20-dev-852, origin/rrup/KT-2324) NI: clean calls in coroutine inference before the second analysis of `+=` only for right side (vor 4 Tagen) <Victor Petukhov>
* 1f66049a1e3 - (tag: build-1.4.20-dev-849) Build: Fix plugin marker publication to a remote repository (vor 4 Tagen) <Vyacheslav Gerasimov>
* 2fd657b7681 - (tag: build-1.4.20-dev-845) [box-tests] Fixed test for K/N (vor 4 Tagen) <Igor Chevdar>
* 8b5f2f94748 - (tag: build-1.4.20-dev-843) Fix duplicate stepping filter adding on plugin start-up (KT-38628) (vor 4 Tagen) <Yan Zhulanow>
* 235b9b9269f - Add kotlin-stdlib-js and kotlin-test-js to IDE artifact dependencies (vor 4 Tagen) <Yan Zhulanow>
* 470fef94fba - (tag: build-1.4.20-dev-826) Use bound resolution facade in DeprecationResolver usages (vor 4 Tagen) <Pavel Kirpichenkov>
* 82ef6bf96cf - FIR2IR: honor user-contributed members in data class if any (vor 4 Tagen) <Jinseong Jeon>
* b839a910500 - (tag: build-1.4.20-dev-821) Mute 3 FIR BB tests due to LowPriorityInOverloadResolution in reflect (vor 4 Tagen) <Mikhail Glukhikh>
* d009c90e3a7 - Revert "Mute two FIR BB tests due to LowPriorityInOverloadResolution in reflect" (vor 4 Tagen) <Mikhail Glukhikh>
* 3768af4f92d - (tag: build-1.4.20-dev-818) Mute two FIR BB tests due to LowPriorityInOverloadResolution in reflect (vor 4 Tagen) <Mikhail Glukhikh>
* d44a7ff8f9b - (tag: build-1.4.20-dev-815) Add test for obsolete issue (vor 4 Tagen) <Mikhail Zarechenskiy>
* 559561ca6bd - Add missing intellij-core dependency for sam-with-receiver tests (vor 4 Tagen) <Yan Zhulanow>
* 713a305f45e - Update change data for IrTextTestCaseGenerated (vor 4 Tagen) <Yan Zhulanow>
* ec5a04a6c7d - (tag: build-1.4.20-dev-813) Update public jvm API dump after introduction of javaType (vor 4 Tagen) <Ilya Gorbunov>
* a067d138e9e - Enable test for new inference after df1595e4 (vor 4 Tagen) <Mikhail Zarechenskiy>
* df1595e4bcf - (tag: build-1.4.20-dev-812) Fix SAM conversions for derived classes (vor 4 Tagen) <Mikhail Zarechenskiy>
* ee6d432cedd - (tag: build-1.4.20-dev-809) Add forgotten test files (vor 4 Tagen) <Georgy Bronnikov>
* cf6eb138cef - (tag: build-1.4.20-dev-800, origin/abannykh/ic-1-s) [box-tests] Turned on a test for JS_IR (vor 4 Tagen) <Igor Chevdar>
* 2bf73ccfe5a - [IR] Supported extension receivers in SAM conversions (vor 4 Tagen) <Igor Chevdar>
* 8c2baf0704a - (tag: build-1.4.20-dev-798) Add missing definitelyDoesNotContainName methods (vor 4 Tagen) <Ilya Muradyan>
* 573c60ed6b9 - Add missing recordLookup implementations (vor 4 Tagen) <Ilya Muradyan>
* 7526ff94844 - Compare lookups without respect to their order (vor 4 Tagen) <Ilya Muradyan>
* 3634ad2d54f - (tag: build-1.4.20-dev-797) Added a test (vor 4 Tagen) <Igor Chevdar>
* ecf97275681 - [IR] Supported IrEnumEntry (vor 4 Tagen) <Igor Chevdar>
* e13a38a7582 - (tag: build-1.4.20-dev-793) Fix OnlyInputType usage in tests where it can be invisible (vor 4 Tagen) <Ilya Gorbunov>
* 9e9ca4953f4 - (tag: build-1.4.20-dev-791) FIR2IR: coerce to Unit when "when" expr is not effectively exhaustive (vor 4 Tagen) <Jinseong Jeon>
* 62dcfcde790 - (tag: build-1.4.20-dev-782) (CoroutineDebugger) -core jar has precedence over -debug (vor 5 Tagen) <Vladimir Ilmov>
* 4739adb6dcf - (tag: build-1.4.20-dev-780) KT-36992 Do not generate annotations on synthetic accessors (vor 5 Tagen) <Dmitry Petrov>
* 03651f1dd46 - (tag: build-1.4.20-dev-774) IR: Fix inner class type parameters in IrTypeSystemContext (vor 5 Tagen) <Steven Schäfer>
* 650469024e7 - (tag: build-1.4.20-dev-772) Fix expected FQ name in JavaTypeTest.nestedTypes (vor 5 Tagen) <Alexander Udalov>
* 2be94d9d2f3 - Fix compilation of stdlib when JDK_16 points to JDK 8+ (vor 5 Tagen) <Alexander Udalov>
* c0154639263 - (tag: build-1.4.20-dev-769) IR: remove field fake overrides (vor 5 Tagen) <Georgy Bronnikov>
* 1bb3f60bad8 - IR: use super qualifier in Java field accesses (vor 5 Tagen) <Georgy Bronnikov>
* 36f22dafc5c - IR: remove field fake override usage (vor 5 Tagen) <Georgy Bronnikov>
* 41131e46d76 - (tag: build-1.4.20-dev-766) Shadow addSuppressed member with an extension (vor 5 Tagen) <Ilya Gorbunov>
* 95625d0fae7 - Do not place copyrights in stdlib api dump .kt files (vor 5 Tagen) <Ilya Gorbunov>
* 2fe222e8e7d - Add SKIP_DCE_DRIVEN directive in JS-IR tests (vor 5 Tagen) <Ilya Gorbunov>
* de6154980d3 - Make ReadOnlyProperty and PropertyDelegateProvider fun interfaces (vor 5 Tagen) <Ilya Gorbunov>
* d2ea108123d - Make Comparator fun interface in Common and JS (vor 5 Tagen) <Ilya Gorbunov>
* 388e619d903 - (tag: build-1.4.20-dev-761) Increase memory for Kotlin compile daemon to 2200M (vor 5 Tagen) <Ilya Gorbunov>
* f3a2ff86464 - Advance bootstrap to 1.4.20-dev-710 (vor 5 Tagen) <Ilya Gorbunov>
* 117aae8a6b5 - Use experimental javaType in full reflect where it's not supported yet (vor 5 Tagen) <Alexander Udalov>
* 9e37b62f62e - Support KType.javaType in stdlib (vor 5 Tagen) <Alexander Udalov>
* 55595fe2c6b - (tag: build-1.4.20-dev-751) Make sure that commonizer is enabled before adding -no-default-libs argument (vor 5 Tagen) <Dmitry Savvinov>
* db127bb414b - (tag: build-1.4.20-dev-743) (CoroutineDebugger) fails to start in gradle mode (vor 5 Tagen) <Vladimir Ilmov>
* 3d86e92bf58 - (tag: build-1.4.20-dev-727) gradle.kts standalone scripts: show actions inside single notification (vor 5 Tagen) <Sergey Rostov>
* 64b1cc7fd47 - gradle.kts legacy: out of project script notification (vor 5 Tagen) <Sergey Rostov>
* cc95c16ac24 - minor: rename GradleScriptNotificationProvider (vor 5 Tagen) <Sergey Rostov>
* bc16fbf4385 - gradle.kts: check gradle version before loading from fs cache (vor 5 Tagen) <Sergey Rostov>
* 7d31d7f20c9 - default scripting support: remove notifications after script definitions update (vor 5 Tagen) <Sergey Rostov>
* b9fda902fb6 - gradle.kts: update notification only after caches updated (vor 5 Tagen) <Sergey Rostov>
* ce201960069 - GradleScriptConfigurationsImportingFeature (vor 5 Tagen) <Sergey Rostov>
* 631e68c99a8 - gradle.kts  postponed loading: hide notifaction right after click on action (vor 5 Tagen) <Sergey Rostov>
* ace7ae19b43 - gradle.kts standalone scripts: load configuration after switching without prompt (vor 5 Tagen) <Sergey Rostov>
* 07654b4c0ee - gradle.kts, minor: cleanup & simplify code (vor 5 Tagen) <Sergey Rostov>
* b2e629dceb2 - gradle.kts legacy: don't start loading without prompt on first opening (vor 5 Tagen) <Sergey Rostov>
* 02346788044 - gradle.kts: update notifications when scripting support was changed (vor 5 Tagen) <Sergey Rostov>
* caa5aadc981 - GradleBuildRootsManager: check gradle version change in gradle-wrapper.properties (vor 5 Tagen) <Sergey Rostov>
* 463908f6f4e - scriptConfigurationsNeedToBeUpdatedBalloon registry key (vor 5 Tagen) <Sergey Rostov>
* cc67ac631f2 - GradleBuildRootsManager: update notifications in corner cases (vor 5 Tagen) <Sergey Rostov>
* a150014e74a - GradleBuildRootsManager: implement getScriptFirstSeenTs (vor 5 Tagen) <Sergey Rostov>
* b543588ccd0 - GradleScriptNotifications: suggest to import and link gradle project (vor 5 Tagen) <Sergey Rostov>
* 9096d21fcd0 - GradleScriptNotifications: extract and fix i18n strings (vor 5 Tagen) <Sergey Rostov>
* 632e88459ec - GradleBuildRootsManager: fix for autoload (vor 5 Tagen) <Sergey Rostov>
* de7d82e42b6 - GradleScriptNotifications: typo in code (vor 5 Tagen) <Sergey Rostov>
* 6f0bd6c122c - GradleBuildRoot: ability to detect if file was existed before import (vor 5 Tagen) <Sergey Rostov>
* 7384c89dddc - GradleBuildRootsManager, minor: fix notifications (vor 5 Tagen) <Sergey Rostov>
* fd9b14ed29e - GradleBuildRoot: require LastModifiedFiles explicitly (vor 5 Tagen) <Sergey Rostov>
* 2ed68643cb4 - GradleBuildRoot: remove classes nesting (vor 5 Tagen) <Sergey Rostov>
* d8892ced9d2 - gradle.kts: standalone scripts support (without ui and persistence) (vor 5 Tagen) <Sergey Rostov>
* 5ed7abd15db - scripting: drop ManualConfigurationLoading and kotlin.gradle.scripts.useIdeaProjectImport registry flag (vor 5 Tagen) <Sergey Rostov>
* 69dc963f97d - LastModifiedFiles: fix concurrency (vor 5 Tagen) <Sergey Rostov>
* 19cc9c81dc0 - GradleBuildRoot: std scripts under project roots should be treated as new (vor 5 Tagen) <Sergey Rostov>
* 7b1b50499de - GradleBuildRoot: add projects from settings (vor 5 Tagen) <Sergey Rostov>
* a3750b64196 - GradleBuildRoot: extract GradleBuildRootsLocator for testing (vor 5 Tagen) <Sergey Rostov>
* c0f4ee7dc92 - (tag: build-1.4.20-dev-726, origin/rrni/revert_recursion_problematic_commit) Revert "Add missing definitelyDoesNotContainName methods" (vor 5 Tagen) <Victor Petukhov>
* 447308dcfca - (tag: build-1.4.20-dev-721) Revert "Revert "Revert "Completely rewrite reifiedIntTypeAnalysis, making it more streamline""" (vor 5 Tagen) <Victor Petukhov>
* 1cccceabb98 - Revert "Fix merging two reference values" (vor 5 Tagen) <Ilmir Usmanov>
* d9821412d07 - Do not generate fields for unused suspend lambda parameters (vor 5 Tagen) <Ilmir Usmanov>
* a292eb865be - (tag: build-1.4.20-dev-713) Add script definition for extension scripts and... (vor 5 Tagen) <Ilya Chernikov>
* 1329030281c - (tag: build-1.4.20-dev-711) IDE perf tests for K/N: Re-enable PerformanceNativeProjectsTest (vor 5 Tagen) <Dmitriy Dolovov>
* 10e5dc1f639 - IDE perf tests for K/N: Add assertion on failed Gradle project import (vor 5 Tagen) <Dmitriy Dolovov>
* d9e5407ecb2 - IDE perf tests for K/N: Switch to 1.4-M2 (vor 5 Tagen) <Dmitriy Dolovov>
* 439808952db - (tag: build-1.4.20-dev-710) [Commonizer] Fix incorrect merging KLIB dependencies (vor 5 Tagen) <Dmitriy Dolovov>
* 901b794af36 - (tag: build-1.4.20-dev-697) Use lexical scope from trace during checking suspend context if the analysis of engaged parent function isn't completed (vor 6 Tagen) <Victor Petukhov>
* 02f6a03ff77 - (tag: build-1.4.20-dev-695) JVM_IR: fix nullability annotations on synthetic marker parameters (vor 6 Tagen) <Dmitry Petrov>
* 2656eeb1641 - (tag: build-1.4.20-dev-693) NI: Optimize some potential hot places (vor 6 Tagen) <Ilya Chernikov>
* d385a9b29e8 - (tag: build-1.4.20-dev-687) Add more detailed exception message in KtExpression.isUsedAsExpression (vor 6 Tagen) <Mikhail Glukhikh>
* f64f9c2144b - FIR: inherit property accessor modifiers from property and vice versa (vor 6 Tagen) <Jinseong Jeon>
* 6f957c7b317 - Provide more accurate clash check in JsDeclarationTable (vor 6 Tagen) <Mikhail Glukhikh>
* aaacbaaaecf - Add KDoc to ObsoleteDescriptorBasedAPI (vor 6 Tagen) <Mikhail Glukhikh>
* a035404c96e - Mark IrSymbolBase/IrPublicSymbolBase.descriptor as obsolete API (vor 6 Tagen) <Mikhail Glukhikh>
* 3297237f3d2 - Drop ObsoleteDescriptorBasedAPI in ClassGenerator (module-wide) (vor 6 Tagen) <Mikhail Glukhikh>
* 175e94c0aaf - Revert kotlinx-serialization-compiler-plugin OptIn dependency (vor 6 Tagen) <Mikhail Glukhikh>
* fe615303571 - Declare IrGeneratorContext.builtIns as obsolete descriptor-based API (vor 6 Tagen) <Mikhail Glukhikh>
* ab5cb13daed - Rename: DescriptorBasedIr -> ObsoleteDescriptorBasedAPI (vor 6 Tagen) <Mikhail Glukhikh>
* cbbb497edf0 - Make descriptor-based API in ir:tree more granular (vor 6 Tagen) <Mikhail Glukhikh>
* c4b24548cb1 - IrValidator: report errors without rendering descriptors (vor 6 Tagen) <Mikhail Glukhikh>
* 293df7bd500 - [IR BE common] Use Descriptor-based IR only in CheckIrElementVisitor (vor 6 Tagen) <Mikhail Glukhikh>
* 63394858ac5 - Minor typo fix (vor 6 Tagen) <Mikhail Glukhikh>
* e787dbf374c - [IR.serialization.jvm] Use Descriptor-based IR in JvmIrLinker only (vor 6 Tagen) <Mikhail Glukhikh>
* 1c2fbb61fe9 - [IR] Introduce & use declaration-based SymbolTable.withReferenceScope (vor 6 Tagen) <Mikhail Glukhikh>
* 7a0f986823b - [IR] Introduce & use DescriptorBasedIr OptIn (vor 6 Tagen) <Mikhail Glukhikh>
* 67158caf730 - FunctionGenerator: use owner instead of descriptor (vor 6 Tagen) <Mikhail Glukhikh>
* 41306d25fde - JsDeclarationTable: drop descriptors in assertion (vor 6 Tagen) <Mikhail Glukhikh>
* 8e8710efecc - (tag: build-1.4.20-dev-682) Minor: replace println() with logger (vor 6 Tagen) <Nikolay Krasko>
* 982cbf11481 - (tag: build-1.4.20-dev-680) NI: clear calls info in coroutine inference before the second analysis of `+=` right side (vor 6 Tagen) <Victor Petukhov>
* d3d3b41dea2 - (tag: build-1.4.20-dev-679) Disable all verification tasks if special option is passed (vor 6 Tagen) <Nikolay Krasko>
* 74c697af926 - (tag: build-1.4.20-dev-678) Fix SamWithReceiver tests for scripts, add tests... (vor 6 Tagen) <Ilya Chernikov>
* 8fb41e45622 - Process compiler plugins and options in scripting compiler (vor 6 Tagen) <Ilya Chernikov>
* a72eeb800d0 - [minor] Add serialization plugin to kotlin paths (vor 6 Tagen) <Ilya Chernikov>
* 060b2eaf271 - (tag: build-1.4.20-dev-672) Increase warm-up, test iterations in PerformanceTypingIndentationTest (vor 6 Tagen) <Dmitry Gridin>
* ca15c33a62a - (tag: build-1.4.20-dev-667) [FIR] Make light tree consistent with raw FIR for empty init case (vor 6 Tagen) <Mikhail Glukhikh>
* 9db9e2ad57b - (tag: build-1.4.20-dev-665) Fix build error messages (vor 6 Tagen) <Ilya Muradyan>
* 71f53d49caf - (tag: build-1.4.20-dev-661) Revert: Bootstrap: 1.4.20-dev-498 (vor 6 Tagen) <Yunir Salimzyanov>
* d9b4e24b292 - (tag: build-1.4.20-dev-659) Exclude JS API dumps from FIR consistency tests (vor 6 Tagen) <Mikhail Glukhikh>
* 7b897170924 - (tag: build-1.4.20-dev-654) [Gradle, JS] Add task requirements only after evaluated (vor 6 Tagen) <Ilya Goncharov>
* aaf3410708f - [Gradle, JS] Break Task Configuration Avoidance to get all required NPM dependencies (vor 6 Tagen) <Ilya Goncharov>
* 48ec104a341 - [Gradle, JS] Store npm dependencies by compilation (vor 6 Tagen) <Ilya Goncharov>
* 4080bd1325a - [Gradle, JS] Move tranform from requiredNpmDependencies to TasksRequirements (vor 6 Tagen) <Ilya Goncharov>
* 8f156f3609c - [Gradle, JS] Extract TasksRequirements.kt (vor 6 Tagen) <Ilya Goncharov>
* e51874d46a7 - [Gradle, JS] Use set in task requirements (vor 6 Tagen) <Ilya Goncharov>
* 464c8eb77a9 - [Gradle, JS] Add kotlin-js-test-runner to dependencies by default (vor 6 Tagen) <Ilya Goncharov>
* 4a525963446 - [Gradle, JS] Remove devServer from common part of legacy (vor 6 Tagen) <Ilya Goncharov>
* 1f5012684b3 - [Gradle, JS] Force full configuring of NPM tasks in idea import (vor 6 Tagen) <Ilya Goncharov>
* aab4fd72258 - [Gradle, JS] Use unique representation for npm dependency (vor 6 Tagen) <Ilya Goncharov>
* 92c224b616b - [Gradle, JS] Fix NpmDependency toString (vor 6 Tagen) <Ilya Goncharov>
* 1a81f023770 - [Gradle, JS] Add tools npm dependencies as input to package json task (vor 6 Tagen) <Ilya Goncharov>
* d0c0ddd7e59 - [Gradle, JS] Move initialization of RequiresNpmDepends in project resolver (vor 6 Tagen) <Ilya Goncharov>
* 3283a10561d - [Gradle, JS] Define compilation on constructor of RequiresNpmDepends (vor 6 Tagen) <Ilya Goncharov>
* db42b5b0626 - [Gradle, JS] Get npm dependencies in compilation npm resolver (vor 6 Tagen) <Ilya Goncharov>
* 49710c9509a - [Gradle, JS] Remove task oriented taskRequirements (vor 6 Tagen) <Ilya Goncharov>
* 8f679bf1d38 - [Gradle, JS] Tools npm dependencies resolved in task execution (vor 6 Tagen) <Ilya Goncharov>
* 1ab6a9bc84d - [Gradle, JS] No NPM tools configuration (vor 6 Tagen) <Ilya Goncharov>
* 34aff5953f1 - [Gradle, JS] TaskRequirements inside NodeJsRootExtension (vor 6 Tagen) <Ilya Goncharov>
* 791dfb78ab4 - [Gradle, JS] Dukat only for main compilation (vor 6 Tagen) <Ilya Goncharov>
* 99e05b777a9 - [Gradle, JS] PackageJsonDukatExecutor -> DukatExecutor (vor 6 Tagen) <Ilya Goncharov>
* 10c501d4749 - [Gradle, JS] DukatExecutor -> DukatRunner (vor 6 Tagen) <Ilya Goncharov>
* f5db4b12ba2 - [Gradle, JS] Rename of DukatTaskss (vor 6 Tagen) <Ilya Goncharov>
* cf65b1f87a4 - [Gradle, JS] Rename on AbstractDukatTask (vor 6 Tagen) <Ilya Goncharov>
* 9f45ef8df50 - [Gradle, JS] Rename DEFAULT_GENERATE_EXTERNALS (vor 6 Tagen) <Ilya Goncharov>
* 0f47a38042b - [Gradle, JS] Enable Dukat by default with false generateExternals (vor 6 Tagen) <Ilya Goncharov>
* f285a31a5a1 - [Gradle, JS] Make default generate kotlin externals as false (vor 6 Tagen) <Ilya Goncharov>
* 2ca0e37be7b - [Gradle, JS] Use default generate externals from property (vor 6 Tagen) <Ilya Goncharov>
* eb6e797001e - [Gradle, JS] In npm dependency extension use default generate value from properties (vor 6 Tagen) <Ilya Goncharov>
* 6316949e36c - [Gradle, JS] Rename generateKotlinExternals on generateExternals (vor 6 Tagen) <Ilya Goncharov>
* 85840578ad3 - (tag: build-1.4.20-dev-652) Increase warm-up, test iterations in PerformanceTypingIndentationTest (vor 6 Tagen) <Dmitry Gridin>
* af1dd6251ee - (tag: build-1.4.20-dev-649, origin/rr/ddol/commonizer-lift-up-declarations) [Commonizer] Fallback for const val properties with different values (vor 6 Tagen) <Dmitriy Dolovov>
* ee455abe52e - (tag: build-1.4.20-dev-646) Bootstrap: 1.4.20-dev-498 (vor 6 Tagen) <Yunir Salimzyanov>
* 3766dbff69d - (tag: build-1.4.20-dev-644) Revert "Bootstrap: 1.4.20-dev-498" (vor 6 Tagen) <Yunir Salimzyanov>
* 846fc135190 - (tag: build-1.4.20-dev-642) JVM IR: Fix inline class constructor ABI (KT-37013, KT-37015) (vor 6 Tagen) <Steven Schäfer>
* b93c49afae0 - (tag: build-1.4.20-dev-639) Promote ArrayDeque and MutableList.removeFirst/LastOrNull to stable (vor 7 Tagen) <Abduqodiri Qurbonzoda>
* 99c55857900 - (tag: build-1.4.20-dev-636) Allow dynamic types in ir fake override substitution arguments (vor 7 Tagen) <Alexander Gorshenev>
* 1a7b30c13a8 - (tag: build-1.4.20-dev-627) [FIR] Fix incorrect name in anonymous object class id (vor 7 Tagen) <simon.ogorodnik>
* 2f89ba9499d - [FIR] Fix incorrect referential equals on Name instance (vor 7 Tagen) <simon.ogorodnik>
* cb8addc4cd7 - (tag: build-1.4.20-dev-624) 202: Fix NPE in BaseKotlinJpsBuildTestCase.tearDown() (vor 7 Tagen) <Nikita Bobko>
* 9cac2e19456 - Minor: fix splitting the line (vor 7 Tagen) <Nikolay Krasko>
* 1b47d538aec - (tag: build-1.4.20-dev-616) Flaky test fix: MultiFileHighlightingTestGenerated (vor 7 Tagen) <Andrei Klunnyi>
* 51d74d78c68 - (tag: build-1.4.20-dev-603) Bootstrap: 1.4.20-dev-498 (vor 7 Tagen) <Yunir Salimzyanov>
* d5ae06e7ed5 - (tag: build-1.4.20-dev-600) Add run configuration for stdlib-js ApiTest (vor 7 Tagen) <Ilya Gorbunov>
* 05f9154bdda - Use fixed versions of node.js and npm packages in tests (vor 7 Tagen) <Ilya Gorbunov>
* d7df249480b - (tag: build-1.4.20-dev-599) Convert contributed descriptors to list... (vor 7 Tagen) <Ilya Chernikov>
* a6feae0fbbe - (tag: build-1.4.20-dev-597) Add test for KMM Wizard (vor 7 Tagen) <Kirill Shmakov>
* a22fb2c1bab - Mention downstream usage of new wizard backend (vor 7 Tagen) <Kirill Shmakov>
* fe4bb24a3ed - (tag: build-1.4.20-dev-596) Don't use labels for caching (vor 7 Tagen) <Mikhail Bogdanov>
* db50afeafee - Fix compilation with ASM 8 (vor 7 Tagen) <Mikhail Bogdanov>
* 1186d1affd0 - (tag: build-1.4.20-dev-594) [FIR-TEST] Count all `ConeKotlinErrorType` as error types (vor 7 Tagen) <Dmitriy Novozhilov>
* d7ee168dffb - [FIR] Create error candidate for completion instead of simple error reference (vor 7 Tagen) <Dmitriy Novozhilov>
* 7c57c4a2fb6 - [FIR] Add FirErrorProperty node (vor 7 Tagen) <Dmitriy Novozhilov>
* 535534cf66d - (tag: build-1.4.20-dev-587) Allow shadowing member addSuppressed with extension (vor 7 Tagen) <Ilya Gorbunov>
* f0ff8f202cd - (tag: build-1.4.20-dev-582) [JVM IR] Use JVM8 support for unsigned int operations (vor 7 Tagen) <Kristoffer Andersen>
* c95216dc5de - (tag: build-1.4.20-dev-573) KotlinLikeLangLineIndentProvider: cleanup code (vor 7 Tagen) <Dmitry Gridin>
* 01707800c16 - KotlinLikeLangLineIndentProvider: improve indent for braces (vor 7 Tagen) <Dmitry Gridin>
* 9d6ea3c0734 - KotlinLikeLangLineIndentProvider: fix options for parentheses (vor 7 Tagen) <Dmitry Gridin>
* 306abc79ed3 - LineIndentProvider: support empty brackets (vor 7 Tagen) <Dmitry Gridin>
* d69ce74ca50 - KotlinLikeLangLineIndentProvider: remove debug function (vor 7 Tagen) <Dmitry Gridin>
* da5b2cfb646 - LineIndentProvider: support inside block body between `{` and first statement/expression (vor 7 Tagen) <Dmitry Gridin>
* 63a0b5bfdee - KotlinLikeLangLineIndentProvider: support braces in blocks (vor 7 Tagen) <Dmitry Gridin>
* 447549f20dd - LineIndentProvider: support declarations with body expression (vor 7 Tagen) <Dmitry Gridin>
* 145b2c260b8 - indentationOnNewLine: sort tests (vor 7 Tagen) <Dmitry Gridin>
* f833b4fe632 - LineIndentProvider: support elvis operator (vor 7 Tagen) <Dmitry Gridin>
* cf655a829cc - KotlinLikeLangLineIndentProvider: support options for parentheses (vor 7 Tagen) <Dmitry Gridin>
* a8cb6b2edea - LineIndentProvider: add options for parentheses (vor 7 Tagen) <Dmitry Gridin>
* 7c99a6fef4a - LineIndentProvider: support `catch` and `finally` (vor 7 Tagen) <Dmitry Gridin>
* acc15e5fad5 - LineIndentProvider: fix for do-while (vor 7 Tagen) <Dmitry Gridin>
* 7a58a591149 - Implement `EnterBetweenBracesAndBracketsNoCommitDelegate` (vor 7 Tagen) <Dmitry Gridin>
* e72fb755a00 - LineIndentProvider: support control flow constructions (vor 7 Tagen) <Dmitry Gridin>
* 201b115ee0b - Add hack for KotlinMultilineStringEnterHandler (vor 7 Tagen) <Dmitry Gridin>
* 8e7bbf1780b - LineIndentProvider: add restriction on position (vor 7 Tagen) <Dmitry Gridin>
* c0d7e565bcd - add debug info (vor 7 Tagen) <Dmitry Gridin>
* 29ceb25f5c3 - LineIndentProvider: support string templates (vor 7 Tagen) <Dmitry Gridin>
* 3a6b9c8d084 - init `line-indent-provider` module (vor 7 Tagen) <Dmitry Gridin>
* 9d98240272e - Create KotlinLineIndentProvider and delegate it to formatter (vor 7 Tagen) <Dmitry Gridin>
* 0f10faabbf6 - (tag: build-1.4.20-dev-569) [Commonizer] More precise approximation of callables (vor 7 Tagen) <Dmitriy Dolovov>
* 205510863aa - [Commonizer] Stats collector: support aggregated stats (vor 7 Tagen) <Dmitriy Dolovov>
* f7ceacb15c2 - [Commonizer] Update stats collector: report receivers & parameters (vor 7 Tagen) <Dmitriy Dolovov>
* 077853d2ad6 - Minor. Add words to project dictionary (vor 7 Tagen) <Dmitriy Dolovov>
* 3b4cef1b565 - Minor. Rename excludes list (vor 7 Tagen) <Dmitriy Dolovov>
* cbabb4f76a6 - JS stdlib api test: various changes (vor 7 Tagen) <Anton Bannykh>
* 7b61bf91784 - (tag: build-1.4.20-dev-567) FIR: Add nullability smartcast after !is check (vor 7 Tagen) <Denis Zharkov>
* 24948a8b3f6 - FIR: Fix incorrect handling bare types when subject is type alias (vor 7 Tagen) <Denis Zharkov>