### PR TITLE
[kotlin compiler][update] 1.4.20-dev-1696 

### DIFF
--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -249,6 +249,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                 parseShortModuleName(arguments, configuration, outputKind)?.let {
                     put(SHORT_MODULE_NAME, it)
                 }
+                put(DISABLE_FAKE_OVERRIDE_VALIDATOR, arguments.disableFakeOverrideValidator)
             }
         }
     }

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -145,6 +145,9 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     )
     var exportedLibraries: Array<String>? = null
 
+    @Argument(value="-Xdisable-fake-override-validator", description = "Disable IR fake override validator")
+    var disableFakeOverrideValidator: Boolean = false
+
     @Argument(
             value = "-Xframework-import-header",
             valueDescription = "<header>",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -18,6 +18,8 @@ class KonanConfigKeys {
                 = CompilerConfigurationKey.create("compatible compiler versions")
         val DEBUG: CompilerConfigurationKey<Boolean>
                 = CompilerConfigurationKey.create("add debug information")
+        val DISABLE_FAKE_OVERRIDE_VALIDATOR: CompilerConfigurationKey<Boolean>
+                = CompilerConfigurationKey.create("disable fake override validator")
         val DISABLED_PHASES: CompilerConfigurationKey<List<String>> 
                 = CompilerConfigurationKey.create("disable backend phases")
         val BITCODE_EMBEDDING_MODE: CompilerConfigurationKey<BitcodeEmbedding.Mode>

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesInInlineLamb
 import org.jetbrains.kotlin.backend.common.lower.loops.ForLoopsLowering
 import org.jetbrains.kotlin.backend.common.phaser.*
 import org.jetbrains.kotlin.backend.konan.lower.*
-import org.jetbrains.kotlin.backend.konan.lower.ExpectDeclarationsRemoving
 import org.jetbrains.kotlin.backend.konan.lower.FinallyBlocksLowering
 import org.jetbrains.kotlin.backend.konan.lower.InitializersLowering
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -23,22 +22,22 @@ private fun makeKonanFileLoweringPhase(
         lowering: (Context) -> FileLoweringPass,
         name: String,
         description: String,
-        prerequisite: Set<AnyNamedPhase> = emptySet()
+        prerequisite: Set<NamedCompilerPhase<Context, *>> = emptySet()
 ) = makeIrFilePhase(lowering, name, description, prerequisite, actions = filePhaseActions)
 
 private fun makeKonanModuleLoweringPhase(
         lowering: (Context) -> FileLoweringPass,
         name: String,
         description: String,
-        prerequisite: Set<AnyNamedPhase> = emptySet()
+        prerequisite: Set<NamedCompilerPhase<Context, *>> = emptySet()
 ) = makeIrModulePhase(lowering, name, description, prerequisite, actions = modulePhaseActions)
 
 internal fun makeKonanFileOpPhase(
         op: (Context, IrFile) -> Unit,
         name: String,
         description: String,
-        prerequisite: Set<AnyNamedPhase> = emptySet()
-) = namedIrFilePhase(
+        prerequisite: Set<NamedCompilerPhase<Context, *>> = emptySet()
+) = NamedCompilerPhase(
         name, description, prerequisite, nlevels = 0,
         lower = object : SameTypeCompilerPhase<Context, IrFile> {
             override fun invoke(phaseConfig: PhaseConfig, phaserState: PhaserState<IrFile>, context: Context, input: IrFile): IrFile {
@@ -53,8 +52,8 @@ internal fun makeKonanModuleOpPhase(
         op: (Context, IrModuleFragment) -> Unit,
         name: String,
         description: String,
-        prerequisite: Set<AnyNamedPhase> = emptySet()
-) = namedIrModulePhase(
+        prerequisite: Set<NamedCompilerPhase<Context, *>> = emptySet()
+) = NamedCompilerPhase(
         name, description, prerequisite, nlevels = 0,
         lower = object : SameTypeCompilerPhase<Context, IrModuleFragment> {
             override fun invoke(phaseConfig: PhaseConfig, phaserState: PhaserState<IrModuleFragment>, context: Context, input: IrModuleFragment): IrModuleFragment {
@@ -108,7 +107,7 @@ internal val sharedVariablesPhase = makeKonanModuleLoweringPhase(
         prerequisite = setOf(lateinitPhase)
 )
 
-internal val extractLocalClassesFromInlineBodies = namedIrModulePhase(
+internal val extractLocalClassesFromInlineBodies = NamedCompilerPhase(
         lower = object : SameTypeCompilerPhase<Context, IrModuleFragment> {
             override fun invoke(phaseConfig: PhaseConfig, phaserState: PhaserState<IrModuleFragment>, context: Context, input: IrModuleFragment): IrModuleFragment {
                 LocalClassesInInlineLambdasLowering(context).run {
@@ -130,7 +129,7 @@ internal val extractLocalClassesFromInlineBodies = namedIrModulePhase(
         actions = modulePhaseActions
 )
 
-internal val inlinePhase = namedIrModulePhase(
+internal val inlinePhase = NamedCompilerPhase(
         lower = object : SameTypeCompilerPhase<Context, IrModuleFragment> {
             override fun invoke(phaseConfig: PhaseConfig, phaserState: PhaserState<IrModuleFragment>, context: Context, input: IrModuleFragment): IrModuleFragment {
                 FunctionInlining(context, NativeInlineFunctionResolver(context)).run {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -254,8 +254,10 @@ internal val psiToIrPhase = konanUnitPhase(
             symbolTable.noUnboundLeft("Unbound symbols left after linker")
 
             module.acceptVoid(ManglerChecker(KonanManglerIr, Ir2DescriptorManglerAdapter(KonanManglerDesc)))
-            val fakeOverrideChecker = FakeOverrideChecker(KonanManglerIr, KonanManglerDesc)
-            linker.modules.values.forEach{ fakeOverrideChecker.check(it) }
+            if (!config.configuration.getBoolean(KonanConfigKeys.DISABLE_FAKE_OVERRIDE_VALIDATOR)) {
+                val fakeOverrideChecker = FakeOverrideChecker(KonanManglerIr, KonanManglerDesc)
+                linker.modules.values.forEach { fakeOverrideChecker.check(it) }
+            }
 
             irModule = module
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -169,6 +169,9 @@ internal val psiToIrPhase = konanUnitPhase(
 
             val irProviderForCEnumsAndCStructs =
                     IrProviderForCEnumAndCStructStubs(generatorContext, interopBuiltIns, symbols)
+
+            val deserializeFakeOverrides = config.configuration.getBoolean(CommonConfigurationKeys.DESERIALIZE_FAKE_OVERRIDES)
+
             val linker =
                 KonanIrLinker(
                     moduleDescriptor,
@@ -179,7 +182,8 @@ internal val psiToIrPhase = konanUnitPhase(
                     forwardDeclarationsModuleDescriptor,
                     stubGenerator,
                     irProviderForCEnumsAndCStructs,
-                    exportedDependencies
+                    exportedDependencies,
+                    deserializeFakeOverrides
             )
 
             translator.addPostprocessingStep { module ->

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -336,7 +336,7 @@ internal val linkerPhase = konanUnitPhase(
         description = "Linker"
 )
 
-internal val allLoweringsPhase = namedIrModulePhase(
+internal val allLoweringsPhase = NamedCompilerPhase(
         name = "IrLowering",
         description = "IR Lowering",
         // TODO: The lowerings before inlinePhase should be aligned with [NativeInlineFunctionResolver.kt]
@@ -353,37 +353,39 @@ internal val allLoweringsPhase = namedIrModulePhase(
                 performByIrFile(
                         name = "IrLowerByFile",
                         description = "IR Lowering by file",
-                        lower = forLoopsPhase then
-                                stringConcatenationPhase then
-                                enumConstructorsPhase then
-                                initializersPhase then
-                                localFunctionsPhase then
-                                tailrecPhase then
-                                defaultParameterExtentPhase then
-                                innerClassPhase then
-                                dataClassesPhase then
-                                singleAbstractMethodPhase then
-                                ifNullExpressionsFusionPhase then
-                                builtinOperatorPhase then
-                                finallyBlocksPhase then
-                                testProcessorPhase then
-                                enumClassPhase then
-                                delegationPhase then
-                                callableReferencePhase then
-                                interopPhase then
-                                varargPhase then
-                                compileTimeEvaluatePhase then
-                                kotlinNothingValueExceptionPhase then
-                                coroutinesPhase then
-                                typeOperatorPhase then
-                                bridgesPhase then
-                                autoboxPhase then
-                                returnsInsertionPhase
+                        lower = listOf(
+                            forLoopsPhase,
+                            stringConcatenationPhase,
+                            enumConstructorsPhase,
+                            initializersPhase,
+                            localFunctionsPhase,
+                            tailrecPhase,
+                            defaultParameterExtentPhase,
+                            innerClassPhase,
+                            dataClassesPhase,
+                            singleAbstractMethodPhase,
+                            ifNullExpressionsFusionPhase,
+                            builtinOperatorPhase,
+                            finallyBlocksPhase,
+                            testProcessorPhase,
+                            enumClassPhase,
+                            delegationPhase,
+                            callableReferencePhase,
+                            interopPhase,
+                            varargPhase,
+                            compileTimeEvaluatePhase,
+                            kotlinNothingValueExceptionPhase,
+                            coroutinesPhase,
+                            typeOperatorPhase,
+                            bridgesPhase,
+                            autoboxPhase,
+                            returnsInsertionPhase,
+                        )
                 ),
         actions = setOf(defaultDumper, ::moduleValidationCallback)
 )
 
-internal val dependenciesLowerPhase = SameTypeNamedPhaseWrapper(
+internal val dependenciesLowerPhase = NamedCompilerPhase(
         name = "LowerLibIR",
         description = "Lower library's IR",
         prerequisite = emptySet(),
@@ -421,35 +423,31 @@ internal val dependenciesLowerPhase = SameTypeNamedPhaseWrapper(
             }
         })
 
-internal val entryPointPhase = SameTypeNamedPhaseWrapper(
+internal val entryPointPhase = makeCustomPhase<Context, IrModuleFragment>(
         name = "addEntryPoint",
         description = "Add entry point for program",
         prerequisite = emptySet(),
-        lower = object : CompilerPhase<Context, IrModuleFragment, IrModuleFragment> {
-            override fun invoke(phaseConfig: PhaseConfig, phaserState: PhaserState<IrModuleFragment>,
-                                context: Context, input: IrModuleFragment): IrModuleFragment {
-                assert(context.config.produce == CompilerOutputKind.PROGRAM)
+        op = { context, _ ->
+            assert(context.config.produce == CompilerOutputKind.PROGRAM)
 
-                val originalFile = context.ir.symbols.entryPoint!!.owner.file
-                val originalModule = originalFile.packageFragmentDescriptor.containingDeclaration
-                val file = if (context.llvmModuleSpecification.containsModule(originalModule)) {
-                    originalFile
-                } else {
-                    // `main` function is compiled to other LLVM module.
-                    // For example, test running support uses `main` defined in stdlib.
-                    context.irModule!!.addFile(originalFile.fileEntry, originalFile.fqName)
-                }
-
-                require(context.llvmModuleSpecification.containsModule(
-                        file.packageFragmentDescriptor.containingDeclaration))
-
-                file.addChild(makeEntryPoint(context))
-                return input
+            val originalFile = context.ir.symbols.entryPoint!!.owner.file
+            val originalModule = originalFile.packageFragmentDescriptor.containingDeclaration
+            val file = if (context.llvmModuleSpecification.containsModule(originalModule)) {
+                originalFile
+            } else {
+                // `main` function is compiled to other LLVM module.
+                // For example, test running support uses `main` defined in stdlib.
+                context.irModule!!.addFile(originalFile.fileEntry, originalFile.fqName)
             }
+
+            require(context.llvmModuleSpecification.containsModule(
+                    file.packageFragmentDescriptor.containingDeclaration))
+
+            file.addChild(makeEntryPoint(context))
         }
 )
 
-internal val bitcodePhase = namedIrModulePhase(
+internal val bitcodePhase = NamedCompilerPhase(
         name = "Bitcode",
         description = "LLVM Bitcode generation",
         lower = contextLLVMSetupPhase then

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -101,7 +101,7 @@ private fun KotlinToCCallBuilder.addArgument(
     if (!variadic) cFunctionBuilder.addParameter(cArgument.type)
 }
 
-private fun KotlinToCCallBuilder.buildKotlinBridgeCall(transformCall: (IrMemberAccessExpression) -> IrExpression = { it }): IrExpression =
+private fun KotlinToCCallBuilder.buildKotlinBridgeCall(transformCall: (IrMemberAccessExpression<*>) -> IrExpression = { it }): IrExpression =
         bridgeCallBuilder.build(
                 bridgeBuilder.buildKotlinBridge().also {
                     this.stubs.addKotlin(it)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -186,7 +186,7 @@ internal class KotlinCallBuilder(private val irBuilder: IrBuilderWithScope, priv
 
     fun build(
             function: IrFunction,
-            transformCall: (IrMemberAccessExpression) -> IrExpression = { it }
+            transformCall: (IrMemberAccessExpression<*>) -> IrExpression = { it }
     ): IrExpression {
         val arguments = this.arguments.toMutableList()
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -424,7 +424,7 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
     }
 
     private fun IrBuilderWithScope.lowerConstructorCallToValue(
-            expression: IrMemberAccessExpression,
+            expression: IrMemberAccessExpression<*>,
             callee: IrConstructor
     ): IrExpression = if (callee.isPrimary) {
         expression.getValueArgument(0)!!

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -266,7 +266,7 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
                 throw AssertionError("Unexpected delegating constructor call within enum entry: $enumEntry")
             }
 
-            abstract fun createConstructorCall(startOffset: Int, endOffset: Int, loweredConstructor: IrConstructorSymbol): IrMemberAccessExpression
+            abstract fun createConstructorCall(startOffset: Int, endOffset: Int, loweredConstructor: IrConstructorSymbol): IrMemberAccessExpression<*>
         }
 
         private inner class InEnumEntryClassConstructor(enumEntry: IrEnumEntry) : InEnumEntry(enumEntry) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -270,7 +270,7 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
             return sliceExpression(expression)
         }
 
-        override fun visitMemberAccess(expression: IrMemberAccessExpression): IrExpression {
+        override fun visitMemberAccess(expression: IrMemberAccessExpression<*>): IrExpression {
             expression.transformChildrenVoid(this)
 
             return sliceExpression(expression)
@@ -281,7 +281,7 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
             irBuilder.run {
                 val children = when (expression) {
                     is IrSetField -> listOf(expression.receiver, expression.value)
-                    is IrMemberAccessExpression -> (
+                    is IrMemberAccessExpression<*> -> (
                             listOf(expression.dispatchReceiver, expression.extensionReceiver)
                                     + (0 until expression.valueArgumentsCount).map { expression.getValueArgument(it) }
                             )
@@ -365,7 +365,7 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
                         expression.receiver = newChildren[0]
                         expression.value = newChildren[1]!!
                     }
-                    is IrMemberAccessExpression -> {
+                    is IrMemberAccessExpression<*> -> {
                         expression.dispatchReceiver = newChildren[0]
                         expression.extensionReceiver = newChildren[1]
                         newChildren.drop(2).forEachIndexed { index, newChild ->
@@ -549,7 +549,7 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
         }
     }
 
-    fun IrBlockBodyBuilder.irSuccess(value: IrExpression): IrMemberAccessExpression {
+    fun IrBlockBodyBuilder.irSuccess(value: IrExpression): IrMemberAccessExpression<*> {
         val createResult = symbols.kotlinResult.owner.constructors.single { it.isPrimary }
         return irCall(createResult).apply {
             putValueArgument(0, value)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReflectionSupport.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/ReflectionSupport.kt
@@ -67,7 +67,7 @@ internal class KTypeGenerator(
 
     private fun IrBuilderWithScope.irKTypeProjectionsList(
             irTypeArguments: List<IrTypeArgument>
-    ): IrMemberAccessExpression {
+    ): IrMemberAccessExpression<*> {
         val kTypeProjectionType = symbols.kTypeProjection.typeWithoutArguments
 
         return if (irTypeArguments.isEmpty()) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DFGBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DFGBuilder.kt
@@ -116,7 +116,7 @@ private class ExpressionValuesExtractor(val context: Context,
 
             is IrWhen -> expression.branches.forEach { forEachValue(it.result, block) }
 
-            is IrMemberAccessExpression -> block(expression)
+            is IrMemberAccessExpression<*> -> block(expression)
 
             is IrGetValue -> block(expression)
 
@@ -319,7 +319,7 @@ internal class ModuleDFGBuilder(val context: Context, val irModule: IrModuleFrag
 
         override fun visitExpression(expression: IrExpression) {
             when (expression) {
-                is IrMemberAccessExpression,
+                is IrMemberAccessExpression<*>,
                 is IrGetField,
                 is IrGetObjectValue,
                 is IrVararg,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -32,7 +32,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
-import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyClass
 import org.jetbrains.kotlin.ir.descriptors.IrAbstractFunctionFactory
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
@@ -54,13 +53,13 @@ object KonanFakeOverrideClassFilter : PlatformFakeOverrideClassFilter {
 
     // This is an alternative to .isObjCClass that doesn't need to walk up all the class heirarchy,
     // rather it only looks at immediate super class symbols.
-    private fun IrClass.isObjCClass() = this.superTypes
+    private fun IrClass.hasInteropSuperClass() = this.superTypes
         .mapNotNull { it.classOrNull }
         .filter { it is IrPublicSymbolBase<*> }
         .any { it.signature.isInteropSignature() }
 
     override fun constructFakeOverrides(clazz: IrClass): Boolean {
-        return !clazz.isObjCClass()
+        return !clazz.hasInteropSuperClass()
     }
 }
 
@@ -151,19 +150,6 @@ internal class KonanIrLinker(
             if (descriptor.isCEnumsOrCStruct()) return resolveCEnumsOrStruct(descriptor, idSig, symbolKind)
 
             val symbolOwner = stubGenerator.generateMemberStub(descriptor) as IrSymbolOwner
-
-            // Make sure all class hierarchy is available, otherwise we won't be able
-            // to build fake overrides.
-            // TODO: we actually only need it to tell if class .isObjCClass
-            // So if we could come up with a way to tell without looking at class hierarchy
-            // this hack could be erased.
-            if (symbolOwner is IrLazyClass) {
-                symbolOwner.superTypes.forEach {
-                    it.classOrNull?.let {
-                        symbolTable.referenceClassFromLinker(it.descriptor, it.signature)
-                    }
-                }
-            }
 
             return symbolOwner.symbol
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -293,7 +293,7 @@ fun IrBuilderWithScope.irCatch(type: IrType) =
  * Binds the arguments explicitly represented in the IR to the parameters of the accessed function.
  * The arguments are to be evaluated in the same order as they appear in the resulting list.
  */
-fun IrMemberAccessExpression.getArgumentsWithIr(): List<Pair<IrValueParameter, IrExpression>> {
+fun IrMemberAccessExpression<*>.getArgumentsWithIr(): List<Pair<IrValueParameter, IrExpression>> {
     val res = mutableListOf<Pair<IrValueParameter, IrExpression>>()
     val irFunction = when (this) {
         is IrFunctionAccessExpression -> this.symbol.owner

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -100,6 +100,13 @@ ext.testLibraryDir = "${project.property("konan.home")}/klib/platform/${project.
 // Add executor to run tests depending on a target
 project.convention.plugins.executor = ExecutorServiceKt.create(project)
 
+
+compileTestKotlin {
+    kotlinOptions {
+        freeCompilerArgs += "-Xskip-prerelease-check"
+    }
+}
+
 // Do not generate run tasks for konan built artifacts
 ext.konanNoRun = true
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -4177,7 +4177,7 @@ if (isAppleTarget(project)) {
         framework(frameworkName) {
             sources = ['objcexport']
             library = libraryName
-            opts = ["-Xemit-lazy-objc-header=$lazyHeader"]
+            opts = ["-Xemit-lazy-objc-header=$lazyHeader", "-Xopt-in=kotlin.ExperimentalStdlibApi"]
         }
         swiftSources = ['objcexport']
     }
@@ -4208,6 +4208,7 @@ if (isAppleTarget(project)) {
             artifact = frameworkArtifactName
             library = libraryName
             isStatic = true
+            opts = ['-Xstatic-framework', "-Xopt-in=kotlin.ExperimentalStdlibApi"]
         }
         swiftSources = ['objcexport']
     }

--- a/build-tools/build.gradle.kts
+++ b/build-tools/build.gradle.kts
@@ -90,7 +90,7 @@ val compileGroovy: GroovyCompile by tasks
 
 // https://youtrack.jetbrains.com/issue/KT-37435
 compileKotlin.apply {
-    kotlinOptions.freeCompilerArgs += "-Xno-optimized-callable-references"
+    kotlinOptions.freeCompilerArgs += listOf("-Xno-optimized-callable-references", "-Xskip-prerelease-check")
 }
 
 // Add Kotlin classes to a classpath for the Groovy compiler

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-9619
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9619,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-1329,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-1329
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-1329,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-1329
-kotlinStdlibTestsVersion=1.4.20-dev-1329
-testKotlinCompilerVersion=1.4.20-dev-1329
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-1696,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-1696
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-1696,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-1696
+kotlinStdlibTestsVersion=1.4.20-dev-1696
+testKotlinCompilerVersion=1.4.20-dev-1696
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/coroutines/cancellation/CancellationException.kt
+++ b/runtime/src/main/kotlin/kotlin/coroutines/cancellation/CancellationException.kt
@@ -5,14 +5,11 @@
 
 package kotlin.coroutines.cancellation
 
-/**
- * Thrown by cancellable suspending functions if the coroutine is cancelled while it is suspended.
- * It indicates _normal_ cancellation of a coroutine.
- */
+@ExperimentalStdlibApi
 @SinceKotlin("1.4")
-public open class CancellationException : IllegalStateException {
-    constructor() : super()
-    constructor(message: String?) : super(message)
+public actual open class CancellationException : IllegalStateException {
+    actual constructor() : super()
+    actual constructor(message: String?) : super(message)
     constructor(message: String?, cause: Throwable?) : super(message, cause)
     constructor(cause: Throwable?) : super(cause)
 }


### PR DESCRIPTION
* d8f701ee61d - (tag: build-1.4.20-dev-1696) Add test for obsolete issue (vor 22 Stunden) <Mikhail Zarechenskiy>
* 03d5fe8d6cd - (tag: build-1.4.20-dev-1692) Add dispatchAllInvocationEvents to editor actions in perf tests (vor 2 Tagen) <Vladimir Dolzhenko>
* a830c69a307 - (tag: build-1.4.20-dev-1691) Regenerate TypingIndentationTestBaseGenerated (vor 2 Tagen) <Vladimir Dolzhenko>
* 75b1cf8a230 - (tag: build-1.4.20-dev-1686) Explicitly specify id of `KotlinNonJvmSourceRootConverterProvider` (vor 2 Tagen) <Vladimir Krivosheev>
* 6ecd2e57fb3 - (tag: build-1.4.20-dev-1681) Created bunch 203 (vor 3 Tagen) <Vyacheslav Karpukhin>
* 357746e3443 - (tag: build-1.4.20-dev-1680) Do not force FULL analysis for PARTIAL_FOR_COMPLETION for the current open file (vor 3 Tagen) <Vladimir Dolzhenko>
* 51375ed2786 - (tag: build-1.4.20-dev-1679) PluginStartupListener clean up (vor 3 Tagen) <Vladimir Dolzhenko>
* 0b2e15d20c0 - (tag: build-1.4.20-dev-1678) PluginStartupListener clean up (vor 3 Tagen) <Vladimir Dolzhenko>
* 01f2b0e26b0 - (tag: build-1.4.20-dev-1676) Fix test data about `JsExport` (vor 3 Tagen) <Mikhail Zarechenskiy>
* 9a080851464 - Fix redundant semicolon inspection before soft keywords (vor 3 Tagen) <Mikhail Zarechenskiy>
* a0ecfce7b7b - Update test data: add correct error (vor 3 Tagen) <Mikhail Zarechenskiy>
* 87a520fc301 - 202: Overcome failure in PathManager.getHomePath() because of the wrong dir (vor 3 Tagen) <Nikolay Krasko>
* d63728afe57 - (tag: build-1.4.20-dev-1675, tag: build-1.4.20-dev-1666) [Commonizer] Use 'index:Int' instead of Name for addressing type parameters (vor 3 Tagen) <Dmitriy Dolovov>
* 0ee7306d9ce - (tag: build-1.4.20-dev-1664, tag: build-1.4.20-dev-1663) Fix coercion to `Unit` when variable already have other constraints (vor 3 Tagen) <Mikhail Zarechenskiy>
* 026f54f3d83 - (tag: build-1.4.20-dev-1662) Fix Kapt3 tests (vor 3 Tagen) <Dmitry Petrov>
* 761e47264a4 - JVM_IR: fix property reference generation for inline class primary val (vor 3 Tagen) <Dmitry Petrov>
* 1450cf5f637 - (tag: build-1.4.20-dev-1661) Fix KOTLIN_BUNDLED registration (vor 3 Tagen) <Vladimir Dolzhenko>
* d1455d0d229 - (tag: build-1.4.20-dev-1660) KotlinOptimizeImportsRefactoringHelper: should remove unused directives by pointer (vor 3 Tagen) <Dmitry Gridin>
* 62e252ec26b - (tag: build-1.4.20-dev-1656) Inline refactoring: should support set/get operator (vor 3 Tagen) <Dmitry Gridin>
* e31ea0c243b - (tag: build-1.4.20-dev-1655) ReplaceWith: suggest to replace for 'get/set' operator functions (vor 3 Tagen) <Toshiaki Kameyama>
* 82b6ecfa64b - [FIR-TEST] Add test for KT-39075 (vor 3 Tagen) <Dmitriy Novozhilov>
* 59bedaaa55d - [FIR] Rename FirElvisCall to FirElvisExpression (vor 3 Tagen) <Dmitriy Novozhilov>
* 1db2ba51d24 - [FIR] Don't pass flow from inplace lambdas throw when and elvis expressions (vor 3 Tagen) <Dmitriy Novozhilov>
* 1429cba2d42 - [FIR] Fix CCE in postponed lambda resolution (vor 3 Tagen) <Dmitriy Novozhilov>
* 8311c1f0e20 - [FIR] Fix projection of Comparable supertype for ILT (vor 3 Tagen) <Dmitriy Novozhilov>
* a882a9dff5f - [FIR] Create scope for type parameter as scope for intersection of bounds (vor 3 Tagen) <Dmitriy Novozhilov>
* 44d0af85979 - (tag: build-1.4.20-dev-1648, tag: build-1.4.20-dev-1633) FIR2IR: handle 'this' as reference to outer object (vor 3 Tagen) <Jinseong Jeon>
* 1798542db76 - (tag: build-1.4.20-dev-1632, tag: build-1.4.20-dev-1629) Fix and enable embedded tests in scripting-ide-services (vor 3 Tagen) <Ilya Muradyan>
* e88bef42750 - Fix jar-dependent test in scripting-ide-services (vor 3 Tagen) <Ilya Muradyan>
* d51bb2c0539 - Add compatibility resolve when variable has "bad" intersection type (vor 3 Tagen) <Mikhail Zarechenskiy>
* 92a51b97941 - (tag: build-1.4.20-dev-1628) [FIR] Add illegal underscore check in BaseFirBuilder (vor 3 Tagen) <Ivan Kylchik>
* cc4b50fdc11 - [FIR] Add illegal underscore diagnostic (vor 3 Tagen) <Ivan Kylchik>
* 54945b7fbc0 - Extract illegal underscore check function to ParseUtils (vor 3 Tagen) <Ivan Kylchik>
* d0f6997e6d6 - [FIR] Fix some of fir spec tests for real-literals (vor 3 Tagen) <Ivan Kylchik>
* 17c15cfe0a4 - (tag: build-1.4.20-dev-1622) JVM, JVM_IR: update bytecode listing testData for inline classes (vor 4 Tagen) <Dmitry Petrov>
* 6e0bb0b4686 - JVM: no nullability annotations for inline class '-impl' methods (vor 4 Tagen) <Dmitry Petrov>
* ea042eb6c46 - JVM_IR: no nullability annotations for inline class '-impl' methods (vor 4 Tagen) <Dmitry Petrov>
* a238d6a8903 - JVM_IR: no annotations on parameters of 'property$annotations' methods (vor 4 Tagen) <Dmitry Petrov>
* 8da988b18e6 - JVM_IR: Mangle primary val getter of inline class if required (vor 4 Tagen) <Dmitry Petrov>
* 62d2581faf8 - JVM_IR: Don't generate annotations on generated inline class members (vor 4 Tagen) <Dmitry Petrov>
* dc4b9d3887b - JVM_IR: Don't mangle internal constructor-impl for inline classes (vor 4 Tagen) <Dmitry Petrov>
* 5cfac8fa3fc - (tag: build-1.4.20-dev-1621) FIR IDE: introduce symbol pointers for restoring symbols in another read action (vor 4 Tagen) <Ilya Kirillov>
* f88ebed1a37 - FIR IDE: move types to its own package (vor 4 Tagen) <Ilya Kirillov>
* 5f548fc4591 - FIR IDE: add creating stdlib symbols by fqName tests (vor 4 Tagen) <Ilya Kirillov>
* 799a49649ce - FIR IDE: introduce symbol modality (vor 4 Tagen) <Ilya Kirillov>
* 75a96f01533 - FIR IDE: add info about varargs to parmater symbol (vor 4 Tagen) <Ilya Kirillov>
* f10f6c63609 - FIR IDE: introduce package symbol (vor 4 Tagen) <Ilya Kirillov>
* 18d46a86aee - FIR IDE: add identity weak map based cache for KtSymbolByFirBuilder (vor 4 Tagen) <Ilya Kirillov>
* a26063b3f85 - FIR IDE: rename Invalidatable -> ValidityOwner (vor 4 Tagen) <Ilya Kirillov>
* 226d514788a - FIR IDE: rename reference classes to KtFir*Reference for consistency (vor 4 Tagen) <Ilya Kirillov>
* 66933ea2fe8 - FIR IDE: use withValidityAssertion instead of explicit check in FirAnalysisSession (vor 4 Tagen) <Ilya Kirillov>
* 83682848172 - FIR IDE: introduce KtType (vor 4 Tagen) <Ilya Kirillov>
* c44756bbfde - FIR IDE: add tests for building kt symbols by PSI (vor 4 Tagen) <Ilya Kirillov>
* 8a52954bf84 - FIR IDE: introduce symbol provider (vor 4 Tagen) <Ilya Kirillov>
* 20b93507abb - FIR IDE: use symbols for reference resolve (vor 4 Tagen) <Ilya Kirillov>
* 749afbd141e - FIR IDE: use symbols for call resolve (vor 4 Tagen) <Ilya Kirillov>
* 82866176fb1 - FIR IDE: introduce symbol API (vor 4 Tagen) <Ilya Kirillov>
* ba948cda38e - (tag: build-1.4.20-dev-1620) Report warning on characters which can cause problems on Windows (vor 4 Tagen) <Alexander Udalov>
* 181965f6e83 - IR: inline namedIrModulePhase and namedIrFilePhase phase builders (vor 4 Tagen) <Alexander Udalov>
* 15a969b3ba2 - IR: refactor performByIrFile a little (vor 4 Tagen) <Alexander Udalov>
* 4475325ffae - IR: refactor PhaseBuilders a little (vor 4 Tagen) <Alexander Udalov>
* 7997d4afd31 - IR: do not use AnyNamedPhase where there is Context parameter (vor 4 Tagen) <Alexander Udalov>
* ef58f1e72e1 - IR: simplify phaser code a little (vor 4 Tagen) <Alexander Udalov>
* 74ce26cdc28 - (tag: build-1.4.20-dev-1619) Fix 1.4-M2 ChangeLog.md (vor 4 Tagen) <Stanislav Erokhin>
* 18d71c79074 - (tag: build-1.4.20-dev-1617) Build: Encode build number in teamcity build url (vor 4 Tagen) <Vyacheslav Gerasimov>
* 8e1269cc328 - Build: Add hacky workaround for retrying PublishToMavenRepository tasks (vor 4 Tagen) <Vyacheslav Gerasimov>
* 3bb234b17c3 - (tag: build-1.4.20-dev-1615, tag: build-1.4.20-dev-1613) [Commonizer] Clean-up CirTypeSignature usages (vor 4 Tagen) <Dmitriy Dolovov>
* ffd0c696986 - [Commonizer] Use ClassId instead of FqName for addressing classes and TAs (vor 4 Tagen) <Dmitriy Dolovov>
* 57aefbcd57b - (tag: build-1.4.20-dev-1605) FIR IDE: migrate to 201 (vor 4 Tagen) <Ilya Kirillov>
* 1124887aa04 - (tag: build-1.4.20-dev-1598) [JVM_IR] Fix stepping behavior for assignments to local variables. (vor 4 Tagen) <Mads Ager>
* 543efffa5c7 - (tag: build-1.4.20-dev-1596) Turn off stability check for PerformanceTypingIndentationTest (vor 4 Tagen) <Vladimir Dolzhenko>
* 89d5c030dc7 - (tag: build-1.4.20-dev-1594) Improve incremental analisys for nested blocks (vor 4 Tagen) <Igor Yakovlev>
* efdeb7b449b - (tag: build-1.4.20-dev-1591, tag: build-1.4.20-dev-1586) Introduce "Add '== true'" quick fix for TYPE_MISMATCH (vor 4 Tagen) <Toshiaki Kameyama>
* 5bf18c09bb9 - (tag: build-1.4.20-dev-1584) Advance bootstrap to 1.4.20-dev-1530 (vor 4 Tagen) <Dmitriy Novozhilov>
* a73dac75d4c - Optimize KotlinScriptDependenciesClassFinder (vor 4 Tagen) <Natalia Selezneva>
* f46970219f3 - (tag: build-1.4.20-dev-1583) [FIR2IR] Simplify elvis conversion (vor 4 Tagen) <Mikhail Glukhikh>
* 68b84722c4a - [FIR2IR] Simplify generateWhen (vor 4 Tagen) <Mikhail Glukhikh>
* 24c8eb43a2f - [FIR2IR] Don't build stub FirWhen for converting elvis expression (vor 4 Tagen) <Mikhail Glukhikh>
* 6229d2e2156 - [FIR2IR] Extract generateWhen & toIrWhenBranch (vor 4 Tagen) <Mikhail Glukhikh>
* 31765a4abc3 - [FIR2IR] Move visitElvis & visitWhen close to one another (vor 4 Tagen) <Mikhail Glukhikh>
* f4d5070a7b2 - [FIR-TEST] Mute BB test due to KT-39659 (vor 4 Tagen) <Dmitriy Novozhilov>
* a7ed9c7dc5d - [FIR] Add conversion of FirElvisCall to backend IR (vor 4 Tagen) <Dmitriy Novozhilov>
* 102c9c08d04 - [FIR] Resolve elvis call as special synthetic call (vor 4 Tagen) <Dmitriy Novozhilov>
* b49b3245afd - [FIR] Add special node for elvis call (vor 4 Tagen) <Dmitriy Novozhilov>
* 648953085f0 - [FIR] Replace `kotlin/Throwable` with `java/lang/Throwable` in JvmMappedScope (vor 4 Tagen) <Dmitriy Novozhilov>
* 624b9306f0b - [FIR] Resolve LHS of type operator call in independent context (vor 4 Tagen) <Dmitriy Novozhilov>
* c9e423bf641 - (tag: build-1.4.20-dev-1580) FIR deserializer: fix parameter shift for constructor of inner classes and enums (vor 4 Tagen) <Jinseong Jeon>
* 8e24256f95c - (tag: build-1.4.20-dev-1578) JVM_IR: avoid descriptors when tracking inline properties (vor 4 Tagen) <Georgy Bronnikov>
* 385d522d278 - JVM_IR: do not use descriptor in isCompiledToJvmDefault (vor 4 Tagen) <Georgy Bronnikov>
* 3270c7e0166 - (tag: build-1.4.20-dev-1575, tag: build-1.4.20-dev-1568) Introduce CancellationException (vor 4 Tagen) <Vsevolod Tolstopyatov>
* 5ec110c33fc - (tag: build-1.4.20-dev-1560) *.gradle.kts: catch exceptions during GradleBuildRootManager initialization (vor 4 Tagen) <Natalia Selezneva>
* c7c7ffb0e01 - *.gradle.kts: get java home from build environment instead of execution settings (vor 4 Tagen) <Natalia Selezneva>
* 5cdf053c8ed - (tag: build-1.4.20-dev-1556) Coroutines: Fix RedundantLocalsEliminationMethodTransformer (vor 5 Tagen) <Steven Schäfer>
* 3113281e2d2 - (tag: build-1.4.20-dev-1552) Adapted fake override checker to inheritance from friend module internal interfaces (vor 5 Tagen) <Alexander Gorshenev>
* 07feb2185b6 - (tag: build-1.4.20-dev-1551, tag: build-1.4.20-dev-1549) Fix exception in FirExposedVisibilityChecker (vor 5 Tagen) <Mikhail Glukhikh>
* 697c8637ee7 - (tag: build-1.4.20-dev-1545) For all int-like typed variables, use int as field type and coerce (vor 5 Tagen) <Ilmir Usmanov>
* e7f33ac0518 - (tag: build-1.4.20-dev-1541) IR: do not inherit IrFunctionReference from IrFunctionAccessExpression (vor 5 Tagen) <Alexander Udalov>
* d4605f58165 - IR: add type parameter to IrMemberAccessExpression and some subclasses (vor 5 Tagen) <Alexander Udalov>
* d794c9dc4d2 - IR: remove non-supertype usages of abstract impl classes (vor 5 Tagen) <Alexander Udalov>
* ccac23f5b29 - IR: make mapOptimized non-inline, rename to transformIfNeeded (vor 5 Tagen) <Alexander Udalov>
* 6a699c93849 - IR: minor, remove accept from some interfaces (vor 5 Tagen) <Alexander Udalov>
* 1e3019798ac - (tag: build-1.4.20-dev-1540) FIR2IR: discard fake overrides for property accessors according to base visibility (vor 5 Tagen) <Jinseong Jeon>
* 6985c5fd2a0 - (tag: build-1.4.20-dev-1535, tag: build-1.4.20-dev-1533) 202: Fix `KotlinJpsBuildTest` tests (vor 5 Tagen) <Nikita Bobko>
* 4e65b2fb9ed - Refactoring: mark const strings with const keyword (vor 5 Tagen) <Nikita Bobko>
* 31e45d4f4c2 - 202: Fix some `ParameterInfoTestGenerated` (vor 5 Tagen) <Nikita Bobko>
* cbc57351f53 - 202: Fix `SlicerLeafGroupingTestGenerated` tests (vor 5 Tagen) <Nikita Bobko>
* 0d71b7ac2cd - 202: Add fastutil jar to tests dependencies (vor 5 Tagen) <Nikolay Krasko>
* ca7169b84f8 - 202: Disable ignored plugins check in compiler environment (vor 5 Tagen) <Nikolay Krasko>
* ef562598ea4 - 202: Fix `MultiFileJvmBasicCompletionTestGenerated` (vor 5 Tagen) <Nikita Bobko>
* 3187bb2aa42 - 202: Fix `KotlinMavenImporterTest#testJDKImport` test (vor 5 Tagen) <Nikita Bobko>
* 5c95c48c90a - 202: Fix `GradleFacetImportTest#testJDKImport` test (vor 5 Tagen) <Nikita Bobko>
* 536c4bbab1a - 202: Fix `KotlinEvaluateExpressionTestGenerated.SingleBreakpoint` (vor 5 Tagen) <Nikita Bobko>
* 046030e301f - 202: Fix "Module 'foo': No SDK defined" in tests (vor 5 Tagen) <Nikita Bobko>
* 8fb82c2cb7e - 202: Fix missing formatting in nJ2K tests (vor 5 Tagen) <Nikita Bobko>
* 264094861df - 202: Fix null passed to @NotNull in `PomModelImpl` (vor 5 Tagen) <Nikita Bobko>
* 853503d75f0 - (tag: build-1.4.20-dev-1532) Force perform FULL analysis to avoid redundant analysis for the current open file (vor 5 Tagen) <Vladimir Dolzhenko>
* 1a82c949799 - (tag: build-1.4.20-dev-1531) revert accidentally committed project.xml (vor 5 Tagen) <Sergey Rostov>
* d9fc71b8c07 - (tag: build-1.4.20-dev-1530) Advance bootstrap to 1.4.20-dev-1515 (vor 5 Tagen) <Mikhail Zarechenskiy>
* 3ce980fd88a - (tag: build-1.4.20-dev-1527) Fix incremental compilation for calls to inner classes from supertypes (vor 5 Tagen) <Denis Zharkov>
* 6b81cc8b777 - (tag: build-1.4.20-dev-1515) Update test data as stdlib now isn't pre-release (vor 6 Tagen) <Mikhail Zarechenskiy>
* 94dcff5bab6 - Advance bootstrap to 1.4.20-dev-1508 (vor 6 Tagen) <Mikhail Zarechenskiy>
* f37f89a151d - (tag: build-1.4.20-dev-1508) Set KotlinCompilerVersion.IS_PRE_RELEASE = false (vor 6 Tagen) <Mikhail Zarechenskiy>
* b5b5c8aebc7 - (tag: build-1.4.20-dev-1507) Check target for -Xjvm-default modes (vor 6 Tagen) <Mikhail Bogdanov>
* 3e42b9d527b - (tag: build-1.4.20-dev-1502) [Commonizer] Remove unused property from CirFunction (vor 6 Tagen) <Dmitriy Dolovov>
* 21fa2bf98c1 - (tag: build-1.4.20-dev-1500) Switch to 201 platform (vor 6 Tagen) <Nikolay Krasko>
* 50863b69856 - Fix using swing ComboBox and wrong bunching (vor 6 Tagen) <Nikolay Krasko>
* 2c1b01fcf6c - Setup standalone environment in BuiltInsSerializer (vor 6 Tagen) <Nikolay Krasko>
* 3b2e1cfa391 - Show TeamCity user for agent builds (vor 6 Tagen) <Nikolay Krasko>
* 86fe10ba446 - (tag: build-1.4.20-dev-1499) AddDefaultConstructorFix: fix testData (vor 6 Tagen) <Dmitry Gridin>
* 7be54108779 - Add a quick fix for NO_CONSTRUCTOR error on 'expect' annotation entry (vor 6 Tagen) <Toshiaki Kameyama>
* d846a22e333 - (tag: build-1.4.20-dev-1497) [FIR] Introduce & use FirTypeRef.coneType (vor 6 Tagen) <Mikhail Glukhikh>
* 0392fe75fc9 - (tag: build-1.4.20-dev-1496) Convert to block body: specify non-nullable type when body expression is platform type and overriden method is non-nullable type (vor 6 Tagen) <Toshiaki Kameyama>
* d37b616e1f3 - (tag: build-1.4.20-dev-1495) JVM_IR: Fix enum classes ABI (vor 6 Tagen) <Dmitry Petrov>
* f753824429a - (tag: build-1.4.20-dev-1491) Advance bootstrap version to 1.4.20-dev-1401 (vor 6 Tagen) <Stanislav Erokhin>
* 7536da788c2 - Minor. Update test (vor 6 Tagen) <Ilmir Usmanov>
* 34174d6e7d4 - (tag: build-1.4.20-dev-1488) FIR deserializer: load annotations for property and fields, along with use-site targets (vor 6 Tagen) <Jinseong Jeon>
* 3580c7c28c1 - (tag: build-1.4.20-dev-1476) Write proto flag about compatibility mode (vor 6 Tagen) <Mikhail Bogdanov>
* f372a0fe6cb - (tag: build-1.4.20-dev-1475) Force full analysis even if incremental analysis is available but existed is erroneous (vor 6 Tagen) <Vladimir Dolzhenko>
* 343e6452828 - (tag: build-1.4.20-dev-1472) Rename and refactor kmm plugin packages, task names, ids and etc. (vor 6 Tagen) <Konstantin Tskhovrebov>
* 48a9226e1c3 - (tag: build-1.4.20-dev-1471) Fix copy-paste from KTS files (vor 6 Tagen) <Vladimir Dolzhenko>
* 0a230905aea - (tag: build-1.4.20-dev-1469) Remove redundant spread operator: don't report if overloaded functions cannot be resolved (vor 6 Tagen) <Toshiaki Kameyama>
* f179b39c703 - (tag: build-1.4.20-dev-1468) Wizard: fix project template list size (vor 6 Tagen) <Ilya Kirillov>
* b9b068ff63b - (tag: build-1.4.20-dev-1455) Fix FirMultiModuleResolveTestGenerated tests (vor 6 Tagen) <Aleksei Cherepanov>
* 8ba131290a8 - (tag: build-1.4.20-dev-1448) Fixup for 1f5fa5eb7 – adjust error message (vor 6 Tagen) <Sergey Igushkin>
* 1f5fa5eb7c1 - (tag: build-1.4.20-dev-1443) Add back empty stub implementations of KotlinGradleSubplugin (KT-39809) (vor 6 Tagen) <Sergey Igushkin>
* cb936dd82e5 - Fix internals with symlinked friend paths (KT-35341) (vor 6 Tagen) <Sergey Igushkin>
* 5b1d019bb05 - (tag: build-1.4.20-dev-1441) Added Incomplete destructuring inspection (vor 6 Tagen) <kvirolainen>
* e6bca819d49 - (tag: build-1.4.20-dev-1438) Remove kotlin.native.linkFromSources, expose tasks' sources (vor 6 Tagen) <Sergey Igushkin>
* c3b5b21845f - (tag: build-1.4.20-dev-1437) [JVM] Extend stepping tests with <clinit> stepping. (vor 6 Tagen) <Mads Ager>
* 2693664aa73 - (tag: build-1.4.20-dev-1436) FIR IDE: unmute tests after introducing fake element kinds (vor 6 Tagen) <Ilya Kirillov>
* 9baced20c40 - FIR IDE: find FIR element by PSI one only if FIR have a real source (vor 6 Tagen) <Ilya Kirillov>
* 5acdad29ec3 - FIR: change source of existing type refs in DataClassMembersGenerator to avoid sources clash (vor 6 Tagen) <Ilya Kirillov>
* 650f2dd7131 - FIR: consider source of FirSingleExpressionBlock as a fake one (vor 6 Tagen) <Ilya Kirillov>
* 1c564e1bd6e - FIR: add ImplicitTypeRef to the control flow fir element sources (vor 6 Tagen) <Ilya Kirillov>
* 94967bcd004 - FIR: introduce element kind for source elements (vor 6 Tagen) <Ilya Kirillov>
* f6e653b242a - (tag: build-1.4.20-dev-1435) [FIR] Fix compilation broken in 309050d9 (vor 6 Tagen) <Dmitriy Novozhilov>
* 309050d956b - (tag: build-1.4.20-dev-1433) [FIR] Add `ExtensionFunctionType` attribute (vor 6 Tagen) <Dmitriy Novozhilov>
* 1d3c0f56a95 - [FIR] Save type attributes in substitution (vor 6 Tagen) <Dmitriy Novozhilov>
* 25fd5cd4ac2 - [FIR] Save type attributes in `ConeKotlinType.withNullability` (vor 6 Tagen) <Dmitriy Novozhilov>
* 840d3975cc4 - [FIR] Add computing type attributes for deserialized types (vor 6 Tagen) <Dmitriy Novozhilov>
* cfa250957ad - [FIR] Fix creating type attributes for intersection types (vor 6 Tagen) <Dmitriy Novozhilov>
* fab9ee47f92 - (tag: build-1.4.20-dev-1429) FIR deserializer: proper annotation loading for value parameter of property setter (vor 6 Tagen) <Jinseong Jeon>
* 9308525d938 - (tag: build-1.4.20-dev-1428) Add receiver of kotlin.text.toPattern to standard Kotlin injections (vor 6 Tagen) <Toshiaki Kameyama>
* 787d22c93e3 - (tag: build-1.4.20-dev-1422) Created bunch 203 (vor 6 Tagen) <Vyacheslav Karpukhin>
* 09a111239e1 - (tag: build-1.4.20-dev-1421, tag: build-1.4.20-dev-1420, tag: build-1.4.20-dev-1419, tag: build-1.4.20-dev-1418, tag: build-1.4.20-dev-1417, tag: build-1.4.20-dev-1413) Stabilize ProjectTaskRunner registration order (vor 7 Tagen) <Egor Zhdan>
* 866e5397d9c - New ultimate modules (vor 7 Tagen) <Vyacheslav Karpukhin>
* ed80b431f09 - (tag: build-1.4.20-dev-1412, tag: build-1.4.20-dev-1408, tag: build-1.4.20-dev-1401) Restore refined int-type analysis (vor 7 Tagen) <Ilmir Usmanov>
* 8920e68584f - (tag: build-1.4.20-dev-1400) Muted .IncrementalJsKlibCompilerRunnerTestGenerated.ClassHierarchyAffected.testMethodRemoved until we have full fledged fake override support in klib (vor 7 Tagen) <Alexander Gorshenev>
* 41a472693a6 - Updated extraHelp test data for the new flags (vor 7 Tagen) <Alexander Gorshenev>
* bf419bc243a - Compute correct signature for fake override properties with type parameters (vor 7 Tagen) <Alexander Gorshenev>
* d90c3832872 - Fine tuned fake override validator for internals (vor 7 Tagen) <Alexander Gorshenev>
* e08b800eb9a - Treat internals as publics for fake override construction (vor 7 Tagen) <Alexander Gorshenev>
* e61960f3330 - Fake override construction fallback mode (vor 7 Tagen) <Alexander Gorshenev>
* de79e3bec36 - Added -Xdisable-fake-override-validator (vor 7 Tagen) <Alexander Gorshenev>
* f127a0f5936 - (tag: build-1.4.20-dev-1399) Add flag to disable new spilled variable type analysis (vor 7 Tagen) <Ilmir Usmanov>
* d7df6e1e0c3 - (tag: build-1.4.20-dev-1398) Avoid references to `DeprecatedSinceKotlin` to fix JPS build (vor 7 Tagen) <Mikhail Zarechenskiy>
* 28e6028af44 - (tag: build-1.4.20-dev-1395) Minor. Add test (vor 7 Tagen) <Ilmir Usmanov>
* da12532669b - Ignore fake inliner variables in merge operation (vor 7 Tagen) <Ilmir Usmanov>
* b0b8d40b710 - (tag: build-1.4.20-dev-1394) Update ApiTest.testIrStdlib for JS, an addition to 9be8c5b5 (vor 7 Tagen) <Mikhail Zarechenskiy>
* e4198466b8e - (tag: build-1.4.20-dev-1389) JVM_IR: No nullability annotations on static lambda instances (vor 7 Tagen) <Dmitry Petrov>
* eefa621c560 - JVM_IR KT-37006: InlineOnly property accessors are private in bytecode (vor 7 Tagen) <Dmitry Petrov>
* b94a4d9fc3f - (tag: build-1.4.20-dev-1382) Render more information on inner classes in bytecode listing tests (vor 7 Tagen) <Alexander Udalov>
* 4bb670e667a - (tag: build-1.4.20-dev-1380) Build: Use project kotlin-reflect in fir tree generator (vor 7 Tagen) <Vyacheslav Gerasimov>
* 1ef68dfffd1 - Build: Fix kotlin-test-js-ir:commonMainSources to copy only sources (vor 7 Tagen) <Vyacheslav Gerasimov>
* 5198020c296 - Build: Fix kotlin-stdlib related errors during jps build import (vor 7 Tagen) <Vyacheslav Gerasimov>
* 63b73500463 - Build: Use sources from kotlin mpp source set in `sourcesJar` helper (vor 7 Tagen) <Vyacheslav Gerasimov>
* 77a8cf4e66c - Build: Use attributes to resolve test dependencies in jps build mode (vor 7 Tagen) <Vyacheslav Gerasimov>
* a32f901ab93 - (tag: build-1.4.20-dev-1378) Make property initializer modification is OutOfBlock change (vor 7 Tagen) <Igor Yakovlev>
* 507a7186324 - (tag: build-1.4.20-dev-1376) Update tests for completion after adding `DeprecatedSinceKotlin` (vor 7 Tagen) <Mikhail Zarechenskiy>
* 87014f816cd - (tag: build-1.4.20-dev-1373) Update ApiTest.testStdlib for JS, an addition to 9be8c5b5 (vor 7 Tagen) <Mikhail Zarechenskiy>
* d798071e069 - (tag: build-1.4.20-dev-1371) IrConstTransformer: drop unnecessary argument existence check (vor 7 Tagen) <Mikhail Glukhikh>
* c3fc524c0d5 - FIR: handle named arguments in annotations properly (vor 7 Tagen) <Jinseong Jeon>
* 4f366977375 - (tag: build-1.4.20-dev-1369) [FIR2IR] Mute 2 BB tests failing due to signature clashing (vor 7 Tagen) <Mikhail Glukhikh>
* 6cb3687d5de - [FIR2IR] Replace 'throw AssertionError()' with error() / assert() {...} (vor 7 Tagen) <Mikhail Glukhikh>
* 69ec8f2d89c - [FIR2IR] Allow to get cached symbols in fake override generator (vor 7 Tagen) <Mikhail Glukhikh>
* c4d41f48a36 - [IR] Allow Fir2Ir symbols in function factory (vor 7 Tagen) <Mikhail Glukhikh>
* a6234eb2613 - [FIR2IR] Don't compose signatures for private declarations (vor 7 Tagen) <Mikhail Glukhikh>
* 19d115778b1 - [IR] Allow fast reference path in SymbolTable for wrapped descriptors (vor 7 Tagen) <Mikhail Glukhikh>
* 90f9b9c1c91 - [FIR2IR] Unmute 6 fixed BB tests (vor 7 Tagen) <Mikhail Glukhikh>
* 2d5e6bb90b6 - [FIR2IR] Introduce lazy properties (vor 7 Tagen) <Mikhail Glukhikh>
* efd614194bd - [FIR2IR] Make Fir2IrBindableSymbol public API (vor 7 Tagen) <Mikhail Glukhikh>
* ca5e560f1f4 - [FIR2IR] Introduce lazy constructors (vor 7 Tagen) <Mikhail Glukhikh>
* fcabd02fe86 - [FIR] Take class expect flag into account in its substitution scope (vor 7 Tagen) <Mikhail Glukhikh>
* c1609ed490c - [FIR] Make expect class members also expect (vor 7 Tagen) <Mikhail Glukhikh>
* 2fefa682b7f - [FIR2IR] Do not compose signature for local class members (vor 7 Tagen) <Mikhail Glukhikh>
* 9a0e7637611 - [FIR2IR] Require classId from parent class for fake overrides (vor 7 Tagen) <Mikhail Glukhikh>
* 34a21962954 - FirClassSubstitutionScope: extract SubstitutedData & reorder functions (vor 7 Tagen) <Mikhail Glukhikh>
* bf009a49496 - [FIR2IR] Handle delegating constructor call type arguments properly (vor 7 Tagen) <Mikhail Glukhikh>
* 2cffbadbd5e - [FIR2IR] Use overridden symbol when handling delegating constructor call (vor 7 Tagen) <Mikhail Glukhikh>
* 456508a3329 - IR SymbolTable: don't allow unbound symbols in declare by signature only (vor 7 Tagen) <Mikhail Glukhikh>
* 7243d04f583 - [FIR2IR] Simplification of property building in lazy class (vor 7 Tagen) <Mikhail Glukhikh>
* a8db7b3ba62 - [FIR2IR] Simplification of function building in lazy class (vor 7 Tagen) <Mikhail Glukhikh>
* f7be3737116 - Add extra parent checks in Fir2IrLazyClass (vor 7 Tagen) <Mikhail Glukhikh>
* 13f7b6a22eb - (tag: build-1.4.20-dev-1366) Create separate constructor for ir interpreter with only ir builtins (vor 7 Tagen) <Ivan Kylchik>
* de2b20482a4 - Allow IrConstTransformer to visit and evaluate vararg elements (vor 7 Tagen) <Ivan Kylchik>
* 6fa03297f9d - Allow IrConstTransformer to visit annotations of all declarations (vor 7 Tagen) <Ivan Kylchik>
* c87b12ec2ff - Speed up fir2ir constant evaluation (vor 7 Tagen) <Ivan Kylchik>
* 032fdd63d92 - Ignore codegen test for Android (vor 7 Tagen) <Mikhail Zarechenskiy>
* 6ea0c37e52a - (tag: build-1.4.20-dev-1365) Update test data with new package name after 901d8f3e7a3c45c692f089fc984f4cf1684e6026 (vor 7 Tagen) <Leonid Startsev>
* 6efa7a51c6f - (tag: build-1.4.20-dev-1363) Fix priority for "add import" action wrt DeprecatedSinceKotlin (vor 7 Tagen) <Mikhail Zarechenskiy>
* beca7fca304 - Fix completion order & presentation wrt to DeprecatedSinceKotlin (vor 7 Tagen) <Mikhail Zarechenskiy>
* bcaa635a4ed - Fix parameter info presentation with regard to DeprecatedSinceKotlin (vor 7 Tagen) <Mikhail Zarechenskiy>
* 9be8c5b5270 - Update test data about built-ins (vor 7 Tagen) <Mikhail Zarechenskiy>
* b7df9ec05a0 - Implement equals/hashCode as this class previously was a `data` one (vor 7 Tagen) <Mikhail Zarechenskiy>
* a2da00eb493 - Prohibit using DeprecatedSinceKotlin outside `kotlin` subpackage (vor 7 Tagen) <Mikhail Zarechenskiy>
* 790433984bf - Prohibit using DeprecatedSinceKotlin annotation without arguments (vor 7 Tagen) <Mikhail Zarechenskiy>
* 67100d5ebec - Reject values of `DeprecatedSince..` that are not parseable as a version (vor 7 Tagen) <Mikhail Zarechenskiy>
* 5d880589289 - Place DeprecatedSinceKotlin annotation under 1.4 version (vor 7 Tagen) <Mikhail Zarechenskiy>
* 2f55a3fa0dd - Add various test for `DeprecatedSinceKotlin` annotation (vor 7 Tagen) <Mikhail Zarechenskiy>
* 0f2c96c64d7 - Don't perform additional lookups for `DeprecatedSinceKotlin` annotation (vor 7 Tagen) <Mikhail Zarechenskiy>
* 158013ef3a3 - Remove message and replaceWith parameters from DeprecatedSinceKotlin (vor 7 Tagen) <Mikhail Zarechenskiy>
* 60c51476f23 - Introduce declaration checker for DeprecatedSinceKotlin annotation (vor 7 Tagen) <Mikhail Zarechenskiy>
* 0aaf29c0459 - Introduce DeprecatedSinceKotlin annotation (vor 7 Tagen) <Alexander Udalov>
* b2022144e63 - (tag: build-1.4.20-dev-1355) [Commonizer] Fast-pass for library fragments absent for some targets (vor 7 Tagen) <Dmitriy Dolovov>
* ee22488ab29 - (tag: build-1.4.20-dev-1350) [FIR] Cleanup FIR modules. Part 8 (`types` package) (vor 7 Tagen) <Dmitriy Novozhilov>
* 2c3fe8b8ec3 - [FIR] Cleanup FIR modules. Part 7 (`scopes` package) (vor 7 Tagen) <Dmitriy Novozhilov>
* c6124f6d564 - [FIR] Cleanup FIR modules. Part 6 (`transformers` package) (vor 7 Tagen) <Dmitriy Novozhilov>
* e817f919c2c - [FIR] Cleanup FIR modules. Part 5 (`body.resolve` package) (vor 7 Tagen) <Dmitriy Novozhilov>
* 285b6d28af9 - [FIR] Cleanup FIR modules. Part 4 (`providers` and `resolve` packages) (vor 7 Tagen) <Dmitriy Novozhilov>
* 1d903028484 - [FIR] Cleanup FIR modules. Part 3 (`inference` package) (vor 7 Tagen) <Dmitriy Novozhilov>
* 1766c22f6f8 - [FIR] Cleanup FIR modules. Part 2 (`dfa` package) (vor 7 Tagen) <Dmitriy Novozhilov>
* 604c68b3a01 - [FIR] Cleanup FIR modules. Part 1 (`calls` package) (vor 7 Tagen) <Dmitriy Novozhilov>
* 1ac0e8449b9 - [FIR] Move FirJavaTypeRef to fir.jvm module (vor 7 Tagen) <Dmitriy Novozhilov>
* fd1de9b2983 - [FIR] Fix typo in FirCloneableSymbolProvider (vor 7 Tagen) <Dmitriy Novozhilov>
* 57b9baac537 - [FIR] Get rid of FirSession.inferenceContext (vor 7 Tagen) <Dmitriy Novozhilov>
* 43bb60addba - [FIR] Remove workaround for KT-39659 (vor 7 Tagen) <Dmitriy Novozhilov>
* 7834284bece - [FIR] Support deserialization of value parameter annotations (vor 7 Tagen) <Dmitriy Novozhilov>
* 2b2f9b3386f - [FIR] Remove delegate specific methods from abstract inference session (vor 7 Tagen) <Dmitriy Novozhilov>
* 9c6ed2ea02c - [FIR] Complete delegate calls in default inference session (vor 7 Tagen) <Dmitriy Novozhilov>
* dbbb999952f - [FIR] Support builder (coroutine) inference (vor 7 Tagen) <Dmitriy Novozhilov>
* 6a9504f26a9 - [FIR-TEST] Add coroutines diagnostic tests from old FE to FIR test suite (vor 7 Tagen) <Dmitriy Novozhilov>
* d0affc6c6a5 - [FIR] Rename `ResolverParts.kt` to `ResolutionStages.kt` (vor 7 Tagen) <Dmitriy Novozhilov>
* de1b5cd056c - [FIR] Add extracting `@Exact` and `@NoInfer` attributes from annotations (vor 7 Tagen) <Dmitriy Novozhilov>
* 7ab3dd04a07 - [FIR] Add attributes for `@Exact` and `@NoInfer` (vor 7 Tagen) <Dmitriy Novozhilov>
* ac51e5dbd1a - [FIR] Add workaround for KT-19306 (vor 7 Tagen) <Dmitriy Novozhilov>
* 3f5db6b86e9 - [FIR] Add `ConeAttributes` to `ConeKotlinType` (vor 7 Tagen) <Dmitriy Novozhilov>
* e76f3f93f61 - [FIR] Move ArrayMap to `cones` module (vor 7 Tagen) <Dmitriy Novozhilov>
* d3fb9cc5f36 - Deprecate with error mixed Int/FP contains operator for ranges KT-22423 (vor 7 Tagen) <Abduqodiri Qurbonzoda>
* ab20b3e083a - (tag: build-1.4.20-dev-1347) Add InterruptedException handler to CancellableSimpleLock (vor 7 Tagen) <Vladimir Dolzhenko>
* a9444c386d6 - Use actual import list on PlainTextPaste (vor 7 Tagen) <Vladimir Dolzhenko>
* 30f98e67302 - (tag: build-1.4.20-dev-1344) Inline refactoring: shouldn't lose return type information (vor 7 Tagen) <Dmitry Gridin>
* c3b726f10a1 - Inline refactoring: should add explicit type argument for parameters (vor 7 Tagen) <Dmitry Gridin>
* 45234c97847 - Inline refactoring: fix case with introduction of variable to return (vor 7 Tagen) <Dmitry Gridin>