### PR TITLE
[KT-38821] Add android/native_window_jni.h to Android platform libs

### DIFF
--- a/platformLibs/src/platform/android/android.def
+++ b/platformLibs/src/platform/android/android.def
@@ -12,7 +12,7 @@ headers = jni.h stdbool.h \
      android/keycodes.h \
      android/log.h android/looper.h \
      android/multinetwork.h \
-     android/native_activity.h android/native_window.h android/ndk-version.h \
+     android/native_activity.h android/native_window.h android/native_window_jni.h android/ndk-version.h \
      android/obb.h \
      android/rect.h \
      android/sensor.h android/set_abort_message.h android/sharedmem.h android/sharedmem_jni.h \


### PR DESCRIPTION
Adds a missing platform header for Android, fixing KT-38821. 
Header: https://android.googlesource.com/platform/frameworks/native/+/master/include/android/native_window_jni.h
