### PR TITLE
[kotlin compiler][update] 1.4.20-dev-4195

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
 import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
 import org.jetbrains.kotlin.backend.konan.descriptors.findPackage
 import org.jetbrains.kotlin.builtins.functions.FunctionClassDescriptor
+import org.jetbrains.kotlin.builtins.functions.FunctionClassKind
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.ir.declarations.*
@@ -113,7 +114,7 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
 
     val builtFunctionNClasses get() = builtClassesMap.values.mapNotNull {
         with(it.descriptor as FunctionClassDescriptor) {
-            if (functionKind == FunctionClassDescriptor.Kind.Function)
+            if (functionKind == FunctionClassKind.Function)
                 FunctionalInterface(it, arity)
             else null
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanReflectionTypes.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanReflectionTypes.kt
@@ -5,7 +5,8 @@
 
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.builtins.KOTLIN_REFLECT_FQ_NAME
+
+import org.jetbrains.kotlin.builtins.StandardNames.KOTLIN_REFLECT_FQ_NAME
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
+import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.acceptVoid

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -235,7 +235,6 @@ internal val psiToIrPhase = konanUnitPhase(
                     .forEach(irProviderForCEnumsAndCStructs::referenceAllEnumsAndStructsFrom)
 
             val irProviders = listOf(linker)
-            stubGenerator.setIrProviders(irProviders)
 
             expectDescriptorToSymbol = mutableMapOf<DeclarationDescriptor, IrSymbol>()
             val module = translator.generateModuleFragment(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -43,6 +43,7 @@ import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.util.OperatorNameConventions
 import org.jetbrains.kotlin.backend.konan.getObjCMethodInfo
 import org.jetbrains.kotlin.backend.konan.lower.CallableReferenceLowering
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.ir.descriptors.*
 
 internal interface KotlinStubs {
@@ -762,7 +763,7 @@ private fun KotlinStubs.mapType(type: IrType, retained: Boolean, variadic: Boole
         mapType(type, retained, variadic, location, { reportUnsupportedType(it, type, location) })
 
 private fun IrType.isTypeOfNullLiteral(): Boolean = this is IrSimpleType && hasQuestionMark
-        && classifier.isClassWithFqName(KotlinBuiltIns.FQ_NAMES.nothing)
+        && classifier.isClassWithFqName(StandardNames.FqNames.nothing)
 
 internal fun IrType.isVector(): Boolean {
     if (this is IrSimpleType && !this.hasQuestionMark) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrTryImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.impl.*
+import org.jetbrains.kotlin.ir.types.impl.IrUninitializedType
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.irBuilder
 import org.jetbrains.kotlin.ir.util.irCatch
@@ -108,7 +108,7 @@ private fun createKotlinBridge(
         isExternal: Boolean
 ): IrFunction {
     val bridgeDescriptor = WrappedSimpleFunctionDescriptor()
-    @Suppress("DEPRECATION") val bridge = IrFunctionImpl(
+    val bridge = IrFunctionImpl(
             startOffset,
             endOffset,
             IrDeclarationOrigin.DEFINED,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/Ir.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.backend.konan.descriptors.kotlinNativeInternal
 import org.jetbrains.kotlin.backend.konan.llvm.findMainEntryPoint
 import org.jetbrains.kotlin.backend.konan.lower.TestProcessor
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.builtins.UnsignedType
 import org.jetbrains.kotlin.config.coroutinesIntrinsicsPackageFqName
 import org.jetbrains.kotlin.config.coroutinesPackageFqName
@@ -320,7 +321,7 @@ internal class KonanSymbols(
     }
     
     val copyInto = arrays.map { symbol ->
-        val packageViewDescriptor = builtIns.builtInsModule.getPackage(KotlinBuiltIns.COLLECTIONS_PACKAGE_FQ_NAME)
+        val packageViewDescriptor = builtIns.builtInsModule.getPackage(StandardNames.COLLECTIONS_PACKAGE_FQ_NAME)
         val functionDescriptor = packageViewDescriptor.memberScope
                 .getContributedFunctions(Name.identifier("copyInto"), NoLookupLocation.FROM_BACKEND)
                 .single {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.backend.konan.ir
 
 import org.jetbrains.kotlin.backend.common.atMostOne
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ir.declarations.*
@@ -37,15 +38,15 @@ val IrFunction.allParameters: List<IrValueParameter>
         explicitParameters
     }
 
-fun IrClass.isUnit() = this.fqNameForIrSerialization == KotlinBuiltIns.FQ_NAMES.unit.toSafe()
+fun IrClass.isUnit() = this.fqNameForIrSerialization == StandardNames.FqNames.unit.toSafe()
 
-fun IrClass.isKotlinArray() = this.fqNameForIrSerialization == KotlinBuiltIns.FQ_NAMES.array.toSafe()
+fun IrClass.isKotlinArray() = this.fqNameForIrSerialization == StandardNames.FqNames.array.toSafe()
 
 val IrClass.superClasses get() = this.superTypes.map { it.classifierOrFail as IrClassSymbol }
 fun IrClass.getSuperClassNotAny() = this.superClasses.map { it.owner }.atMostOne { !it.isInterface && !it.isAny() }
 
-fun IrClass.isAny() = this.fqNameForIrSerialization == KotlinBuiltIns.FQ_NAMES.any.toSafe()
-fun IrClass.isNothing() = this.fqNameForIrSerialization == KotlinBuiltIns.FQ_NAMES.nothing.toSafe()
+fun IrClass.isAny() = this.fqNameForIrSerialization == StandardNames.FqNames.any.toSafe()
+fun IrClass.isNothing() = this.fqNameForIrSerialization == StandardNames.FqNames.nothing.toSafe()
 
 fun IrClass.getSuperInterfaces() = this.superClasses.map { it.owner }.filter { it.isInterface }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
-import org.jetbrains.kotlin.ir.types.impl.*
+import org.jetbrains.kotlin.ir.types.impl.IrUninitializedType
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperClassNotAny
 import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
@@ -82,8 +82,6 @@ internal interface DescriptorToIrTranslationMixin {
     fun createConstructor(constructorDescriptor: ClassConstructorDescriptor): IrConstructor {
         val irConstructor = symbolTable.declareConstructor(constructorDescriptor) {
             with(constructorDescriptor) {
-                // TODO: [IrUninitializedType] is deprecated.
-                @Suppress("DEPRECATION")
                 IrConstructorImpl(
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB, it, name, visibility,
                     IrUninitializedType, isInline, isEffectivelyExternal(), isPrimary, isExpect

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.backend.konan.objcexport
 
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.builtins.functions.FunctionClassDescriptor
 import org.jetbrains.kotlin.builtins.functions.FunctionClassKind
 import org.jetbrains.kotlin.builtins.getFunctionalClassKind
@@ -32,7 +33,7 @@ internal object CustomTypeMappers {
      *
      * Don't forget to update [hiddenTypes] after adding new one.
      */
-    private val predefined: Map<ClassId, CustomTypeMapper> = with(KotlinBuiltIns.FQ_NAMES) {
+    private val predefined: Map<ClassId, CustomTypeMapper> = with(StandardNames.FqNames) {
         val result = mutableListOf<CustomTypeMapper>()
 
         result += Collection(list, "NSArray")
@@ -73,7 +74,7 @@ internal object CustomTypeMappers {
         if (descriptor.isMappedFunctionClass()) {
             // TODO: somewhat hacky, consider using FunctionClassDescriptor.arity later.
             val arity = descriptor.declaredTypeParameters.size - 1 // Type parameters include return type.
-            assert(classId == KotlinBuiltIns.getFunctionClassId(arity))
+            assert(classId == StandardNames.getFunctionClassId(arity))
             return Function(arity)
         }
 
@@ -141,7 +142,7 @@ internal object CustomTypeMappers {
 
     private class Function(private val parameterCount: Int) : CustomTypeMapper {
         override val mappedClassId: ClassId
-            get() = KotlinBuiltIns.getFunctionClassId(parameterCount)
+            get() = StandardNames.getFunctionClassId(parameterCount)
 
         override fun mapType(mappedSuperType: KotlinType, translator: ObjCExportTranslatorImpl, objCExportScope: ObjCExportScope): ObjCNonNullReferenceType {
             return translator.mapFunctionTypeIgnoringNullability(mappedSuperType, objCExportScope, returnsVoid = false)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/CustomTypeMapper.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.backend.konan.objcexport
 
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.functions.FunctionClassDescriptor
+import org.jetbrains.kotlin.builtins.functions.FunctionClassKind
 import org.jetbrains.kotlin.builtins.getFunctionalClassKind
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.name.ClassId
@@ -16,7 +17,7 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeUtils
 
 internal fun ClassDescriptor.isMappedFunctionClass() =
-        this.getFunctionalClassKind() == FunctionClassDescriptor.Kind.Function &&
+        this.getFunctionalClassKind() == FunctionClassKind.Function &&
                 // Type parameters include return type.
                 declaredTypeParameters.size - 1 < CustomTypeMappers.functionTypeMappersArityLimit
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -8,11 +8,8 @@ package org.jetbrains.kotlin.backend.konan.objcexport
 import org.jetbrains.kotlin.backend.common.serialization.findSourceFile
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.descriptors.*
-import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.builtins.*
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns.isAny
-import org.jetbrains.kotlin.builtins.getReceiverTypeFromFunctionType
-import org.jetbrains.kotlin.builtins.getReturnTypeFromFunctionType
-import org.jetbrains.kotlin.builtins.getValueParameterTypesFromFunctionType
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.resolve.constants.ArrayValue
@@ -682,7 +679,7 @@ internal class ObjCExportTranslatorImpl(
         return null
     }
 
-    private val throwableClassId = ClassId.topLevel(KotlinBuiltIns.FQ_NAMES.throwable)
+    private val throwableClassId = ClassId.topLevel(StandardNames.FqNames.throwable)
 
     private fun getEffectiveThrows(method: FunctionDescriptor): Sequence<ClassId> {
         method.overriddenDescriptors.firstOrNull()?.let { return getEffectiveThrows(it) }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.backend.konan.ir.interop.IrProviderForCEnumAndCStruc
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.konan.isNativeStdlib
 import org.jetbrains.kotlin.descriptors.konan.kotlinLibrary
+import org.jetbrains.kotlin.ir.builders.TranslationPluginContext
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFileImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
@@ -87,6 +88,8 @@ internal class KonanIrLinker(
     override fun isBuiltInModule(moduleDescriptor: ModuleDescriptor): Boolean = moduleDescriptor.isNativeStdlib()
 
     override val fakeOverrideBuilder = FakeOverrideBuilder(symbolTable, IdSignatureSerializer(KonanManglerIr), builtIns, KonanFakeOverrideClassFilter)
+    override val translationPluginContext: TranslationPluginContext?
+        get() = TODO("Not yet implemented")
 
     private val forwardDeclarationDeserializer = forwardModuleDescriptor?.let { KonanForwardDeclarationModuleDeserialier(it) }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.backend.konan.KonanBackendContext
 import org.jetbrains.kotlin.backend.konan.KonanCompilationException
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
 import org.jetbrains.kotlin.backend.konan.ir.buildSimpleAnnotation
-import org.jetbrains.kotlin.builtins.KOTLIN_REFLECT_FQ_NAME
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.descriptors.ParameterDescriptor
 import org.jetbrains.kotlin.descriptors.Visibilities
@@ -390,7 +390,7 @@ fun IrFunction.isRestrictedSuspendFunction(languageVersionSettings: LanguageVers
 fun IrFunction.isTypeOfIntrinsic(): Boolean =
         this.name.asString() == "typeOf" &&
                 this.valueParameters.isEmpty() &&
-                (this.parent as? IrPackageFragment)?.fqName == KOTLIN_REFLECT_FQ_NAME
+                (this.parent as? IrPackageFragment)?.fqName == StandardNames.KOTLIN_REFLECT_FQ_NAME
 
 fun IrBuilderWithScope.irByte(value: Byte) =
         IrConstImpl.byte(startOffset, endOffset, context.irBuiltIns.byteType, value)

--- a/build.gradle
+++ b/build.gradle
@@ -287,6 +287,7 @@ task detectJarCollision(type: CollisionDetector) {
     resolvingRules["META-INF/type-system.kotlin_module"] = "kotlin-compiler"
     resolvingRules["META-INF/util.runtime.kotlin_module"] = "kotlin-compiler"
     resolvingRules["META-INF/kotlin-native-utils.kotlin_module"] = "kotlin-compiler"
+    resolvingRules["META-INF/compiler.common.kotlin_module"] = "kotlin-compiler"
 
     // These collisions are introduced by kotlinx-metadata-klib.
     resolvingRules["META-INF/serialization.kotlin_module"] = "kotlin-compiler"

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3898,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-3898
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-3898,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-3898
-kotlinStdlibTestsVersion=1.4.20-dev-3898
-testKotlinCompilerVersion=1.4.20-dev-3898
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-4195,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.20-dev-4195
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-4195,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.20-dev-4195
+kotlinStdlibTestsVersion=1.4.20-dev-4195
+testKotlinCompilerVersion=1.4.20-dev-4195
 konanVersion=1.4.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/KlibPrinter.kt
+++ b/klib/src/main/kotlin/org/jetbrains/kotlin/cli/klib/KlibPrinter.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.cli.klib
 
 import org.jetbrains.kotlin.backend.konan.descriptors.getPackageFragments
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.impl.DeclarationDescriptorVisitorEmptyBodies
 import org.jetbrains.kotlin.renderer.*
@@ -143,7 +144,7 @@ class KlibPrinter(out: Appendable) {
             modifiers = DescriptorRendererModifier.ALL
             overrideRenderingPolicy = OverrideRenderingPolicy.RENDER_OVERRIDE
             annotationArgumentsRenderingPolicy = AnnotationArgumentsRenderingPolicy.UNLESS_EMPTY
-            excludedAnnotationClasses += setOf(KotlinBuiltIns.FQ_NAMES.suppress)
+            excludedAnnotationClasses += setOf(StandardNames.FqNames.suppress)
 
             classWithPrimaryConstructor = true
             renderConstructorKeyword = true


### PR DESCRIPTION
* b050ef99708 - (HEAD -> master, tag: build-1.4.20-dev-4195, origin/master, origin/HEAD) [FIR] Remove print in UnusedChecker (vor 21 Stunden) <vldf>
* 9c3ff6828a0 - (tag: build-1.4.20-dev-4188) Export kotlin.test packages with annotations and underlying frameworks (vor 2 Tagen) <Ilya Gorbunov>
* ef57c625762 - (tag: build-1.4.20-dev-4185) [Gradle, Cocoapods] refactor I/O, improve Up-To-Date (vor 2 Tagen) <Andrey.Lozhkin>
* 1888462dc06 - [Gradle, Cocoapods] move tasks from per target (vor 2 Tagen) <Andrey.Lozhkin>
* fcf50609070 - [Gradle, Cocoapods] implement DSL to support Cocoapods Dependencies from Git or Web (vor 2 Tagen) <Andrey Lozhkin>
* b02f0f0a251 - (tag: build-1.4.20-dev-4173) JVM IR: Fix compilation of nested inner classes (vor 3 Tagen) <Steven Schäfer>
* 02e78bcd76c - JVM IR: Use package visibility for fields of captured variables (vor 3 Tagen) <Steven Schäfer>
* 443269af0a7 - (tag: build-1.4.20-dev-4167) [IR] Drop `irProviders` from stub generator (vor 3 Tagen) <Roman Artemev>
* 39808789c37 - [KLIB] Fix SOE in K/N (vor 3 Tagen) <Roman Artemev>
* 23f87d413aa - (tag: build-1.4.20-dev-4166) Use initial system for completion if common one is effectively empty (vor 3 Tagen) <Mikhail Zarechenskiy>
* bb18203ae6b - (tag: build-1.4.20-dev-4163) [FIR] Various checkers performance fixes (vor 3 Tagen) <Nick>
* 5c88eb722dc - (tag: build-1.4.20-dev-4146) Fix transitive deps on MPP with host-specific source sets (KT-41083) (vor 3 Tagen) <Sergey Igushkin>
* 9097d0918c8 - (tag: build-1.4.20-dev-4143) [JS BE] Support passing an array as argument of vararg in named form (vor 3 Tagen) <Zalim Bashorov>
* 606232a5849 - [JS IR] Don't generate "import" statements for external interfaces (vor 3 Tagen) <Zalim Bashorov>
* ba846830c9c - [JS IR] Support nativeGetter, nativeSetter and nativeInvoke (vor 3 Tagen) <Zalim Bashorov>
* c804319e65a - (tag: build-1.4.20-dev-4142) FIR IDE: fix compilation on AS (vor 3 Tagen) <Ilya Kirillov>
* 36cc73602ed - FIR IDE: fix testdata of AbstractFirLazyResolveTest (vor 3 Tagen) <Ilya Kirillov>
* 3cd445563ed - FIR IDE: implement KotlinExpressionTypeProvider for FIR (vor 3 Tagen) <Ilya Kirillov>
* fcc7db52243 - FIR IDE: introduce analyseInModalWindow function (vor 3 Tagen) <Ilya Kirillov>
* 81be2305411 - FIR IDE: add validity assertion on analysis session access (vor 3 Tagen) <Ilya Kirillov>
* db48884a4e2 - FIR IDE: add check canceled check between diagnostics (vor 3 Tagen) <Ilya Kirillov>
* 95a96f32bf2 - FIR IDE: log errors on diagnostics, not throw them (vor 3 Tagen) <Ilya Kirillov>
* ebafd0fb518 - FIR IDE: resolve ambiguity & inapplicable references (vor 3 Tagen) <Ilya Kirillov>
* 4fa2dd85b4f - FIR IDE: move lazy resolve to FirLazyDeclarationResolver (vor 3 Tagen) <Ilya Kirillov>
* 8faaff00fa3 - FIR IDE: run lazy resolve on declaration when getting phased fir (vor 3 Tagen) <Ilya Kirillov>
* 78bb1f10763 - FIR IDE: fix testdata in idea-frontend-fir (vor 3 Tagen) <Ilya Kirillov>
* 30ac80a5061 - FIR IDE: introduce property accessor symbols (vor 3 Tagen) <Ilya Kirillov>
* aae56cadac9 - FIR IDE: add ModuleInfo for ide sessions as they are used for getting resolve components (vor 3 Tagen) <Ilya Kirillov>
* bc3e98b1165 - FIR IDE: allow PCE between resolve phases, forbid in other cases (vor 3 Tagen) <Ilya Kirillov>
* 8363c711e6c - FIR IDE: fix lazy resolve for local declarations (vor 3 Tagen) <Ilya Kirillov>
* 9d237033ad7 - FIR IDE: minor, rename FirIdeModuleLibraryDependenciesSession to FirIdeLibrariesSession (vor 3 Tagen) <Ilya Kirillov>
* 8b782d59547 - FIR IDE: fix session provider implementation as it only provides only 2 sessions (vor 3 Tagen) <Ilya Kirillov>
* a07d3f24256 - FIR IDE: minor: rename FirIdeJavaModuleBasedSession to FirIdeSourcesSession (vor 3 Tagen) <Ilya Kirillov>
* f76b5bbf1b1 - FIR IDE: allow KtFirPackageScope to work without providers (vor 3 Tagen) <Ilya Kirillov>
* f4c17dadb3f - FIR IDE: remove unused FirIdeModuleLibraryDependenciesSymbolProvider (vor 3 Tagen) <Ilya Kirillov>
* a156cca02a5 - FIR: make class FirObjectImportedCallableScope to be name aware (vor 3 Tagen) <Ilya Kirillov>
* 333213bbb9a - (tag: build-1.4.20-dev-4140) Wizard: add descriptions for some settings (vor 3 Tagen) <Ilya Kirillov>
* 37b869ebc5c - Wizard: add descriptions for settings (vor 3 Tagen) <Ilya Kirillov>
* 09ed0c3e821 - (tag: build-1.4.20-dev-4137) [FIR-TEST] Update testdata (vor 3 Tagen) <Dmitriy Novozhilov>
* e7b5a88cbd7 - [FIR] Remove dependency on :compiler:frontend from :compiler:fir:resolve (vor 3 Tagen) <Dmitriy Novozhilov>
* abeb42ca20e - [FIR] Don't use ProjectExtensionDescriptor in FirExtensionRegistrar (vor 3 Tagen) <Dmitriy Novozhilov>
* f09e17a5ae3 - [FIR] Remove unused import (vor 3 Tagen) <Dmitriy Novozhilov>
* e405a02e8ee - [FIR] Fix contract serialization (vor 3 Tagen) <Dmitriy Novozhilov>
* eaf8af919d5 - [FIR] Use PersistentList instead of guava's ImmutableList in SupertypeResolution (vor 3 Tagen) <Dmitriy Novozhilov>
* 148e8fe76e7 - Move `FlatSignature` to :compiler:resolution.common (vor 3 Tagen) <Dmitriy Novozhilov>
* 64766e125c2 - Move common inference classes to :compiler:resolution.common (vor 3 Tagen) <Dmitriy Novozhilov>
* 068d21635e6 - [NI] Get rid of KotlinType usages in MutableConstraintStorage.kt (vor 3 Tagen) <Dmitriy Novozhilov>
* af0df35623e - [NI] Get rid of FE 1.0 types in ConstraintInjector (vor 3 Tagen) <Dmitriy Novozhilov>
* ad039a28bd6 - [NI] Get rid of left FE 1.0 types in NewConstraintSystemImpl (vor 3 Tagen) <Dmitriy Novozhilov>
* 6914aba5c22 - [NI] Commonize detection of @OnlyInputTypes in NewConstraintSystemImpl (vor 3 Tagen) <Dmitriy Novozhilov>
* 64f0ee21c19 - Get rid of FE 1.0 classes usage in ConstraintIncorporator (vor 3 Tagen) <Dmitriy Novozhilov>
* 1050f7f0665 - Extract PostponedResolvedAtomMarker to separate file (vor 3 Tagen) <Dmitriy Novozhilov>
* 1cadabb0993 - Extract ResolutionCandidateApplicability to separate file (vor 3 Tagen) <Dmitriy Novozhilov>
* 775df6dfc3c - [NI] Get rid of FE 1.0 type usages in ResultTypeResolver (vor 3 Tagen) <Dmitriy Novozhilov>
* aae1681b761 - [NI] Get rid of ResolvedAtom usage in ConstraintSystemCompletionContext (vor 3 Tagen) <Dmitriy Novozhilov>
* 11e8552861e - [NI] Get rid of PostponedArgumentInputTypesResolver.Context (vor 3 Tagen) <Dmitriy Novozhilov>
* 970a2581a19 - [NI] Extract PostponedArgumentsAnalyzerContext from PostponedArgumentsAnalyzer (vor 3 Tagen) <Dmitriy Novozhilov>
* b15f847943c - [NI] Extract common parts from KotlinConstraintSystemCompleter (vor 3 Tagen) <Dmitriy Novozhilov>
* 12fbb938715 - [NI] Extract FE 1.0 specific part from NewCommonSuperTypeCalculator (vor 3 Tagen) <Dmitriy Novozhilov>
* b21a0213df9 - [NI] Get rid of FE 1.0 types in AbstractTypeApproximator (vor 3 Tagen) <Dmitriy Novozhilov>
* 527c5a771d3 - [NI] Get rid of FE 1.0 types in AbstractTypeCheckerContextForConstraintSystem (vor 3 Tagen) <Dmitriy Novozhilov>
* 686c17a2342 - [NI] Rename `NewConstraintSystem.diagnostics` to `errors` (vor 3 Tagen) <Dmitriy Novozhilov>
* 59b2cb63935 - [NI] Split KotlinCallDiagnostics and inference errors to different hierarchies (vor 3 Tagen) <Dmitriy Novozhilov>
* fae21d4db39 - Introduce frontend independent constraint positions (vor 3 Tagen) <Dmitriy Novozhilov>
* e5e3d7cab1a - Extract FE 1.0 related parts from NewConstraintSystem (vor 3 Tagen) <Dmitriy Novozhilov>
* be1033a4a70 - [FIR] Implement ConeTypeContext.createTypeWithAlternativeForIntersectionResult (vor 3 Tagen) <Dmitriy Novozhilov>
* f247cc31653 - (tag: build-1.4.20-dev-4136) [NI] Properly detecting suitability of candidate for builder inference (vor 3 Tagen) <Dmitriy Novozhilov>
* b2d9e5be913 - (tag: build-1.4.20-dev-4133) [kotlinx-metadata-klib] Drop dependency on descriptors (vor 3 Tagen) <Sergey Bogolepov>
* 7170a23f633 - (tag: build-1.4.20-dev-4127) [FIR] Use coroutine intrinsics in tower resolver manager (vor 3 Tagen) <Simon Ogorodnik>
* 7cb5c0a6d8f - [FIR] Cleanup hides members condition (vor 3 Tagen) <Simon Ogorodnik>
* bf2e17b133b - [FIR] Extract invoke processing from TowerLevelHandler (vor 3 Tagen) <Simon Ogorodnik>
* 96f100381aa - Use proper manifest for kotlin-reflect in jps build (vor 3 Tagen) <Simon Ogorodnik>
* 34f5cfbf963 - [FIR] Fix integer approximation on safe calls (vor 3 Tagen) <Simon Ogorodnik>
* 2a4e1a0b99a - [FIR] Clarify testData for invokes (vor 3 Tagen) <Simon Ogorodnik>
* 74c6d2b9519 - (tag: build-1.4.20-dev-4125) Do not generate non-standard compareTo as primitive comparison in all backends (vor 4 Tagen) <Alexander Udalov>
* 9d81e50128c - (tag: build-1.4.20-dev-4118) IR: undeprecate IrUninitializedType (vor 4 Tagen) <Alexander Udalov>
* 5649cbc2e1c - (tag: build-1.4.20-dev-4117) Wire KotlinTypeRefiner in areCallableDescriptorsEquivalent (vor 4 Tagen) <Dmitry Savvinov>
* 421efaa5653 - Add test for overload resoultion ambiguity in HMPP (vor 4 Tagen) <Dmitry Savvinov>
* 68d931969da - Minor: explicitly opt-in for diagnostics messages in MultiplatformAnalysisTests (vor 4 Tagen) <Dmitry Savvinov>
* 9cde42e2bce - (tag: build-1.4.20-dev-4106) [NI] Fix `shouldRunCompletion` for builder inference session (vor 4 Tagen) <Dmitriy Novozhilov>
* e98cbf81cff - [NI] Don't always complete builder inference lambda in FULL mode (vor 4 Tagen) <Dmitriy Novozhilov>
* 6a15e0410fb - (tag: build-1.4.20-dev-4104) [FIR] Fix CLI tests to prevent non-relevant errors from appearing (vor 4 Tagen) <vldf>
* 6c2ece9a6e7 - Rename: FirSourceElement.getChildren() -> getChild() + minor fixes (vor 4 Tagen) <vldf>
* bf363e8f1a4 - [FIR] Update/add extended checker tests (vor 4 Tagen) <vldf>
* acbb67f851c - [FIR] Fix collectDataForNode backward traverse (vor 4 Tagen) <Oleg Ivanov>
* f9c7cce11dd - [FIR] Add some helper functions for checkers (vor 4 Tagen) <vldf>
* 96f24a43be6 - [FIR] Introduce unused variable extended checker (vor 4 Tagen) <vldf>
* e718f608331 - [FIR] Refactoring extended checkers (vor 4 Tagen) <vldf>
* aefb7dc10f1 - [FIR] Add checkerContext parameter to ControlFlowAnalyserCheckers (vor 4 Tagen) <vldf>
* 14eaa113e0c - [FIR] Add new errors for extended checkers (around unused variable) (vor 4 Tagen) <vldf>
* 58c5d3a6ca1 - [FIR] Fix destructuring declaration creation via light tree (vor 4 Tagen) <vldf>
* 3428a5434b5 - [FIR] Add methods to access child/children of FirSourceElement (vor 4 Tagen) <vldf>
* 5e0dc53295a - [FIR] Refactor CanBeValChecker (vor 4 Tagen) <vldf>
* 5cf76aa9508 - (tag: build-1.4.20-dev-4102) KT-41425 Project can not be launched with Gradle runner (vor 4 Tagen) <Andrei Klunnyi>
* f57f920dc03 - (tag: build-1.4.20-dev-4098, tag: build-1.4.20-dev-4090) Mark IdeReplExecutionTest.testOnePlusOne as flaky (vor 4 Tagen) <Nikolay Krasko>
* 866666f3ffc - Update test data for MultiModuleHighlightingTest.testLanguageVersionsViaFacets (vor 4 Tagen) <Nikolay Krasko>
* 4b937f09297 - Mute stable CompilerDaemonTest.testParallelDaemonStart (vor 4 Tagen) <Nikolay Krasko>
* 0c0b394cc23 - (tag: build-1.4.20-dev-4089) [formatter] fix performance issue (vor 4 Tagen) <Dmitry Gridin>
* 9818321b46a - (tag: build-1.4.20-dev-4086) [JS, Wizard] Use react template in full stack (vor 4 Tagen) <Ilya Goncharov>
* cd0bdc190b7 - [JS, Wizard] Use IR in gradle.properties and otherwise use as a param (vor 4 Tagen) <Ilya Goncharov>
* 13bf15b403a - [JS, Wizard] Set js compiler per module (vor 4 Tagen) <Ilya Goncharov>
* f824f03fa27 - Wizard: fix filtering values in DropDownComponent (vor 4 Tagen) <Ilya Kirillov>
* 98f98d58562 - [JS, Wizard] Add different compilers for JS wizard (vor 4 Tagen) <Ilya Goncharov>
* c797f3044eb - [JS, Wizard] Add react template plugin (vor 4 Tagen) <Ilya Goncharov>
* 220ff6c6484 - [JS, Wizard] Add redux and react router (vor 4 Tagen) <Ilya Goncharov>
* d5340803bdd - [JS, Wizard] Add react application template (vor 4 Tagen) <Ilya Goncharov>
* 01064a4e461 - [JS, Wizard] Add react application template (vor 4 Tagen) <Ilya Goncharov>
* 96e1b1c0e02 - [JS, Wizard] Separate browser application without react (vor 4 Tagen) <Ilya Goncharov>
* 491eb5e3663 - [JS, Wizard] Move subtarget settings in separate object (vor 4 Tagen) <Ilya Goncharov>
* 94f8a788934 - [JS, Wizard] Fix source set name for js wizard (vor 4 Tagen) <Ilya Goncharov>
* cba13c3c35e - (tag: build-1.4.20-dev-4079) Take into account captured types with variables during fixation (vor 4 Tagen) <Mikhail Zarechenskiy>
* 5dbb6fdf506 - (tag: build-1.4.20-dev-4076) [inspections] NamingConversion: add missing space in description (vor 4 Tagen) <Dmitry Gridin>
* e12c35de5f9 - (tag: build-1.4.20-dev-4063) Traverse all pages of muted tests on Teamcity (KTI-326) (vor 5 Tagen) <Yunir Salimzyanov>
* 06a592c0188 - (tag: build-1.4.20-dev-4062) Fix SOE when recursive type argument is used with star projection (vor 5 Tagen) <Mikhail Zarechenskiy>
* 674e9e455f7 - Fold lower constraints like (T!!..T) and (T..T?) into the latter one (vor 5 Tagen) <Mikhail Zarechenskiy>
* e91b378b7dc - Don't perform unnecessary SAM conversions (vor 5 Tagen) <Mikhail Zarechenskiy>
* 6a7ed96be58 - Consider T <: Nothing! as trivial during constraint incorporation (vor 5 Tagen) <Mikhail Zarechenskiy>
* 567e6ca9ca5 - Fix OOM when there are several lambdas with extension function types (vor 5 Tagen) <Mikhail Zarechenskiy>
* 085e0dc1de6 - (tag: build-1.4.20-dev-4056) FIR2IR: allow array expression as named argument for vararg (vor 5 Tagen) <Jinseong Jeon>
* 54d3c5fb0a9 - (tag: build-1.4.20-dev-4055, tag: build-1.4.20-dev-4052, tag: build-1.4.20-dev-4051) Pick up script language level from used stdlib in a gradle's classpath (vor 5 Tagen) <Vladimir Dolzhenko>
* 949c67078d7 - (tag: build-1.4.20-dev-4043) NJ2K: fix testdata of MultiFileTestGenerated.testNullabilityByDFa (vor 5 Tagen) <Ilya Kirillov>
* c8ab827fa01 - Wizard: fix invalid path in generated buildscript on windows (vor 5 Tagen) <Ilya Kirillov>
* c93ae645466 - Uast: `KotlinClassViaConstructorUSimpleReferenceExpression` resolve to `PsiClass` (KT-41290) (vor 5 Tagen) <Nicolay Mitropolsky>
* 99924ea5e48 - Fix Typo: equals() & hashCode(), toString() are written with the first uppercase letter (vor 5 Tagen) <Vladimir Dolzhenko>
* 553ae68c968 - (tag: build-1.4.20-dev-4035) FIR2IR: convert adapted callable reference with vararg (vor 5 Tagen) <Jinseong Jeon>
* 48034092e9b - (tag: build-1.4.20-dev-4026, tag: build-1.4.20-dev-4023) Fix SOE on library source based lightclass lookup (vor 5 Tagen) <Igor Yakovlev>
* 99286a6ce36 - (tag: build-1.4.20-dev-4020) FIR2IR: introduce & use ClassId-based lookup for local class as IrParent (vor 5 Tagen) <Jinseong Jeon>
* 777b16e0a30 - (tag: build-1.4.20-dev-4013) Fix @Language injection when using named parameters (vor 6 Tagen) <Aurimas Liutikas>
* a9ddf02556c - (tag: build-1.4.20-dev-4011) Replace deprecated usages of max/min with maxOrNull/minOrNull (vor 6 Tagen) <Alexander Udalov>
* 81dda96ece6 - (tag: build-1.4.20-dev-4010) Mute flaky KotlinFindUsagesWithLibraryTestGenerated.KotlinLibrary (vor 6 Tagen) <Nikolay Krasko>
* 3a1158b4ef5 - Minor: move mute KotlinFindUsagesWithLibraryTestGenerated to common (vor 6 Tagen) <Nikolay Krasko>
* 125819f9bf7 - Mute flaky testUsingReadOnlyInterfaces test (vor 6 Tagen) <Nikolay Krasko>
* 1928390121d - Prevent flaky behaviour from MakeOverriddenMemberOpenFix in tests (vor 6 Tagen) <Nikolay Krasko>
* 5702fb3b223 - (tag: build-1.4.20-dev-4002) FIR: fix CCE in AttributeArrayOwner (vor 6 Tagen) <Mikhail Glukhikh>
* 962059a878e - Introduce FirProperty.hasBackingField & use it in FIR2IR (vor 6 Tagen) <Mikhail Glukhikh>
* c6417696cfb - FirProperty: return back 'isReferredViaField' attribute (vor 6 Tagen) <Mikhail Glukhikh>
* 3e9ac75cfc2 - FIR: record use of backing field symbol to indeed add a backing field (vor 6 Tagen) <Jinseong Jeon>
* 0cc3762f9af - (tag: build-1.4.20-dev-3993) Build: Fix kotlinx-metadata-klib publication (vor 6 Tagen) <Vyacheslav Gerasimov>
* 36f2f1fcf7e - (tag: build-1.4.20-dev-3992) [FIR] Add lightTree support to extended checkers + minor refactorings (vor 6 Tagen) <vldf>
* da702992d9d - [FIR] Fix null source on destructuring declaration (vor 6 Tagen) <vldf>
* 30d24ed9432 - (tag: build-1.4.20-dev-3986) Tests, Gradle: Fix broken test for KT-40834 (vor 6 Tagen) <Ilya Matveev>
* 920f1184bd7 - Revert "Revert "CocoaPods: Skip synthetic task on non-mac hosts"" (vor 6 Tagen) <Ilya Matveev>
* fd9bfe44f18 - (tag: build-1.4.20-dev-3985) [FIR] Visit class annotations without the class's scope (vor 6 Tagen) <Nick>
* 3cad88a58c6 - (tag: build-1.4.20-dev-3979) [FIR] Fir Helpers hotfix (vor 6 Tagen) <vldf>
* 0d6b363179f - [FIR] Refactoring for extended checkers (vor 10 Tagen) <vldf>
* e2016499f30 - [FIR] Fixed CFA bug (vor 10 Tagen) <vldf>
* ac074384893 - [FIR] Speed up CFA-checkers (vor 10 Tagen) <vldf>
* 638a0d3b82c - [FIR] Checkers performance improvement and some refactoring (vor 10 Tagen) <vldf>
* d86c81cb38b - (tag: build-1.4.20-dev-3975) [JS, Gradle] Fix test on overflow, now throw exception on overflow (vor 6 Tagen) <Ilya Goncharov>
* 8b4e8a2c0ce - (tag: build-1.4.20-dev-3972) Diagnostics: add diagnostic for reporting contract description blocks in old frontend (vor 6 Tagen) <Arsen Nagdalian>
* 80d7f6b6889 - Ignore the "contract" keyword in code completion (vor 6 Tagen) <Arsen Nagdalian>
* ede1c08a9be - [FIR] Add resolution of contracts that are written using the new syntax (vor 6 Tagen) <Arsen Nagdalian>
* b8b60864fd9 - [FIR] Add contracts tests and place them in a separate directory (vor 6 Tagen) <Arsen Nagdalian>
* 86e07cd626d - Parser tests: move the contract description blocks tests to a separate folder and add a test for property accessors' contracts (vor 6 Tagen) <Arsen Nagdalian>
* 66f72503808 - [FIR] Add contract description blocks support to "lightTree2FIR" conversion (vor 6 Tagen) <Arsen Nagdalian>
* 9fd104eec87 - [FIR] Add contract description blocks support to RawFirBuilder (vor 6 Tagen) <Arsen Nagdalian>
* d53f3b9ba82 - [PSI] Add some useful getters to psi nodes (vor 6 Tagen) <Arsen Nagdalian>
* a936c6331ab - [Parser] Add getters' and setters' contracts parsing (vor 6 Tagen) <Arsen Nagdalian>
* 6c06008b4dc - [FIR] Add a class representing the old syntax contract description in order to use the previous class for the new syntax (vor 6 Tagen) <Arsen Nagdalian>
* b83aa88eff8 - [FIR] Add function for getting ConeEffectDeclaration from FirEffectDeclaration and use it where needed (vor 6 Tagen) <Arsen Nagdalian>
* 991b18fec49 - [FIR] Add a Fir node that wraps a ConeEffectDeclaration (vor 6 Tagen) <Arsen Nagdalian>
* 32a64b888ea - [Parser] Add parsing of function's contract either before or after type constraints (vor 6 Tagen) <Arsen Nagdalian>
* 1b578897730 - Clean the code (vor 6 Tagen) <Arsen Nagdalian>
* f781a9993ba - Parser tests: add tests for contract description blocks (vor 6 Tagen) <Arsen Nagdalian>
* 2e9a898f450 - [Parser] Move function's contracts parsing in before type constraints parsing (vor 6 Tagen) <Arsen Nagdalian>
* 09904348401 - [Parser] Modify parser so that it could parse contract description blocks of functions (vor 6 Tagen) <Arsen Nagdalian>
* e3fe9c3314c - [PSI] Add new Psi nodes representing contract effects list and each individual contract effect in the list (vor 6 Tagen) <Arsen Nagdalian>
* 4b7d34b5377 - Add "contract" keyword (vor 6 Tagen) <Arsen Nagdalian>
* 316e0e66095 - (tag: build-1.4.20-dev-3966) [FIR] Update testdata (vor 6 Tagen) <Dmitriy Novozhilov>
* 3ccb72bb1ae - (tag: build-1.4.20-dev-3964) Shadow :core:compiler.common inside kotlinx.metadata (vor 6 Tagen) <Dmitriy Novozhilov>
* 811a2206a53 - Fix usages of KotlinBuiltIns after rebase (vor 6 Tagen) <Dmitriy Novozhilov>
* bc1b6d3588b - Rename `:core:descriptors.common` to `:core:compiler.common` (vor 6 Tagen) <Dmitriy Novozhilov>
* 864cf21f03a - Merge :core:type-system into :core:descriptors.common (vor 6 Tagen) <Dmitriy Novozhilov>
* 5fa80a2f8c9 - Merge :core:deserialization:deserialization.common into :core:descriptors.common (vor 6 Tagen) <Dmitriy Novozhilov>
* bbac270b333 - Move OperatorNameConventions to :core.descriptors.common (vor 6 Tagen) <Dmitriy Novozhilov>
* 2760a187a97 - Move FunctionClassKind utils to :core.descriptors.common (vor 6 Tagen) <Dmitriy Novozhilov>
* 2285d3e3cf8 - Move Variance and AnnotationUseSiteTarget to :core.descriptors.common (vor 6 Tagen) <Dmitriy Novozhilov>
* 167f18b7389 - Move SourceElement and SourceFile to :deserialization.common (vor 6 Tagen) <Dmitriy Novozhilov>
* a7647320203 - Rename `KotlinBuiltInsNames` to `StandardNames` (vor 6 Tagen) <Dmitriy Novozhilov>
* d032fdfc440 - [FIR] Cleanup dependencies in :compiler:fir:raw-fir modules (vor 6 Tagen) <Dmitriy Novozhilov>
* b6fd6c3a841 - [FIR] Remove dependency on descriptors from :compiler:fir:raw-fir.raw-fir.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* 71a517c6861 - [FIR] Rename :compiler:fir:raw-fir:fir-common to :compiler:fir:raw-fir:raw-fir.common (vor 6 Tagen) <Dmitriy Novozhilov>
* 7d4349edc29 - [FIR] Remove dependency on descriptors from :compiler:fir:tree module (vor 6 Tagen) <Dmitriy Novozhilov>
* 95346f834b7 - [FIR] Fix forgotten dependency to contracts of FE 1.0 (vor 6 Tagen) <Dmitriy Novozhilov>
* 73ace6d161e - Remove dependency to descriptors from :compiler:config module (vor 6 Tagen) <Dmitriy Novozhilov>
* 82a9b1492bf - Move RenderingUtils to :core:descriptors.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* ba6b1c37d04 - Move TargetPlatform to :core:descriptors.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* d6d2be8e583 - Move incremental components to :core:descriptors.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* 3a48265077c - Move ModuleDescriptor.Capability to :core:descriptors.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* 6f0cd14afac - Move common classes to new :core:deserialization:deserialization.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* 079a2dfe1e6 - Move EventOccurrencesRange class to :core:descriptors.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* f7f489537bb - [FIR] Remove dependency on :core:descriptors from :compiler:fir:tree (vor 6 Tagen) <Dmitriy Novozhilov>
* e92caae609e - [FIR] Remove dependency on :core:descriptors from :compiler:fir:cones (vor 6 Tagen) <Dmitriy Novozhilov>
* 45cf221b976 - Move util functions from KotlinBuiltIns to :core:descriptors.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* 20a2ad82230 - Move FunctionClassDescriptor.Kind to :core:descriptors.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* 7a7fe77b8e8 - Move static constants with builtin names to :core:descriptors.common module (vor 6 Tagen) <Dmitriy Novozhilov>
* 2e92fe9be9a - [FIR2IR] Add fir2ir component for converting fir visibility to FE 1.0 (vor 6 Tagen) <Dmitriy Novozhilov>
* a02109d8578 - [FIR] Add `FirVisibilityChecker` session component (vor 6 Tagen) <Dmitriy Novozhilov>
* 18ae593700d - [FIR] Rename new visibilities to CamelCase (vor 6 Tagen) <Dmitriy Novozhilov>
* 43821b681c2 - [FIR] Introduce new `Visibility` class which not depends on descriptors (vor 6 Tagen) <Dmitriy Novozhilov>
* 9d9f9c52c02 - Extract some classes from descriptors module to `:core:common` (vor 6 Tagen) <Dmitriy Novozhilov>
* 41ba9b0a2d4 - [FIR] Add flag to disable transformers required only for plugins (vor 6 Tagen) <Dmitriy Novozhilov>
* 53ad502d2a0 - (tag: build-1.4.20-dev-3963, tag: build-1.4.20-dev-3960, tag: build-1.4.20-dev-3959) [FIR2IR] Generate fake overrides earlier and bind them later (vor 6 Tagen) <Mikhail Glukhikh>
* ee9c5977671 - (tag: build-1.4.20-dev-3947) Build: Remove exclusion of kotlinx-coroutines-core in scripting-compiler (vor 7 Tagen) <Ilya Chernikov>
* 741f5de0f91 - (tag: build-1.4.20-dev-3942, tag: build-1.4.20-dev-3939) Clean PSI elements in KotlinExpressionMover (vor 7 Tagen) <Nikolay Krasko>
* 18195b3296d - Rewrite SmartCompletionMultifileHandlerTest to KotlinFixtureCompletionBaseTestCase (vor 7 Tagen) <Nikolay Krasko>
* e95c3e2905d - Rewrite CompletionMultiFileHandlerTest to KotlinFixtureCompletionBaseTestCase (vor 7 Tagen) <Nikolay Krasko>
* f92083989ab - [JS, Wizard] Fix build integrity (vor 7 Tagen) <Ilya Goncharov>
* 60404913736 - (tag: build-1.4.20-dev-3938) Revert "CocoaPods: Skip synthetic task on non-mac hosts" (vor 7 Tagen) <Nikolay Krasko>
* 621c87ee84b - (tag: build-1.4.20-dev-3936) Overflowed teamcity messages should failed build (vor 7 Tagen) <Ilya Goncharov>
* e7b12b9bb11 - (tag: build-1.4.20-dev-3932, tag: build-1.4.20-dev-3931) [FIR] Fix false positive SUPER_NOT_AVAILABLE (vor 7 Tagen) <Nick>
* a2dabe11c58 - (tag: build-1.4.20-dev-3930, tag: build-1.4.20-dev-3927, tag: build-1.4.20-dev-3925) JVM KT-41150: Fix backward compatibility for inline vals in inline class (vor 7 Tagen) <Dmitry Petrov>
* 27a22fc1e99 - (tag: build-1.4.20-dev-3924) Cleanup Coroutine panel in case connection gets disposed soon after (vor 7 Tagen) <Vladimir Ilmov>
* cb2ab4676bd - (CoroutineDebugger) Top node added to prevent dumpCoroutine() call (vor 7 Tagen) <Vladimir Ilmov>
* fa45650fd0b - (tag: build-1.4.20-dev-3923) JVM IR: specialize ExpressionCodegen.visitFunctionAccess for constructors (vor 7 Tagen) <Alexander Udalov>
* f9bd935ac62 - (tag: build-1.4.20-dev-3921) Wizard: fix missing module templates (vor 7 Tagen) <Ilya Kirillov>
* 5a91dd0439a - (tag: build-1.4.20-dev-3919) Update main wizard tests (vor 7 Tagen) <Kirill Shmakov>
* 147a8c357d6 - Wizard: switch androidx.core -> android.material (vor 7 Tagen) <Kirill Shmakov>
* 57e9e9a2a19 - Wizard: add android.useAndroidX property (vor 7 Tagen) <Kirill Shmakov>
* 9e88d61be4d - Wizard: switch android:allowBackup (vor 7 Tagen) <Kirill Shmakov>
* 94ae839d2cc - Wizard: update Android Appcompat version (vor 7 Tagen) <Kirill Shmakov>
* 06f9a4e2285 - Wizard: update Android Gradle plugin version (vor 7 Tagen) <Kirill Shmakov>
* a095909d5c3 - (tag: build-1.4.20-dev-3918) [Plugin API] Provide special context in EP for link-time resolve (vor 7 Tagen) <Roman Artemev>
* ea980622418 - (tag: build-1.4.20-dev-3917) JVM IR: Fix compilation of inline functions in  anonymous objects... (vor 7 Tagen) <Steven Schäfer>
* ce029822265 - (tag: build-1.4.20-dev-3915) CocoaPods: Skip synthetic task on non-mac hosts (vor 7 Tagen) <Ilya Matveev>
* b10cc6657e4 - (tag: build-1.4.20-dev-3914) Fix loading of builtins resources in kotlin-reflect in Java modular mode (vor 7 Tagen) <Alexander Udalov>
* 201fa849b85 - Workaround problem with log4j warnings in CLI tests (vor 7 Tagen) <Alexander Udalov>
* 05cfb654baf - (tag: build-1.4.20-dev-3904) [FIR] Fix removeAtInt test (vor 7 Tagen) <Nick>
* 2b983b1c205 - (tag: build-1.4.20-dev-3902) Mute flaky JavaAgainstKotlinBinariesCheckerTestGenerated.testEnumStaticImportInJava (vor 7 Tagen) <Nikolay Krasko>
* 2d8643b6efb - (tag: build-1.4.20-dev-3901) [Gradle, JS] Add nowarn flag for kotlin2js (vor 7 Tagen) <Ilya Goncharov>