### PR TITLE
External tests runner fixes

### DIFF
--- a/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -220,6 +220,10 @@ class RunExternalTestGroup extends JavaExec {
                 line.split(" ").toList().forEach { flags.add("-Xopt-in=$it") }
             }
         }
+        def expectActualLinker = findLinesWithPrefixesRemoved(text, "// EXPECT_ACTUAL_LINKER")
+        if (expectActualLinker.size() != 0) {
+            flags.add("-Xexpect-actual-linker")
+        }
     }
 
     static String markMutableObjects(String text) {

--- a/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -505,13 +505,14 @@ fun runTest() {
                     List<TestModule> orderedModules = DFS.INSTANCE.topologicalOrder(modules.values()) { module ->
                         module.dependencies.collect { modules[it] }.findAll { it != null }
                     }
-                    def libsFlags = []
+                    Set<String> libs = new HashSet<String>()
                     orderedModules.reverse().each { module ->
                         if (!module.isDefaultModule()) {
                             def klibModulePath = "${executablePath()}.${module.name}.klib"
-                            libsFlags += module.linkDependencies(executablePath())
+                            libs.addAll(module.dependencies)
                             runCompiler(compileList.findAll { it.module == module }.collect { it.path },
-                                    klibModulePath, flags + ["-p", "library"] + libsFlags)
+                                    klibModulePath, flags + ["-p", "library"] +
+                                    libs.collectMany { ["-l", "${executablePath()}.${it}.klib"] }.toList())
                         }
                     }
 
@@ -519,9 +520,10 @@ fun runTest() {
                         it.module.isDefaultModule() || it.module == TestModule.support
                     }
                     compileMain.forEach { f ->
-                        libsFlags.addAll(f.module.linkDependencies(executablePath()))
+                        libs.addAll(f.module.dependencies)
                     }
-                    if (!compileMain.empty) runCompiler(compileMain.collect { it.path }, executablePath(), flags + libsFlags)
+                    if (!compileMain.empty) runCompiler(compileMain.collect { it.path }, executablePath(),
+                            flags + libs.collectMany { ["-l", "${executablePath()}.${it}.klib"] }.toList())
                 }
             } catch (Exception ex) {
                 project.logger.quiet("ERROR: Compilation failed for test suite: $name with exception", ex)

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/TestDirectives.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/TestDirectives.kt
@@ -88,9 +88,6 @@ data class TestModule(
 ) {
     fun isDefaultModule() = this == default || name.endsWith(".main")
 
-    fun linkDependencies(outputPath: String): List<String> =
-        dependencies.flatMap { listOf("-l", "$outputPath.$it.klib") }
-
     companion object {
         val default = TestModule("default", emptyList(), emptyList())
         val support = TestModule("support", emptyList(), emptyList())


### PR DESCRIPTION
1. Make link options (`-l lib`) be unique.
2. Add test directive parsing for -Xexpect-actual-linker 