### PR TITLE
[KT-38779] Add gles31.def to Android platform libs

### DIFF
--- a/platformLibs/src/platform/android/gles31.def
+++ b/platformLibs/src/platform/android/gles31.def
@@ -1,0 +1,5 @@
+depends = glesCommon posix
+package = platform.gles31
+headers = GLES3/gl31.h GLES3/gl3ext.h GLES3/gl3platform.h
+headerFilter = GLES3/**
+linkerOpts = -lGLESv3

--- a/platformLibs/src/platform/android/gles31.def
+++ b/platformLibs/src/platform/android/gles31.def
@@ -1,5 +1,5 @@
-depends = glesCommon posix
+depends = gles3 glesCommon posix
 package = platform.gles31
-headers = GLES3/gl31.h GLES3/gl3ext.h GLES3/gl3platform.h
+headers = GLES3/gl31.h
 headerFilter = GLES3/**
 linkerOpts = -lGLESv3


### PR DESCRIPTION
Adds GLES 3.1 APIs to Android. https://developer.android.com/ndk/guides/stable_apis#opengl_es_10_

As discussed in [KT-38779](https://youtrack.jetbrains.com/issue/KT-38779) this doesn't add GLES 3.2 because K/N is linked to Android API level 21.