### PR TITLE
[kotlin compiler][update] 1.4.20-dev-3296

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/CallableReferenceLowering.kt
@@ -71,7 +71,7 @@ internal class CallableReferenceLowering(val context: Context): FileLoweringPass
                 return result
             }
 
-            override fun visitDeclaration(declaration: IrDeclaration): IrStatement {
+            override fun visitDeclaration(declaration: IrDeclarationBase): IrStatement {
                 lateinit var tempGeneratedClasses: MutableList<IrClass>
                 if (declaration is IrClass) {
                     tempGeneratedClasses = generatedClasses

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -136,7 +136,7 @@ object SetDeclarationsParentVisitor : IrElementVisitor<Unit, IrDeclarationParent
         }
     }
 
-    override fun visitDeclaration(declaration: IrDeclaration, data: IrDeclarationParent) {
+    override fun visitDeclaration(declaration: IrDeclarationBase, data: IrDeclarationParent) {
         declaration.parent = data
         super.visitDeclaration(declaration, data)
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -6,14 +6,12 @@
 package org.jetbrains.kotlin.ir.util
 
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
-import org.jetbrains.kotlin.backend.common.descriptors.substitute
 import org.jetbrains.kotlin.backend.konan.KonanBackendContext
 import org.jetbrains.kotlin.backend.konan.KonanCompilationException
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
 import org.jetbrains.kotlin.builtins.KOTLIN_REFLECT_FQ_NAME
 import org.jetbrains.kotlin.config.LanguageVersionSettings
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.ParameterDescriptor
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.impl.PackageFragmentDescriptorImpl
@@ -192,14 +190,6 @@ fun IrFunctionAccessExpression.addArguments(args: Map<IrValueParameter, IrExpres
             this.putValueArgument(it.index, arg)
         }
     }
-}
-
-private fun FunctionDescriptor.substitute(
-        typeArguments: List<IrType>
-): FunctionDescriptor = if (typeArguments.isEmpty()) {
-    this
-} else {
-    this.substitute(*typeArguments.map { it.toKotlinType() }.toTypedArray())
 }
 
 fun IrType.substitute(map: Map<IrTypeParameterSymbol, IrType>): IrType {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3012,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-3012
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3012,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-3012
-kotlinStdlibTestsVersion=1.4.20-dev-3012
-testKotlinCompilerVersion=1.4.20-dev-3012
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3296,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-3296
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3296,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-3296
+kotlinStdlibTestsVersion=1.4.20-dev-3296
+testKotlinCompilerVersion=1.4.20-dev-3296
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 36984009e90 - (tag: build-1.4.20-dev-3296, origin/master, origin/HEAD) Add samples for flatten, unzip functions (vor 5 Stunden) <kvirolainen>
* 41d56156086 - Add samples for mapNotNull, find, getOrNull functions (vor 5 Stunden) <Elijah Verdoorn>
* 62df2b3195d - (tag: build-1.4.20-dev-3285) FIR IDE: run SUPER_TYPES & BODY_RESOLVE phases under global lock (vor 20 Stunden) <Ilya Kirillov>
* 7fb408ecd7f - FIR IDE: enable new project wizard to FIR IDE (vor 20 Stunden) <Ilya Kirillov>
* db7119f04d5 - FIR IDE: fix ability to create new Kotlin files (vor 20 Stunden) <Ilya Kirillov>
* 054d196ec58 - FIR IDE: temporary ignore failing tests (vor 20 Stunden) <Ilya Kirillov>
* 683ec2beffa - FIR IDE: make KtScopeProvider thread local (vor 20 Stunden) <Ilya Kirillov>
* f62204fff16 - FIR: move getCallableNames/getClassifierNames from scope to FirContainingNamesAwareScope (vor 20 Stunden) <Ilya Kirillov>
* 36a161080fe - FIR IDE: introduce KtType rendering (vor 20 Stunden) <Ilya Kirillov>
* 9f33d0147cd - FIR IDE: add info about nullability to KtType (vor 20 Stunden) <Ilya Kirillov>
* 16d22ae7e30 - FIR IDE: correctly build FIR for qualified expressions (vor 20 Stunden) <Ilya Kirillov>
* 66f6fe18d68 - FIR IDE: replace javax threadsafe annotations with custom ones (vor 20 Stunden) <Ilya Kirillov>
* 4595ee2cc06 - FIR IDE: create read only copy of symbol builder only for completion (vor 20 Stunden) <Ilya Kirillov>
* ccf232eaabd - FIR IDE: forbid analysis session to be stored in a variable (vor 20 Stunden) <Ilya Kirillov>
* b41a5f9f346 - FIR: make TypeRegistry thread safe (vor 20 Stunden) <Ilya Kirillov>
* 5f424ed1ec9 - FIR IDE: rewrite low level API (vor 20 Stunden) <Ilya Kirillov>
* 1957be8757b - FIR IDE: fix testdata of tests which now pass (vor 20 Stunden) <Ilya Kirillov>
* 34aa848b152 - FIR: do not allow getting PSI text in RawFirBuilder in stub mode (vor 20 Stunden) <Ilya Kirillov>
* cfc46b0cc87 - FIR IDE: introduce FirIdeAllSourceDependenciesSymbolProvider (vor 20 Stunden) <Ilya Kirillov>
* 7d8ef5c7a26 - FIR IDE: introduce KtFirConstructorDelegationReference (vor 20 Stunden) <Ilya Kirillov>
* 0870ded0540 - FIR IDE: introduce KtFirArrayAccessReference (vor 20 Stunden) <Ilya Kirillov>
* 22054c8507d - FIR IDE: use non-fake override fir elements when finding psi for fir (vor 20 Stunden) <Ilya Kirillov>
* d10e3f91faf - FIR IDE: store FirScope strong references only in KtFirAnalysisSession (vor 20 Stunden) <Ilya Kirillov>
* 7033be588cb - FIR IDE: regenerate member scope test (vor 20 Stunden) <Ilya Kirillov>
* ea3b2d8310f - KT IDE: fix fully-qualified type resolving (vor 20 Stunden) <Ilya Kirillov>
* 50951fdfc37 - KT IDE: use proper package symbol PSI to fix invalidated access exception (vor 20 Stunden) <Ilya Kirillov>
* 9f9ce6ba61a - Fix compilation of KtFirDelegatingScope (vor 20 Stunden) <Ilya Kirillov>
* 1c195ea2bbe - FIR IDE: add kdoc for KtAnalysisSession (vor 20 Stunden) <Ilya Kirillov>
* b8caefa0c4c - FIR IDE: always recreate analysis session in tests to avoid breaking its contract (vor 20 Stunden) <Ilya Kirillov>
* 19efd19c6c4 - FIR IDE: fix AbstractSymbolByFqNameTest after rebase (vor 20 Stunden) <Ilya Kirillov>
* 94b62e2ac65 - FIR IDE: make context-dependent analysis session to use original cache on read-only mode (vor 20 Stunden) <Ilya Kirillov>
* c0f5c90231a - FIR IDE: separate ValidityOwner to ValidityTokenOwner & ValidityToken (vor 20 Stunden) <Ilya Kirillov>
* 6a6580dd971 - FIR IDE: introduce KtConstructorSymbol.ownerClassId (vor 20 Stunden) <Ilya Kirillov>
* 4653cdf794d - FIR IDE: make KtFirDelegatingScope caching a thread safe (vor 20 Stunden) <Ilya Kirillov>
* ebf20c9706c - Add multi-file tests for primitive completion (vor 20 Stunden) <Roman Golyshev>
* 1b3a1a662f5 - Add simple completion of class-like symbols (vor 20 Stunden) <Roman Golyshev>
* 20c627ea471 - Implement collecting class-like names in `KtFirStarImportingScope` (vor 20 Stunden) <Roman Golyshev>
* 29ee233bb9a - Remove repeating scopes collected by `buildCompletionContextForFunction` (vor 20 Stunden) <Roman Golyshev>
* e3778d62e3a - Simplify `canBeCalledWith` function (vor 20 Stunden) <Roman Golyshev>
* b90503decbe - Move `PackageIndexHelper` to `KtFirStarImportingScope.kt` (vor 20 Stunden) <Roman Golyshev>
* d2fbd8e3387 - Remove `KotlinFirCompletionProvider` (vor 20 Stunden) <Roman Golyshev>
* dee58e1d86a - FIR IDE: handle importing scopes in completion in HL API (vor 20 Stunden) <Ilya Kirillov>
* 7aa26944d7f - FIR IDE: rename utils.kt to psiUtils.kt (vor 20 Stunden) <Ilya Kirillov>
* 902b42ae1dc - FIR IDE: fix typo in completion testdata (vor 20 Stunden) <Ilya Kirillov>
* c3a3ab9e89c - Implement the completion using high-level API only (vor 20 Stunden) <Roman Golyshev>
* a6dd84a7e40 - FIR IDE: Modify `KtFirAnalysisSession` for completion (vor 20 Stunden) <Roman Golyshev>
* 54946a793a3 - Fix `FirCompletionContext` for safe access elements (vor 20 Stunden) <Roman Golyshev>
* a2cf01162e2 - Fix bug with member extensions with explicit receiver (vor 20 Stunden) <Roman Golyshev>
* df03e31b869 - FIR IDE: Add `KtCallableSymbol` abstraction (vor 20 Stunden) <Roman Golyshev>
* a4a2d92c08e - FIR IDE: Make `KtFirReference` implement `KtSymbolBasedReference` (vor 20 Stunden) <Roman Golyshev>
* 2eb439899e8 - Use index to get symbols from importing scopes (vor 20 Stunden) <Roman Golyshev>
* cefecdef258 - fixup! Iterate on symbols, not on scopes (vor 20 Stunden) <Dmitriy Novozhilov>
* e7f5594ffe8 - Use more correct check for the constructor symbol (vor 20 Stunden) <Roman Golyshev>
* a3da1ea1a03 - Iterate on symbols, not on scopes (vor 20 Stunden) <Roman Golyshev>
* 708c54f4d25 - Refactor the collecting of callable symbols from scopes (vor 20 Stunden) <Roman Golyshev>
* 81f60bf252b - Add test for smartcast (vor 20 Stunden) <Roman Golyshev>
* ffb907150ac - Use information about receivers in completion (vor 20 Stunden) <Roman Golyshev>
* 0f5fc1fa992 - Add `FirSymbolProvider::getAllCallableNamesInPackage` function (vor 20 Stunden) <Roman Golyshev>
* 97d4918ed39 - Expose local scopes to use in completion (vor 20 Stunden) <Denis Zharkov>
* 6129f4bcef2 - Partial raw FIR building (vor 20 Stunden) <Roman Golyshev>
* a1b621d987e - Completion with FIR (prototype, work-in-progress) (vor 20 Stunden) <Roman Golyshev>
* 2a495c11355 - FIR IDE: introduce composite scopes (vor 20 Stunden) <Ilya Kirillov>
* 9092b337557 - FIR IDE: Introduce module resolve state for completion (vor 20 Stunden) <Ilya Kirillov>
* 1d92fbaa7fe - FIR IDE: correctly set symbol origin for fake overridden ones (vor 20 Stunden) <Ilya Kirillov>
* 88548d988a5 - FIR IDE: implement getCallableNames/getClassifierNames in more scopes (vor 20 Stunden) <Ilya Kirillov>
* 138f11ee270 - FIR IDE: introduce member scope tests (vor 20 Stunden) <Ilya Kirillov>
* f709e6acf39 - FIR IDE: introduce scopes for HL API (vor 20 Stunden) <Ilya Kirillov>
* 6596dc359b8 - fixup! Completion with FIR (prototype, work-in-progress) (vor 20 Stunden) <Dmitriy Novozhilov>
* d62500531b5 - FIR: add getClassifierNames for FirScope (vor 20 Stunden) <Ilya Kirillov>
* 656086f90a1 - Add `FirScope::getCallableNames` function (vor 20 Stunden) <Roman Golyshev>
* 1f3add49f47 - FIR IDE: move trailing comma related registry keys to ide-frontend-independent.xml (vor 20 Stunden) <Ilya Kirillov>
* 055b9756997 - FIR IDE: add tests which failing with exceptions inside FIR (vor 20 Stunden) <Ilya Kirillov>
* 9cf4fdfb71c - FIR IDE: add reference info on reference resolve (vor 20 Stunden) <Ilya Kirillov>
* 5c6d636d02a - Minor: reformat fir ide part of GenerateTests.kt (vor 20 Stunden) <Ilya Kirillov>
* 45e01a8b3d0 - FIR IDE: precalculate DuplicatedFirSourceElementsException error message (vor 20 Stunden) <Ilya Kirillov>
* 964becf1380 - FIR IDE: allow the same entity to be accessed from different threads (vor 20 Stunden) <Ilya Kirillov>
* 4c08dfb2385 - Add invoke reference resolve test without errors in test data (vor 20 Stunden) <Ilya Kirillov>
* 15ecfd84b4b - FIR IDE: cache KtAnalysisSession for modules (vor 20 Stunden) <Ilya Kirillov>
* 8c0197e0816 - FIR IDE: introduce KtAnalysisSessionProvider & helping functions for working with analysis session (vor 20 Stunden) <Ilya Kirillov>
* acb8546583f - FIR IDE: fix ReadOnlyWeakRef error message (vor 20 Stunden) <Ilya Kirillov>
* b09358fe173 - FIR IDE: rename KtFieldSymbol -> KtFirJavaFieldSymbol (vor 20 Stunden) <Ilya Kirillov>
* f98ff2c25e6 - FIR IDE: always pass resolve state as parameter when getting fir by psi (vor 20 Stunden) <Ilya Kirillov>
* 0c13a7f89a1 - (tag: build-1.4.20-dev-3275, tag: build-1.4.20-dev-3274, tag: build-1.4.20-dev-3270) Fix accessibility check for experimental declarations from default scope (vor 3 Tagen) <Mikhail Zarechenskiy>
* b403b63f485 - (tag: build-1.4.20-dev-3264, tag: build-1.4.20-dev-3263, tag: build-1.4.20-dev-3262) Ease field initialization check (vor 3 Tagen) <Ilmir Usmanov>
* 6c0abe7e48f - (tag: build-1.4.20-dev-3253, tag: build-1.4.20-dev-3252) [FIR] Fix CliTestGenerated$Jvm.testFirError (vor 3 Tagen) <Nick>
* 9ca4717d112 - (tag: build-1.4.20-dev-3247) Revert "Introduce @FrontendInternals annotation" (vor 3 Tagen) <Pavel Kirpichenkov>
* 7f2efabe6aa - (tag: build-1.4.20-dev-3241) [JVM_IR]: Improve stepping for `when`. (vor 3 Tagen) <Mads Ager>
* 1009a240f2b - (tag: build-1.4.20-dev-3233) KT-20357: Add samples for filter functions (vor 3 Tagen) <Dat Trieu>
* ca6e430e89f - (tag: build-1.4.20-dev-3231) JVM IR: Handle nested classes in DelegatedPropertyOptimizer (vor 3 Tagen) <Steven Schäfer>
* da9bff40f0d - JVM IR: Don't remove stores to visible locals in DelegatedPropertyOptimizer (vor 3 Tagen) <Steven Schäfer>
* 983c84d6a62 - (tag: build-1.4.20-dev-3229) Wizard: fix default template compilation when using JS IR (vor 3 Tagen) <Ilya Kirillov>
* e4cd7cdbcf2 - (tag: build-1.4.20-dev-3221) IR: remove unused code, cleanup (vor 4 Tagen) <Alexander Udalov>
* b30b2e01792 - IR: minor, render duplicate IR node in checker (vor 4 Tagen) <Alexander Udalov>
* 8db1c3611b8 - IR: introduce abstract class IrDeclarationBase (vor 4 Tagen) <Alexander Udalov>
* 771e7574f4e - IR: make subtypes of IrDeclaration classes (vor 4 Tagen) <Alexander Udalov>
* 3cecf81176a - IR: transform base classes of lazy IR to interfaces (vor 4 Tagen) <Alexander Udalov>
* b02653a5243 - IR: remove base classes IrDeclarationBase and IrFunctionBase (vor 4 Tagen) <Alexander Udalov>
* 9152df4702e - PIR: transform base implementation classes to interfaces (vor 4 Tagen) <Alexander Udalov>
* 13766d50757 - (tag: build-1.4.20-dev-3214, tag: build-1.4.20-dev-3213) [Gradle, JS] Update test data (vor 4 Tagen) <Ilya Goncharov>
* 52110a08d9c - [Gradle, JS] Update versions (vor 4 Tagen) <Ilya Goncharov>
* f6356199d3c - (tag: build-1.4.20-dev-3211) Fix typealias usage nullability and annotations lost in deserialization (vor 4 Tagen) <Sergey Igushkin>
* 4063aba6777 - (tag: build-1.4.20-dev-3206) Remade launch of `NativeRunConfigurationTest` against master version of gradle plugin (vor 4 Tagen) <Alexander Dudinsky>
* 69ce6bd9520 - Add tests for setup native run gutters. (vor 4 Tagen) <Konstantin Tskhovrebov>
* b5d4e4c44c7 - (tag: build-1.4.20-dev-3200) Enable compatibility metadata variant by default in HMPP (vor 4 Tagen) <Sergey Igushkin>
* 2eb17df962e - (tag: build-1.4.20-dev-3197, tag: build-1.4.20-dev-3189) Do not compute `SamType` too eagerly as it can force member resolution (vor 4 Tagen) <Mikhail Zarechenskiy>
* 6ec0e9546b0 - (tag: build-1.4.20-dev-3181) Fix 192 compilation for UI for standalone gradle scripts (vor 4 Tagen) <Vladimir Dolzhenko>
* 66c1bd8c899 - (tag: build-1.4.20-dev-3180, tag: build-1.4.20-dev-3177, tag: build-1.4.20-dev-3174, tag: build-1.4.20-dev-3172) Revert "Update KMM plugin user texts." (vor 4 Tagen) <Konstantin Tskhovrebov>
* c0e713980b5 - (tag: build-1.4.20-dev-3171) Add helpers for getting commonly used services without an opt-in (vor 4 Tagen) <Pavel Kirpichenkov>
* ffc3d8bdfc7 - Introduce @FrontendInternals annotation (vor 4 Tagen) <Pavel Kirpichenkov>
* eff58393693 - (tag: build-1.4.20-dev-3169, tag: build-1.4.20-dev-3167) "Kotlin Multiplatform Projects are an ~experimental~ Alpha feature." (vor 4 Tagen) <Sergey Igushkin>
* 6c475e614a1 - (tag: build-1.4.20-dev-3166, tag: build-1.4.20-dev-3165) Minor. Update debugger tests (vor 5 Tagen) <Ilmir Usmanov>
* 68342a1f725 - Initialize fake inliner variables on resume path (vor 5 Tagen) <Ilmir Usmanov>
* bb5a99ec18d - Do not put $completion to LVT if is dead (vor 5 Tagen) <Ilmir Usmanov>
* 99258662931 - (tag: build-1.4.20-dev-3164) 203: Fix compilation (vor 5 Tagen) <Florian Kistner>
* c7920924104 - Bump fastutil version to match 203 (vor 5 Tagen) <Florian Kistner>
* c5398e8317f - (tag: build-1.4.20-dev-3163) Move 'radixPrefix' from compiler modules to IDE modules (vor 5 Tagen) <Nikita Bobko>
* 093d4b3108a - (tag: build-1.4.20-dev-3157) Revert "Fix typealias usage nullability and annotations lost in deserialization" (vor 5 Tagen) <Sergey Igushkin>
* 5edbc75d7b9 - (tag: build-1.4.20-dev-3154) Update KMM plugin user texts. (vor 5 Tagen) <Konstantin Tskhovrebov>
* b57794d96e8 - (tag: build-1.4.20-dev-3145, tag: build-1.4.20-dev-3144) IR util: IrExpression.isSafeToUseWithoutCopying (vor 5 Tagen) <Jinseong Jeon>
* 7ef1c74bbf2 - FIR2IR: apply adapted reference conversion to coercion-to-unit (vor 5 Tagen) <Jinseong Jeon>
* 5f80bfd5d4e - (tag: build-1.4.20-dev-3142) [FIR] Don't report UNINITIALIZED_VARIABLE on lateinit local variable (vor 5 Tagen) <Mikhail Glukhikh>
* 54d96a2dd74 - (tag: build-1.4.20-dev-3138) UI for standalone gradle scripts (vor 5 Tagen) <Natalia Selezneva>
* fc874e72b1a - (tag: build-1.4.20-dev-3134, tag: build-1.4.20-dev-3132, tag: build-1.4.20-dev-3129, tag: build-1.4.20-dev-3124, tag: build-1.4.20-dev-3119) [FIR2IR] Initialize components a bit earlier to prevent lateinit errors (vor 5 Tagen) <Mikhail Glukhikh>
* 17b289fa007 - [FIR] Code cleanup: get rid of FirClass.buildUseSiteMemberScope() (vor 5 Tagen) <Mikhail Glukhikh>
* 8bb5488a266 - [FIR] look at intersectionOverride during override processing (vor 5 Tagen) <Mikhail Glukhikh>
* f1356a809e0 - Fir2IrLazySimpleFunction: generate overridden symbols via FirTypeScope (vor 5 Tagen) <Mikhail Glukhikh>
* 52c01abb83f - (tag: build-1.4.20-dev-3113) Increase Xmx size after investigation OOM problem in KMM-316 (vor 5 Tagen) <Alexander Dudinsky>
* d012cd3272f - Add kotlin-test-junit:install in dependencies for the kotlin-plugin install (vor 5 Tagen) <Alexander Dudinsky>
* ea0099aa395 - Fix testPlatformToCommonExpByInComposite. (vor 5 Tagen) <Alexander Dudinsky>
* 05d6217f78e - Changed gradle-plugin version in Gradle tests. (vor 5 Tagen) <Alexander Dudinsky>
* 6652a7072ce - Fix testData due to KT-40551. (vor 5 Tagen) <Alexander Dudinsky>
* 0298795b18b - Add gradle.properties with kotlin.stdlib.default.dependency=false for tests (vor 5 Tagen) <Alexander Dudinsky>
* bc623e97ecc -  Add Gradle version 6.5.1 for tests. (vor 5 Tagen) <Alexander Dudinsky>
* 1da05c54beb - Change gradle-plugin versions for tests from 1.3.50 to 1.3.72 (vor 5 Tagen) <Alexander Dudinsky>
* f15f5bccc82 - [FIR] Add more diagnostic messages (vor 5 Tagen) <Nick>
* f45de9d8fb3 - (tag: build-1.4.20-dev-3112) NI: approximate not top-level captured types during code generation (vor 5 Tagen) <Victor Petukhov>
* f6d7e7c52ae - (tag: build-1.4.20-dev-3111) CocoaPods: Fix setting custom framework name (vor 5 Tagen) <Ilya Matveev>
* a45f73867a2 - (tag: build-1.4.20-dev-3104) Add compatibility resolve when SAM conversion was applied partially (vor 5 Tagen) <Mikhail Zarechenskiy>
* 070848a1c14 - (tag: build-1.4.20-dev-3103, tag: build-1.4.20-dev-3102) Fix typealias usage nullability and annotations lost in deserialization (vor 5 Tagen) <Sergey Igushkin>
* ec4f04095c7 - (tag: build-1.4.20-dev-3101) [FIR] Rearrange FirErrors.kt (vor 5 Tagen) <Nick>
* 207027b84c7 - (tag: build-1.4.20-dev-3099) [FIR] Fix light tree's supertype FirDelegatedConstructorCall source (vor 5 Tagen) <Nick>
* a59cedcd39b - [FIR] Fix non-fake sources for constructor delegates (vor 5 Tagen) <Nick>
* f74eb072031 - [FIR] Fix incorrect diagnostic behaviour + several enum diagnostics (vor 5 Tagen) <Nick>
* b76f757d473 - [FIR] Add diagnostic for missing primary constructor (vor 5 Tagen) <Nick>
* 0f213e58db6 - [FIR] Add diagnostic for primary constructor not called (vor 5 Tagen) <Nick>
* bb0e1b73902 - [FIR] Add diagnostic for constructor delegation cycles (vor 5 Tagen) <Nick>
* e841b3a77b6 - [FIR] Add diagnostic collection to KotlinToJVMBytecodeCompiler (vor 5 Tagen) <Mikhail Glukhikh>
* 9c3b8484b91 - [FIR TEST] Add CLI test with should-be-error (not yet) (vor 5 Tagen) <Mikhail Glukhikh>
* 824991a9dde - (tag: build-1.4.20-dev-3090) Minor. Add tests. (vor 6 Tagen) <Ilmir Usmanov>
* bbd4c215955 - Cleanup spilled variables (vor 6 Tagen) <Ilmir Usmanov>
* 999b41068bf - Minor. Refactor variables spilling (vor 6 Tagen) <Ilmir Usmanov>
* 405c9743ef6 - Do not spill dispatch receiver of suspend functions if it is not used (vor 6 Tagen) <Ilmir Usmanov>
* 5db79572308 - (tag: build-1.4.20-dev-3082) FIR2IR: use type arguments from fully expanded type (vor 6 Tagen) <Jinseong Jeon>
* 606dc2f7239 - (tag: build-1.4.20-dev-3073) Fix binary compatibility problems in ImportInsertHelper & ShortenReferences (vor 6 Tagen) <Ilya Kirillov>
* af48f08f9c9 - (tag: build-1.4.20-dev-3072) NI: take into account flexible types during capturing arguments from expression (vor 6 Tagen) <Victor Petukhov>
* 65ebd02a39b - (tag: build-1.4.20-dev-3068) [FIR] Fix for CanBeReplacedWithOperatorAssignment Checker (vor 6 Tagen) <vldf>
* 6f3df6faf41 - (tag: build-1.4.20-dev-3063) [FIR] Regenerate extended checker tests (vor 6 Tagen) <Mikhail Glukhikh>
* 181a8bb79ef - (tag: build-1.4.20-dev-3061) [FIR TEST] Mute failing BB test with Byte/Short.and usage (vor 6 Tagen) <Mikhail Glukhikh>
* 47c47be3d35 - FIR serializer: serialize annotations on FirTypeRef, not ConeKotlinType (vor 6 Tagen) <Jinseong Jeon>
* 0a28e5e031f - Add argument unwrapping for case when argument is named (vor 6 Tagen) <Ivan Kylchik>
* 2e2099afae8 - [FIR] Introduce NOT_AN_ANNOTATION_CLASS diagnostic (vor 6 Tagen) <Mikhail Glukhikh>
* 8fd087a9644 - [FIR] Don't report duplicated UNRESOLVED_REFERENCE on annotation entries (vor 6 Tagen) <Mikhail Glukhikh>
* a6e811a67a5 - [FIR] Add status to Java annotation constructor (fix after rebase) (vor 6 Tagen) <Mikhail Glukhikh>
* 8379b3794a9 - [FIR2IR] Return fallback mode for annotation resolved placeholder (vor 6 Tagen) <Mikhail Glukhikh>
* b63257345ba - [FIR] Map `Class` to `KClass` in java annotations (vor 6 Tagen) <Dmitriy Novozhilov>
* 282a295d436 - [FIR] Enable arrayOf transformer in completion (inside annotations) (vor 6 Tagen) <Mikhail Glukhikh>
* 721b9b4d8c5 - [FIR] Resolve annotations as calls (vor 6 Tagen) <Dmitriy Novozhilov>
* bc1fa8ed7f0 - [FIR] Add constructor for java annotations (vor 6 Tagen) <Dmitriy Novozhilov>
* 644e9843f9e - [FIR] Add initialization of calleeReference for FirAnnotationCall (vor 6 Tagen) <Dmitriy Novozhilov>
* 614291b2cc4 - [FIR] Make FirAnnotationCall resolvable (vor 6 Tagen) <Dmitriy Novozhilov>
* ffd30566bec - [FIR] Add FirErrorResolvedQualifier for qualifiers with resolve diagnostic (vor 6 Tagen) <Dmitriy Novozhilov>
* a5e9401a0a9 - (tag: build-1.4.20-dev-3058) [configuration] change updater number to 1.4.* and 1.5.* (vor 6 Tagen) <Dmitry Gridin>
* 88f508446ad - (tag: build-1.4.20-dev-3054) Make repeat example more expressive (vor 6 Tagen) <Julian Kotrba>
* a5178bb826f - (tag: build-1.4.20-dev-3053) Minor: fix toJavaDuration docs (vor 6 Tagen) <Ilya Gorbunov>
* 99eb7f391ba - Fix doc wording around covariance/invariance (vor 6 Tagen) <Ilya Gorbunov>
* 4f73e087049 - (tag: build-1.4.20-dev-3048) [KLIB] Make fake override resolver garbage free as much as possible (vor 7 Tagen) <Roman Artemev>
* 876ee265f2a - [KLIB] Fix memory leak in fake override resolver (vor 7 Tagen) <Roman Artemev>
* e189cb1895a - [KLIB] Fix memory leak in linker through `haveSeen` set (vor 7 Tagen) <Roman Artemev>
* 19b5fda7508 - [KLIB] Do not duplicate origin mapping per file (vor 7 Tagen) <Roman Artemev>
* c253042948d - [KLIB] Reduce amount of descriptors loaded during desc-idSig resolution (vor 7 Tagen) <Roman Artemev>
* 851c2871057 - [KLIB] Use SoftReference to hold proto memory (vor 7 Tagen) <Roman Artemev>
* add0ad67335 - [KLIB] Change KLIB IO API (vor 7 Tagen) <Roman Artemev>
* 0e54f98b79e - (tag: build-1.4.20-dev-3038) FIR: support adapted callable reference with vararg (vor 7 Tagen) <Jinseong Jeon>
* 4332e95b8a4 - [FIR] Don't transform setter parameter type if it's given explicitly (vor 7 Tagen) <Mikhail Glukhikh>
* 8813ebd950d - [FIR] Add RedundantSetterParameterType Checker (vor 7 Tagen) <vldf>
* a6c9d869fbc - [FIR] Move RedundantCallOfConversionMethod to extended checkers (vor 7 Tagen) <vldf>
* 3349739d1e4 - (tag: build-1.4.20-dev-3037, tag: build-1.4.20-dev-3017) [FIR] Fixes for RedundantReturnUnitType checker (vor 7 Tagen) <vldf>
* 2384afdd934 - [FIR] refactoring for running extended checkers (vor 7 Tagen) <vladislavf7@gmail.com>
* cfc09048c6a - (tag: build-1.4.20-dev-3016) [FIR] Add RedundantCallOfConversionMethod checker (vor 7 Tagen) <vldf>