### PR TITLE
[kotlin compiler][update] 1.4.20-dev-3586

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -114,7 +114,7 @@ internal fun KotlinStubs.generateCCall(expression: IrCall, builder: IrBuilderWit
 
     val callBuilder = KotlinToCCallBuilder(builder, this, isObjCMethod = false)
 
-    val callee = expression.symbol.owner as IrSimpleFunction
+    val callee = expression.symbol.owner
 
     // TODO: consider computing all arguments before converting.
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -254,13 +254,13 @@ internal class KonanSymbols(
 
     val throwIndexOutOfBoundsException = internalFunction("ThrowIndexOutOfBoundsException")
 
-    override val ThrowNullPointerException = internalFunction("ThrowNullPointerException")
+    override val throwNullPointerException = internalFunction("ThrowNullPointerException")
 
-    override val ThrowNoWhenBranchMatchedException = internalFunction("ThrowNoWhenBranchMatchedException")
+    override val throwNoWhenBranchMatchedException = internalFunction("ThrowNoWhenBranchMatchedException")
 
-    override val ThrowTypeCastException = internalFunction("ThrowTypeCastException")
+    override val throwTypeCastException = internalFunction("ThrowTypeCastException")
 
-    override val ThrowKotlinNothingValueException  = internalFunction("ThrowKotlinNothingValueException")
+    override val throwKotlinNothingValueException  = internalFunction("ThrowKotlinNothingValueException")
 
     val throwClassCastException = internalFunction("ThrowClassCastException")
 
@@ -271,7 +271,7 @@ internal class KonanSymbols(
     val throwIllegalArgumentExceptionWithMessage = internalFunction("ThrowIllegalArgumentExceptionWithMessage")
 
 
-    override val ThrowUninitializedPropertyAccessException = internalFunction("ThrowUninitializedPropertyAccessException")
+    override val throwUninitializedPropertyAccessException = internalFunction("ThrowUninitializedPropertyAccessException")
 
     override val stringBuilder = symbolTable.referenceClass(
             builtInsPackage("kotlin", "text").getContributedClassifier(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumByValueFunctionGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumByValueFunctionGenerator.kt
@@ -86,7 +86,7 @@ internal class CEnumByValueFunctionGenerator(
                         )
                     }
                 }
-                +irCall(symbols.ThrowNullPointerException, irBuiltIns.nothingType)
+                +irCall(symbols.throwNullPointerException, irBuiltIns.nothingType)
             })
         }
         return byValueIrFunction

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1405,7 +1405,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
             ifThen(not(genInstanceOf(srcArg, dstClass))) {
                 if (dstClass.defaultType.isObjCObjectType()) {
                     callDirect(
-                            context.ir.symbols.ThrowTypeCastException.owner,
+                            context.ir.symbols.throwTypeCastException.owner,
                             emptyList(),
                             Lifetime.GLOBAL
                     )

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrPropertySymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
+import org.jetbrains.kotlin.ir.transformStatement
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.*
@@ -448,7 +449,7 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
 
             (irConstructor.body as IrBlockBody).statements.forEach { statement ->
                 statement.setDeclarationsParent(result)
-                +statement.transform(object : IrElementTransformerVoid() {
+                +statement.transformStatement(object : IrElementTransformerVoid() {
                     override fun visitDelegatingConstructorCall(expression: IrDelegatingConstructorCall): IrExpression {
                         expression.transformChildrenVoid()
 
@@ -479,8 +480,7 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
 
                         return expression
                     }
-
-                }, null)
+                })
             }
             +irReturn(irGet(thisVar))
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -273,7 +273,7 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
             IrBlockImpl(startOffset, endOffset, irBuiltIns.unitType).apply {
                 statements.addIfNotNull(expression.receiver)
                 statements += expression.value
-                statements += IrCallImpl(startOffset, endOffset, irBuiltIns.nothingType, symbols.ThrowNullPointerException)
+                statements += IrCallImpl(startOffset, endOffset, irBuiltIns.nothingType, symbols.throwNullPointerException)
                 statements += IrGetObjectValueImpl(startOffset, endOffset, irBuiltIns.unitType, irBuiltIns.unitClass)
             }
         } else {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -110,7 +110,7 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                         startOffset  = job.startOffset,
                         endOffset    = job.endOffset,
                         overriddenFunction = overriddenJobDescriptor,
-                        targetSymbol = job.symbol)
+                        targetSymbol = jobFunction.symbol)
                 bridges += bridge
                 expression.putValueArgument(3, IrFunctionReferenceImpl(
                         startOffset   = job.startOffset,
@@ -218,7 +218,7 @@ private fun IrBlockBodyBuilder.buildTypeSafeBarrier(function: IrFunction,
 }
 
 private fun Context.buildBridge(startOffset: Int, endOffset: Int,
-                                overriddenFunction: OverriddenFunctionInfo, targetSymbol: IrFunctionSymbol,
+                                overriddenFunction: OverriddenFunctionInfo, targetSymbol: IrSimpleFunctionSymbol,
                                 superQualifierSymbol: IrClassSymbol? = null): IrFunction {
 
     val bridge = specialDeclarationsFactory.getBridge(overriddenFunction)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BuiltinOperatorLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BuiltinOperatorLowering.kt
@@ -57,8 +57,8 @@ internal class BuiltinOperatorLowering(val context: Context) : FileLoweringPass,
             irBuiltins.checkNotNullSymbol -> lowerCheckNotNull(expression)
 
             irBuiltins.noWhenBranchMatchedExceptionSymbol -> IrCallImpl(expression.startOffset, expression.endOffset,
-                    context.ir.symbols.ThrowNoWhenBranchMatchedException.owner.returnType,
-                    context.ir.symbols.ThrowNoWhenBranchMatchedException)
+                    context.ir.symbols.throwNoWhenBranchMatchedException.owner.returnType,
+                    context.ir.symbols.throwNoWhenBranchMatchedException)
 
             else -> expression
         }
@@ -181,7 +181,7 @@ internal class BuiltinOperatorLowering(val context: Context) : FileLoweringPass,
 
     private fun lowerCheckNotNull(expression: IrCall) = builder.at(expression).irBlock(resultType = expression.type) {
         val temp = irTemporary(expression.getValueArgument(0)!!)
-        +irIfThen(context.irBuiltIns.unitType, irEqeqNull(irGet(temp)), irCall(symbols.ThrowNullPointerException))
+        +irIfThen(context.irBuiltIns.unitType, irEqeqNull(irGet(temp)), irCall(symbols.throwNullPointerException))
         +irGet(temp)
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -715,7 +715,7 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
 
             return builder.at(expression).run {
                 val classPtr = getRawPtr(expression.extensionReceiver!!)
-                callAllocAndInit(classPtr, initMethodInfo, arguments, expression, callee as IrSimpleFunction)
+                callAllocAndInit(classPtr, initMethodInfo, arguments, expression, callee)
             }
         }
 
@@ -753,7 +753,7 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
                         receiver = expression.dispatchReceiver ?: expression.extensionReceiver!!,
                         arguments = arguments,
                         call = expression,
-                        method = callee as IrSimpleFunction
+                        method = callee
                 )
             }
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -698,7 +698,7 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
                     +irIfThen(
                             context.irBuiltIns.unitType,
                             irEqeqeq(irGet(temp), irNull()),
-                            irCall(symbols.ThrowNullPointerException)
+                            irCall(symbols.throwNullPointerException)
                     )
                     +irGet(temp)
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PostInlineLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/PostInlineLowering.kt
@@ -47,7 +47,7 @@ internal class PostInlineLowering(val context: Context) : FileLoweringPass {
                     builder.irKClass(context, symbol)
                 } else {
                     // E.g. for `T::class` in a body of an inline function itself.
-                    builder.irCall(context.ir.symbols.ThrowNullPointerException.owner)
+                    builder.irCall(context.ir.symbols.throwNullPointerException.owner)
                 }
             }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOperatorLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOperatorLowering.kt
@@ -47,7 +47,7 @@ private class TypeOperatorTransformer(val context: CommonBackendContext, val fun
 
     private val builder = context.createIrBuilder(function)
 
-    val throwNullPointerException = context.ir.symbols.ThrowNullPointerException
+    val throwNullPointerException = context.ir.symbols.throwNullPointerException
 
     override fun visitFunction(declaration: IrFunction): IrStatement {
         // ignore inner functions during this pass

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DFGBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DFGBuilder.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyClass
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
@@ -338,7 +339,7 @@ internal class ModuleDFGBuilder(val context: Context, val irModule: IrModuleFrag
                         ?: error("A function reference expected")
                 val jobInvocation = IrCallImpl(expression.startOffset, expression.endOffset,
                         jobFunctionReference.symbol.owner.returnType,
-                        jobFunctionReference.symbol)
+                        jobFunctionReference.symbol as IrSimpleFunctionSymbol)
                 jobInvocation.putValueArgument(0, producerInvocation)
 
                 expressions += jobInvocation
@@ -665,7 +666,6 @@ internal class ModuleDFGBuilder(val context: Context, val irModule: IrModuleFrag
                                     if (callee is IrConstructor) {
                                         error("Constructor call should be done with IrConstructorCall")
                                     } else {
-                                        callee as IrSimpleFunction
                                         if (callee.isOverridable && value.superQualifierSymbol == null) {
                                             val owner = callee.parentAsClass
                                             val actualReceiverType = value.dispatchReceiver!!.type

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
@@ -1402,7 +1402,7 @@ internal object Devirtualization {
                                                    actualType: IrType,
                                                    devirtualizedCallee: DevirtualizedCallee,
                                                    arguments: List<IrExpression>): IrCall {
-            val actualCallee = devirtualizedCallee.callee.irFunction!!
+            val actualCallee = devirtualizedCallee.callee.irFunction as IrSimpleFunction
             val call = IrCallImpl(
                     callSite.startOffset, callSite.endOffset,
                     actualType,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -238,7 +238,7 @@ fun IrBuilderWithScope.irCall(symbol: IrFunctionSymbol, typeArguments: List<IrTy
 fun IrBuilderWithScope.irCall(irFunction: IrFunction, typeArguments: List<IrType> = emptyList()) =
         irCall(irFunction.symbol, typeArguments)
 
-internal fun irCall(startOffset: Int, endOffset: Int, irFunction: IrFunction, typeArguments: List<IrType>): IrCall =
+internal fun irCall(startOffset: Int, endOffset: Int, irFunction: IrSimpleFunction, typeArguments: List<IrType>): IrCall =
         IrCallImpl(
                 startOffset, endOffset, irFunction.substitutedReturnType(typeArguments),
                 irFunction.symbol, typeArguments.size

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3296,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-3296
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3296,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-3296
-kotlinStdlibTestsVersion=1.4.20-dev-3296
-testKotlinCompilerVersion=1.4.20-dev-3296
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3586,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-3586
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3586,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-3586
+kotlinStdlibTestsVersion=1.4.20-dev-3586
+testKotlinCompilerVersion=1.4.20-dev-3586
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/androidNativeActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/androidNativeActivity/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/calculator/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/calculator/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/cocoapods/kotlin-library/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/cocoapods/kotlin-library/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* 75be9cf31fa - (tag: build-1.4.20-dev-3586) [Commonizer] Tests on rewriting callables names to succeed commonization (vor 9 Stunden) <Dmitriy Dolovov>
* de0b6e06cf2 - [Commonizer] Keep parameters names hash in approximation keys for ObjC callables (vor 9 Stunden) <Dmitriy Dolovov>
* 3b901a28d59 - [Commonizer] More compact approximation keys (vor 9 Stunden) <Dmitriy Dolovov>
* 4418dc85cae - [Commonizer] Allow rewriting callables names to succeed commonization (vor 9 Stunden) <Dmitriy Dolovov>
* 8904f5652bf - [Commonizer] Allow extended lookup for classifiers in test mode (vor 9 Stunden) <Dmitriy Dolovov>
* 3b398ed57f5 - [Commonizer] Small clean-up in IllegalCommonizerStateException (vor 9 Stunden) <Dmitriy Dolovov>
* 494fb393998 - [Commonizer] CLI: Report duration even if it's 0ms long (vor 9 Stunden) <Dmitriy Dolovov>
* 9ef727747b1 - [Commonizer] Use Array instead of List in AbstractListCommonizer (vor 9 Stunden) <Dmitriy Dolovov>
* e468a347b54 - (tag: build-1.4.20-dev-3571, tag: build-1.4.20-dev-3570) [box-tests] Tests on field init optimization (vor 2 Tagen) <Igor Chevdar>
* 0328fcaf5d7 - (tag: build-1.4.20-dev-3562) JVM IR: Avoid IMPLICIT_NOTNULL checks on special bridge methods (vor 3 Tagen) <Steven Schäfer>
* 9026f89ba59 - JVM IR: Avoid CHECKCASTs on type operators (KT-39520) (vor 3 Tagen) <Steven Schäfer>
* 469b1645556 - (tag: build-1.4.20-dev-3560) IR: minor optimizations to IR validation (vor 3 Tagen) <Alexander Udalov>
* 7468518f355 - JVM IR: minor, optimize forceSingleValueParameterBoxing (vor 3 Tagen) <Alexander Udalov>
* 35cace2540c - JVM IR: collect potentialBridgeTargets in a list, then create bridges for all of them (vor 3 Tagen) <Alexander Udalov>
* 9607414cf16 - IR: make allOverridden return Set instead of Sequence, move to IrUtils (vor 3 Tagen) <Alexander Udalov>
* adcfbdec24f - JVM IR: optimize special method / signature computation in BridgeLowering (vor 3 Tagen) <Alexander Udalov>
* 0727e9055bb - JVM IR: use a simpler way to check if class is local (vor 3 Tagen) <Alexander Udalov>
* 6db5ad7310e - IR: remove cast to IrStatement in IrDeclarationBase.transform (vor 3 Tagen) <Alexander Udalov>
* fb8e39a6219 - IR: optimize transformation of declarations/statements lists in-place (vor 3 Tagen) <Alexander Udalov>
* 4f0585950e4 - IR: inline some transformChildren calls in IrElementTransformer{,Void} (vor 3 Tagen) <Alexander Udalov>
* 3a883e12362 - (tag: build-1.4.20-dev-3553) Replace bintray bootstrap with space bootstrap repo (vor 3 Tagen) <Nikolay Krasko>
* f484ceec803 - Use GPG agent for signing in PublishedKotlinModule (KTI-314) (vor 3 Tagen) <Nikolay Krasko>
* bbf8b12c65f - Sign with GnuPG agent (KTI-314) (vor 3 Tagen) <Nikolay Krasko>
* 635ffcd53ba - Update maven signing for working with gpg 2 (KTI-314) (vor 3 Tagen) <Nikolay Krasko>
* a121ec1e399 - (tag: build-1.4.20-dev-3549, tag: build-1.4.20-dev-3542, tag: build-1.4.20-dev-3534) Update Kotlin/Native: 1.4.20-dev-16314 (vor 3 Tagen) <Ilya Matveev>
* fa2c49a311a - (tag: build-1.4.20-dev-3532) [Plugin API] Add extension point to contribute synthetic properties (vor 3 Tagen) <Roman Artemev>
* 5ede37d6ab9 - (tag: build-1.4.20-dev-3531) Report warnings on safe call + nullable extension operator (vor 3 Tagen) <Denis Zharkov>
* 852d22470e5 - (tag: build-1.4.20-dev-3520) Revert "FIR Completion: Add idea-fir dependency to run completion tests" (vor 4 Tagen) <Roman Golyshev>
* 89cc5777ced - (tag: build-1.4.20-dev-3514) Put parameters on line: don't suggest if parameters has end-of-line comments (vor 4 Tagen) <Toshiaki Kameyama>
* efa981db36e - "Create class from usage": add visibility to primary constructor if needed (vor 4 Tagen) <Toshiaki Kameyama>
* b1e8238ea2a - (tag: build-1.4.20-dev-3513) "Convert reference to lambda" intention: handle extension function reference with extension function call (vor 4 Tagen) <Toshiaki Kameyama>
* 9ff7539ff0a - (tag: build-1.4.20-dev-3512) "Merge 'if's" intention: do not remove nested comments (vor 4 Tagen) <Toshiaki Kameyama>
* f6e70cfed8c - (tag: build-1.4.20-dev-3511) Wrap with let: fix it works correctly for invoking function type (vor 4 Tagen) <Toshiaki Kameyama>
* babdeacdaf5 - (tag: build-1.4.20-dev-3501) [Gradle, JS] Add resolution configuration method (vor 4 Tagen) <Ilya Goncharov>
* 85f23d8c6e1 - [Gradle, JS] Fix test with new API (vor 4 Tagen) <Ilya Goncharov>
* 5eda8e95bfb - [Gradle, JS] Revert kotlinTargets (vor 4 Tagen) <Ilya Goncharov>
* 855554ac38f - [Gradle, JS] Move yarn resolutions from dependency constraints (vor 4 Tagen) <Ilya Goncharov>
* fecda8548b5 - [Gradle, JS] Override maven and ivy publishing aware context (vor 4 Tagen) <Ilya Goncharov>
* 58284c8b084 - [Gradle, JS] Add yarn resolution gradle integration test (vor 4 Tagen) <Ilya Goncharov>
* 9df604cb3de - [Gradle, JS] Migrate on set for npm ranges (vor 4 Tagen) <Ilya Goncharov>
* 1dd92f011c8 - [Gradle, JS] Compare range lists as sets (vor 4 Tagen) <Ilya Goncharov>
* 50ccb522b9b - [Gradle, JS] Add intersect tests (vor 4 Tagen) <Ilya Goncharov>
* bd01ac52afa - [Gradle, JS] Add union test with fixed issue in union method (vor 4 Tagen) <Ilya Goncharov>
* 7aaa1cf5565 - [Gradle, JS] Add invert test (vor 4 Tagen) <Ilya Goncharov>
* 9b8a64ef7b2 - [Gradle, JS] Add hasIntersection test (vor 4 Tagen) <Ilya Goncharov>
* 814c0b73e34 - [Gradle, JS] Add doc into NpmRange (vor 4 Tagen) <Ilya Goncharov>
* dc7d7135f81 - [Gradle, JS] Add min start, max end, min end tests (vor 4 Tagen) <Ilya Goncharov>
* c25bcb4028f - [Gradle, JS] Add max start test (vor 4 Tagen) <Ilya Goncharov>
* 42090e48395 - [Gradle, JS] Add failing test (vor 4 Tagen) <Ilya Goncharov>
* d4524e4050b - [Gradle, JS] Small refactoring (vor 4 Tagen) <Ilya Goncharov>
* b95eb660324 - [Gradle, JS] RejectAll => reject wildcard (vor 4 Tagen) <Ilya Goncharov>
* d4c0d62eebe - [Gradle, JS] Require version use caret (vor 4 Tagen) <Ilya Goncharov>
* 3ed42d394b4 - [Gradle, JS] Support hyphenated range (vor 4 Tagen) <Ilya Goncharov>
* a4de85da136 - [Gradle, JS] Right wildcard range (vor 4 Tagen) <Ilya Goncharov>
* f848b7cbebf - [Gradle, JS] Right equals and hashCode for npm range (vor 4 Tagen) <Ilya Goncharov>
* 68880e6f476 - [Gradle, JS] NpmRangeVisitor without nulls (vor 4 Tagen) <Ilya Goncharov>
* 7f3a2ac953a - [Gradle, JS] Renames (vor 4 Tagen) <Ilya Goncharov>
* fec8c6c0ae7 - [Gradle, JS] Min and max are not nullable (vor 4 Tagen) <Ilya Goncharov>
* 966c9dae689 - [Gradle, JS] Use not inverted visitor but straightforward visitor (vor 4 Tagen) <Ilya Goncharov>
* 9bb49ac370a - [Gradle, JS] Union of Npm Ranges (vor 4 Tagen) <Ilya Goncharov>
* 14fac83e2b1 - [Gradle, JS] Intersect of NpmRange (vor 4 Tagen) <Ilya Goncharov>
* 90bee78ddab - [Gradle, JS] None range instead of none version (vor 4 Tagen) <Ilya Goncharov>
* f1b8c622316 - [Gradle, JS] Use rejected versions (vor 4 Tagen) <Ilya Goncharov>
* d232e2ceb36 - [Gradle, JS] Add ANTLR visitor for inverting of npm versions (vor 4 Tagen) <Ilya Goncharov>
* 768b9a0340a - [Gradle, JS] Use NpmVersionConstraint (vor 4 Tagen) <Ilya Goncharov>
* bb569f36b16 - [Gradle, JS] Implement reason and other methods beside version (vor 4 Tagen) <Ilya Goncharov>
* 30f78847b19 - [Gradle, JS] Not publish npm dependency constraints in metadata (vor 4 Tagen) <Ilya Goncharov>
* 0473648b0e3 - [Gradle, JS] Use gradle dependency constraints for yarn resolutions (vor 4 Tagen) <Ilya Goncharov>
* 7d883f18068 - (tag: build-1.4.20-dev-3498, tag: build-1.4.20-dev-3497) FIR Completion: Add idea-fir dependency to run completion tests (vor 4 Tagen) <Roman Golyshev>
* 31e4ddafd1d - (tag: build-1.4.20-dev-3496) Minor. Add test with boolean parameter (vor 4 Tagen) <Ilmir Usmanov>
* bcbb050326a - Use fields for spilled variables for lambda parameters as well (vor 4 Tagen) <Ilmir Usmanov>
* f5ab3a445f8 - (tag: build-1.4.20-dev-3491) [Gradle, JS] Fix abstract task on default (vor 4 Tagen) <Ilya Goncharov>
* 9ecf416a8a8 - (tag: build-1.4.20-dev-3490, tag: build-1.4.20-dev-3482, tag: build-1.4.20-dev-3481) Parse multiple buildTypeIds for one bunch and synchronize muted tests (vor 4 Tagen) <Yunir Salimzyanov>
* aafe41cf7a0 - (tag: build-1.4.20-dev-3474, tag: build-1.4.20-dev-3472) Do not force coercion to Unit for nullable lambda return type (vor 4 Tagen) <Mikhail Zarechenskiy>
* d9bac4d5e49 - (tag: build-1.4.20-dev-3462) Build: Warn about empty directories in sources (vor 5 Tagen) <Vyacheslav Gerasimov>
* 27578e6056e - (tag: build-1.4.20-dev-3454) Build: Upgrade gradle to 6.6 (vor 5 Tagen) <Vyacheslav Gerasimov>
* 166b6db764d - (tag: build-1.4.20-dev-3452) Make keyword lookup objects correctly comparable (vor 5 Tagen) <Roman Golyshev>
* 18ae665d419 - IR: make IrCall take IrSimpleFunctionSymbol (vor 5 Tagen) <Georgy Bronnikov>
* 4901cdb11ff - ConvertCallChainIntoSequence: support functions added in Kotlin 1.4 (vor 5 Tagen) <Toshiaki Kameyama>
* 5e91ffb1562 - Move to class body: don't suggest on data class (vor 5 Tagen) <Toshiaki Kameyama>
* 28700ed64c7 - (tag: build-1.4.20-dev-3438) [FIR] Supertype and inheritance checkers group (vor 5 Tagen) <Nick>
* 252eb1ad23e - (tag: build-1.4.20-dev-3431) [FIR] Fix typo in FirDataFlowAnalyzer (vor 5 Tagen) <Oleg Ivanov>
* e3bbc54e854 - Add change-notes for 1.4 (vor 5 Tagen) <Anton Yalyshev>
* 21b86797999 - (tag: build-1.4.20-dev-3425, tag: build-1.4.20-dev-3424, tag: build-1.4.20-dev-3422) [FIR] Add ReturnsImplies effect analyzer (vor 5 Tagen) <Oleg Ivanov>
* 3454ae7ca47 - [FIR] Add VariableStorage and flow on nodes into CFG reference (vor 5 Tagen) <Oleg Ivanov>
* 15598b62c95 - [FIR] Add replaceControlFlowGraphReference function for FirFunction (vor 5 Tagen) <Oleg Ivanov>
* 7da94cc299b - [FIR] Fix wrong ConstantReference for returnsNotNull in EffectExtractor (vor 5 Tagen) <Oleg Ivanov>
* f6f3787b51a - (tag: build-1.4.20-dev-3421) Disable FUS for Code Completion in 1.4.20 (vor 5 Tagen) <Anton Yalyshev>
* 20371b874ae - (tag: build-1.4.20-dev-3416) Configuration caching - register listener only once per project (vor 6 Tagen) <Andrey Uskov>
* d2fda2a07cb - Fir2Ir: bug fix (vor 6 Tagen) <Georgy Bronnikov>
* 8a098545e68 - (tag: build-1.4.20-dev-3413) Minor. Add test (vor 6 Tagen) <Ilmir Usmanov>
* 00bf07fc418 - Force boxing kotlin.Result return type of suspend functions (vor 6 Tagen) <Ilmir Usmanov>
* b06218c4561 - (tag: build-1.4.20-dev-3411) Minor. Update test data (vor 6 Tagen) <Ilmir Usmanov>
* f21d8a4c5ba - (tag: build-1.4.20-dev-3398) JVM_IR, minor: use vals instead of objects (vor 6 Tagen) <Georgy Bronnikov>
* 6e016ce0418 - (tag: build-1.4.20-dev-3395) ktFile has to return script declaration from stub as well (vor 6 Tagen) <Vladimir Dolzhenko>
* 4367d6631f6 - (tag: build-1.4.20-dev-3389) [FIR] Add CallsInPlace contract analyzer (vor 6 Tagen) <Oleg Ivanov>
* cc9c5b9e3c6 - [FIR] Add CFG nodes, add multiple subGraphs for CFGOwner (vor 6 Tagen) <Oleg Ivanov>
* 128075e7809 - [FIR] Add fir source saving in resolved contract description (vor 6 Tagen) <Oleg Ivanov>
* f467dccc687 - [FIR] Rename confusing variable in CFGTraverser (vor 6 Tagen) <Oleg Ivanov>
* bcf1ee3907a - Minor, fix test data for kotlinx.serialization bytecode text test (vor 6 Tagen) <Alexander Udalov>
* 53fe30eb45b - JVM IR: Don't produce CHECKCASTs on null constants (KT-36650) (vor 6 Tagen) <Steven Schäfer>
* 7503f134c23 - (tag: build-1.4.20-dev-3386) IR: use IdSignature to compare classes in FqNameEqualityChecker (vor 6 Tagen) <Alexander Udalov>
* 36a1a65d98e - IR: make IrBranch/IrCatch/IrSpreadElement/IrModuleFragment/IrPackageFragment classes (vor 6 Tagen) <Alexander Udalov>
* 08a35f0674e - IR: make IrBody and subtypes classes (vor 6 Tagen) <Alexander Udalov>
* 4351f5235b1 - IR: make IrExpression and subtypes classes (vor 6 Tagen) <Alexander Udalov>
* ba7ff362749 - IR: make IrDeclarationReference and subtypes classes (vor 6 Tagen) <Alexander Udalov>
* ee904a975a5 - IR: make IrMemberAccessExpression and subtypes classes (vor 6 Tagen) <Alexander Udalov>
* fde7314aaf9 - IR: do not inherit IrExpressionWithCopy from IrExpression (vor 6 Tagen) <Alexander Udalov>
* 9aa7da44e25 - IR: remove IrTerminalExpressionBase, Ir{Terminal,}DeclarationReferenceBase (vor 6 Tagen) <Alexander Udalov>
* 868018f51fa - IR: do not inherit IrFunctionReferenceImpl from IrCallWithIndexedArgumentsBase (vor 6 Tagen) <Alexander Udalov>
* e3dfd5fb49b - IR: push down implementations of startOffset/endOffset/type/... (vor 6 Tagen) <Alexander Udalov>
* 03f804b1c5f - (tag: build-1.4.20-dev-3384) FIR Completion: Move completion files to `idea-fir` module (vor 6 Tagen) <Roman Golyshev>
* d861373c6d1 - (tag: build-1.4.20-dev-3373, tag: build-1.4.20-dev-3372) Hack attributes for continuation of suspend function in SAM-adapter (vor 6 Tagen) <Ilmir Usmanov>
* 2e131b870a6 - (tag: build-1.4.20-dev-3371) Add tests for obsolete issues (vor 6 Tagen) <Mikhail Zarechenskiy>
* 7f4df19dd1a - (tag: build-1.4.20-dev-3369, tag: build-1.4.20-dev-3368) JVM_IR: reorganize throw... functions in Symbols (vor 6 Tagen) <Georgy Bronnikov>
* 6a16d6a246e - (tag: build-1.4.20-dev-3367) FIR: Simplify delegating constructors call resolution (vor 6 Tagen) <Denis Zharkov>
* 8b71f5e5582 - FIR: Do not leave cyclic upper bounds of type parameters (vor 6 Tagen) <Denis Zharkov>
* a5a93d00a72 - FIR: Rework delegation constructor calls resolution (vor 6 Tagen) <Denis Zharkov>
* db93b9052b4 - FIR: Fix incorrect optimization for integer literals (vor 6 Tagen) <Denis Zharkov>
* ad8709b2dcb - (tag: build-1.4.20-dev-3361) Build: Remove exclusion of kotlinx-coroutines-core in scripting-common (vor 7 Tagen) <Vyacheslav Gerasimov>
* 8540f47c158 - (tag: build-1.4.20-dev-3357) Fixed FindUsages case on look up implementation getter/setters via property names (vor 7 Tagen) <Vladimir Dolzhenko>
* e49cdf0ca2e - (tag: build-1.4.20-dev-3356) Prohibit using `suspend` functions as SAM in `fun` interfaces (vor 7 Tagen) <Mikhail Zarechenskiy>
* 607f99ed3c0 - (tag: build-1.4.20-dev-3353) Don't generate implicit overrides delegating to Java defaults (vor 7 Tagen) <Mikhael Bogdanov>
* 07aee8831eb - (tag: build-1.4.20-dev-3352, tag: build-1.4.20-dev-3350) Fix stdlib-by-default with non-compiled source sets (KT-40559) (vor 7 Tagen) <Sergey Igushkin>
* 6e2887e0832 - (tag: build-1.4.20-dev-3347) FIR Completion: Add insertion handling for functions with lambdas (vor 7 Tagen) <Roman Golyshev>
* b3a674abee5 - FIR IDE: Add parameter's and type's properties required for completion (vor 7 Tagen) <Roman Golyshev>
* 67ed33367f5 - FIR Completion: Add function insert handler (vor 7 Tagen) <Roman Golyshev>
* b547feb00d7 - FIR Completion: Render `vararg` modifier in lookups (vor 7 Tagen) <Roman Golyshev>
* 582b00f5b26 - FIR Completion: Add `UniqueLookupElement` to the lookup elements (vor 7 Tagen) <Roman Golyshev>
* b6ee4781907 - FIR Completion: Add psi element to the lookups (vor 7 Tagen) <Roman Golyshev>
* 53180e707e5 - FIR Completion: Fix invalid `isAbstract` condition (vor 7 Tagen) <Roman Golyshev>
* ef461260b0f - FIR Completion: Add simple insertion handler to lookup elements (vor 7 Tagen) <Roman Golyshev>
* 10598ee98e5 - FIR Completion: Add simple lookup decorating with icon and parameters (vor 7 Tagen) <Roman Golyshev>
* 64187b40c9f - FIR Completion: Prevent immediate completion in number literals (vor 7 Tagen) <Roman Golyshev>
* d86c14243e3 - (tag: build-1.4.20-dev-3346) Add @SinceKotlin to kotlinx.browser and kotlinx.dom packages (vor 7 Tagen) <Alexey Trilis>
* 0e53d11dd48 - (tag: build-1.4.20-dev-3345) Disable AllowResultInReturnType feature (vor 7 Tagen) <Dmitriy Novozhilov>
* 30ff8867540 - (tag: build-1.4.20-dev-3341) Improve docs for createTempDir/createTempFile (vor 7 Tagen) <Valeriy.Vyrva>
* 4fe68804892 - (tag: build-1.4.20-dev-3328) Cyrillic 'c' fix in inspectionLikeProcessings.kt (vor 7 Tagen) <Vladimir Ilmov>
* 0a2f113a248 - (tag: build-1.4.20-dev-3324) [FIR] Fix slow string conversions in FirEffectiveVisibilityResolver (vor 7 Tagen) <Nick>
* e67518c349d - (tag: build-1.4.20-dev-3313) Update gradle plugin version in GradleFacetImportTest (vor 7 Tagen) <Alexander Dudinsky>
* f431da2a665 - (tag: build-1.4.20-dev-3312) Reapply "Introduce @FrontendInternals annotation"" (vor 7 Tagen) <Pavel Kirpichenkov>
* 5e8e60a3990 - (tag: build-1.4.20-dev-3310) Move back the 'KotlinStructureViewElement.isPublic' property used externally (vor 7 Tagen) <Yan Zhulanow>
* aec87744f2c - Run `ImportAndCheckNavigation` tests only vs the master version of plugin (vor 7 Tagen) <Alexander Dudinsky>
* 2042db598ac - Mute `GradleNativeLibrariesInIDENamingTest.testLibrariesNaming` in 192, 193 (vor 7 Tagen) <Alexander Dudinsky>
* 988480d649a - (tag: build-1.4.20-dev-3308) Fix source JARs missing in Kotlin/Native targets with HMPP (KT-39051) (vor 7 Tagen) <Sergey Igushkin>
* a766369e728 - (tag: build-1.4.20-dev-3305) KT-33908 Make Kotlin Gradle plugin compatible with configuration cache (vor 7 Tagen) <Nataliya Valtman>
* ea57b4cccbe - (tag: build-1.4.20-dev-3302) IR: add and unmute tests (vor 7 Tagen) <Georgy Bronnikov>
* 85ba170217e - JVM_IR: use IrBasedDescriptors across codegen (vor 7 Tagen) <Georgy Bronnikov>
* 0b4c43083d1 - IR: add IrBasedDescriptors (vor 7 Tagen) <Georgy Bronnikov>
* dafcdc527d7 - IR: propagate original declaration info via attributeOwnerId (vor 7 Tagen) <Georgy Bronnikov>
* 04d93dfbce5 - IR: move containerSource from descriptor to IrFunction, IrProperty (vor 7 Tagen) <Georgy Bronnikov>
* 4669e019d14 - (tag: build-1.4.20-dev-3301) [FIR] Add diagnostic CONFLICTING_OVERLOADS & REDECLARATION (vor 7 Tagen) <Nick>