### PR TITLE
[IR] Fix for https://youtrack.jetbrains.com/issue/KT-41394 + test

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -48,12 +48,8 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
             "${function.name}COROUTINE\$${context.coroutineCount++}".synthesizedName
 
     override fun initializeStateMachine(coroutineConstructors: List<IrConstructor>, coroutineClassThis: IrValueDeclaration) {
-        for (constructor in coroutineConstructors) {
-            val labelField = constructor.parentAsClass.declarations.single { it is IrField && it.name.asString() == "label" } as IrField
-            (constructor.body as IrBlockBody).statements += with(context.createIrBuilder(constructor.symbol, constructor.startOffset, constructor.endOffset)) {
-                irSetField(irGet(coroutineClassThis), labelField, irCall(symbols.getNativeNullPtr.owner))
-            }
-        }
+        // Nothing to do: it's redundant to initialize the "label" field with null
+        // since all freshly allocated objects are zeroed out.
     }
 
     override fun IrBlockBodyBuilder.generateCoroutineStart(invokeSuspendFunction: IrFunction, receiver: IrExpression) {

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -1836,6 +1836,11 @@ task coroutines_functionReference_lambdaAsSuspendLambda(type: KonanLocalTest) {
     source = "codegen/coroutines/functionReference_lambdaAsSuspendLambda.kt"
 }
 
+task coroutines_kt41394(type: KonanLocalTest) {
+    goldValue = ""
+    source = "codegen/coroutines/kt41394.kt"
+}
+
 standaloneTest('coroutines_suspendConversion') {
     goldValue = ""
     source = "codegen/coroutines/suspendConversion.kt"

--- a/backend.native/tests/codegen/coroutines/kt41394.kt
+++ b/backend.native/tests/codegen/coroutines/kt41394.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package codegen.coroutines.kt41394
+
+import kotlin.test.*
+
+import kotlin.coroutines.*
+import kotlin.coroutines.intrinsics.*
+
+open class EmptyContinuation(override val context: CoroutineContext = EmptyCoroutineContext) : Continuation<Any?> {
+    companion object : EmptyContinuation()
+    override fun resumeWith(result: Result<Any?>) { result.getOrThrow() }
+}
+
+suspend fun suspendHere(): Int = suspendCoroutineUninterceptedOrReturn { x ->
+    x.resume(42)
+    COROUTINE_SUSPENDED
+}
+
+suspend fun foo(label: String): String {
+    val x = suspendHere()
+    return label + x.toString()
+}
+
+fun builder(c: suspend () -> Unit) {
+    c.startCoroutine(EmptyContinuation)
+}
+
+@Test fun runTest() {
+    var result = ""
+
+    builder {
+        result = foo("zzz")
+    }
+
+    assertEquals("zzz42", result)
+}


### PR DESCRIPTION
It is redundant to initialize the "label" field with null, since all freshly allocated objects are zeroed out