### PR TITLE
Fix setColorUnlessGreen

### DIFF
--- a/runtime/src/main/cpp/Memory.h
+++ b/runtime/src/main/cpp/Memory.h
@@ -236,9 +236,9 @@ struct ContainerHeader {
 
   inline void setColorUnlessGreen(unsigned color) {
     // TODO: do we need atomic color update?
-    unsigned objectCount_ = objectCount_;
-    if ((objectCount_ & CONTAINER_TAG_GC_COLOR_MASK) != CONTAINER_TAG_GC_GREEN)
-        objectCount_ = (objectCount_ & ~CONTAINER_TAG_GC_COLOR_MASK) | color;
+    unsigned objectCount = objectCount_;
+    if ((objectCount & CONTAINER_TAG_GC_COLOR_MASK) != CONTAINER_TAG_GC_GREEN)
+        objectCount_ = (objectCount & ~CONTAINER_TAG_GC_COLOR_MASK) | color;
   }
 
   inline bool buffered() const {


### PR DESCRIPTION
Currently this method effectively does nothing. Luckily, it was only used to reset color during freezing, which is fine: frozen objects do not use color.