### PR TITLE
[runtime][codegen] Added lifetime constraint check

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/ContextUtils.kt
@@ -519,6 +519,7 @@ internal class Llvm(val context: Context, val llvmModule: LLVMModuleRef) {
     val lookupTLS = importRtFunction("LookupTLS")
     val initRuntimeIfNeeded = importRtFunction("Kotlin_initRuntimeIfNeeded")
     val mutationCheck = importRtFunction("MutationCheck")
+    val checkLifetimesConstraint = importRtFunction("CheckLifetimesConstraint")
     val freezeSubgraph = importRtFunction("FreezeSubgraph")
     val checkMainThread = importRtFunction("CheckIsMainThread")
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -1633,6 +1633,9 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
                 functionGenerationContext.call(context.llvm.mutationCheck,
                         listOf(functionGenerationContext.bitcast(codegen.kObjHeaderPtr, thisPtr)),
                         Lifetime.IRRELEVANT, ExceptionHandler.Caller)
+
+                if (functionGenerationContext.isObjectType(valueToAssign.type))
+                    functionGenerationContext.call(context.llvm.checkLifetimesConstraint, listOf(thisPtr, valueToAssign))
             }
             functionGenerationContext.storeAny(valueToAssign, fieldPtrOfClass(thisPtr, value.symbol.owner), false)
         } else {

--- a/runtime/src/main/cpp/Memory.cpp
+++ b/runtime/src/main/cpp/Memory.cpp
@@ -3439,6 +3439,14 @@ void MutationCheck(ObjHeader* obj) {
     ThrowInvalidMutabilityException(obj);
 }
 
+void CheckLifetimesConstraint(ObjHeader* obj, ObjHeader* pointee) {
+  if (!obj->local() && pointee != nullptr && pointee->local()) {
+    konan::consolePrintf("Attempt to store a stack object %p into a heap object %p\n", pointee, obj);
+    konan::consolePrintf("This is a compiler bug, please report it to https://kotl.in/issue\n");
+    konan::abort();
+  }
+}
+
 void EnsureNeverFrozen(ObjHeader* object) {
   ensureNeverFrozen(object);
 }

--- a/runtime/src/main/cpp/Memory.h
+++ b/runtime/src/main/cpp/Memory.h
@@ -541,6 +541,7 @@ OBJ_GETTER(DerefStablePointer, void*) RUNTIME_NOTHROW;
 OBJ_GETTER(AdoptStablePointer, void*) RUNTIME_NOTHROW;
 // Check mutability state.
 void MutationCheck(ObjHeader* obj);
+void CheckLifetimesConstraint(ObjHeader* obj, ObjHeader* pointee) RUNTIME_NOTHROW;
 // Freeze object subgraph.
 void FreezeSubgraph(ObjHeader* obj);
 // Ensure this object shall block freezing.


### PR DESCRIPTION
Current memory model forbids a heap object to reference a stack object,
so check that explicitly on each field store for now