### PR TITLE
[kotlin compiler][update]  1.4.20-dev-2426

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
@@ -74,7 +74,8 @@ internal val Context.getBoxFunction: (IrClass) -> IrSimpleFunction by Context.la
             isSuspend = false,
             isExpect = false,
             isFakeOverride = false,
-            isOperator = false
+            isOperator = false,
+            isInfix = false
     ).also { function ->
         function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(
@@ -128,7 +129,8 @@ internal val Context.getUnboxFunction: (IrClass) -> IrSimpleFunction by Context.
             isSuspend = false,
             isExpect = false,
             isFakeOverride = false,
-            isOperator = false
+            isOperator = false,
+            isInfix = false
     ).also { function ->
         function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -144,7 +144,7 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
             with(descriptor) {
                 IrFunctionImpl(
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, origin, it, name, visibility, modality, returnType,
-                    isInline, isExternal, isTailrec, isSuspend, isOperator, isExpect
+                    isInline, isExternal, isTailrec, isSuspend, isOperator, isInfix, isExpect
                 )
             }
         }
@@ -289,7 +289,8 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                 descriptor.run {
                     IrFunctionImpl(
                             offset, offset, memberOrigin, s, name, visibility, modality, returnType,
-                            isInline, isExternal, isTailrec, isSuspend, isOperator, isExpect, true
+                            isInline, isExternal, isTailrec, isSuspend, isOperator, isInfix, isExpect,
+                            isFakeOverride = true
                     )
                 }
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -148,7 +148,8 @@ internal class SpecialDeclarationsFactory(val context: Context) {
                 returnType = returnType,
                 isExpect = false,
                 isFakeOverride = false,
-                isOperator = false
+                isOperator = false,
+                isInfix = false
         ).apply {
             val bridge = this
             descriptor.bind(bridge)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
@@ -42,7 +42,8 @@ internal fun makeEntryPoint(context: Context): IrFunction {
             isSuspend = false,
             isExpect = false,
             isFakeOverride = false,
-            isOperator = false
+            isOperator = false,
+            isInfix = false
     ).also { function ->
         function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
             IrValueParameterImpl(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -99,7 +99,8 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
                     isSuspend = false,
                     isExpect = false,
                     isFakeOverride = false,
-                    isOperator = false
+                    isOperator = false,
+                    isInfix = false
             ).apply {
                 it.bind(this)
                 parent = implObject

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -576,7 +576,8 @@ private fun KotlinStubs.createFakeKotlinExternalFunction(
             isSuspend = false,
             isExpect = false,
             isFakeOverride = false,
-            isOperator = false
+            isOperator = false,
+            isInfix = false
     )
     bridgeDescriptor.bind(bridge)
 
@@ -1283,7 +1284,7 @@ private class ObjCBlockPointerValuePassing(
                 Visibilities.PUBLIC, Modality.FINAL,
                 returnType = functionType.arguments.last().typeOrNull!!,
                 isInline = false, isExternal = false, isTailrec = false, isSuspend = false, isExpect = false,
-                isFakeOverride = false, isOperator = false
+                isFakeOverride = false, isOperator = false, isInfix = false
         )
         invokeMethodDescriptor.bind(invokeMethod)
         invokeMethod.overriddenSymbols += overriddenInvokeMethod.symbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -123,7 +123,8 @@ private fun createKotlinBridge(
             isSuspend = false,
             isExpect = false,
             isFakeOverride = false,
-            isOperator = false
+            isOperator = false,
+            isInfix = false
     )
     bridgeDescriptor.bind(bridge)
     if (isExternal) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -509,7 +509,8 @@ private val Context.getLoweredInlineClassConstructor: (IrConstructor) -> IrSimpl
             returnType = irConstructor.returnType,
             isExpect = false,
             isFakeOverride = false,
-            isOperator = false
+            isOperator = false,
+            isInfix = false
     ).apply {
         descriptor.bind(this)
         parent = irConstructor.parent

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -82,7 +82,8 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                                 returnType = context.irBuiltIns.anyNType,
                                 isExpect = false,
                                 isFakeOverride = false,
-                                isOperator = false
+                                isOperator = false,
+                                isInfix = false
                     ).apply {
                             it.bind(this)
                         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
@@ -322,7 +322,8 @@ internal class CallableReferenceLowering(val context: Context): FileLoweringPass
                     isSuspend = superFunction.isSuspend,
                     isExpect = false,
                     isFakeOverride = false,
-                    isOperator = false
+                    isOperator = false,
+                    isInfix = false
             ).apply {
                 it.bind(this)
                 val function = this

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
@@ -121,7 +121,8 @@ internal class InitializersLowering(val context: CommonBackendContext) : ClassLo
                         isTailrec = false,
                         isExpect = false,
                         isFakeOverride = false,
-                        isOperator = false
+                        isOperator = false,
+                        isInfix = false
                 ).apply {
                     it.bind(this)
                     parent = irClass

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -258,7 +258,8 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
                 isSuspend = false,
                 isExpect = false,
                 isFakeOverride = false,
-                isOperator = false
+                isOperator = false,
+                isInfix = false
         ).also { result ->
             resultDescriptor.bind(result)
             result.parent = irClass
@@ -402,7 +403,8 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
                     isSuspend = false,
                     isExpect = false,
                     isFakeOverride = false,
-                    isOperator = false
+                    isOperator = false,
+                    isInfix = false
             ).apply {
                 it.bind(this)
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -490,7 +490,8 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
                 isSuspend = false,
                 isExpect = false,
                 isFakeOverride = false,
-                isOperator = false
+                isOperator = false,
+                isInfix = false
         ).apply {
             it.bind(this)
         }
@@ -511,7 +512,8 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
                 isSuspend = false,
                 isExpect = false,
                 isFakeOverride = false,
-                isOperator = false
+                isOperator = false,
+                isInfix = false
         ).apply {
             it.bind(this)
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -350,7 +350,8 @@ internal class TestProcessor (val context: Context) {
                 isSuspend = false,
                 isExpect = false,
                 isFakeOverride = false,
-                isOperator = false
+                isOperator = false,
+                isInfix = false
         ).apply {
             descriptor.bind(this)
             parent = owner
@@ -389,7 +390,8 @@ internal class TestProcessor (val context: Context) {
                 isSuspend = false,
                 isExpect = false,
                 isFakeOverride = false,
-                isOperator = false
+                isOperator = false,
+                isInfix = false
         ).apply {
             descriptor.bind(this)
             parent = owner

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.4.0-dev-9619
-buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9619,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.4.20-dev-2133
+buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2133,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2426,branch:default:any,pinned:true/artifacts/content/maven
 kotlinVersion=1.4.20-dev-2426

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.0-dev-9619
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-9619,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2077,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-2077
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2077,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-2077
-kotlinStdlibTestsVersion=1.4.20-dev-2077
-testKotlinCompilerVersion=1.4.20-dev-2077
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2426,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-2426
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2426,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-2426
+kotlinStdlibTestsVersion=1.4.20-dev-2426
+testKotlinCompilerVersion=1.4.20-dev-2426
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.4.20-dev-2133
-buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2133,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.4.20-dev-2167
+buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
 kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2426,branch:default:any,pinned:true/artifacts/content/maven
 kotlinVersion=1.4.20-dev-2426

--- a/runtime/src/main/kotlin/generated/_ArraysNative.kt
+++ b/runtime/src/main/kotlin/generated/_ArraysNative.kt
@@ -321,8 +321,9 @@ public actual fun <T> Array<out T>?.contentDeepToString(): String {
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boolean {
     return this.contentEquals(other)
 }
@@ -334,8 +335,9 @@ public actual infix fun <T> Array<out T>.contentEquals(other: Array<out T>): Boo
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
     return this.contentEquals(other)
 }
@@ -347,8 +349,9 @@ public actual infix fun ByteArray.contentEquals(other: ByteArray): Boolean {
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
     return this.contentEquals(other)
 }
@@ -360,8 +363,9 @@ public actual infix fun ShortArray.contentEquals(other: ShortArray): Boolean {
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun IntArray.contentEquals(other: IntArray): Boolean {
     return this.contentEquals(other)
 }
@@ -373,8 +377,9 @@ public actual infix fun IntArray.contentEquals(other: IntArray): Boolean {
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun LongArray.contentEquals(other: LongArray): Boolean {
     return this.contentEquals(other)
 }
@@ -386,8 +391,9 @@ public actual infix fun LongArray.contentEquals(other: LongArray): Boolean {
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
     return this.contentEquals(other)
 }
@@ -399,8 +405,9 @@ public actual infix fun FloatArray.contentEquals(other: FloatArray): Boolean {
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
     return this.contentEquals(other)
 }
@@ -412,8 +419,9 @@ public actual infix fun DoubleArray.contentEquals(other: DoubleArray): Boolean {
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean {
     return this.contentEquals(other)
 }
@@ -425,8 +433,9 @@ public actual infix fun BooleanArray.contentEquals(other: BooleanArray): Boolean
  * The elements are compared for equality with the [equals][Any.equals] function.
  * For floating point numbers it means that `NaN` is equal to itself and `-0.0` is not equal to `0.0`.
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual infix fun CharArray.contentEquals(other: CharArray): Boolean {
     return this.contentEquals(other)
 }
@@ -596,8 +605,9 @@ public actual infix fun CharArray?.contentEquals(other: CharArray?): Boolean {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun <T> Array<out T>.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -605,8 +615,9 @@ public actual fun <T> Array<out T>.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun ByteArray.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -614,8 +625,9 @@ public actual fun ByteArray.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun ShortArray.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -623,8 +635,9 @@ public actual fun ShortArray.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun IntArray.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -632,8 +645,9 @@ public actual fun IntArray.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun LongArray.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -641,8 +655,9 @@ public actual fun LongArray.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun FloatArray.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -650,8 +665,9 @@ public actual fun FloatArray.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun DoubleArray.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -659,8 +675,9 @@ public actual fun DoubleArray.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun BooleanArray.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -668,8 +685,9 @@ public actual fun BooleanArray.contentHashCode(): Int {
 /**
  * Returns a hash code based on the contents of this array as if it is [List].
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun CharArray.contentHashCode(): Int {
     return this.contentHashCode()
 }
@@ -787,8 +805,9 @@ public actual fun CharArray?.contentHashCode(): Int {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun <T> Array<out T>.contentToString(): String {
     return this.contentToString()
 }
@@ -798,8 +817,9 @@ public actual fun <T> Array<out T>.contentToString(): String {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun ByteArray.contentToString(): String {
     return this.contentToString()
 }
@@ -809,8 +829,9 @@ public actual fun ByteArray.contentToString(): String {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun ShortArray.contentToString(): String {
     return this.contentToString()
 }
@@ -820,8 +841,9 @@ public actual fun ShortArray.contentToString(): String {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun IntArray.contentToString(): String {
     return this.contentToString()
 }
@@ -831,8 +853,9 @@ public actual fun IntArray.contentToString(): String {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun LongArray.contentToString(): String {
     return this.contentToString()
 }
@@ -842,8 +865,9 @@ public actual fun LongArray.contentToString(): String {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun FloatArray.contentToString(): String {
     return this.contentToString()
 }
@@ -853,8 +877,9 @@ public actual fun FloatArray.contentToString(): String {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun DoubleArray.contentToString(): String {
     return this.contentToString()
 }
@@ -864,8 +889,9 @@ public actual fun DoubleArray.contentToString(): String {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun BooleanArray.contentToString(): String {
     return this.contentToString()
 }
@@ -875,8 +901,9 @@ public actual fun BooleanArray.contentToString(): String {
  * 
  * @sample samples.collections.Arrays.ContentOperations.contentToString
  */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
 @SinceKotlin("1.1")
-@kotlin.internal.LowPriorityInOverloadResolution
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
 public actual fun CharArray.contentToString(): String {
     return this.contentToString()
 }

--- a/runtime/src/main/kotlin/kotlin/Annotations.kt
+++ b/runtime/src/main/kotlin/kotlin/Annotations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
  * that can be found in the LICENSE file.
  */
 
@@ -36,6 +36,27 @@ public annotation class Deprecated(
     val message: String,
     val replaceWith: ReplaceWith = ReplaceWith(""),
     val level: DeprecationLevel = DeprecationLevel.WARNING
+)
+
+/**
+ * Marks the annotated declaration as deprecated. In contrast to [Deprecated], severity of the reported diagnostic is not a constant value,
+ * but differs depending on the API version of the usage (the value of the `-api-version` argument when compiling the module where
+ * the usage is located). If the API version is greater or equal than [hiddenSince], the declaration will not be accessible from the code
+ * (as if it was deprecated with level [DeprecationLevel.HIDDEN]), otherwise if the API version is greater or equal than [errorSince],
+ * the usage will be marked as an error (as with [DeprecationLevel.ERROR]), otherwise if the API version is greater or equal
+ * than [warningSince], the usage will be marked as a warning (as with [DeprecationLevel.WARNING]), otherwise the annotation is ignored.
+ *
+ * @property warningSince the version, since which this deprecation should be reported as a warning.
+ * @property errorSince the version, since which this deprecation should be reported as a error.
+ * @property hiddenSince the version, since which the annotated declaration should not be available in code.
+ */
+@Target(CLASS, FUNCTION, PROPERTY, ANNOTATION_CLASS, CONSTRUCTOR, PROPERTY_SETTER, PROPERTY_GETTER, TYPEALIAS)
+@MustBeDocumented
+@SinceKotlin("1.4")
+public annotation class DeprecatedSinceKotlin(
+    val warningSince: String = "",
+    val errorSince: String = "",
+    val hiddenSince: String = ""
 )
 
 /**
@@ -89,7 +110,7 @@ public annotation class ParameterName(val name: String)
  * Suppresses the given compilation warnings in the annotated element.
  * @property names names of the compiler diagnostics to suppress.
  */
-@Target(CLASS, ANNOTATION_CLASS, PROPERTY, FIELD, LOCAL_VARIABLE, VALUE_PARAMETER,
+@Target(CLASS, ANNOTATION_CLASS, TYPE_PARAMETER, PROPERTY, FIELD, LOCAL_VARIABLE, VALUE_PARAMETER,
         CONSTRUCTOR, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER, TYPE, EXPRESSION, FILE, TYPEALIAS)
 @Retention(SOURCE)
 public annotation class Suppress(vararg val names: String)

--- a/runtime/src/main/kotlin/kotlin/text/StringNumberConversions.kt
+++ b/runtime/src/main/kotlin/kotlin/text/StringNumberConversions.kt
@@ -52,6 +52,14 @@ external internal fun longToString(value: Long, radix: Int): String
 public actual inline fun Long.toString(radix: Int): String = longToString(this, checkRadix(radix))
 
 /**
+ * Returns `true` if the content of this string is equal to the word "true", ignoring case, and `false` otherwise.
+ */
+@Deprecated("Use Kotlin compiler 1.4 to avoid deprecation warning.")
+@DeprecatedSinceKotlin(hiddenSince = "1.4")
+@kotlin.internal.InlineOnly
+public actual inline fun String.toBoolean(): Boolean = this.toBoolean()
+
+/**
  * Returns `true` if this string is not `null` and its content is equal to the word "true", ignoring case, and `false` otherwise.
  */
 @SinceKotlin("1.4")


### PR DESCRIPTION
* e5e50eabe9b - (tag: build-1.4.20-dev-2426) Update testdata after 41a0cfe00249df02c9b5695f435a90677ef7fa68 (vor 5 Stunden) <Mikhail Zarechenskiy>
* b351556b1f2 - (tag: build-1.4.20-dev-2425) Fix testJarsWithDependenciesWithinClasses() compilation after unsuccessful cherry-pick (vor 12 Stunden) <Yan Zhulanow>
* 64aaeb52f5f - (tag: build-1.4.20-dev-2420) Add change notes for 1.4-M1,2,3,RC builds #KT-40311 Fixed (vor 24 Stunden) <Anton Yalyshev>
* a4a398239b1 - (tag: build-1.4.20-dev-2414) Fallback to fileEntry provided by irFile (vor 2 Tagen) <Jim Sproch>
* c901e82a558 - (tag: build-1.4.20-dev-2413) IR: add IrSimpleFunction.isInfix (vor 2 Tagen) <Georgy Bronnikov>
* 8e4bc06b3cf - (tag: build-1.4.20-dev-2408) Create a valid jar in KaptIncrementalWithIsolatingApt test (vor 3 Tagen) <Ivan Gavrilovic>
* 77ba9a1bbbd - KT-34604: Fix race condition in KAPT (vor 3 Tagen) <Ivan Gavrilovic>
* 111a2ece72b - KAPT: Fix error reporting (vor 3 Tagen) <Ivan Gavrilovic>
* 11251a93ac7 - KAPT: Fix serialization of class structure data (vor 3 Tagen) <Ivan Gavrilovic>
* ccbb2eaba97 - (tag: build-1.4.20-dev-2406) Make linker visible to compiler plugins (vor 3 Tagen) <Jim Sproch>
* 80e4e7939d7 - (tag: build-1.4.20-dev-2404) "Create abstract function" quick fix: don't suggest it if super classes are not writable (vor 3 Tagen) <Toshiaki Kameyama>
* 0c832e30bfc - (tag: build-1.4.20-dev-2400) (CoroutineDebugger) Memory leak fixed on IDEA quit: 'org.jetbrains.kotlin.idea.debugger.coroutine.view.XCoroutineView (vor 3 Tagen) <Vladimir Ilmov>
* 6de848a15c7 - (tag: build-1.4.20-dev-2399) [Commonizer] Introduce success marker file in Gradle task (vor 3 Tagen) <Dmitriy Dolovov>
* 178b5db8dee - [Commonizer] More precise up-to-date checks in Gradle task (vor 3 Tagen) <Dmitriy Dolovov>
* d3f9f4f3e8a - (tag: build-1.4.20-dev-2397) Fix stdlib-by-default failures when configuration has been resolved (vor 3 Tagen) <Sergey Igushkin>
* dccac34282e - (tag: build-1.4.20-dev-2390) J2K: do not run runUndoTransparentAction outside EDT (vor 3 Tagen) <Ilya Kirillov>
* d16f246375b - Wizard: do not add stdlib for gradle based projects (vor 3 Tagen) <Ilya Kirillov>
* d2113766e19 - Wizard: do not add NPM dependencies for Kotlin/JS wrappers (vor 3 Tagen) <Ilya Kirillov>
* 9f5dd59d750 - Wizard: do not add test task for JS when no test framework is chosen (vor 3 Tagen) <Ilya Kirillov>
* 0208fad0577 - Wizard: do not allow to choose Frontend Application template & JS Library at the same time (vor 3 Tagen) <Ilya Kirillov>
* fdc06b2c1cb - Wizard: fix Android SDK path on Windows (vor 3 Tagen) <Ilya Kirillov>
* a153e7fe300 - (tag: build-1.4.20-dev-2382) Changes after review (vor 3 Tagen) <Pavel Kirpichenkov>
* 10bd3a11b83 - (tag: build-1.4.20-dev-2378) Improve message about compatibility warning a bit (vor 3 Tagen) <Mikhail Zarechenskiy>
* fcf7a55ccc4 - Fix delegated property resolve on number literals and proper types (vor 3 Tagen) <Mikhail Zarechenskiy>
* e5bca3ce291 - (tag: build-1.4.20-dev-2376) Enable execution of muted on database tests marked as FLAKY (KTI-288) (vor 3 Tagen) <Yunir Salimzyanov>
* 27e7116f607 - (tag: build-1.4.20-dev-2375) Added the gradle plugin SNAPSHOT version support for some tests. (vor 3 Tagen) <Alexander Dudinsky>
* 80022cccd9e - (tag: build-1.4.20-dev-2374, tag: build-1.4.20-dev-2372) [FIR] Introduce & use processOverriddenPropertiesWithDepth (vor 3 Tagen) <Mikhail Glukhikh>
* 13ef97e51ee - (tag: build-1.4.20-dev-2371) FIR2IR: set proper visibility of backing fields with @JvmField (vor 3 Tagen) <Jinseong Jeon>
* f3475fd098f - (tag: build-1.4.20-dev-2366, tag: build-1.4.20-dev-2358, tag: build-1.4.20-dev-2355) FIR2IR: store and convert annotations on enum entry (vor 3 Tagen) <Jinseong Jeon>
* a1ffc0b25a5 - (tag: build-1.4.20-dev-2349) Handle standalone gradle scripts before (build|settnings|init).gradle.kts (vor 3 Tagen) <Vladimir Dolzhenko>
* a6e58edfb9c - (tag: build-1.4.20-dev-2348) Update test data, unmute test (vor 3 Tagen) <Mikhail Zarechenskiy>
* a05681001f7 - (tag: build-1.4.20-dev-2346) Mark with @DeprecatedSinceKotlin #KT-22423 and #KT-28753 (vor 3 Tagen) <Abduqodiri Qurbonzoda>
* 87cb6372a03 - (tag: build-1.4.20-dev-2342) Specify DeprecatedSinceKotlin for recently deprecated min/max funs (vor 4 Tagen) <Ilya Gorbunov>
* a9f4479557d - Add stdlib-gen DSL support for DeprecatedSinceKotlin annotation (vor 4 Tagen) <Ilya Gorbunov>
* 5eb02429412 - (tag: build-1.4.20-dev-2338) Add missed application component PluginStartupComponent for AS40 (vor 4 Tagen) <Vladimir Dolzhenko>
* fa1e3169df5 - (tag: build-1.4.20-dev-2329) Update dukat dependency to 0.5.7 (vor 4 Tagen) <Shagen Ogandzhanian>
* 026a6ffab25 - FirUpperBoundViolatedChecker: code cleanup (vor 4 Tagen) <Mikhail Glukhikh>
* 1ea5678932f - [FIR] UPPER_BOUND_VIOLATED optimizations (vor 4 Tagen) <Nick>
* 41a0cfe0024 - [FIR] Add diagnostic UPPER_BOUND_VIOLATED (vor 4 Tagen) <Nick>
* b9a220c6242 - (tag: build-1.4.20-dev-2323) AddSuspendModifierFix: suggest in inline lambda (vor 4 Tagen) <Toshiaki Kameyama>
* 982f429d6b6 - (tag: build-1.4.20-dev-2318) Moved the IdeaDefaultIdeTargetPlatformKindProvider declaration from jps.xml back to jvm-common.xml (vor 4 Tagen) <Vyacheslav Karpukhin>
* 3c4f0d3c9e5 - (tag: build-1.4.20-dev-2314) [box-tests] Added test (vor 4 Tagen) <Igor Chevdar>
* 8bbbee8ffd1 - [IR] Supported IrFunctionExpression in ClosureAnnotator (vor 4 Tagen) <Igor Chevdar>
* c9fdef8233f - (tag: build-1.4.20-dev-2312) IR: use buildField where possible (vor 4 Tagen) <Alexander Udalov>
* 2d723f1c517 - IR: use buildClass where possible (vor 4 Tagen) <Alexander Udalov>
* 5b1193407ad - IR: use buildConstructor where possible (vor 4 Tagen) <Alexander Udalov>
* 6aa09f61d45 - IR: use buildFun where possible (vor 4 Tagen) <Alexander Udalov>
* 39e38c70493 - IR: introduce buildVariable, use where possible (vor 4 Tagen) <Alexander Udalov>
* c3560e58542 - IR: use buildTypeParameter, minor cleanup (vor 4 Tagen) <Alexander Udalov>
* 4b5464c6cc0 - IR: introduce buildReceiverParameter, use where possible (vor 4 Tagen) <Alexander Udalov>
* b36a6114aae - IR: use buildValueParameter where possible (vor 4 Tagen) <Alexander Udalov>
* 378d0a757a2 - (tag: build-1.4.20-dev-2310) DebuggerClassNameProvider refactoring (vor 4 Tagen) <Vladimir Ilmov>
* f6a16c52038 - (tag: build-1.4.20-dev-2303) Move some tests from common `mute database` to platforms specific (vor 4 Tagen) <Alexander Dudinsky>
* e754585e389 - (tag: build-1.4.20-dev-2302) NI: add fallback strategy to get lexical scope to checking coroutine call legality (vor 4 Tagen) <Victor Petukhov>
* 5951e7500a3 - Register KOTLIN_BUNDLED via application component in 193 (vor 4 Tagen) <Vladimir Dolzhenko>
* 345528d8f5d - Use public api to register KOTLIN_BUNDLED macros (vor 4 Tagen) <Vladimir Dolzhenko>
* ab2128f55d1 - (tag: build-1.4.20-dev-2301) [FIR] extended checkers infrastructure refactoring (vor 4 Tagen) <vladislavf7@gmail.com>
* 38543ce2a3d - [FIR] add way to configure session in Diagnostic Tests (vor 4 Tagen) <vladislavf7@gmail.com>
* 609f0ca9bc7 - (tag: build-1.4.20-dev-2296) [JS IR] .d.ts generation for module systems (vor 4 Tagen) <Svyatoslav Kuzmich>
* ee23e39b3cb - (tag: build-1.4.20-dev-2294) KT-37720 replace FileSystemLocation with File for TransformAction (vor 4 Tagen) <nataliya.valtman>
* 63ba883a771 - (tag: build-1.4.20-dev-2290) Refactoring of muteWithDatabase (vor 4 Tagen) <Yunir Salimzyanov>
* fb9b3f96dec - KT-40301 Add more diagnostics for 'Module is not contained in resolver' (vor 4 Tagen) <Roman Golyshev>
* 8fd16f4a39b - Add contract to `checkWithAttachment` (vor 4 Tagen) <Roman Golyshev>
* 1ac9b4c38fd - Add dependency scopes option for scripting resolvers (vor 6 Tagen) <Ilya Muradyan>
| * 628efcb1897 - Build: Add kotlin.build.dependencies.iu.enabled property (vor 4 Tagen) <Vyacheslav Gerasimov>
| * 996e5299441 - Build: Allow intellijUltimateEnabled without kotlin-ultimate directory (vor 4 Tagen) <Vyacheslav Gerasimov>
| * 34c1316ae02 - Build: Enable local build cache with `org.gradle.caching=true` (vor 4 Tagen) <Vyacheslav Gerasimov>
| * 2e7cb2b8297 - Build: Enable parallel builds with `org.gradle.parallel=true` (vor 4 Tagen) <Vyacheslav Gerasimov>
| * 50f1f8f0eb1 - FIR: consider more functional types during SAM resolution (vor 4 Tagen) <Jinseong Jeon>
| * d66c6c7e1e7 - FIR serializer: transform KSuspendFunction types too (vor 4 Tagen) <Jinseong Jeon>
| * 85e822e283d - (tag: build-1.4.20-dev-2283) [FIR] Support smartcast after reference equality check (vor 4 Tagen) <Ivan Kylchik>
| * 63f7e95c89c - (tag: build-1.4.20-dev-2281) [FIR] Add RedundantExplicitTypeChecker (vor 4 Tagen) <vladislavf7@gmail.com>
| * 3c798502c80 - (tag: build-1.4.20-dev-2274) Synchronize muted TeamCity tests with database for .bunch configurations (vor 4 Tagen) <Yunir Salimzyanov>
| * c7a37eb6b28 - (tag: build-1.4.20-dev-2270) FIR deserializer: load annotations on extension receiver parameters (vor 4 Tagen) <Jinseong Jeon>
| * 02f08b16d6c - (tag: build-1.4.20-dev-2269) [Commonizer] Ignore CallableDescriptor.hasSynthesizedParameterNames attribute (vor 4 Tagen) <Dmitriy Dolovov>
| * 100a6f70ca8 - (tag: build-1.4.20-dev-2266) Relax rules about inferring to Nothing for special calls (vor 4 Tagen) <Mikhail Zarechenskiy>
| * e45cd02b012 - (tag: build-1.4.20-dev-2258, tag: build-1.4.20-dev-2250, tag: build-1.4.20-dev-2246) KLIB: add EmptyPackageFragment's to fix ModuleDescritor.getSubPackagesOf (vor 5 Tagen) <Anton Bannykh>
| * d2c9fc41f1d - (tag: build-1.4.20-dev-2244) Replace @LowPriorityInOverloadResolution with @DeprecatedSinceKotlin #KT-37101 (vor 5 Tagen) <Abduqodiri Qurbonzoda>
| * 4ac1b7748a7 - Advance bootstrap to 1.4.20-dev-2133 (vor 5 Tagen) <Abduqodiri Qurbonzoda>
| * cd9f59325e5 - (tag: build-1.4.20-dev-2238) [KLIB] Fix deserialization of anonymous classes (vor 5 Tagen) <Roman Artemev>
| * d31de6c8de0 - [Psi2IR] Improve assertion message (vor 5 Tagen) <Roman Artemev>
| * d89083cd8c3 - (tag: build-1.4.20-dev-2232) Fixup the tests vs master-gradle-plugin (vor 5 Tagen) <Alexander Dudinsky>
| * 005314ce064 - Support running import tests on bootstrap version of gradle plugin (vor 5 Tagen) <Andrey Uskov>
| * b0c96a61ec4 - (tag: build-1.4.20-dev-2230) Don't try to infer postponed variables on lambdas without `BuilderInference` annotation ^KT-39618 Fixed (vor 5 Tagen) <Victor Petukhov>
| * 9e737156dd8 - (tag: build-1.4.20-dev-2229) KT-37720 Replace ArtifactTransform with TransformAction (vor 5 Tagen) <nataliya.valtman>
| * b9585dabd49 - (tag: build-1.4.20-dev-2223) KT-32368 Rework Inline hints settings // fix QuickFixTestGenerated$AutoImports.testKt17525 (vor 5 Tagen) <Andrei Klunnyi>
| * 1639cadbb7b - (tag: build-1.4.20-dev-2220) KT-32368 Rework Inline hints settings // remove non-existent ReturnHintLinePainter (vor 5 Tagen) <Andrei Klunnyi>
| * 30b91b128a5 - (tag: build-1.4.20-dev-2219) FIR: adjust type of integer operator call as property initializer (vor 5 Tagen) <Jinseong Jeon>
| * ddd26de139d - (tag: build-1.4.20-dev-2218) FirTypeIntersectionScope: extract 'createIntersectionOverride' (vor 5 Tagen) <Mikhail Glukhikh>
| * 9934f7d56eb - [FIR TEST] Add test for KT-40327 (vor 5 Tagen) <Mikhail Glukhikh>
| * 92d40c27e20 - FirBasedSignatureComposer: build signature even for private classes (vor 5 Tagen) <Mikhail Glukhikh>
| * 07b0ffef847 - [FIR] Introduce & use remapArgumentsWithVararg (vor 5 Tagen) <Mikhail Glukhikh>
| * 5c4f9780737 - FIR: transform arrayOf call with empty arguments (vor 5 Tagen) <Jinseong Jeon>
| * db9d42c153d - IrConstTransformer: handle vararg with spread elements properly (vor 5 Tagen) <Jinseong Jeon>
| * 5600eefea54 - FIR: add support for varargs in annotation calls (vor 5 Tagen) <Jinseong Jeon>
| * 4e6bd33eca0 - FIR: create argument mapping for annotation call in general (vor 5 Tagen) <Jinseong Jeon>
| * 1a861b2df90 - FIR2IR: don't create synthetic class for enum entry w/o members (vor 5 Tagen) <Jinseong Jeon>
| * 2ea35792811 - [FIR] add support for generic cases of delegation by implementation (vor 5 Tagen) <Juan Chen>
| * 93632d2a18a - FIR declaration transformer: unwrap synthetic property accessor properly (vor 5 Tagen) <Mikhail Glukhikh>
| * 031f03a9037 - Introduce FirDeclarationOrigin.INTERSECTION_OVERRIDE (vor 5 Tagen) <Mikhail Glukhikh>
| * 9107944b053 - FirSyntheticProperty: take returnTypeRef directly from delegate (vor 5 Tagen) <Mikhail Glukhikh>
| * e2678149cb3 - FirClassSubstitutionScope: fix overridden symbols traversing (vor 5 Tagen) <Mikhail Glukhikh>
| * 10a1d5c03b5 - FirTypeIntersectionScope: add intersection overrides caching (vor 5 Tagen) <Mikhail Glukhikh>
| * c1d223dbde6 - FirTypeIntersectionScope: enhance support of inherited default parameters (vor 5 Tagen) <Mikhail Glukhikh>
| * c46fac34640 - FirTypeIntersectionScope: support inherited default parameters (vor 5 Tagen) <Mikhail Glukhikh>
| * 7a2ea49399b - FirTypeIntersectionScope: introduce "intersection" fake overrides (vor 5 Tagen) <Mikhail Glukhikh>
| * 5a422b5ef63 - FirTypeIntersectionScope: optimize/cleanup processOverriddenFunctions (vor 5 Tagen) <Mikhail Glukhikh>
| * 1bbed6c4ed9 - [FIR2IR] Use FIR-specific methods to search for overridden functions (vor 5 Tagen) <Mikhail Glukhikh>
| * 59cc9d4bc6c - [FIR] Introduce FirTypeScope.processOverriddenFunctionWithDepth (vor 5 Tagen) <Mikhail Glukhikh>
| * 8a29021aad3 - [FIR2IR] Make data class synthetic members public API (vor 5 Tagen) <Mikhail Glukhikh>
| * 521901f09a9 - [FIR2IR] Cache type parameters for existing IR classes properly (vor 5 Tagen) <Mikhail Glukhikh>
| * d2f5fbdd088 - (tag: build-1.4.20-dev-2217) Fix failing on AS test with inserting `-Xinline-classes` to build script (vor 5 Tagen) <Victor Petukhov>
| * c8b3e622f1a - (tag: build-1.4.20-dev-2209) Fix typo in field name (vor 5 Tagen) <Kirill Shmakov>
| * d96772444eb - (tag: build-1.4.20-dev-2207) [FIR] Fix redundant visibility checker (vor 5 Tagen) <vladislavf7@gmail.com>
| * 9b8128aaa86 - (tag: build-1.4.20-dev-2201) Coerce commonTest to common in HMPP (vor 5 Tagen) <Dmitry Savvinov>
|/  
* 742b98bed68 - (tag: build-1.4.20-dev-2193) Build: Fix stdlib-js-ir commonMainSources task dependency on version (vor 6 Tagen) <Vyacheslav Gerasimov>
* fb5fb449930 - (tag: build-1.4.20-dev-2192) [FIR] Add RedundantModalityModifierChecker (vor 6 Tagen) <vladislavf7@gmail.com>
* e7c88a4349f - (tag: build-1.4.20-dev-2186) Build: Add KotlinVersionCurrentValue to runtime classpath normalization (vor 6 Tagen) <Vyacheslav Gerasimov>
* e215d94b7b8 - Build: Fix JavaExec task configuration (vor 6 Tagen) <Vyacheslav Gerasimov>
* bf23b39d76f - (tag: build-1.4.20-dev-2185) Add using `-Xinline-classes` by default in IDE intentions ^KT-34209 Fixed (vor 6 Tagen) <Victor Petukhov>
* 79d7babb576 - (tag: build-1.4.20-dev-2180) Add test checking file annotations resolution (vor 6 Tagen) <Pavel Kirpichenkov>
* 36a46482c5d - (tag: build-1.4.20-dev-2179) Unmute IdeReplCompletionTestGenerated.testDefinedExtension in 202 (vor 6 Tagen) <Nikolay Krasko>
* 5954fe528b3 - (tag: build-1.4.20-dev-2176) gradle.kts: do not return ErrorScriptDefinition into GradleBuildRootManager (vor 6 Tagen) <Natalia Selezneva>
* 3e3f8aeb936 - Mark importing as complete in case of some unexpected behavior (vor 6 Tagen) <Natalia Selezneva>
* 2c67ab924f4 - (tag: build-1.4.20-dev-2171) [Gradle, JS] this globalObject in webpack (vor 6 Tagen) <Ilya Goncharov>
* 93a82060d40 - (tag: build-1.4.20-dev-2167) KT-39788 MPP, Gradle runner: Run does not add resource directory to classpath // gradle runner support (vor 6 Tagen) <Andrei Klunnyi>
* 681c2e9492d - KT-39788 MPP, Gradle runner: Run does not add resource directory to classpath // classpath fix (vor 6 Tagen) <Andrei Klunnyi>
* 07b566dd02c - Add @JvmDefault for getPossibleSyntheticNestedClassNames (vor 6 Tagen) <Ilya Muradyan>
* 340512e27ae - [KJS] Throw exception on recursive types provided to typeOf and provide proper support later within KT-40173 (vor 6 Tagen) <Zalim Bashorov>
* c5529334596 - [Test infra] Take into account transitive compatible targets while checking compatibility. (vor 6 Tagen) <Zalim Bashorov>
* ca37c6bfe65 - [KJS FE] Allow using typeOf with non-reified type parameters (vor 6 Tagen) <Zalim Bashorov>
* 9d362875da6 - [Gradle, JS] Fail build in case when mpp or js targets not configured (vor 6 Tagen) <Ilya Goncharov>
* 62aed1b53ad - Add `kotlin.stdlib.default.dependency=false` to avoid stdlib default dep (vor 6 Tagen) <Sergey Igushkin>
* ad9d011ed02 - Fix stdlib default dependencies with Android (vor 6 Tagen) <Sergey Igushkin>
* d83d3304a5b - KT-38221: Stdlib by default; KT-40225 Single dependency on kotlin-test (vor 6 Tagen) <Sergey Igushkin>
* 49c8d99f61f - (tag: build-1.4.20-dev-2162) [Gradle, JS] Resolution of compilation's configurations inside NPM conf (vor 6 Tagen) <Ilya Goncharov>
* 40311dbe054 - [Gradle, JS] Fix test on public package json with dependencies (vor 6 Tagen) <Ilya Goncharov>
* c5f89ebc0d3 - [Gradle, JS] Add dev dependencies into public package json (vor 6 Tagen) <Ilya Goncharov>
* bb23556eadf - (tag: build-1.4.20-dev-2159) Don't perform `Unit`-conversion for functional types with type variables (vor 6 Tagen) <Mikhail Zarechenskiy>
* 09b44b31898 - Fix rewrite at slice exception for callable references inside `flatMap` (vor 6 Tagen) <Mikhail Zarechenskiy>
* 1e4c554bcd5 - KT-32368 Rework Inline hints settings // compatibility with earlier IDEA versions (vor 6 Tagen) <Andrei Klunnyi>
* 604e270a732 - KT-32368 Rework Inline hints settings // preview text (vor 6 Tagen) <Andrei Klunnyi>
* 7a69cf587e5 - KT-32368 Rework Inline hints settings // HintType cleanup (vor 6 Tagen) <Andrei Klunnyi>
* d6692a80625 - KT-32368 Rework Inline hints settings // flattern parameter name hints menu (vor 6 Tagen) <Andrei Klunnyi>
* be0cde1d704 - KT-32368 Rework Inline hints settings // remove suspending call hints (vor 6 Tagen) <Andrei Klunnyi>
* 49d4f55c87c - KT-32368 Rework Inline hints settings // special case for lambda hints (vor 6 Tagen) <Andrei Klunnyi>
* d1722e39758 - KT-32368 Rework Inline hints settings // migrate tests for types (vor 6 Tagen) <Andrei Klunnyi>
* 36f34315590 - KT-32368 Rework Inline hints settings // migrate tests for suspending calls (vor 6 Tagen) <Andrei Klunnyi>
* b0dece756a0 - KT-32368 Rework Inline hints settings // migrate tests for lambdas (vor 6 Tagen) <Andrei Klunnyi>
* 5fe1eaea17e - KT-32368 Rework Inline hints settings // remove outdated KotlinCodeHintsPass (vor 6 Tagen) <Andrei Klunnyi>
* 533507de254 - KT-32368 Rework Inline hints settings // split KotlinInlayParameterHintsProvider (vor 6 Tagen) <Andrei Klunnyi>
* 5ec93fd74cd - (tag: build-1.4.20-dev-2154) Fixup for the fix of KT-39809 (vor 6 Tagen) <Sergey Igushkin>
* 4c273e1fc5b - Fix resolving dependency on self in HMPP (KT-39037) (vor 6 Tagen) <Sergey Igushkin>
* aebca19fd75 - Fix resolving an MPP dependency in custom configurations (KT-32239) (vor 6 Tagen) <Sergey Igushkin>
* 8158ba2be37 - (tag: build-1.4.20-dev-2152) Add tests for obsolete issues (vor 6 Tagen) <Mikhail Zarechenskiy>
* 19dc3f071c7 - (tag: build-1.4.20-dev-2150) Gradle, native: Enable assertions for in process compiler execution (vor 6 Tagen) <Ilya Matveev>
* 275ce16faa0 - (tag: build-1.4.20-dev-2144) [FIR] add RedundantReturnUnitTypeChecker (vor 6 Tagen) <vladislavf7@gmail.com>
* 5c88b1e80a3 - (tag: build-1.4.20-dev-2138) Allow depending on Native stdlib even if platforms do not match under HMPP (vor 6 Tagen) <Dmitry Savvinov>
* 21026001db3 - Add logging into ideaModelDependencies (vor 6 Tagen) <Dmitry Savvinov>
* 010e530ac4b - (tag: build-1.4.20-dev-2133) Make common KClass extend common KClassifier (vor 7 Tagen) <Ilya Gorbunov>
* 1878ae8222d - (tag: build-1.4.20-dev-2129) Don't apply copyright notice to Kotlin Ultimate (vor 7 Tagen) <Florian Kistner>
* ce39b75cc83 - (tag: build-1.4.20-dev-2128) Don't apply copyright notice to Kotlin Ultimate (vor 7 Tagen) <Florian Kistner>
* bbb3032e1cc - (tag: build-1.4.20-dev-2125) [Gradle, JS] Rename package-candidate.json to pre-package.json (vor 7 Tagen) <Ilya Goncharov>
* 6a0315fe7a2 - [Gradle, JS] force write package json in all cases (vor 7 Tagen) <Ilya Goncharov>
* b4a774e8217 - [Gradle, JS] Use package.json candidate (vor 7 Tagen) <Ilya Goncharov>
* 8586d5e2065 - [Gradle, JS] Small refactoring of yarn imported (vor 7 Tagen) <Ilya Goncharov>
* cfd91023be1 - Add native targets check to "isAllowCommonizer" method. (vor 7 Tagen) <Konstantin Tskhovrebov>
* 797449f7e45 - (tag: build-1.4.20-dev-2124) [Gradle, JS] Add TC client on TC output handler for browser run task (vor 7 Tagen) <Ilya Goncharov>
* 943d0128750 - (tag: build-1.4.20-dev-2115) Fix comparison for SdkAndMockLibraryProjectDescriptor (vor 7 Tagen) <Nikolay Krasko>
* 0db7806dec6 - Use test classpath for annotations.jar search (vor 7 Tagen) <Nikolay Krasko>
* 07e3dd9ec75 - (tag: build-1.4.20-dev-2107) [Gradle, Cocoapods] Fixed bug in `scheme` name for pods (vor 7 Tagen) <Yaroslav Chernyshev>
* 67e58ff152c - (tag: build-1.4.20-dev-2106) [FIR] Fix redundant calls to firEffectiveVisibility() (vor 7 Tagen) <Nick>
* 5340cf55676 - (tag: build-1.4.20-dev-2101) Add property kotlin.build.useIR to enable JVM IR in Kotlin build (vor 7 Tagen) <Alexander Udalov>
* 9c36c743572 - Build: do not pass JVM compiler arguments to common KotlinCompile (vor 7 Tagen) <Alexander Udalov>
* 8d79a6ae039 - (tag: build-1.4.20-dev-2098, tag: build-1.4.20-dev-2090) [JVM IR] Copy inline class constructor annotations (vor 7 Tagen) <Kristoffer Andersen>
* 678b76cab16 - (tag: build-1.4.20-dev-2089) Fix presence of `Deprecated` hidden annotation for reference arguments (vor 7 Tagen) <Mikhail Zarechenskiy>
* c2e0cd60d71 - (tag: build-1.4.20-dev-2085) Gradle tests: Temporary disable NativePlatformLibsIT for Windows (vor 7 Tagen) <Ilya Matveev>
* 3ef760604b1 - (tag: build-1.4.20-dev-2080) Force expansion to have the same nullability as abbreviation (vor 7 Tagen) <Dmitry Savvinov>
* 8890ae10d4d - Add test on signatures with nullable abbreviated types (vor 7 Tagen) <Dmitry Savvinov>