### PR TITLE
Handle some special characters in deprecation message in ObjCExport

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -1237,7 +1237,23 @@ private fun Deprecation.toDeprecationAttribute(): String {
     // TODO: consider avoiding code generation for unavailable.
 
     val message = this.message.orEmpty()
-            .replace("\n", "\\n")
 
-    return "$attribute(\"$message\")"
+    return "$attribute(${quoteAsCStringLiteral(message)})"
+}
+
+private fun quoteAsCStringLiteral(str: String): String = buildString {
+    append('"')
+    for (c in str) {
+        when (c) {
+            '\n' -> append("\\n")
+
+            '\r' -> append("\\r")
+
+            '"', '\\' -> append('\\').append(c)
+
+            // TODO: handle more special cases.
+            else -> append(c)
+        }
+    }
+    append('"')
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -1237,6 +1237,7 @@ private fun Deprecation.toDeprecationAttribute(): String {
     // TODO: consider avoiding code generation for unavailable.
 
     val message = this.message.orEmpty()
+            .replace("\n", "\\n")
 
     return "$attribute(\"$message\")"
 }

--- a/backend.native/tests/objcexport/expectedLazy.h
+++ b/backend.native/tests/objcexport/expectedLazy.h
@@ -513,6 +513,18 @@ __attribute__((swift_name("Kt38641Kt")))
 + (void)setOverrideVarDescriptionImpl:(id<KtKT38641OverrideVar>)impl newValue:(NSString *)newValue __attribute__((swift_name("setOverrideVarDescription(impl:newValue:)")));
 @end;
 
+__attribute__((swift_name("JsonConfiguration")))
+@interface KtJsonConfiguration : KtBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer)) __attribute__((unavailable("This class is deprecated for removal during serialization 1.0 API stabilization.\nFor configuring Json instances, the corresponding builder function can be used instead, e.g. instead of'Json(JsonConfiguration.Stable.copy(isLenient = true))' 'Json { isLenient = true }' should be used.\nInstead of storing JsonConfiguration instances of the code, Json instances can be used directly:'Json(MyJsonConfiguration.copy(prettyPrint = true))' can be replaced with 'Json(from = MyApplicationJson) { prettyPrint = true }'")));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("Kt39206Kt")))
+@interface KtKt39206Kt : KtBase
++ (int32_t)myFunc __attribute__((swift_name("myFunc()"))) __attribute__((deprecated("Don't call this\nPlease")));
+@end;
+
 __attribute__((objc_subclassing_restricted))
 __attribute__((swift_name("LibraryKt")))
 @interface KtLibraryKt : KtBase

--- a/backend.native/tests/objcexport/expectedLazy.h
+++ b/backend.native/tests/objcexport/expectedLazy.h
@@ -520,6 +520,13 @@ __attribute__((swift_name("JsonConfiguration")))
 @end;
 
 __attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("MoreTrickyChars")))
+@interface KtMoreTrickyChars : KtBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer)) __attribute__((deprecated("'\"\\@$(){}\r\n")));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
 __attribute__((swift_name("Kt39206Kt")))
 @interface KtKt39206Kt : KtBase
 + (int32_t)myFunc __attribute__((swift_name("myFunc()"))) __attribute__((deprecated("Don't call this\nPlease")));

--- a/backend.native/tests/objcexport/kt39206.kt
+++ b/backend.native/tests/objcexport/kt39206.kt
@@ -1,0 +1,14 @@
+// See https://youtrack.jetbrains.com/issue/KT-39206.
+@Deprecated("Don't call this\nPlease")
+fun myFunc() = 17
+
+// See https://youtrack.jetbrains.com/issue/KT-41193.
+@Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "This class is deprecated for removal during serialization 1.0 API stabilization.\n" +
+                "For configuring Json instances, the corresponding builder function can be used instead, e.g. instead of" +
+                "'Json(JsonConfiguration.Stable.copy(isLenient = true))' 'Json { isLenient = true }' should be used.\n" +
+                "Instead of storing JsonConfiguration instances of the code, Json instances can be used directly:" +
+                "'Json(MyJsonConfiguration.copy(prettyPrint = true))' can be replaced with 'Json(from = MyApplicationJson) { prettyPrint = true }'"
+)
+public open class JsonConfiguration

--- a/backend.native/tests/objcexport/kt39206.kt
+++ b/backend.native/tests/objcexport/kt39206.kt
@@ -12,3 +12,6 @@ fun myFunc() = 17
                 "'Json(MyJsonConfiguration.copy(prettyPrint = true))' can be replaced with 'Json(from = MyApplicationJson) { prettyPrint = true }'"
 )
 public open class JsonConfiguration
+
+@Deprecated("'\"\\@\$(){}\r\n")
+class MoreTrickyChars

--- a/backend.native/tests/objcexport/kt39206.swift
+++ b/backend.native/tests/objcexport/kt39206.swift
@@ -1,0 +1,13 @@
+import Kt
+
+private func test1() throws {
+    try assertEquals(actual: Kt39206Kt.myFunc(), expected: 17)
+}
+
+class Kt39206Tests : SimpleTestProvider {
+    override init() {
+        super.init()
+
+        test("Test1", test1)
+    }
+}

--- a/backend.native/tests/objcexport/kt39206.swift
+++ b/backend.native/tests/objcexport/kt39206.swift
@@ -4,10 +4,15 @@ private func test1() throws {
     try assertEquals(actual: Kt39206Kt.myFunc(), expected: 17)
 }
 
+private func test2() throws {
+    try assertTrue(MoreTrickyChars() as AnyObject is MoreTrickyChars)
+}
+
 class Kt39206Tests : SimpleTestProvider {
     override init() {
         super.init()
 
         test("Test1", test1)
+        test("Test2", test2)
     }
 }


### PR DESCRIPTION
Fix [KT-39206](https://youtrack.jetbrains.com/issue/KT-39206).