### PR TITLE
[IR][codegen] Ignore SET_FIELD with default values in constructors

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
@@ -69,7 +69,7 @@ internal class InitializersLowering(val context: CommonBackendContext) : ClassLo
                     val initExpression = initializer.expression
                     initializers.add(IrBlockImpl(startOffset, endOffset,
                             context.irBuiltIns.unitType,
-                            STATEMENT_ORIGIN_ANONYMOUS_INITIALIZER,
+                            IrStatementOrigin.INITIALIZE_FIELD,
                             listOf(
                                     IrSetFieldImpl(startOffset, endOffset, declaration.symbol,
                                             IrGetValueImpl(
@@ -78,7 +78,7 @@ internal class InitializersLowering(val context: CommonBackendContext) : ClassLo
                                             ),
                                             initExpression,
                                             context.irBuiltIns.unitType,
-                                            STATEMENT_ORIGIN_ANONYMOUS_INITIALIZER)))
+                                            IrStatementOrigin.INITIALIZE_FIELD)))
                     )
 
                     // We shall keep initializer for constants for compile-time instantiation.


### PR DESCRIPTION
The runtime guarantees all newly allocated objects to be zeroed out, hence it is
redundant to initialize fields with default values. See KT-39100 for details.