### PR TITLE
[kotlin compiler][update] 1.4.20-dev-2727

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -192,9 +192,6 @@ internal class Context(config: KonanConfig) : KonanBackendContext(config) {
     lateinit var environment: KotlinCoreEnvironment
     lateinit var bindingContext: BindingContext
 
-    override val declarationFactory
-        get() = TODO("not implemented")
-
     lateinit var moduleDescriptor: ModuleDescriptor
 
     lateinit var objCExport: ObjCExport

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -1,8 +1,11 @@
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.backend.common.*
-import org.jetbrains.kotlin.backend.common.extensions.IrPluginContextImpl
+import org.jetbrains.kotlin.backend.common.CheckDeclarationParentsVisitor
+import org.jetbrains.kotlin.backend.common.IrValidator
+import org.jetbrains.kotlin.backend.common.IrValidatorConfig
+import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContextImpl
 import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideChecker
 import org.jetbrains.kotlin.backend.common.phaser.*
 import org.jetbrains.kotlin.backend.common.serialization.mangle.ManglerChecker
@@ -144,9 +147,8 @@ internal val psiToIrPhase = konanUnitPhase(
 
             val symbolTable = symbolTable!!
 
-            val translator = Psi2IrTranslator(config.configuration.languageVersionSettings,
-                    Psi2IrConfiguration(false), KonanIdSignaturer(KonanManglerDesc))
-            val generatorContext = translator.createGeneratorContext(moduleDescriptor, bindingContext, symbolTable = symbolTable)
+            val translator = Psi2IrTranslator(config.configuration.languageVersionSettings, Psi2IrConfiguration(false))
+            val generatorContext = translator.createGeneratorContext(moduleDescriptor, bindingContext, symbolTable)
 
             val pluginExtensions = IrGenerationExtension.getInstances(config.project)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2426,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-2426
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2426,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-2426
-kotlinStdlibTestsVersion=1.4.20-dev-2426
-testKotlinCompilerVersion=1.4.20-dev-2426
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2727,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-2727
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2727,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-2727
+kotlinStdlibTestsVersion=1.4.20-dev-2727
+testKotlinCompilerVersion=1.4.20-dev-2727
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 635869f15a8 - (tag: build-1.4.20-dev-2746, tag: build-1.4.20-dev-2737, tag: build-1.4.20-dev-2727) Rewrite className helper to fix tests on android (vor 2 Tagen) <Zalim Bashorov>
* 0ded1d70065 - (tag: build-1.4.20-dev-2719) FirBasedSignatureComposer: generate better error messages (vor 3 Tagen) <Mikhail Glukhikh>
* 40256aa43df - Fir2IrLazyClass: generate enum values() / valueOf() properly (vor 3 Tagen) <Mikhail Glukhikh>
* 8bae0f2d0c1 - [FIR2IR] Handle local visibility around signature composer properly (vor 3 Tagen) <Mikhail Glukhikh>
* 828524bde43 - [FIR2IR] Fix conversion of default vararg arguments for annotations (vor 3 Tagen) <Mikhail Glukhikh>
* 240baa64a5f - Fir2IrConverter: initialize call generator earlier to avoid lateinit err (vor 3 Tagen) <Mikhail Glukhikh>
* 2b52988f1b9 - [FIR TEST] Add failing BB test with Deprecated annotation (vor 3 Tagen) <Mikhail Glukhikh>
* df1719c64ca - (tag: build-1.4.20-dev-2718, tag: build-1.4.20-dev-2707, tag: build-1.4.20-dev-2698) Fix incorrect mixed named/positioned arguments in project code (vor 3 Tagen) <Denis Zharkov>
* dc6efa5a611 - Fix incorrect handling of mixed named/positional arguments (vor 3 Tagen) <Denis Zharkov>
* d0832973666 - (tag: build-1.4.20-dev-2697) Support additional flags in MPP tests. Add diagnostic tests for defaults (vor 3 Tagen) <Mikhail Bogdanov>
* 125c72cb8d8 - New default checks for mixed hierarchies (vor 3 Tagen) <Mikhail Bogdanov>
* de02b31ad7c - (tag: build-1.4.20-dev-2696) FIR: Use phasedFir in resolve (vor 3 Tagen) <Denis Zharkov>
* 0de29e641dd - (tag: build-1.4.20-dev-2694) Fixed bug with `pureKotlinSourceFolders` for common modules (vor 3 Tagen) <Yaroslav Chernyshev>
* 142bd2e0090 - Filtering `pureKotlinSourceFolders` for existing package directories (vor 3 Tagen) <Yaroslav Chernyshev>
* e6670d439f0 - Small renaming `classifier` -> `disambiguationClassifier` (vor 3 Tagen) <Yaroslav Chernyshev>
* 96d9dad4296 - Fixed tests for `pureKotlinSourceFolders` by extending created facets (vor 3 Tagen) <Yaroslav Chernyshev>
* f4900851426 - Support `pureKotlinSourceFolders` for MPP projects (vor 3 Tagen) <Yaroslav Chernyshev>
* fde8a34c329 - (tag: build-1.4.20-dev-2693) KT-40058 NPE from mpp gradle plugin on kotlinx.benchmarks (vor 3 Tagen) <nataliya.valtman>
* bc41681a2e9 - (tag: build-1.4.20-dev-2677) Fix gradle import error after introducing new gradle task in benchmarks (vor 4 Tagen) <Ivan Kylchik>
* 96ac6e612db - (tag: build-1.4.20-dev-2676, tag: build-1.4.20-dev-2674, tag: build-1.4.20-dev-2672) Build: Replace androidIdeTest task with kaptIdeTest (vor 4 Tagen) <Vyacheslav Gerasimov>
* 803d24cd422 - Build: Remove pluginTests task and deduplicate kapt test task (vor 4 Tagen) <Vyacheslav Gerasimov>
* ee642e69b0c - Build: Introduce mainIdeTests task (vor 4 Tagen) <Vyacheslav Gerasimov>
* e2a4ca10d6d - (tag: build-1.4.20-dev-2671) JVM_IR: fix inner class attributes for private class in interface (vor 4 Tagen) <Dmitry Petrov>
* 07417814623 - Compare inner class access flags in bytecode listing tests (vor 4 Tagen) <Dmitry Petrov>
* 8d894929ae8 - (tag: build-1.4.20-dev-2662) Minor: unify logging in scripting (vor 4 Tagen) <Natalia Selezneva>
* 8a6cdcba293 - (tag: build-1.4.20-dev-2661) Do not hold a lock during loading script templates from dependencies (vor 4 Tagen) <Natalia Selezneva>
* 493c287bb08 - Minor: fix notification text when script configuration is missing after request (vor 4 Tagen) <Natalia Selezneva>
* 265873becd3 - (tag: build-1.4.20-dev-2656) Comment out runBenchmark tasks due to gradle import error (vor 4 Tagen) <Ivan Kylchik>
* be06c51aa76 - (tag: build-1.4.20-dev-2654) KT-40363 Handle non-octal int literals in for-loop conversions (vor 4 Tagen) <Roman Golyshev>
* cba671a3ef8 - KT-40359 Catch `NumberFormatException` during literal conversion (vor 4 Tagen) <Roman Golyshev>
* cc0a7877351 - Add null-checking to `KotlinIdeaResolutionException` constructors (vor 4 Tagen) <Roman Golyshev>
* f7031e65bac - (tag: build-1.4.20-dev-2643) Uast: don't throw exception if can't get a receiver parameter for annotation (KT-40494) (vor 4 Tagen) <Nicolay Mitropolsky>
* 7872b219142 - (tag: build-1.4.20-dev-2639) FIR: handle object invoke via type alias (vor 4 Tagen) <Jinseong Jeon>
* 4a803e9d2f7 - (tag: build-1.4.20-dev-2636) [JS IR] Support object declaration export (vor 4 Tagen) <Svyatoslav Kuzmich>
* 4027dae594a - [JS] Add js/js.translator/testData/package-lock.json (vor 4 Tagen) <Svyatoslav Kuzmich>
* be371c9294b - (tag: build-1.4.20-dev-2629) Remove optimization in KotlinScriptDependenciesClassFinder (vor 5 Tagen) <Natalia Selezneva>
* be8374a1a8d - Minor: fix comments (vor 5 Tagen) <Natalia Selezneva>
* e708e3f1c5c - Do not suggest to load gradle.kts configurations after project reopening (vor 5 Tagen) <Natalia Selezneva>
* 300e9581dea - Fix UI for Kotlin Scripting page (vor 5 Tagen) <Natalia Selezneva>
* dd20b9062a7 - Completion for script inside module should provide classes from related module (vor 5 Tagen) <Natalia Selezneva>
* 65d3ae62530 - (tag: build-1.4.20-dev-2627) JS IR: move declaration creation from IrBuilder to JsIrDeclarationBuilder (vor 5 Tagen) <Alexander Udalov>
* d3a34a8898d - Psi2Ir: somewhat simplify Psi2IrTranslator API (vor 5 Tagen) <Alexander Udalov>
* 241f82c70fc - IR: avoid storing unnecessary fields in IrPropertyImpl (vor 5 Tagen) <Alexander Udalov>
* 3f06f8a6ba0 - IR: avoid storing unnecessary fields in IrFunctionImpl (vor 5 Tagen) <Alexander Udalov>
* 517c3e10203 - IR: introduce IrFakeOverrideFunction, IrFakeOverrideProperty (vor 5 Tagen) <Alexander Udalov>
* ca5eb40fa5c - IR: minor, avoid usages of IrBlockBodyImpl/IrExpressionBodyImpl (vor 5 Tagen) <Alexander Udalov>
* 174576af61b - (tag: build-1.4.20-dev-2626) ForLoopsLowering: Handle `Sequence<*>.withIndex()`. (vor 5 Tagen) <Mark Punzalan>
* 132960a6955 - ForLoopsLowering: Eliminate use of @ObsoleteDescriptorBasedAPI. (vor 5 Tagen) <Mark Punzalan>
* b1ce21bc55e - ForLoopsLowering: Reduce unnecessary temporary variables for the "checked step" (check for a positive step arg) and "negated step" (negate the step arg when the nested step is negative). (vor 5 Tagen) <Mark Punzalan>
* 291d62f6536 - ForLoopsLowering: Move handlers to sub-package and separate files. (vor 5 Tagen) <Mark Punzalan>
* 44d283eb07d - Fix FIR benchmark memory leak (vor 5 Tagen) <Ivan Kylchik>
* be4dbf2dcd3 - Create gradle scripts to run and analyze benchmark results (vor 5 Tagen) <Ivan Kylchik>
* 29d0e3dbb5c - Reuse createSession function for FIR in benchmark (vor 5 Tagen) <Ivan Kylchik>
* 1272162a7f6 - JVM_IR: generate "safe" names for functions in init blocks (vor 5 Tagen) <Dmitry Petrov>
* bb8f8578097 - [Gradle, Import] Added externalSystemId into facet for mpp projects (vor 5 Tagen) <Yaroslav Chernyshev>
* e5b0498eb62 - (tag: build-1.4.20-dev-2593) Fix tests for Gradle kts and groovy dsl (vor 5 Tagen) <Ilya Goncharov>
* ae0bedd2ac3 - [Gradle, JS] Different module kind for browser and nodejs (vor 5 Tagen) <Ilya Goncharov>
* 38ec3ffb4a8 - [Gradle, JS] Statically calculated module configurator id (vor 5 Tagen) <Ilya Goncharov>
* bf1b85343ff - [Gradle, JS] Remove copyright from template of node.js (vor 5 Tagen) <Ilya Goncharov>
* 2d60d2c0e61 - [Gradle, JS] Divide allowSinglePlatform (vor 5 Tagen) <Ilya Goncharov>
* af367b01ec6 - [Gradle, JS] Add test on node js single platform project (vor 5 Tagen) <Ilya Goncharov>
* cb60b9e59c4 - [Gradle, JS] singleplatformJs -> singlePlatformJsBrowser (vor 5 Tagen) <Ilya Goncharov>
* 01ec8b52627 - [Gradle, JS] Fix typo and add node js module configurator (vor 5 Tagen) <Ilya Goncharov>
* 0d606e1346c - [Gradle, JS] Fix id and text in simple js module configurators (vor 5 Tagen) <Ilya Goncharov>
* 4c5cd44e75e - [Gradle, JS] Localize Module Type (vor 5 Tagen) <Ilya Goncharov>
* 29e37ee15f7 - [Gradle, JS] Fix test for js single platform (vor 5 Tagen) <Ilya Goncharov>
* a866e514023 - [Gradle, JS] NodeJs template files (vor 5 Tagen) <Ilya Goncharov>
* 95f66692752 - [Gradle, JS] Add NodeJs template plugin (vor 5 Tagen) <Ilya Goncharov>
* 6866fdc3e1b - [Gradle, JS] Add NodeJs template project (vor 5 Tagen) <Ilya Goncharov>
* 4de31da0f36 - [Gradle, JS] Fix typo (vor 5 Tagen) <Ilya Goncharov>
* e8dfc4dcd03 - [Gradle, JS] JsSinglePlatform -> BrowserJsSinglePlatform (vor 5 Tagen) <Ilya Goncharov>
* b4334a3a3b0 - (tag: build-1.4.20-dev-2592) [Gradle, JS] Fix formatting in Gradle Kotlin/JS wizard (vor 5 Tagen) <Ilya Goncharov>
* e1abaa9b512 - (tag: build-1.4.20-dev-2584) FIR: special visibility handling for monitor{Enter|Exit} (vor 5 Tagen) <Jinseong Jeon>
* 85f692ab404 - FIR2IR: use DescriptorWithContainerSource if container source is available (vor 5 Tagen) <Jinseong Jeon>
* c076d81f0ca - [IR FAKE OVERRIDES] Properly account for outer class type parameters (vor 5 Tagen) <Alexander Gorshenev>
* 1ef17c6f3ab - (tag: build-1.4.20-dev-2582) Drop isErrorTypeAllowed flag from type system context (vor 5 Tagen) <Pavel Kirpichenkov>
* 710659324cc - [NI] Fix common supertype of types with error supertypes (vor 5 Tagen) <Pavel Kirpichenkov>
* 95cc35f22e5 - (tag: build-1.4.20-dev-2576) Package builtins with jvm reflect into IDEA plugin only (vor 5 Tagen) <Ilya Gorbunov>
* 0c094b17191 - Serialize jvm reflect into builtIns (vor 5 Tagen) <Stanislav Erokhin>
* 67090e1afbb - Move KTypeProjection to separate file (vor 5 Tagen) <Stanislav Erokhin>
* ee26fd49592 - (tag: build-1.4.20-dev-2575) [KJS FE] Change severity of NON_EXPORTABLE_TYPE from error to warning (vor 5 Tagen) <Zalim Bashorov>
* 41bd0137967 - (tag: build-1.4.20-dev-2573) Fix incorrect usages of @NotNull type parameters in project sources (vor 5 Tagen) <Denis Zharkov>
* 037ff2fa529 - Fix incorrect handling of @NotNull type parameters (vor 5 Tagen) <Denis Zharkov>
* f1c68a9080c - Introduce JavaTypeEnhancement component (vor 5 Tagen) <Denis Zharkov>
* 240311d9c7e - Minor. Reformat JavaNullabilityChecker (vor 5 Tagen) <Denis Zharkov>
* d93885e71c7 - (tag: build-1.4.20-dev-2562) Add tests for deprecated properties (vor 6 Tagen) <Dmitry Petrov>
* e84339a0d36 - JVM_IR: fields for deprecated enum entries have ACC_DEPRECATED flag (vor 6 Tagen) <Dmitry Petrov>
* edab3e3ba9c - (tag: build-1.4.20-dev-2557) [PLUGIN API] Add `referenceTypeAlias` API to `IrPluginContext` (vor 6 Tagen) <Roman Artemev>
* c4b4912a71c - Revert "[PLUGIN API] Make `referenceClass` resolve type aliases too" (vor 6 Tagen) <Roman Artemev>
* cb15570d750 - (tag: build-1.4.20-dev-2552) [JS IR BE] Fix validation errors (duplicate nodes and incorrect parent) (vor 6 Tagen) <Anton Bannykh>
* d36d62e2262 - (tag: build-1.4.20-dev-2547) Add info about `-Pteamcity` to readme and make warning less annoying (vor 6 Tagen) <Vyacheslav Gerasimov>
* a4457ba7ac4 - (tag: build-1.4.20-dev-2539) Build: Setup dependency on dist for :compiler:fir:analysis-tests:test (vor 6 Tagen) <Vyacheslav Gerasimov>
* 58ee95c8a38 - Build: Add root IDE test tasks to split tests in 3 parts (vor 6 Tagen) <Vyacheslav Gerasimov>
* 036c3599935 - Build: Make local profile warning more visible (vor 6 Tagen) <Vyacheslav Gerasimov>
* d9fbaadb2e7 - Build: Upgrade Gradle Enterprise plugin to 3.3.4 (vor 6 Tagen) <Vyacheslav Gerasimov>
* d7a0dbfae8d - (tag: build-1.4.20-dev-2530) [PLUGIN API] Make `referenceClass` resolve type aliases too (vor 6 Tagen) <Roman Artemev>
* a0154b98510 - (tag: build-1.4.20-dev-2528) Add JarUtil.getJarAttribute to proguard rules (vor 6 Tagen) <Leonid Startsev>
* e3f42721e90 - Mute/ignore 'PROVIDED_RUNTIME_TOO_LOW' in tests (vor 6 Tagen) <Leonid Startsev>
* df5f38fec87 - Implement reading kx.serialization runtime metadata from jar manifest (vor 6 Tagen) <Leonid Startsev>
* 7db0bf8195e - Add new serialization runtime packages (vor 6 Tagen) <Leonid Startsev>
* 8b9fb6a6cdb - (tag: build-1.4.20-dev-2517) [FIR] Remove FirOperatorCall node from fir tree (vor 6 Tagen) <Ivan Kylchik>
* 3c01a398460 - [FIR] Update test data after introducing new fir nodes (vor 6 Tagen) <Ivan Kylchik>
* d77d7332440 - [FIR] Complement fir rendering with newly created nodes (vor 6 Tagen) <Ivan Kylchik>
* 9a119a67571 - [FIR] Replace all necessary usages of operator call with new ones (vor 6 Tagen) <Ivan Kylchik>
* def47bdd9d5 - [FIR] Add new equalityOperatorCall node in control flow graph (vor 6 Tagen) <Ivan Kylchik>
* d23e9940ec0 - [FIR] Change fir builder to use newly created nodes (vor 6 Tagen) <Ivan Kylchik>
* 708c8b8ef34 - [FIR] Create additional nodes to replace operator call in some places (vor 6 Tagen) <Ivan Kylchik>
* 8c4930da2ee - (tag: build-1.4.20-dev-2511) [KLIB] Drop API which is no longer used (vor 6 Tagen) <Roman Artemev>
* bb20e4759ba - [KLIB] Use queue to track classes required fake override resolve (vor 6 Tagen) <Roman Artemev>
* 2b0639d4ad5 - (tag: build-1.4.20-dev-2505) [FIR] Cleanup and refactoring for checkers (vor 6 Tagen) <vladislavf7@gmail.com>
* fb946a6a3f3 - [FIR] Move extended checkers list (vor 6 Tagen) <vladislavf7@gmail.com>
* 751ed60e42a - [FIR] Fix redundant visibility modifier checker (vor 6 Tagen) <vladislavf7@gmail.com>
* a8ff5d17dc3 - [FIR] Fix redundant modality modifier checker (vor 6 Tagen) <vladislavf7@gmail.com>
* a988234bbf9 - [FIR] Fix redundant explicit type checker (vor 6 Tagen) <vladislavf7@gmail.com>
* eecb43d4c95 - (tag: build-1.4.20-dev-2501) Ignore test in Native backend (vor 6 Tagen) <Pavel Punegov>
* bace1b80554 - (tag: build-1.4.20-dev-2497) Increase stdlib-js mocha test timeouts to 10s (vor 6 Tagen) <Ilya Gorbunov>
* d62a6a26316 - (tag: build-1.4.20-dev-2495) JVM IR: Do not create accessors for enum entry constructors (vor 7 Tagen) <Steven Schäfer>
* 71730696b2e - (tag: build-1.4.20-dev-2494) JVM IR: rename JvmDeclarationFactory -> JvmCachedDeclarations (vor 7 Tagen) <Alexander Udalov>
* c7f9dc1c408 - IR: rename DeclarationFactory to InnerClassesSupport, move out of context (vor 7 Tagen) <Alexander Udalov>
* cf884fb048f - IR: remove JVM-specific methods from DeclarationFactory (vor 7 Tagen) <Alexander Udalov>
* 6907decd99c - Report file name on exception from ASM in BinaryJavaClass (vor 7 Tagen) <Alexander Udalov>
* 221d49a995a - (tag: build-1.4.20-dev-2492) Set wantsDiagnostics() in AbstractFilteringTrace (vor 7 Tagen) <Matthew Gharrity>
* 2e31f955549 - (tag: build-1.4.20-dev-2490) Update testData (vor 7 Tagen) <Dmitry Petrov>
* 2b9606becfd - JVM_IR: field for suspend main parameter is synthetic (vor 7 Tagen) <Dmitry Petrov>
* 7be9b18ff44 - JVM: field for suspend main parameter is synthetic (vor 7 Tagen) <Dmitry Petrov>
* 6bc44a366af - JVM_IR: fields for suspend lambda parameters are synthetic (vor 7 Tagen) <Dmitry Petrov>
* bae6037f007 - JVM: fields for suspend lambda parameters are synthetic (vor 7 Tagen) <Dmitry Petrov>
* fa75518bd7a - JVM_IR: don't skip nullability annotations on private fields (vor 7 Tagen) <Dmitry Petrov>
* d30c67db14d - JVM: don't skip nullability annotations on private fields (vor 7 Tagen) <Dmitry Petrov>
* b0ac046b05f - (tag: build-1.4.20-dev-2486) NI: decrease fixation priority for variables which have only incorporated from upper bound constraints (vor 7 Tagen) <Victor Petukhov>
* 081248f859a - (tag: build-1.4.20-dev-2482) [Gradle, JS] Extract properties provider in KotlinJsTarget (vor 7 Tagen) <Ilya Goncharov>
* 49176435831 - [Gradle, JS] Check if not both compiler (vor 7 Tagen) <Ilya Goncharov>
* 61b5a738dab - (tag: build-1.4.20-dev-2477) [Gradle, JS] Rename flag for legacy (vor 7 Tagen) <Ilya Goncharov>
* e7764444596 - [Gradle, JS] binaries executable for legacy by default (vor 7 Tagen) <Ilya Goncharov>
* f7beea10a5d - [Gradle, JS] Common configure should be last otherwise user settings can be overwrote (vor 7 Tagen) <Ilya Goncharov>
* 814bd48148a - (tag: build-1.4.20-dev-2473, tag: build-1.4.20-dev-2464) Keep members of com.google.common dependencies intact (vor 7 Tagen) <Jim Sproch>
* 236dfe60f14 - (tag: build-1.4.20-dev-2456) [FIR] Correctly build scopes for resolve of different parts of constructors (vor 7 Tagen) <Dmitriy Novozhilov>
* 94ff457e431 - [FIR] Handle erroneous situation with type projection in supertype (vor 7 Tagen) <Dmitriy Novozhilov>
* c94d583e2e5 - [FIR] Add substitution for inner classes to supertype resolve (vor 7 Tagen) <Dmitriy Novozhilov>
* cf555ef2b60 - [FIR] Move FirNestedClassifierScopeWithSubstitution to separate file (vor 7 Tagen) <Dmitriy Novozhilov>
* 07e12f98b59 - [FIR] Substitute supertypes in nested classifier scope (vor 7 Tagen) <Dmitriy Novozhilov>
* cedd1c133ef - [FIR] Match type in `super<type>` access with actual supertypes of class (vor 7 Tagen) <Dmitriy Novozhilov>
* 1ce4eca3a62 - [FIR] Infer type arguments for captured parameters of inner classes (vor 7 Tagen) <Dmitriy Novozhilov>
* 1c622a5a3f8 - [FIR] Add `transformConversionTypeRef` to FirTypeOperatorCall (vor 7 Tagen) <Dmitriy Novozhilov>
* 1b78950ebb2 - [FIR] Don't transform property initializers in type resolve (vor 7 Tagen) <Dmitriy Novozhilov>
* 9e941898521 - [FIR] Add `transformTypeParameters` to FirTypeParameterRefsOwner (vor 7 Tagen) <Dmitriy Novozhilov>
* 4083111dab5 - (tag: build-1.4.20-dev-2455) Fix SAM conversion when lambda is the last expression of another lambda (vor 7 Tagen) <Mikhail Zarechenskiy>
* a15d3c76b66 - Fix references to sam adapted functions, also fix lookup location (vor 7 Tagen) <Mikhail Zarechenskiy>
* 0c79de1a98d - Prohibit adapted reference resolve against reflective types (vor 7 Tagen) <Mikhail Zarechenskiy>
* d8de37f665d - (tag: build-1.4.20-dev-2452, tag: build-1.4.20-dev-2445) (CoroutineDebugger) using WeakReference as lastObservedFrame (vor 7 Tagen) <Vladimir Ilmov>
* bcf1954860c - (CoroutineDebugger) added support for DebugCoroutineInfoImpl in kotlinx-coroutines-core:1.3.8 (vor 7 Tagen) <Vladimir Ilmov>
* b43b238030a - (CoroutineDebugger) embed agent into gradle JavaExec task (vor 7 Tagen) <Vladimir Ilmov>
* 217428212fc - (CoroutineDebugger) Refactoring of retrieving BaseContinuationImpl chains (vor 7 Tagen) <Vladimir Ilmov>
* 14766a3e1ad - (CoroutineDebugger) lv 'task' added to tests in EventLoopImplBase kotlinx-coroutines-core:1.3.7 (vor 7 Tagen) <Vladimir Ilmov>
* e49f3b567b1 - (CoroutineDebugger) minimum supported version kotlinx-coroutines-core.1.3.8 (vor 7 Tagen) <Vladimir Ilmov>
* cd896ae6c82 - (tag: build-1.4.20-dev-2442) FIR: Implement FE 1.0 semantics for super unqualified calls (vor 7 Tagen) <Denis Zharkov>
* dfc75f34474 - FIR: Support fake elements for light tree (vor 7 Tagen) <Denis Zharkov>
* fea1fb0fc32 - FIR: Rename FirSourceElement::withKind to fakeElement (vor 7 Tagen) <Denis Zharkov>
* 376d3385d0f - FIR: Handle super-receiver case in a special way (vor 7 Tagen) <Denis Zharkov>
* 628b8b56b7d - (tag: build-1.4.20-dev-2433) FIR2IR: convert annotations on type aliases (vor 7 Tagen) <Jinseong Jeon>
* 4e14f9500f6 - (tag: build-1.4.20-dev-2432) FIR: account for vararg when creating KFunction type for callable reference (vor 7 Tagen) <Jinseong Jeon>