### PR TITLE
IEEE754: hypot with NaN & Inf and unary minus with floating point operand

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/CodeGenerator.kt
@@ -588,6 +588,7 @@ internal class FunctionGenerationContext(val function: LLVMValueRef,
 
     fun fsub(arg0: LLVMValueRef, arg1: LLVMValueRef, name: String = ""): LLVMValueRef = LLVMBuildFSub(builder, arg0, arg1, name)!!
     fun fadd(arg0: LLVMValueRef, arg1: LLVMValueRef, name: String = ""): LLVMValueRef = LLVMBuildFAdd(builder, arg0, arg1, name)!!
+    fun fneg(arg: LLVMValueRef, name: String = ""): LLVMValueRef = LLVMBuildFNeg(builder, arg, name)!!
 
     fun select(ifValue: LLVMValueRef, thenValue: LLVMValueRef, elseValue: LLVMValueRef, name: String = ""): LLVMValueRef =
             LLVMBuildSelect(builder, ifValue, thenValue, elseValue, name)!!

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IntrinsicGenerator.kt
@@ -699,10 +699,10 @@ internal class IntrinsicGenerator(private val environment: IntrinsicGeneratorEnv
     private fun FunctionGenerationContext.emitUnaryMinus(args: List<LLVMValueRef>): LLVMValueRef {
         val first = args[0]
         val destTy = first.type
-        val const0 = makeConstOfType(destTy, 0)
         return if (destTy.isFloatingPoint()) {
-            fsub(const0, first)
+            fneg(first)
         } else {
+            val const0 = makeConstOfType(destTy, 0)
             sub(const0, first)
         }
     }

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2208,6 +2208,10 @@ task ieee754(type: KonanLocalTest) {
     source = "runtime/basic/ieee754.kt"
 }
 
+standaloneTest("hypotenuse") {
+    source = "runtime/basic/hypot.kt"
+}
+
 task array_list1(type: KonanLocalTest) {
     goldValue = "OK\n"
     source = "runtime/collections/array_list1.kt"

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -2364,17 +2364,20 @@ standaloneTest("custom_hook") {
     source = "runtime/exceptions/custom_hook.kt"
 }
 
-task runtime_math_exceptions(type: KonanLocalTest) {
+standaloneTest("runtime_math_exceptions") {
     enabled = (project.testTarget != 'wasm32')
     source = "stdlib_external/numbers/MathExceptionTest.kt"
+    flags = ['-tr']
 }
 
-task runtime_math(type: KonanLocalTest) {
+standaloneTest("runtime_math") {
     source = "stdlib_external/numbers/MathTest.kt"
+    flags = ['-tr']
 }
 
-task runtime_math_harmony(type: KonanLocalTest) {
+standaloneTest("runtime_math_harmony") {
     source = "stdlib_external/numbers/HarmonyMathTests.kt"
+    flags = ['-tr']
 }
 
 task catch3(type: KonanLocalTest) {

--- a/backend.native/tests/runtime/basic/hypot.kt
+++ b/backend.native/tests/runtime/basic/hypot.kt
@@ -22,4 +22,7 @@ fun main() {
     println("Double.-Inf: ${Double.NEGATIVE_INFINITY} ${Double.NEGATIVE_INFINITY.toRawBits().toUInt().toString(16)}")
     println(Double.POSITIVE_INFINITY == Double.NEGATIVE_INFINITY)
     assertEquals(Double.POSITIVE_INFINITY, hypot(Double.NEGATIVE_INFINITY, Double.NaN))
+
+    println("hypot NaN, 0: ${hypot(Double.NaN, 0.0).toRawBits().toString(16)}")
+    assertTrue(hypot(Double.NaN, 0.0).isNaN())
 }

--- a/backend.native/tests/runtime/basic/hypot.kt
+++ b/backend.native/tests/runtime/basic/hypot.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+import kotlin.test.*
+import kotlin.math.*
+
+fun main() {
+    val hf = hypot(Float.NEGATIVE_INFINITY, Float.NaN)
+    println("float hypot: $hf ${hf.toRawBits().toString(16)}")
+    println("Float.NaN: ${Float.NaN.toRawBits().toString(16)}")
+    println("Float.+Inf: ${Float.POSITIVE_INFINITY} ${Float.POSITIVE_INFINITY.toRawBits().toString(16)}")
+    println("Float.-Inf: ${Float.NEGATIVE_INFINITY} ${Float.NEGATIVE_INFINITY.toRawBits().toUInt().toString(16)}")
+    println(Float.POSITIVE_INFINITY == Float.NEGATIVE_INFINITY)
+    assertEquals(Float.POSITIVE_INFINITY, hypot(Float.NEGATIVE_INFINITY, Float.NaN))
+
+    val hd = hypot(Double.NEGATIVE_INFINITY, Double.NaN)
+    println("Double hypot: $hd ${hd.toRawBits().toString(16)}")
+    println("Double.NaN: ${Double.NaN.toRawBits().toString(16)}")
+    println("Double.+Inf: ${Double.POSITIVE_INFINITY} ${Double.POSITIVE_INFINITY.toRawBits().toString(16)}")
+    println("Double.-Inf: ${Double.NEGATIVE_INFINITY} ${Double.NEGATIVE_INFINITY.toRawBits().toUInt().toString(16)}")
+    println(Double.POSITIVE_INFINITY == Double.NEGATIVE_INFINITY)
+    assertEquals(Double.POSITIVE_INFINITY, hypot(Double.NEGATIVE_INFINITY, Double.NaN))
+}

--- a/runtime/src/main/cpp/KotlinMath.cpp
+++ b/runtime/src/main/cpp/KotlinMath.cpp
@@ -132,7 +132,12 @@ KDouble Kotlin_math_acosh(KDouble x) {
 
 KDouble Kotlin_math_atanh(KDouble x) { return atanh(x); }
 
-KDouble Kotlin_math_hypot(KDouble x, KDouble y) { return hypot(x, y); }
+KDouble Kotlin_math_hypot(KDouble x, KDouble y) {
+  if (isinf(x) || isinf(y)) return INFINITY;
+  if (isnan(x) || isnan(y)) return NAN;
+  return hypot(x, y);
+}
+
 KDouble Kotlin_math_sqrt(KDouble x) { return sqrt(x); }
 KDouble Kotlin_math_exp(KDouble x) { return exp(x); }
 KDouble Kotlin_math_expm1(KDouble x) { return expm1(x); }
@@ -200,7 +205,12 @@ KFloat Kotlin_math_acoshf(KFloat x) {
 
 KFloat Kotlin_math_atanhf(KFloat x) { return atanhf(x); }
 
-KFloat Kotlin_math_hypotf(KFloat x, KFloat y) { return hypotf(x, y); }
+KFloat Kotlin_math_hypotf(KFloat x, KFloat y) {
+  if (isinf(x) || isinf(y)) return INFINITY;
+  if (isnan(x) || isnan(y)) return NAN;
+  return hypotf(x, y);
+}
+
 KFloat Kotlin_math_sqrtf(KFloat x) { return sqrtf(x); }
 KFloat Kotlin_math_expf(KFloat x) { return expf(x); }
 KFloat Kotlin_math_expm1f(KFloat x) { return expm1f(x); }


### PR DESCRIPTION
1. According to the https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.math/hypot.html it should return `+Inf` if any of the operand is `Inf`, and `NaN` if any is `NaN`.
Tests show that on some platforms either 1-st or 2-nd case doesn't show the desired result as we use C `hypot()` function.
Such cases are required only if C compiler supports IEC 559, but clang doesn't. Failures are found on linux-mips32 and iOS arm64 targets.

2. Floating point unary operator should use LLVM's `fneg` instruction, because `0 - arg` doens't work if `arg = 0.0`, returning `0.0` instead of `-0.0`. See https://llvm.org/docs/LangRef.html#fneg-instruction