### PR TITLE
[kotlin compiler][update] 1.4.20-dev-3012

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -153,7 +153,7 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
     }
 
     private fun createIrClass(symbol: IrClassSymbol, descriptor: ClassDescriptor): IrClass =
-        createIrClassFromDescriptor(offset, offset, DECLARATION_ORIGIN_FUNCTION_CLASS, symbol, descriptor)
+        IrFactoryImpl.createIrClassFromDescriptor(offset, offset, DECLARATION_ORIGIN_FUNCTION_CLASS, symbol, descriptor)
 
     private fun createClass(descriptor: FunctionClassDescriptor, declarator: SymbolTable.((IrClassSymbol) -> IrClass) -> IrClass): IrClass =
         symbolTable?.declarator { createIrClass(it, descriptor) }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.konan.descriptors.KonanSharedVariablesManage
 import org.jetbrains.kotlin.backend.konan.descriptors.findPackage
 import org.jetbrains.kotlin.backend.konan.descriptors.kotlinNativeInternal
 import org.jetbrains.kotlin.backend.konan.ir.KonanIr
+import org.jetbrains.kotlin.builtins.konan.KonanBuiltIns
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
@@ -20,11 +21,12 @@ import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.ir.IrElement
-import org.jetbrains.kotlin.ir.declarations.IrFile
-import org.jetbrains.kotlin.builtins.konan.KonanBuiltIns
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFactory
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.name.Name
@@ -66,6 +68,8 @@ internal abstract class KonanBackendContext(val config: KonanConfig) : CommonBac
     override val mapping: Mapping = DefaultMapping()
 
     override val extractedLocalClasses: MutableSet<IrClass> = mutableSetOf()
+
+    override val irFactory: IrFactory = IrFactoryImpl
 }
 
 internal fun IrElement.getCompilerMessageLocation(containingFile: IrFile): CompilerMessageLocation? =

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.descriptors.konan.isNativeStdlib
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
@@ -112,7 +113,7 @@ private var Context.symbolTable: SymbolTable? by Context.nullValue()
 
 internal val createSymbolTablePhase = konanUnitPhase(
         op = {
-            this.symbolTable = SymbolTable(KonanIdSignaturer(KonanManglerDesc))
+            this.symbolTable = SymbolTable(KonanIdSignaturer(KonanManglerDesc), IrFactoryImpl)
         },
         name = "CreateSymbolTable",
         description = "Create SymbolTable"

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
@@ -50,7 +50,7 @@ internal interface DescriptorToIrTranslationMixin {
      */
     fun createClass(descriptor: ClassDescriptor, builder: (IrClass) -> Unit): IrClass =
             symbolTable.declareClass(descriptor) {
-                createIrClassFromDescriptor(
+                symbolTable.irFactory.createIrClassFromDescriptor(
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB, it, descriptor
                 )
             }.also { irClass ->

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1098,7 +1098,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
                     }
                 }
 
-                if (catch.parameter.type == context.builtIns.throwable.defaultType) {
+                if (catch.catchParameter.descriptor.type == context.builtIns.throwable.defaultType) {
                     genCatchBlock()
                     return      // Remaining catch clauses are unreachable.
                 } else {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FinallyBlocksLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FinallyBlocksLowering.kt
@@ -267,12 +267,11 @@ internal class FinallyBlocksLowering(val context: Context): FileLoweringPass, Ir
                     type              = context.irBuiltIns.nothingType,
                     tryResult         = transformedTry,
                     catches           = listOf(
-                            irCatch(catchParameter).apply {
-                                result = irBlock {
-                                    +copy(finallyExpression)
-                                    +irThrow(irGet(catchParameter))
-                                }
-                            }),
+                            irCatch(catchParameter, irBlock {
+                                +copy(finallyExpression)
+                                +irThrow(irGet(catchParameter))
+                            })
+                    ),
                     finallyExpression = null
             )
             using(TryScope(syntheticTry, transformedFinallyExpression, this)) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -198,7 +198,7 @@ internal class KonanIrLinker(
             val irFile = getIrFile(packageDescriptor)
 
             val klass = symbolTable.declareClassFromLinker(descriptor, idSig) { symbol ->
-                createIrClassFromDescriptor(offset, offset, FORWARD_DECLARATION_ORIGIN, symbol, descriptor)
+                symbolTable.irFactory.createIrClassFromDescriptor(offset, offset, FORWARD_DECLARATION_ORIGIN, symbol, descriptor)
             }
 
             klass.parent = irFile

--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,7 @@ task detectJarCollision(type: CollisionDetector) {
         librariesWithIgnoredClassCollisions.addAll(["util", "container", "resolution", "serialization", "psi", "frontend",
                                                     "config", "config.jvm", "js.config", "javac-wrapper",
                                                     "frontend.common", "frontend.java", "cli-common", "ir.tree",
+                                                    "ir.tree.impl", "ir.tree.persisting",
                                                     "ir.psi2ir", "ir.backend.common", "backend.jvm", "backend.js",
                                                     "backend.wasm", "ir.serialization.common", "ir.serialization.js",
                                                     "ir.serialization.jvm", "ir.interpreter", "jvm", "compiler.version",

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2727,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-2727
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2727,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-2727
-kotlinStdlibTestsVersion=1.4.20-dev-2727
-testKotlinCompilerVersion=1.4.20-dev-2727
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3012,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-3012
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3012,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-3012
+kotlinStdlibTestsVersion=1.4.20-dev-3012
+testKotlinCompilerVersion=1.4.20-dev-3012
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 39d4b79324b - (tag: build-1.4.20-dev-3012, origin/master, origin/HEAD) [FIR TEST] Fix FE 1.0 / FIR test data for nested / local type alias case (vor 13 Stunden) <Mikhail Glukhikh>
* 7724d060ffc - [FIR] Don't compare SYNTAX diagnostics in light tree diagnostic test (vor 13 Stunden) <Mikhail Glukhikh>
* 4e4fe9f7196 - [FIR] Support some kinds of fake sources in light builder (vor 13 Stunden) <Mikhail Glukhikh>
* 951aa8185e7 - [FIR] Avoid duplicate diagnostics on expression.typeRef (vor 13 Stunden) <Mikhail Glukhikh>
* dc46d51d9a4 - [FIR TEST] Update diagnostic spec test data (vor 13 Stunden) <Mikhail Glukhikh>
* 6eab6f2f879 - [FIR TEST] Replace OTHER_ERROR with UNRESOLVED_REFERENCE in test data (vor 13 Stunden) <Mikhail Glukhikh>
* c55cdf19358 - [FIR] Fix missing ErrorTypeRef for QA and clean DiagnosticCollector (vor 13 Stunden) <Nick>
* 7086b0cbf3b - [FIR] Don't report duplicated errors in component calls typeRefs (vor 13 Stunden) <Nick>
* 4ceae8dc5e3 - [FIR] Don't report duplicated errors in function calls typeRefs (vor 13 Stunden) <Nick>
* 6f85a072900 - [FIR] Don't report duplicated errors in property declarations (vor 13 Stunden) <Nick>
* 889324e972d - [FIR] Ignore failing test, improve DiagnosticKind, fix UPPER_BOUND (vor 13 Stunden) <Nick>
* 9335e09149a - [FIR] Don't report duplicated errors in implicit properties / parameters (vor 13 Stunden) <Mikhail Glukhikh>
* ceaffb1e8b2 - [FIR] Don't report duplicated errors in implicit primary constructors (vor 13 Stunden) <Mikhail Glukhikh>
* 749346b73bf - [FIR] Don't report duplicated errors on default accessor error type refs (vor 13 Stunden) <Mikhail Glukhikh>
* e0d25876b05 - [FIR] Don't report simple diagnostics on fake sources (vor 13 Stunden) <Mikhail Glukhikh>
* 551bdd267d7 - [FIR] Introduce WRONG_NUMBER_OF_TYPE_ARGUMENTS diagnostic (vor 13 Stunden) <Mikhail Glukhikh>
* 0804c6a0f33 - [FIR] Introduce TYPE_ARGUMENTS_NOT_ALLOWED & some other type errors (vor 13 Stunden) <Mikhail Glukhikh>
* c744dfba9c3 - (tag: build-1.4.20-dev-3011) FIR: distinguish anonymous object as enum entry when scoping (vor 13 Stunden) <Jinseong Jeon>
* 52631b7abd4 - FIR2IR: make local storage track scopes, including anonymous init (vor 13 Stunden) <Jinseong Jeon>
* 26e3a111d65 - (tag: build-1.4.20-dev-2997, tag: build-1.4.20-dev-2994) [FIR] Add diagnostics for object related problems (vor 3 Tagen) <Nick>
* 694d3cad4e9 - (tag: build-1.4.20-dev-2993) [FIR] Exposed visibility checker: optimize checks for local visibility (vor 3 Tagen) <Nick>
* 60462bea1c4 - FirEffectiveVisibilityResolver: search parent in containingDeclarations (vor 3 Tagen) <Nick>
* 7145caca40b - [FIR] Refactor effective visibility calculation (vor 3 Tagen) <Nick>
* b15e32936e2 - (tag: build-1.4.20-dev-2991) JVM IR: Optimize delegated properties (KT-36814) (vor 3 Tagen) <Steven Schäfer>
* 8724efbe8a2 - (tag: build-1.4.20-dev-2984) [FIR] Add empty range checker (vor 3 Tagen) <vldf>
* b10defdbabd - [FIR] Add redundant single string expression template checker (vor 3 Tagen) <vldf>
* 95e0ba3d5c0 - [FIR] Add ArrayEqualityOpCanBeReplacedWithEquals checker (vor 3 Tagen) <vldf>
* 4d21a496fe1 - (tag: build-1.4.20-dev-2981) Minor. Update tests (vor 3 Tagen) <Ilmir Usmanov>
* e11c90f26c6 - (tag: build-1.4.20-dev-2978) JVM_IR: KT-40293 Box return type for DefaultImpls methods if required (vor 3 Tagen) <Dmitry Petrov>
* 034d5a948c7 - (tag: build-1.4.20-dev-2976) Add JvmDefault to the new EP method for compatibility with older impls (vor 3 Tagen) <Ilya Chernikov>
* fa8c6deb187 - (tag: build-1.4.20-dev-2960) Support restricted suspend lambdas in JVM_IR (vor 3 Tagen) <Ilmir Usmanov>
* 2c205410fae - (tag: build-1.4.20-dev-2957) Check whether the field is indeed being initialized (vor 3 Tagen) <Ilmir Usmanov>
* d8b76f5b26e - (tag: build-1.4.20-dev-2956) Register additional repository id (vor 4 Tagen) <Nikolay Krasko>
* 7eca13569b2 - (tag: build-1.4.20-dev-2955) (CoroutineDebugger) Enable agent for versions 1.3.8.* (vor 4 Tagen) <Vladimir Ilmov>
* c91858d4709 - (tag: build-1.4.20-dev-2953) Convert member to extension: do not suggest for delegated properties (vor 4 Tagen) <Toshiaki Kameyama>
* 46fccae7d17 - (tag: build-1.4.20-dev-2949) PSI2IR: KT-40499 Fix delegated property desugaring (vor 4 Tagen) <Dmitry Petrov>
* bff36e0199b - (tag: build-1.4.20-dev-2931, tag: build-1.4.20-dev-2927) FIR2IR: convert annotations on FirTypeRef (vor 4 Tagen) <Jinseong Jeon>
* 4ca98041cdd - IR: update test data (vor 4 Tagen) <Georgy Bronnikov>
* a27d63f58fe - JVM_IR: flexible nullability as annotation (vor 4 Tagen) <Georgy Bronnikov>
* a2e9521ad50 - Make DescriptorlessExternalPackageFragmentSymbol public (vor 4 Tagen) <Georgy Bronnikov>
* c2ead0303b5 - IR: remove more descriptor usage (vor 4 Tagen) <Georgy Bronnikov>
* 9a717e9ecfe - (tag: build-1.4.20-dev-2920) Don't copy default value parameters for fake overrides (vor 4 Tagen) <Alexander Gorshenev>
* 2cfd7760925 - (tag: build-1.4.20-dev-2916) ForLoopsLowering: Assume `step` == 1 for *Range (e.g., IntRange) and handle accordingly (e.g., do not read `step` property). (vor 4 Tagen) <Mark Punzalan>
* 09e47fff7b6 - (tag: build-1.4.20-dev-2915) Fix KotlinGradleIT.testCustomCompilerFile (vor 4 Tagen) <Dmitry Petrov>
* dae358c792e - JVM: KT-40664 disable optimization for 'ULong in range of UInt' case (vor 4 Tagen) <Dmitry Petrov>
* f2493d0950a - JVM: KT-40665 more exact check for intrinsified range 'contains' (vor 4 Tagen) <Dmitry Petrov>
* 0559e192ee7 - (tag: build-1.4.20-dev-2912) [JS IR] Support external delegation in case of JS in psi2ir (vor 4 Tagen) <Roman Artemev>
* c254651ed32 - (tag: build-1.4.20-dev-2911) Uast: handling annotations on the property receiver (KT-40539) (vor 4 Tagen) <Nicolay Mitropolsky>
* 325ad56dcdc - (tag: build-1.4.20-dev-2910) Populate Kotlin source set roots with KotlinSourceRootTypes (vor 5 Tagen) <Yaroslav Chernyshev>
* fec845365a0 - (tag: build-1.4.20-dev-2909) Minor. No longer ignore obsolete PRE_RELEASE_CLASS diagnostic (vor 5 Tagen) <Ilmir Usmanov>
* ebfcd7e074b - (tag: build-1.4.20-dev-2907) J2K: Improve presentation of conversions (vor 5 Tagen) <Simon Ogorodnik>
* 5c745facf4c - J2K: Improve error message in case of incorrect detach (vor 5 Tagen) <Simon Ogorodnik>
* dc963e4ff6c - Improve J2K progress reporting (vor 5 Tagen) <Simon Ogorodnik>
* 8bcf1000f6f - J2K: Fix java 9 try-with-resources (vor 5 Tagen) <Simon Ogorodnik>
* c5005f8695d - J2K: Speed-up add imports (vor 5 Tagen) <Simon Ogorodnik>
* cd0c644654a - J2K: Fix incorrect early detaching of elements in for conversion (vor 5 Tagen) <Simon Ogorodnik>
* 8c2dd876b5e - J2K: Fix incorrect argument remapping when introducing defaults (vor 5 Tagen) <Simon Ogorodnik>
* cd7ac55091c - J2K: Show converted/total file counts (vor 5 Tagen) <Simon Ogorodnik>
* 468af0bb85e - J2K: Fix type parameters in LHS of callable reference (vor 5 Tagen) <Simon Ogorodnik>
* 96d0b1c47ae - (tag: build-1.4.20-dev-2906, tag: build-1.4.20-dev-2887) Update serialization runtime and fix test data (vor 5 Tagen) <Leonid Startsev>
* a6a22d1cdee - (tag: build-1.4.20-dev-2880) Revert "Populate Kotlin source set roots with KotlinSourceRootTypes" (vor 5 Tagen) <Nikolay Krasko>
* e2634190881 - (tag: build-1.4.20-dev-2875) Populate Kotlin source set roots with KotlinSourceRootTypes (vor 5 Tagen) <Yaroslav Chernyshev>
* 4fb5f8603a1 - (tag: build-1.4.20-dev-2867) Keep $continuation in LVT (vor 5 Tagen) <Ilmir Usmanov>
* db40808186a - Minor. Remove unused SourceFrames (vor 5 Tagen) <Ilmir Usmanov>
* 70e91bd5dbe - Shrink and split LVT records of variables according to their liveness (vor 5 Tagen) <Ilmir Usmanov>
* e5995f0c12c - Update R8 (vor 5 Tagen) <Ilmir Usmanov>
* 60875f96b40 - Do not take LVT into account when calculating liveness of variables (vor 5 Tagen) <Ilmir Usmanov>
* 687d13a320b - (tag: build-1.4.20-dev-2858) IR: cleanup expression implementations (vor 5 Tagen) <Alexander Udalov>
* e36d3ba4f6a - IR: remove IrNoArgumentsCallableReferenceBase (vor 5 Tagen) <Alexander Udalov>
* f270cd8d6ee - (tag: build-1.4.20-dev-2857) [FIR] Update testdata due to lack of callee reference in FirResolvedQualifier (vor 5 Tagen) <Dmitriy Novozhilov>
* f283f2db43e - [FIR] Improve diagnostic reporting & don't use error symbol for candidate if possible (vor 5 Tagen) <Dmitriy Novozhilov>
* 5c0528b61e9 - (tag: build-1.4.20-dev-2856) [Spec tests] Add tests for primary constructors declaration (vor 5 Tagen) <anastasiia.spaseeva>
* 0488dc985fd - [Spec tests] Add tests for intersection and OR (vor 5 Tagen) <anastasiia.spaseeva>
* 46774fb6d61 - [Spec tests] Add call without an explicit receiver tests for top-level non-extension functions (vor 5 Tagen) <anastasiia.spaseeva>
* bef59055cd9 - [Spec tests] Fix test cases structure (vor 5 Tagen) <anastasiia.spaseeva>
* 4ad3847224f - [Spec tests] Add tests for subtyping rules for simple classifier type (vor 5 Tagen) <anastasiia.spaseeva>
* 1801344c769 - [Spec tests] Add tests for inner-and-nested-type-contexts section (vor 5 Tagen) <anastasiia.spaseeva>
* d5ddb26180c - [Spec tests] Add overload resolution tests for plus assign operator call (vor 5 Tagen) <anastasiia.spaseeva>
* 1d83c59e803 - [Spec tests] Actualize test for callable reference section (vor 5 Tagen) <anastasiia.spaseeva>
* 4db209648dd - [Spec tests] Update spec version (vor 5 Tagen) <anastasiia.spaseeva>
* 3f862830f2e - [Spec tests] Add tests for resolving callable references and some co-tests (vor 5 Tagen) <anastasiia.spaseeva>
* cfbfec77a58 - [Spec tests] Add tests for Algorithm of MSC selection (vor 5 Tagen) <anastasiia.spaseeva>
* 73850e97d7e - [Spec tests] Add test for Coercion to Unit error diagnostics absence (vor 5 Tagen) <anastasiia.spaseeva>
* 26ac87d9bed - [Spec tests] Update spec testData (vor 5 Tagen) <anastasiia.spaseeva>
* f240d51d2c2 - (tag: build-1.4.20-dev-2854) IR: do not inherit IrFakeOverride* from IrFunction/IrProperty (vor 5 Tagen) <Alexander Udalov>
* 4892737cc96 - Use IrFactory in kotlin-serialization-compiler (vor 5 Tagen) <Alexander Udalov>
* 0909894a960 - PIR: make most implementations and carriers internal (vor 5 Tagen) <Alexander Udalov>
* cce55f16096 - IR: add module ir.tree.impl, move main IR implementation there (vor 5 Tagen) <Alexander Udalov>
* 77247deb23d - IR: add module ir.tree.persistent, copy PIR implementation there (vor 5 Tagen) <Alexander Udalov>
* 9aed92d2ddf - Partially revert "Persistent IR implementation" (vor 5 Tagen) <Alexander Udalov>
* 980b91d0829 - (tag: build-1.4.20-dev-2850) JVM: generate 'Deprecated' on method as runtime-visible annotation (vor 6 Tagen) <Dmitry Petrov>
* 4fdccb3b35f - JVM_IR: don't generate repeated ElementType values in @Target (vor 6 Tagen) <Dmitry Petrov>
* c065210b566 - (tag: build-1.4.20-dev-2849) [Gradle, JS] Reuse task requirements (vor 6 Tagen) <Ilya Goncharov>
* 9a3ae4f4fa2 - [Gradle, JS] Common webpack configuration (vor 6 Tagen) <Ilya Goncharov>
* a2b26c00a19 - (tag: build-1.4.20-dev-2846) Uncommented ControlFlowAnalysisBenchmark (vor 6 Tagen) <vldf>
* fca0b7fedd6 - (tag: build-1.4.20-dev-2839) [FIR] Add CFA benchmark (vor 6 Tagen) <vldf>
* d7b3a86f5ec - [FIR] Add "can be val" extended checker (vor 6 Tagen) <vldf>
* da6e96f4f15 - (tag: build-1.4.20-dev-2834) FIR2IR: don't declare dispatch receiver for local functions (vor 6 Tagen) <Jinseong Jeon>
* 5a3367e09cb - (tag: build-1.4.20-dev-2829) FIR: initial support of suspend conversion for function reference (vor 6 Tagen) <Jinseong Jeon>
* b9243aad248 - (tag: build-1.4.20-dev-2827) Minor, fix test data in bytecodeListing/specialBridges (vor 6 Tagen) <Alexander Udalov>
* df324d5a08a - IR: pull up common accept/transform implementations to interfaces (vor 6 Tagen) <Alexander Udalov>
* 12d2a02d222 - JS IR: drop JsIrDeclarationBuilder (vor 6 Tagen) <Alexander Udalov>
* 0d605a6b7ff - IR: create IrBlockBody via IrFactory (vor 6 Tagen) <Alexander Udalov>
* 9ad4a754cef - IR: create IrExpressionBody via IrFactory (vor 6 Tagen) <Alexander Udalov>
* d1dc938a5d7 - IR: use IrFactory in IR builders (vor 6 Tagen) <Alexander Udalov>
* 898dd20a9e2 - IR: use IrFactory in misc utils (vor 6 Tagen) <Alexander Udalov>
* f359f36ed9e - IR: add IrFactory to IrDeclaration, use in deep copy (vor 6 Tagen) <Alexander Udalov>
* 305288aa82a - IR: use IrFactory in psi2ir (vor 6 Tagen) <Alexander Udalov>
* 8c41ba8ee4e - IR: use IrFactory in fir2ir (vor 6 Tagen) <Alexander Udalov>
* 9356f87f281 - IR: use IrFactory in linker (vor 6 Tagen) <Alexander Udalov>
* db4cbe7103d - IR: use IrFactory in SymbolTable (vor 6 Tagen) <Alexander Udalov>
* c6a127e87e5 - IR: introduce IrFactory (vor 6 Tagen) <Alexander Udalov>
* 96968cd9c9d - (tag: build-1.4.20-dev-2825) Fix build after rebasing (vor 6 Tagen) <Kirill Shmakov>
* 96160cbb556 - (tag: build-1.4.20-dev-2821) Adapt AS wizard to changes in main wizard (vor 6 Tagen) <Kirill Shmakov>
* 5c8833f6085 - Wizard: improve mobile app template (vor 6 Tagen) <Kirill Shmakov>
* 63fa6674a3b - Wizard: temporary add ios shortcut target (vor 6 Tagen) <Ilya Kirillov>
* f330cd36978 - Wizard: relocate AndroidManifest.xml for MPP module (vor 6 Tagen) <Ilya Kirillov>
* b3d48cda8c9 - Wizard: add common tests for iOS/Android template (vor 6 Tagen) <Ilya Kirillov>
* 5ffcaf65085 - Wizard: add shared code for iOS/Android template (vor 6 Tagen) <Ilya Kirillov>
* 66c756ad0f7 - Wizard: add ability for wizard to generate expected/actual declarations in MPP module (vor 6 Tagen) <Ilya Kirillov>
* 7d1036ee7e0 - Wizard: use property for storing module dependency (vor 6 Tagen) <Ilya Kirillov>
* dbc43b66bfc - Wizard: introduce ModuleConfiguratorProperty (vor 6 Tagen) <Ilya Kirillov>
* 74d6919c7c5 - Wizard: wrap property into PluginProperty for plugin properties (vor 6 Tagen) <Ilya Kirillov>
* 3c3ba361e8c - Wizard: specify path for plugin entities in one place (vor 6 Tagen) <Ilya Kirillov>
* c05c72387ed - Wizard: fix node js templates (vor 6 Tagen) <Ilya Kirillov>
* 63e2d771b34 - Get rid of reflection in new project wizard core: manually specify properties in plugins (vor 6 Tagen) <aleksandrina-streltsova>
* cc35529b9a8 - Wizard: get rid of reflection: specify plugin path by hand (vor 6 Tagen) <Ilya Kirillov>
* 3ed11c04913 - Wizard: get rid of reflection: force plugins to specify settings & tasks directly (vor 6 Tagen) <Ilya Kirillov>
* eadd3f00f2a - (tag: build-1.4.20-dev-2814) [FIR] Add CanBeReplacedWithOperatorAssignmentChecker (vor 6 Tagen) <vldf>
* fa8c6e7fb69 - (tag: build-1.4.20-dev-2813) Uast: KT-40578: resolve Kotlin property writes to setters (#3597) (vor 6 Tagen) <Kevin Bierhoff>
* 5851a7dea09 - (tag: build-1.4.20-dev-2809) [kotlinx-metadata-klib] Proper support for nullable enum entry fields (vor 6 Tagen) <Sergey Bogolepov>
* 45f0328f21f - (tag: build-1.4.20-dev-2803) scripting: preload scripting support plugins (vor 6 Tagen) <Sergey Rostov>
* b5e04378ed2 - scripting, ucache: don't init caches at start up (vor 6 Tagen) <Sergey Rostov>
* 43fcb2330ec - (tag: build-1.4.20-dev-2794, tag: build-1.4.20-dev-2793) JVM_IR: fix source file name for mutlifile class facades (vor 7 Tagen) <Dmitry Petrov>
* 89a0b3e9444 - Check class source in bytecode listing tests (vor 7 Tagen) <Dmitry Petrov>
* b47946cbba0 - (tag: build-1.4.20-dev-2792) Report interop functions with non-stable parameter names (vor 7 Tagen) <Dmitriy Dolovov>
* 3d9093583fa - Metadata: 'non-stable parameter names' flag for callables (vor 7 Tagen) <Dmitriy Dolovov>
* 8cace2bab4b - (tag: build-1.4.20-dev-2791, tag: build-1.4.20-dev-2789) [Gradle, JS] Add tests on kotlin/js module with js files (vor 7 Tagen) <Ilya Goncharov>
* 0b88f457e80 - [Gradle, JS] Use .meta.js as source of "name" and "main" fields (vor 7 Tagen) <Ilya Goncharov>
* cca64b8faba - (tag: build-1.4.20-dev-2782) NI: use the inferred type to check of nullable array for vararg (vor 7 Tagen) <Victor Petukhov>
* 9d63412b3e7 - (tag: build-1.4.20-dev-2781) JVM IR: Produce correct generic signatures for special bridge methods (vor 7 Tagen) <Steven Schäfer>
* c16b548dff2 - JVM IR: Don't produce annotations on builtin stub, toArray, and bridge methods (vor 7 Tagen) <Steven Schäfer>
* f661b7604ba - (tag: build-1.4.20-dev-2780, tag: build-1.4.20-dev-2775) KT-40557 Scratch: .kt files are treated as Kotlin scratches, opening fails (vor 7 Tagen) <Andrei Klunnyi>
* 0e46a980f6c - EA- 235760 // additional logging (vor 7 Tagen) <Andrei Klunnyi>
* c27453632ea - EA-235769 // StringIndexOutOfBoundsException (vor 7 Tagen) <Andrei Klunnyi>
* 4afa50e081b - EA-235759 // NPE fix (vor 7 Tagen) <Andrei Klunnyi>
* 29281fd0bf5 - EA-235761 // NPE fix (vor 7 Tagen) <Andrei Klunnyi>
* e63951c38c8 - EA-235765 // NPE at refactoring suggestion (vor 7 Tagen) <Andrei Klunnyi>
* e8fd69fde18 - (tag: build-1.4.20-dev-2772) [formatter] fix infinite recursion (vor 7 Tagen) <Dmitry Gridin>
* b1173317c59 - (tag: build-1.4.20-dev-2770) Change scripting Severity enums to order from DEBUG to FATAL. (vor 7 Tagen) <Ryan Nett>
* 59f6c0c2730 - (tag: build-1.4.20-dev-2767) Add flag for avoid double MPP gradle module resolve. (vor 7 Tagen) <Konstantin Tskhovrebov>
* 5444ffaf4b0 - (tag: build-1.4.20-dev-2761) [Gradle, JS] Deprecate produceExecutable (vor 7 Tagen) <Ilya Goncharov>
* d9c269ed6b7 - (tag: build-1.4.20-dev-2756) [Gradle, JS] Disable binaries.executable by default in wizard (vor 7 Tagen) <Ilya Goncharov>
* 8d1f9df802c - (tag: build-1.4.20-dev-2749) Do not show warning when multiple Gradle Definitions are loaded (vor 7 Tagen) <Natalia Selezneva>
* a62f65940d3 - (tag: build-1.4.20-dev-2747) Gradle, CocoaPods: Use synthetic dir as a working dir for pod gen (vor 7 Tagen) <Ilya Matveev>
* 7c3eda31fa1 - Gradle, CocoaPods: Fix non-compilable dummy header (vor 7 Tagen) <Ilya Matveev>
* 85908713b14 - Gradle, CocoaPods: Support pods with dashes in names (vor 7 Tagen) <Ilya Matveev>