### PR TITLE
Increase timeout in worker11 test

### DIFF
--- a/backend.native/tests/runtime/workers/worker11.kt
+++ b/backend.native/tests/runtime/workers/worker11.kt
@@ -102,7 +102,7 @@ val counters = Array(COUNT) { AtomicInt(0) }
         }
     }
     workers.forEach {
-        it.executeAfter(1000*1000, {
+        it.executeAfter(10*1000*1000, {
             println("DELAY EXECUTED")
             assert(false)
         }.freeze())


### PR DESCRIPTION
(with current timeout the test is false positive on MIPS32 emulator)