### PR TITLE
Fix suspend function types (i.e. suspend lambdas) in ObjCExport

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
@@ -65,6 +65,11 @@ internal class RTTIGenerator(override val context: Context) : ContextUtils {
         }
         if (irClass.isInterface)
             result = result or TF_INTERFACE
+
+        if (irClass.defaultType.isSuspendFunction()) {
+            result = result or TF_SUSPEND_FUNCTION
+        }
+
         return result
     }
 
@@ -623,4 +628,5 @@ private const val TF_ACYCLIC   = 2
 private const val TF_INTERFACE = 4
 private const val TF_OBJC_DYNAMIC = 8
 private const val TF_LEAK_DETECTOR_CANDIDATE = 16
+private const val TF_SUSPEND_FUNCTION = 32
 

--- a/backend.native/tests/objcexport/coroutines.kt
+++ b/backend.native/tests/objcexport/coroutines.kt
@@ -164,3 +164,15 @@ class ThrowCancellationExceptionImpl : ThrowCancellationException() {
         throw CancellationException()
     }
 }
+
+fun getSuspendLambda0(): suspend () -> String = { "lambda 0" }
+
+private suspend fun suspendCallableReference0Target(): String = "callable reference 0"
+fun getSuspendCallableReference0(): suspend () -> String = ::suspendCallableReference0Target
+
+fun getSuspendLambda1(): suspend (String) -> String = { "$it 1" }
+
+private suspend fun suspendCallableReference1Target(str: String): String = "$str 1"
+fun getSuspendCallableReference1(): suspend (String) -> String = ::suspendCallableReference1Target
+
+suspend fun invoke1(block: suspend (Any?) -> Any?, argument: Any?): Any? = block(argument)

--- a/backend.native/tests/objcexport/coroutines.swift
+++ b/backend.native/tests/objcexport/coroutines.swift
@@ -253,6 +253,71 @@ private func testImplicitThrows2() throws {
     try assertTrue(error?.kotlinException is KotlinCancellationException)
 }
 
+private func testSuspendFunctionType0(f: KotlinSuspendFunction0, expectedResult: String) throws {
+    try assertTrue((f as AnyObject) is KotlinSuspendFunction0)
+
+    var result: String? = nil
+    var error: Error? = nil
+    var completionCalled = 0
+
+    f.invoke { _result, _error in
+        completionCalled += 1
+        result = _result as? String
+        error = _error
+    }
+
+    try assertEquals(actual: completionCalled, expected: 1)
+    try assertEquals(actual: result, expected: expectedResult)
+    try assertNil(error)
+}
+
+private func testSuspendFunctionType1(f: KotlinSuspendFunction1) throws {
+    try assertTrue((f as AnyObject) is KotlinSuspendFunction1)
+
+    var result: String? = nil
+    var error: Error? = nil
+    var completionCalled = 0
+
+    f.invoke(p1: "suspend function type") { _result, _error in
+        completionCalled += 1
+        result = _result as? String
+        error = _error
+    }
+
+    try assertEquals(actual: completionCalled, expected: 1)
+    try assertEquals(actual: result, expected: "suspend function type 1")
+    try assertNil(error)
+}
+
+private func testSuspendFunctionType() throws {
+    try testSuspendFunctionType0(f: CoroutinesKt.getSuspendLambda0(), expectedResult: "lambda 0")
+    try testSuspendFunctionType0(f: CoroutinesKt.getSuspendCallableReference0(), expectedResult: "callable reference 0")
+    try testSuspendFunctionType1(f: CoroutinesKt.getSuspendLambda1())
+    try testSuspendFunctionType1(f: CoroutinesKt.getSuspendCallableReference1())
+}
+
+private func testSuspendFunctionSwiftImpl() throws {
+    var result: String? = nil
+    var error: Error? = nil
+    var completionCalled = 0
+
+    CoroutinesKt.invoke1(block: SuspendFunction1SwiftImpl(), argument: "suspend function") { _result, _error in
+        completionCalled += 1
+        result = _result as? String
+        error = _error
+    }
+
+    try assertEquals(actual: completionCalled, expected: 1)
+    try assertEquals(actual: result, expected: "suspend function Swift")
+    try assertNil(error)
+}
+
+private class SuspendFunction1SwiftImpl : KotlinSuspendFunction1 {
+    func invoke(p1: Any?, completionHandler: (Any?, Error?) -> Void) {
+        completionHandler("\(p1 ?? "nil") Swift", nil)
+    }
+}
+
 class CoroutinesTests : SimpleTestProvider {
     override init() {
         super.init()
@@ -263,5 +328,7 @@ class CoroutinesTests : SimpleTestProvider {
         test("TestBridges", testBridges)
         test("TestImplicitThrows1", testImplicitThrows1)
         test("TestImplicitThrows2", testImplicitThrows2)
+        test("TestSuspendFunctionType", testSuspendFunctionType)
+        test("TestSuspendFunctionSwiftImpl", testSuspendFunctionSwiftImpl)
     }
 }

--- a/backend.native/tests/objcexport/expectedLazy.h
+++ b/backend.native/tests/objcexport/expectedLazy.h
@@ -306,6 +306,16 @@ __attribute__((swift_name("CoroutinesKt")))
  Other uncaught Kotlin exceptions are fatal.
 */
 + (void)throwCancellationExceptionWithCompletionHandler:(void (^)(KtKotlinUnit * _Nullable, NSError * _Nullable))completionHandler __attribute__((swift_name("throwCancellationException(completionHandler:)")));
++ (id<KtKotlinSuspendFunction0>)getSuspendLambda0 __attribute__((swift_name("getSuspendLambda0()")));
++ (id<KtKotlinSuspendFunction0>)getSuspendCallableReference0 __attribute__((swift_name("getSuspendCallableReference0()")));
++ (id<KtKotlinSuspendFunction1>)getSuspendLambda1 __attribute__((swift_name("getSuspendLambda1()")));
++ (id<KtKotlinSuspendFunction1>)getSuspendCallableReference1 __attribute__((swift_name("getSuspendCallableReference1()")));
+
+/**
+ @note This method converts instances of CancellationException to errors.
+ Other uncaught Kotlin exceptions are fatal.
+*/
++ (void)invoke1Block:(id<KtKotlinSuspendFunction1>)block argument:(id _Nullable)argument completionHandler:(void (^)(id _Nullable, NSError * _Nullable))completionHandler __attribute__((swift_name("invoke1(block:argument:completionHandler:)")));
 @end;
 
 __attribute__((swift_name("FHolder")))

--- a/runtime/src/main/cpp/TypeInfo.h
+++ b/runtime/src/main/cpp/TypeInfo.h
@@ -59,7 +59,8 @@ enum Konan_TypeFlags {
   TF_ACYCLIC   = 1 << 1,
   TF_INTERFACE = 1 << 2,
   TF_OBJC_DYNAMIC = 1 << 3,
-  TF_LEAK_DETECTOR_CANDIDATE = 1 << 4
+  TF_LEAK_DETECTOR_CANDIDATE = 1 << 4,
+  TF_SUSPEND_FUNCTION = 1 << 5,
 };
 
 // Flags per object instance.


### PR DESCRIPTION
 #KT-40976 Fixed