### PR TITLE
[kotlin compiler][update] 1.4.20-dev-3898

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.backend.common.serialization.DeclarationTable
 import org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer
 import org.jetbrains.kotlin.backend.konan.RuntimeNames
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.ir.declarations.IrAnnotationContainer
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
@@ -18,11 +19,15 @@ class KonanIrFileSerializer(
     bodiesOnlyForInlines: Boolean = false
 ): IrFileSerializer(logger, declarationTable, expectDescriptorToSymbol, skipExpects = skipExpects, bodiesOnlyForInlines = bodiesOnlyForInlines) {
 
-    override fun backendSpecificExplicitRoot(declaration: IrFunction) =
-            declaration.annotations.hasAnnotation(RuntimeNames.exportForCppRuntime)
+    override fun backendSpecificExplicitRoot(node: IrAnnotationContainer): Boolean {
+        val fqn = when (node) {
+            is IrFunction -> RuntimeNames.exportForCppRuntime
+            is IrClass -> RuntimeNames.exportTypeInfoAnnotation
+            else -> return false
+        }
 
-    override fun backendSpecificExplicitRoot(declaration: IrClass) =
-            declaration.annotations.hasAnnotation(RuntimeNames.exportTypeInfoAnnotation)
+        return node.annotations.hasAnnotation(fqn)
+    }
 
     override fun backendSpecificSerializeAllMembers(irClass: IrClass) = !KonanFakeOverrideClassFilter.constructFakeOverrides(irClass)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3586,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-3586
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3586,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-3586
-kotlinStdlibTestsVersion=1.4.20-dev-3586
-testKotlinCompilerVersion=1.4.20-dev-3586
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3898,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-3898
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3898,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-3898
+kotlinStdlibTestsVersion=1.4.20-dev-3898
+testKotlinCompilerVersion=1.4.20-dev-3898
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* aeae898b942 - (tag: build-1.4.20-dev-3898, origin/master, origin/HEAD) [FIR] Fix issues with properties' fake sources (vor 2 Stunden) <Nick>
* 61e21dadec0 - [FIR] Add 3 type mismatch diagnostics (vor 2 Stunden) <Nick>
* c8f8908a013 - [FIR] Add NO_THIS & INSTANCE_ACCESS_BEFORE_SUPER_CALL (vor 2 Stunden) <Nick>
* 7e1c2cfd36f - [FIR] Add diagnostic INAPPLICABLE_LATEINIT_MODIFIER + some builtin types (vor 2 Stunden) <Nick>
* 091e12c0933 - [FIR] Add diagnostic CONFLICTING_PROJECTION (vor 2 Stunden) <Nick>
* d40bca4143f - (tag: build-1.4.20-dev-3894) [Commonizer] Short-circuiting of type aliases (vor 4 Stunden) <Dmitriy Dolovov>
* 8a84af8a6fa - (tag: build-1.4.20-dev-3882) Build: Fix idea-gradle test task dependency on dist (vor 2 Tagen) <Vyacheslav Gerasimov>
* a9359eb530a - (tag: build-1.4.20-dev-3875) RangeContainsLowering: Handle unsigned ranges. (vor 3 Tagen) <Mark Punzalan>
* ceba9f231d7 - RangeContainsLowering: Fix bug in additional condition order for `until` ranges. (vor 3 Tagen) <Mark Punzalan>
* 60a2f7d03f0 - RangeContainsLowering: Handle Comparable ranges. (vor 3 Tagen) <Mark Punzalan>
* 1c1b1b4b0fd - Initial version of RangeContainsLowering, which optimizes calls to contains() on ClosedRanges. (vor 3 Tagen) <Mark Punzalan>
* ca541337d17 - (tag: build-1.4.20-dev-3869) FIR: skip return insertion for lambda w/ Unit return type (vor 3 Tagen) <Jinseong Jeon>
* f1ce668edee - (tag: build-1.4.20-dev-3867) IR: minor, don't store unnecessary fields (vor 3 Tagen) <Alexander Udalov>
* 26eb51a9f94 - Minor, fix generateBuiltins test (vor 3 Tagen) <Alexander Udalov>
* d170f46bfc7 - (tag: build-1.4.20-dev-3865) Mute flaky fun usages tests (vor 3 Tagen) <Nikolay Krasko>
* 6293842d816 - Mute XCoroutinesStackTraceTestGenerated flaky test (vor 3 Tagen) <Nikolay Krasko>
* 9d300f56cc0 - Mark SubpluginsIT.testKotlinVersionDowngradeInSupbrojectKt39809 as flaky (vor 3 Tagen) <Nikolay Krasko>
* 8f785f6bb20 - Mute flaky tests in ContinuationStackTraceTestGenerated (vor 3 Tagen) <Nikolay Krasko>
* fd036c26584 - Mute flaky tests in JavaAgainstKotlinBinariesCheckerTestGenerated (vor 3 Tagen) <Nikolay Krasko>
* fcca2c6fa37 - (tag: build-1.4.20-dev-3861) [JS IR] fix failing test (vor 3 Tagen) <Roman Artemev>
* 5722f889d86 - (tag: build-1.4.20-dev-3857) FIR2IR: scan the entire interface tree for delegatable members (vor 3 Tagen) <pyos>
* 99d2fd7c4de - [FIR] Handle open in interface correctly during status resolve (vor 3 Tagen) <Mikhail Glukhikh>
* 8e2c5bf4fea - [FIR] Fix exposed visibility checking for enum entries (vor 3 Tagen) <Mikhail Glukhikh>
* e15e87fdedc - [FIR] Expand aliased type before checking for exposure (vor 3 Tagen) <Mikhail Glukhikh>
* cb6fbc329a3 - (tag: build-1.4.20-dev-3855) FIR: Simplify FirQualifiedAccess hiearchy (vor 3 Tagen) <Denis Zharkov>
* e6837a5b8c7 - (tag: build-1.4.20-dev-3850) [FIR] Unify implementations of `toSymbol` and `getSymbolByLookupTag` (vor 3 Tagen) <Dmitriy Novozhilov>
* d1f6e45b081 - [FIR] Cleanup signature of `getNestedClassifierScope` (vor 3 Tagen) <Dmitriy Novozhilov>
* ffdc68b68d8 - [FIR] Get rid of AbstractFirSymbolProviderWithCache (vor 3 Tagen) <Dmitriy Novozhilov>
* 111b8c01695 - [FIR] Cleanup caching symbol in `ConeClassLikeLookupTagImpl` (vor 3 Tagen) <Dmitriy Novozhilov>
* 9032234e1d1 - [FIR] Get rid of FirSymbolProvider.getNestedClassifierScope (vor 3 Tagen) <Dmitriy Novozhilov>
* 77f52a9ddb2 - [FIR] Add special inline class for caches which are used in symbol providers (vor 3 Tagen) <Dmitriy Novozhilov>
* 4b6193159c3 - [FIR] Get rid of JavaSymbolProvider.getJavaTopLevelClasses (vor 3 Tagen) <Dmitriy Novozhilov>
* d7cfb2fb132 - [FIR] Get rid of FirSymbolProvider.getClassNamesInPackage (vor 3 Tagen) <Dmitriy Novozhilov>
* b31f80aee3f - [FIR] Get rid of FirSymbolProvider.getAllCallableNamesInPackage (vor 3 Tagen) <Dmitriy Novozhilov>
* f32a0fe7ad2 - [FIR-TEST] Unify AbstractFirLoadCompiledKotlin and BuiltInsDeserializationForFirTestCase (vor 3 Tagen) <Dmitriy Novozhilov>
* 913ea9b56de - [FIR-TEST] Get rid of deprecated methods usage in AbstractFirLoadCompiledKotlin (vor 3 Tagen) <Dmitriy Novozhilov>
* 41aa90ad71d - [FIR-TEST] Add flag to take memory dumps in modularized test (vor 3 Tagen) <Dmitriy Novozhilov>
* cb0b25ea39c - [FIR] Replace `Deprecated` with `PrivateForInline` in ScopeSession (vor 3 Tagen) <Dmitriy Novozhilov>
* b4dc7955b44 - [FIR] Avoid collections copying in FirSymbolProvider (vor 3 Tagen) <Dmitriy Novozhilov>
* ce36ae64a18 - [FIR] Deprecate questionable methods of FirSymbolProvider (vor 3 Tagen) <Dmitriy Novozhilov>
* d5bb87cd1f2 - [FIR] Replace inheritance with delegation for FirProvider and FirSymbolProvider (vor 3 Tagen) <Dmitriy Novozhilov>
* ad9e41b828a - [FIR] Mark JavaSymbolProvider.getJavaTopLevelClasses as `@TestOnly` (vor 3 Tagen) <Dmitriy Novozhilov>
* 1d26ce4a4e1 - [FIR] Get rid of useless methods in FirSymbolProvider (vor 3 Tagen) <Dmitriy Novozhilov>
* f0d05a321d6 - [FIR-IDE] Use symbolProvider instead of firProvider in KtFirPackageScope (vor 3 Tagen) <Dmitriy Novozhilov>
* 5a45cc72903 - (tag: build-1.4.20-dev-3834) Update wizard tests (vor 3 Tagen) <Kirill Shmakov>
* cee72023fa0 - Remove TypeSystemContext::mayBeTypeVariable optimization (vor 3 Tagen) <Denis Zharkov>
* 9ac5dd2bced - FIR: Use lookup tags for as type constructors instead of symbols (vor 3 Tagen) <Denis Zharkov>
* 34b55dbeb3a - (tag: build-1.4.20-dev-3833, tag: build-1.4.20-dev-3831) (CoroutineDebugger) Disable agent for MPP projects (vor 3 Tagen) <Vladimir Ilmov>
* 1e96088cc6d - (tag: build-1.4.20-dev-3829) Check unique symbols in Goto*Tests (vor 3 Tagen) <Vladimir Dolzhenko>
* 5f584691a6e - (tag: build-1.4.20-dev-3824) [inspections] disable "Redundant inner modifier" inspection (vor 3 Tagen) <Dmitry Gridin>
* ec253862c69 - (tag: build-1.4.20-dev-3821) Check unique symbols in Goto*Tests (vor 4 Tagen) <Vladimir Dolzhenko>
* 62be688eb75 - (tag: build-1.4.20-dev-3819) Wizard: add missing test dependency (vor 4 Tagen) <Kirill Shmakov>
* e7f22bcfbc8 - (tag: build-1.4.20-dev-3818) [JS IR] Add  test for cross module export (vor 4 Tagen) <Roman Artemev>
* 136d86e5529 - [JS IR] Fix cross-module import/export in case per-module splitting (vor 4 Tagen) <Anton Bannykh>
* 8d61e9ba219 - [KLIB] Load `@JsExport` annotated declarations explicitly (vor 4 Tagen) <Roman Artemev>
* 1a0e3a1d835 - [KLIB] Refactor file serializer a bit (vor 4 Tagen) <Roman Artemev>
* 12e900ef3cf - (tag: build-1.4.20-dev-3816) Minor, do not capitalize words in generated Gradle options docs (vor 4 Tagen) <Alexander Udalov>
* 0ef4b22cf37 - Remove deprecated usages of ContainerUtil (vor 4 Tagen) <Alexander Udalov>
* 2428c180c23 - Suppress warning on usage of old MPP in kotlin-stdlib (vor 4 Tagen) <Alexander Udalov>
* da6d904c6eb - Suppress code warnings in kotlin-stdlib (vor 4 Tagen) <Alexander Udalov>
* 5ef4f7df5a1 - (tag: build-1.4.20-dev-3815, tag: build-1.4.20-dev-3802) Mute more tests (vor 4 Tagen) <Nikolay Krasko>
* 44a95a41059 - Stop running failed AndroidRunner tests (vor 4 Tagen) <Nikolay Krasko>
* 7f91ed69979 - Support mute tests in kotlin-gradle-plugin-integration-tests (KTI-234) (vor 4 Tagen) <Nikolay Krasko>
* 07bddbe4d03 - [FIR CLI] Don't run generation if some errors are found (vor 4 Tagen) <Mikhail Glukhikh>
* 85c1505689f - [FIR2IR] Copy type parameters for trivial fake overrides (vor 4 Tagen) <Mikhail Glukhikh>
* bf0bb9e9467 - JVM IR: remove obsolete code for duplicate signature diagnostics (vor 4 Tagen) <Alexander Udalov>
* 425b192a5f7 - Fix warnings in build-common/daemon code (vor 4 Tagen) <Alexander Udalov>
* 1d15a5547da - Suppress deprecation warnings related to scripting (vor 4 Tagen) <Alexander Udalov>
* 549ee84687d - Fix some compiler warnings in FIR modules (vor 4 Tagen) <Alexander Udalov>
* ced151f3af4 - (tag: build-1.4.20-dev-3799) Add test for KT-41254 (vor 4 Tagen) <Mikhail Zarechenskiy>
* a6f301e84a7 - (tag: build-1.4.20-dev-3790) [JVM_IR] Rebase constructor stepping tests that are working as intended. (vor 4 Tagen) <Mads Ager>
* 2c6b5c8847d - [JVM_IR] Give temporary variable loads meaningful offsets. (vor 4 Tagen) <Mads Ager>
* 413d02621bc - (tag: build-1.4.20-dev-3788) Add a link to docs in MPP stability warning; add a flag that hides it (vor 4 Tagen) <Sergey Igushkin>
* 02e5f140f48 - (tag: build-1.4.20-dev-3779, tag: build-1.4.20-dev-3777) Fir2IrLazyProperty: generate overridden symbols via FirTypeScope (vor 4 Tagen) <Mikhail Glukhikh>
* 25efad2fd7d - [FIR2IR] Extract generateOverriddenAccessorSymbols (vor 4 Tagen) <Mikhail Glukhikh>
* 539d2bc01f9 - (tag: build-1.4.20-dev-3776) FIR Completion: Fix completion with error type as receiver (vor 4 Tagen) <Roman Golyshev>
* bca9754a7b7 - FIR Completion: Move completion from available scopes to separate class (vor 4 Tagen) <Roman Golyshev>
* 7f3f0faa1a8 - (tag: build-1.4.20-dev-3775) FIR: Rework overridden members processing in FirTypeScope (vor 4 Tagen) <Denis Zharkov>
* 8ce9b2d061b - (tag: build-1.4.20-dev-3774) KT-34572 Convert to block body action improperly works with suppress annotations (#2969) (vor 4 Tagen) <Toshiaki Kameyama>
* 9e0bb4ce8e7 - (tag: build-1.4.20-dev-3773) FIR: save resolvePhase of declaration when creating it fake override copy (vor 4 Tagen) <Ilya Kirillov>
* b1d3ab04c2b - (tag: build-1.4.20-dev-3771) FIR [IDE]: provide correct node phase when necessary (vor 4 Tagen) <Ilya Kirillov>
* 119302b0167 - (tag: build-1.4.20-dev-3766) [JVM_IR] Run KotlinSteppingTests with the JVM_IR backend. (vor 4 Tagen) <Mads Ager>
* 01f7da66c68 - (tag: build-1.4.20-dev-3762) Mute ProjectTemplateNewWizardProjectImportTestGenerated.**.testMultiplatformApplication (vor 5 Tagen) <Nikolay Krasko>
* 9d18279ec9f - (tag: build-1.4.20-dev-3761) Mute ReferenceResolveTestGenerated.DelegatedPropertyAccessors.InStandardLibrary.testNotNull (vor 5 Tagen) <Nikolay Krasko>
* d87d42348be - Mute flaky GotoWithMultipleLibrariesTest (vor 5 Tagen) <Nikolay Krasko>
* 179bd1cc3de - Mute KotlinUastTypesTest.testEa101715 (vor 5 Tagen) <Nikolay Krasko>
* 950b139804c - Mute CreateFunction.Invoke.testLambdaArgument (vor 5 Tagen) <Nikolay Krasko>
* 496ede75873 - Mute KotlinUastTypesTest.testEa101715 (vor 5 Tagen) <Nikolay Krasko>
* 4135240cc0c - Mute testFunctionBreakpointInStdlib in AS41 (vor 5 Tagen) <Nikolay Krasko>
* 79822830078 - Copy mutes for AS41 from 201 (vor 5 Tagen) <Nikolay Krasko>
* a3c8427cb23 - Mute GradleScriptListenerTest tests (vor 5 Tagen) <Nikolay Krasko>
* 7de5368b4d0 - Fix AbstractGradleBuildRootsLocatorTest tests (vor 5 Tagen) <Nikolay Krasko>
* 0b2fcd2c4d4 - Remove mutes for navigation tests (vor 5 Tagen) <Nikolay Krasko>
* ebe0489a749 - (tag: build-1.4.20-dev-3757) Fix joined lines in .bunch (vor 5 Tagen) <Yunir Salimzyanov>
* 70cda1b113c - (tag: build-1.4.20-dev-3756, tag: build-1.4.20-dev-3755, tag: build-1.4.20-dev-3753) Refactor and fix files previously affected by 192 patchset (KTI-315) (vor 5 Tagen) <Yunir Salimzyanov>
* 42da9e62db8 - Cleanup 192 patchset files (KTI-315) (vor 5 Tagen) <Yunir Salimzyanov>
* 73aa21aab60 - Refactor and fix files previously affected by as36 patchset (KTI-315) (vor 5 Tagen) <Yunir Salimzyanov>
* 27b2e161411 - Cleanup as36 patchset files (KTI-315) (vor 5 Tagen) <Yunir Salimzyanov>
* 0a9089bc725 - (tag: build-1.4.20-dev-3745, tag: build-1.4.20-dev-3744) Set correct base classloader for REPL evaluation (vor 5 Tagen) <Ilya Chernikov>
* f713e8ad367 - Set context classloader before REPL evaluation (vor 5 Tagen) <Ilya Chernikov>
* d0366d3bcbd - (tag: build-1.4.20-dev-3743) Failed test clean up (vor 5 Tagen) <Vladimir Dolzhenko>
* 4794297640d - (tag: build-1.4.20-dev-3737) used string template instead of concatenation (vor 5 Tagen) <alexjuca>
* f88e492d114 - (tag: build-1.4.20-dev-3734) Support hmpp in template (vor 5 Tagen) <Kirill Shmakov>
* 11044a3ab52 - (tag: build-1.4.20-dev-3733) Surround with null check: fix incorrect check for 'in' expression (vor 5 Tagen) <Toshiaki Kameyama>
* 1188f4617af - (tag: build-1.4.20-dev-3727) Change file's package to match directory: add space after package keyword if needed (vor 5 Tagen) <Toshiaki Kameyama>
* 1ce39222e3c - (tag: build-1.4.20-dev-3721) Build KMM plugin for AS 4.2 (vor 5 Tagen) <Kirill Shmakov>
* 6ed13ef1b64 - (tag: build-1.4.20-dev-3720) Fix unresolved reference to catch parameter from lambda expression (vor 5 Tagen) <Mikhail Zarechenskiy>
* f2fba8a4695 - Fix delegated property resolve when provideDelegate has this as argument (vor 5 Tagen) <Mikhail Zarechenskiy>
* f3be3f449a4 - (tag: build-1.4.20-dev-3718) Scope function conversion: do not suggest when invoked without receiver (vor 5 Tagen) <Toshiaki Kameyama>
* 8ba5548a0f4 - (tag: build-1.4.20-dev-3717)  "Eliminate argument of 'when'": do not suggest if 'when' is used as expression and it has no 'else' branch (#2898) (vor 5 Tagen) <Toshiaki Kameyama>
* d965ad0a987 - (tag: build-1.4.20-dev-3716) IfThenToSafeAccessInspection: do not report if condition is SENSELESS_COMPARISON/USELESS_IS_CHECK (#3007) (vor 5 Tagen) <Toshiaki Kameyama>
* 122bba9102a - (tag: build-1.4.20-dev-3715) UnnecessaryVariableInspection: don't report for overriding property (vor 5 Tagen) <Toshiaki Kameyama>
* c29dbee65e1 - Cover move method refactoring with registry key (disabled by default) (vor 5 Tagen) <Igor Yakovlev>
* ed67517fb98 - Move: make minor refactorings and add GUI form for MoveKotlinMethodDialog (vor 5 Tagen) <aleksandrina-streltsova>
* 55154657603 - Move: Support method moving (vor 5 Tagen) <aleksandrina-streltsova>
* a5368e443c0 - (tag: build-1.4.20-dev-3711) KT-20421 fixing code generation for the case when "object" extends "class". It should look like: "object: class()". (vor 5 Tagen) <Alex Chmyr>
* 26ca205f7ef - Fix a broken hyperlink to Whatsnew at the plugin change-notes (vor 5 Tagen) <Anton Yalyshev>
* ccf285a2847 - FIR IDE: do not recreate analysis session for tests now (vor 5 Tagen) <Ilya Kirillov>
* c191373a6b0 - FIR IDE: always pass ValidityToken to KtAnalysisSessionComponent (vor 5 Tagen) <Ilya Kirillov>
* 2290d2fcc0c - FIR IDE: make FirScopeRegistry belong to a KtFirScopeProvider (vor 5 Tagen) <Ilya Kirillov>
* 7d58588f069 - (tag: build-1.4.20-dev-3709) FIR IDE: Fix `KtFirPropertySymbol::receiverType` (vor 5 Tagen) <Roman Golyshev>
* 8f0aecce58a - (tag: build-1.4.20-dev-3708) JVM_IR: KT-40330 Unify field names for captured 'this' with JVM (vor 5 Tagen) <Dmitry Petrov>
* 24bfc155af1 - (tag: build-1.4.20-dev-3706) IDE perf tests for K/N: Use Gradle 6.6 (vor 5 Tagen) <Dmitriy Dolovov>
* 6a95317f732 - IDE perf tests for K/N: Switch to 1.4.0 (vor 5 Tagen) <Dmitriy Dolovov>
* f7cb165fb90 - (tag: build-1.4.20-dev-3696) Introduce Fir2IrBuiltIns & move extension function type inside (vor 6 Tagen) <Mikhail Glukhikh>
* 97b10b5ab3c - [FIR2IR] Hack-in setting of extension function type annotation (vor 6 Tagen) <Simon Ogorodnik>
* b1c36feef42 - Minor: regenerate FIR diagnostic tests (vor 6 Tagen) <Mikhail Glukhikh>
* 7e22de1e24c - FIR2IR: insert coerce-to-unit expressions in statement containers (vor 6 Tagen) <Jinseong Jeon>
* 1b3ab53e16c - FIR2IR: set superQualifierSymbol for setters too (vor 6 Tagen) <pyos>
* e9659d9c8a0 - FIR2IR: make the scope of body of do-while loop transparent (vor 6 Tagen) <Jinseong Jeon>
* 1b6c4329d2e - FIR2IR: handle unbound reference with adapted arguments (vor 6 Tagen) <Jinseong Jeon>
* a26eeb6ee83 - [FIR] Add CLI flag for running extended checkers (vor 6 Tagen) <vldf>
* 2bf1d3fee82 - [FIR] Add messages for extended checkers' warnings (vor 6 Tagen) <vldf>
* 08e2dd3deab - (tag: build-1.4.20-dev-3690) NJ2K: fix implicit type cast in binary expressions (vor 6 Tagen) <Ilya Kirillov>
* d5d57f84e08 - NJ2K: preserve annotations while converting class to object (vor 6 Tagen) <Ilya Kirillov>
* 3d517c36564 - NJ2K: fix retrieving resolutionFacade on empty context elements list (vor 6 Tagen) <Ilya Kirillov>
* de0c216cfa0 - NJ2K: fix NPE in JavaObjectEqualsToEqOperatorProcessing (vor 6 Tagen) <Ilya Kirillov>
* 38477be4842 - (tag: build-1.4.20-dev-3683) [FIR] Make test fail if profiling requested, but misconfigured (vor 6 Tagen) <Simon Ogorodnik>
* 15d4333e815 - [FIR] Add per-pass profiling support to modularized test (vor 6 Tagen) <Simon Ogorodnik>
* 83ded9badf7 - [FIR] Add pass argument to beforePass of modularized test (vor 6 Tagen) <Simon Ogorodnik>
* 716c3668d67 - (tag: build-1.4.20-dev-3678) [IR] Properly resolve type parameters in case of property accessor (vor 6 Tagen) <Roman Artemev>
* a810dbb41b7 - (tag: build-1.4.20-dev-3658) IR: fix compiler warnings (vor 6 Tagen) <Alexander Udalov>
* be53467bee3 - (tag: build-1.4.20-dev-3656) Flaky and muted navigation tests clean up (vor 6 Tagen) <Vladimir Dolzhenko>
* e2a12602a3e - Fixed getPsiMethodWrappers for KtLightMethodForDecompiledDeclaration (vor 6 Tagen) <Vladimir Dolzhenko>
* ee0250bd35a - Reformat file (vor 6 Tagen) <Vladimir Dolzhenko>
* 5c7054a5abe - Fixed src path for mock library (vor 6 Tagen) <Vladimir Dolzhenko>
* 7b80be5c9d1 - (tag: build-1.4.20-dev-3647) Temporary workaround for gradle issue: wrong navigation for included plugin source code (vor 7 Tagen) <Natalia Selezneva>
* 7dd687cf008 - (tag: build-1.4.20-dev-3646) IR: minor, use lazy instead of lazyVar for readonly value (vor 7 Tagen) <Alexander Udalov>
* a21f273570d - Fix compiler warnings in compiler code (vor 7 Tagen) <Alexander Udalov>
* 9b94e073af9 - Fix warnings related to OptIn/UseExperimental (vor 7 Tagen) <Alexander Udalov>
* 256f4449ced - IR: annotate obsolete API in IrPluginContext with ObsoleteDescriptorBasedAPI (vor 7 Tagen) <Alexander Udalov>
* 9961bd1fe1f - IR: remove unneeded casts after making IrCall's symbol a simple function (vor 7 Tagen) <Alexander Udalov>
* 3bdbfc1e730 - (tag: build-1.4.20-dev-3642) Output total codegen statistics after IR translation/generation (vor 7 Tagen) <Alexander Udalov>
* c3cbcf6d7f5 - Slightly improve performance measurements rendering (vor 7 Tagen) <Alexander Udalov>
* 0045b501d51 - (tag: build-1.4.20-dev-3641) FIR IDE: Fix memory leak in thread locals (vor 7 Tagen) <Simon Ogorodnik>
* 76b078b5611 - FIR IDE: resolve KtFirLocalVariableSymbol only to IMPLICIT_TYPES_BODY_RESOLVE (vor 7 Tagen) <Ilya Kirillov>
* b8920114f8d - FIR: set resolvePhase to BODY_RESOLVE in deserialized Kotlin declarations (vor 7 Tagen) <Ilya Kirillov>
* c7d6a79c252 - FIR IDE: Fix completion in case of function with parameters (vor 7 Tagen) <Simon Ogorodnik>
* 863de52f7ad - (tag: build-1.4.20-dev-3640) Minor: better name for file walking with excludes (vor 7 Tagen) <Nikolay Krasko>
* c30910130ed - Remove minor optimization in CodeConformanceTest (vor 7 Tagen) <Nikolay Krasko>
* 01f3bdfc69a - Exclude kotlin-ultimate/ide/common-cidr-native from author check (vor 7 Tagen) <Nikolay Krasko>
* 31ed803ada6 - More excludes (vor 7 Tagen) <Nikolay Krasko>
* 713dbc225ec - Other repositories monitoring (vor 7 Tagen) <Nikolay Krasko>
* fad15b6627f - Rewrite testThirdPartyCopyrights test (vor 7 Tagen) <Nikolay Krasko>
* bb0ea56d635 - Extract traversing through directories to the common code (vor 7 Tagen) <Nikolay Krasko>
* 8db588c7f04 - Optimize testNoBadSubstringsInProjectCode test (vor 7 Tagen) <Nikolay Krasko>
* 2655d9dab3b - Optimize testForgottenBunchDirectivesAndFiles test (vor 7 Tagen) <Nikolay Krasko>
* 3eb89d6dfd5 - Use own allow list for each repository (vor 7 Tagen) <Nikolay Krasko>
* 8445c8f4a59 - Update copyright conformance excludes (vor 7 Tagen) <Nikolay Krasko>
* 04a1e572a8c - Monitor new usages of kotlin-eap repository (vor 7 Tagen) <Nikolay Krasko>
* d2bf5587d69 - Monitor new usages of kotlin-dev repository (vor 7 Tagen) <Nikolay Krasko>
* 50d85b92daa - Remove more kotlin-dev usages (vor 7 Tagen) <Nikolay Krasko>
* be2badc6ed6 - Remove kotlin-dev from gradle migrate test (vor 7 Tagen) <Nikolay Krasko>
* 0c27e87eb9b - Remove kotlin-dev from gradle configurator tests (vor 7 Tagen) <Nikolay Krasko>
* 3dc3c19c02d - (tag: build-1.4.20-dev-3632, tag: build-1.4.20-dev-3630, tag: build-1.4.20-dev-3627) [Commonizer] Fix ImportAndCheckNavigation IT (vor 7 Tagen) <Dmitriy Dolovov>
* df8b819a55a - (tag: build-1.4.20-dev-3623, tag: build-1.4.20-dev-3620, tag: build-1.4.20-dev-3617, tag: build-1.4.20-dev-3614) JVM_IR: restore dumping for IrLowering phase (vor 7 Tagen) <Georgy Bronnikov>
* c70759673c7 - (tag: build-1.4.20-dev-3609) [Gradle, JS] Update npm versions (vor 7 Tagen) <Ilya Goncharov>
* 61001661857 - (tag: build-1.4.20-dev-3607) JVM IR: Fix special bridge generation with external Kotlin dependencies (vor 7 Tagen) <Steven Schäfer>
* 730e07c52ae - (tag: build-1.4.20-dev-3597) Wizard: fix ExpectedFileTest.kt (vor 7 Tagen) <Ilya Kirillov>
* 35459d2ca70 - (tag: build-1.4.20-dev-3594) "Add not-null asserted (!!) call": add '!!' to receiver of function reference (vor 7 Tagen) <Toshiaki Kameyama>
* 5e5e19f482f - (tag: build-1.4.20-dev-3589) FIR IDE: temporary disable AddFunctionReturnTypeIntention (vor 7 Tagen) <Ilya Kirillov>
* b79deafbc7d - FIR IDE: fix testdata (vor 7 Tagen) <Ilya Kirillov>
* 27c045d0359 - FIR IDE: move all all symbol markers to markers package (vor 7 Tagen) <Ilya Kirillov>
* 052e8e50694 - FIR IDE: make a symbol hierarchy a sealed one (vor 7 Tagen) <Ilya Kirillov>
* 018dd673b31 - FIR IDE: simplify containing declaration provider (vor 7 Tagen) <Ilya Kirillov>
* 37ac6544447 - FIR IDE: rework high level API (vor 7 Tagen) <Ilya Kirillov>
* cadf99ca1e4 - FIR IDE: introduce containingDeclarationProvider for symbols (vor 7 Tagen) <Ilya Kirillov>
* b5a4e4c4094 - FIR IDE: introduce applicable computation & -based inspection (vor 7 Tagen) <Ilya Kirillov>
* c8ab0766c95 - FIR IDE: Implement symbol restoring for member symbols (vor 7 Tagen) <Ilya Kirillov>
* e4995175a47 - FIR IDE: fix idea-frontend-fir testdata (vor 7 Tagen) <Ilya Kirillov>
* 5f20910c793 - FIR IDE: always try to find symbol origin in overridden symbols (vor 7 Tagen) <Ilya Kirillov>
* a700d1fccb2 - FIR IDE: resolve kt symbols only to the phase they actually need (vor 7 Tagen) <Ilya Kirillov>