### PR TITLE
[kotlin compiler][update] 1.4.30-dev-148

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.backend.common.ir.addFakeOverridesViaIncorrectHeuristic
+import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
 import org.jetbrains.kotlin.backend.common.ir.addSimpleDelegatingConstructor
 import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
 import org.jetbrains.kotlin.backend.konan.descriptors.synthesizedName
@@ -115,7 +115,7 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
         )
 
         implObject.superTypes += context.irBuiltIns.anyType
-        implObject.addFakeOverridesViaIncorrectHeuristic()
+        implObject.addFakeOverrides(context.irBuiltIns)
 
         val itemGetterSymbol = symbols.array.functions.single { it.descriptor.name == Name.identifier("get") }
         val enumEntriesMap = enumClass.declarations

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlin.backend.konan.cgen
 
-import org.jetbrains.kotlin.backend.common.ir.addFakeOverridesViaIncorrectHeuristic
+import org.jetbrains.kotlin.backend.common.ir.addFakeOverrides
 import org.jetbrains.kotlin.backend.common.ir.createDispatchReceiverParameter
 import org.jetbrains.kotlin.backend.common.ir.createParameterDeclarations
 import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
@@ -1320,7 +1320,7 @@ private class ObjCBlockPointerValuePassing(
             +irReturn(callBlock(blockPointer, arguments))
         }
 
-        irClass.addFakeOverridesViaIncorrectHeuristic()
+        irClass.addFakeOverrides(stubs.irBuiltIns)
 
         stubs.addKotlin(irClass)
         return constructor

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FunctionReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FunctionReferenceLowering.kt
@@ -331,7 +331,8 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
             }
 
             functionReferenceClass.superTypes += superTypes
-            functionReferenceClass.addFakeOverridesViaIncorrectHeuristic()
+
+            functionReferenceClass.addFakeOverrides(context.irBuiltIns)
 
             return BuiltFunctionReference(functionReferenceClass, constructor)
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropCallConvertors.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropCallConvertors.kt
@@ -229,7 +229,7 @@ private fun InteropCallContext.convertIntegralToEnum(
         enumType: IrType
 ): IrExpression {
     val enumClass = enumType.getClass()!!
-    val companionClass = enumClass.companionObject()!! as IrClass
+    val companionClass = enumClass.companionObject()!!
     val byValue = companionClass.simpleFunctions().single { it.name.asString() == "byValue" }
     val byValueArg = castPrimitiveIfNeeded(value, intergralType, byValue.valueParameters.first().type)
     return builder.irCall(byValue).apply {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -529,7 +529,7 @@ internal class TestProcessor (val context: Context) {
             companionGetter?.let { declarations += it }
 
             superTypes += symbols.baseClassSuite.typeWith(listOf(testClassType, testCompanionType))
-            addFakeOverridesViaIncorrectHeuristic()
+            addFakeOverrides(context.irBuiltIns)
         }
     }
     //endregion

--- a/build.gradle
+++ b/build.gradle
@@ -289,6 +289,8 @@ task detectJarCollision(type: CollisionDetector) {
     resolvingRules["META-INF/kotlin-native-utils.kotlin_module"] = "kotlin-compiler"
     resolvingRules["META-INF/compiler.common.kotlin_module"] = "kotlin-compiler"
     resolvingRules["META-INF/compiler.common.jvm.kotlin_module"] = "kotlin-compiler"
+    resolvingRules["META-INF/deserialization.common.jvm.kotlin_module"] = "kotlin-compiler"
+    resolvingRules["META-INF/deserialization.common.kotlin_module"] = "kotlin-compiler"
 
     // These collisions are introduced by kotlinx-metadata-klib.
     resolvingRules["META-INF/serialization.kotlin_module"] = "kotlin-compiler"

--- a/build.gradle
+++ b/build.gradle
@@ -312,8 +312,9 @@ task detectJarCollision(type: CollisionDetector) {
         resolvingRules["META-INF/extensions/compiler.xml"] = "kotlin-compiler"
         resolvingRules["META-INF/compiler.version"] = "kotlin-compiler"
         resolvingRules["kotlinManifest.properties"] = "kotlin-compiler"
-        librariesWithIgnoredClassCollisions.addAll(["util", "container", "resolution", "serialization", "psi", "frontend",
-                                                    "config", "config.jvm", "js.config", "javac-wrapper",
+        librariesWithIgnoredClassCollisions.addAll(["util", "container", "resolution.common", "resolution", "serialization", "psi",
+                                                    "deserialization.common", "deserialization.common.jvm",
+        											"frontend", "config", "config.jvm", "js.config", "javac-wrapper",
                                                     "frontend.common", "frontend.java", "cli-common", "ir.tree",
                                                     "ir.tree.impl", "ir.tree.persisting",
                                                     "ir.psi2ir", "ir.backend.common", "backend.jvm", "backend.js",

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-4477,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.20-dev-4477
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-4477,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.20-dev-4477
-kotlinStdlibTestsVersion=1.4.20-dev-4477
-testKotlinCompilerVersion=1.4.20-dev-4477
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-148,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-148
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-148,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-148
+kotlinStdlibTestsVersion=1.4.30-dev-148
+testKotlinCompilerVersion=1.4.30-dev-148
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 680dd642115 - (tag: build-1.4.30-dev-148) FIR2IR: pick return target based on matched IrFunction (vor 2 Stunden) <Jinseong Jeon>
* 6ebad9589a2 - FIR2IR: set proper IR origin for iterator in ranges (vor 2 Stunden) <Jinseong Jeon>
* 578e707ab92 - FIR2IR: set VARIABLE_AS_FUNCTION origin only for invoke receivers (vor 2 Stunden) <Mikhail Glukhikh>
* f0a2a62405c - [FIR2IR] Minor: coneTypeSafe -> coneType (vor 3 Stunden) <Mikhail Glukhikh>
* 89ffce22d89 - FIR2IR: set proper IR origin for variable as function (vor 3 Stunden) <Jinseong Jeon>
* bf3a7e5fea6 - (tag: build-1.4.30-dev-139) Add more tasks in Gradle build for running GradleIT in parallel (vor 13 Stunden) <Andrey Uskov>
* a7f57646bf5 - (tag: build-1.4.30-dev-137) Prevent rebuilding by avoid registering doFirst on source tasks (KTI-324) (vor 17 Stunden) <Nikolay Krasko>
* 9250d86915d - (tag: build-1.4.30-dev-135) JVM IR: generate field for private companion object in interface as synthetic (vor 26 Stunden) <Alexander Udalov>
* fc141a52dad - IR: minor, make IrClass.companionObject return IrClass (vor 26 Stunden) <Alexander Udalov>
* 2f86554d5af - (tag: build-1.4.30-dev-129) IR: don't produce fake overrides for static and private declarations (vor 2 Tagen) <Alexander Udalov>
* 703150e3add - (tag: build-1.4.30-dev-127) FIR IDE: Refactor `LowLevelFirApiFacade.kt` (vor 2 Tagen) <Roman Golyshev>
* edb277b30a0 - FIR Completion: Enable passing tests (vor 2 Tagen) <Roman Golyshev>
* dcc22d3e5d9 - FIR IDE: Fix completion in property setters (vor 2 Tagen) <Roman Golyshev>
* 5c1520305b8 - FIR IDE: Build symbols from any `FirValueParameter` (vor 2 Tagen) <Roman Golyshev>
* ae8933dbd29 - FIR IDE: Correctly handle properties in `KtFirCompletionCandidateChecker` (vor 2 Tagen) <Roman Golyshev>
* 6fd871d0ba1 - FIR IDE: Add building completion context for properties (vor 2 Tagen) <Roman Golyshev>
* 58965d1e715 - FIR IDE: Implement `RawFirBuilder::buildPropertyWithBody`, add tests (vor 2 Tagen) <Roman Golyshev>
* 5f57311015a - (tag: build-1.4.30-dev-125) JVM_IR: remove .toKotlinType() from intrinsics.Equals (vor 2 Tagen) <Georgy Bronnikov>
* 2c1735c2118 - JVM_IR: remove descriptor usage from JvmOptimizationLowering (vor 2 Tagen) <Georgy Bronnikov>
* a14c9018b1d - JVM_IR: remove descriptor usage from SyntheticAccessorLowering (vor 2 Tagen) <Georgy Bronnikov>
* 3327524e187 - JVM_IR: remove descriptor usage from TypeAliasAnnotationMethodsLowering (vor 2 Tagen) <Georgy Bronnikov>
* 905978a458e - JVM_IR: remove descriptor usage from JvmCachedDeclarations (vor 2 Tagen) <Georgy Bronnikov>
* 92b03e7ede8 - JVM_IR: Remove descriptor usage from IrSourceCompilerForInline (vor 2 Tagen) <Georgy Bronnikov>
* 0a66dbf2b5f - JVM_IR: remove descriptor usage in CompareTo intrinsic (vor 2 Tagen) <Georgy Bronnikov>
* 370622087b5 - (tag: build-1.4.30-dev-112) Redundant nullable return type: false negative with return expression in local function or lambda (vor 3 Tagen) <Toshiaki Kameyama>
* de3907e8cce - Redundant nullable return type: fix false positive with non-local return (vor 3 Tagen) <Toshiaki Kameyama>
* 349cad7b9ad - (tag: build-1.4.30-dev-110) Minor: migrate remaining scanReduceIndexed usages (vor 3 Tagen) <Ilya Gorbunov>
* 744f290fc48 - (tag: build-1.4.30-dev-107) A proper modality calculation was missing in IR fake override construction algorithm (vor 3 Tagen) <Alexander Gorshenev>
* 2886f48795e - (tag: build-1.4.30-dev-105) Improve spelling in Kotlin Test module's README.md (vor 3 Tagen) <Louis CAD>
* 64408c19f82 - (tag: build-1.4.30-dev-102) Add missing "The" article in kotlin.test doc (vor 3 Tagen) <Louis CAD>
* 175a8bec9d4 - (tag: build-1.4.30-dev-95) Make KotlinCoreEnvironment.disposeApplicationEnvironment() public (vor 3 Tagen) <Andrey Uskov>
* fca64361703 - (tag: build-1.4.30-dev-93) Fix IDE test after bcd33da6f83a50df9063d44403b4705ff5303f57 (vor 3 Tagen) <Victor Petukhov>
* e08763f3dd5 - (tag: build-1.4.30-dev-89) [ULC] Add annotations for PsiTypes in UltraLight classes (vor 3 Tagen) <Igor Yakovlev>
* b82d8cd4f49 - [ULC] Fixed invalid access to lightclass infrastructure from UL (vor 3 Tagen) <Igor Yakovlev>
* 8fc94ddb8cb - [UCL] Minor fixes (vor 3 Tagen) <Igor Yakovlev>
* 97ac86273a8 - [ULC] Add support of const fields to multifile facade (vor 3 Tagen) <Igor Yakovlev>
* 309bf49a832 - Update lightclass tests renderer (vor 3 Tagen) <Igor Yakovlev>
* c70383cc707 - [ULC] Add compiler flag -Xdisable-ultra-light-classes to fallback to light implementation in CLI (vor 3 Tagen) <Igor Yakovlev>
* e53db4c771f - Uast: fixing `WrappedUAnnotation` identifiers (vor 3 Tagen) <Nicolay Mitropolsky>
* 4b8f1bb362c - [ULC] Add LanguageVersionSettings to CliLightClassGenerationSupport (vor 3 Tagen) <Igor Yakovlev>
* 31b4a021a9a - [ULC] Add JvmDeclarationOriginKind.DELEGATION to DeclarationOriginKindForOrigin of delegated methods (vor 3 Tagen) <Igor Yakovlev>
* b263e1c924e - [ULC] Remove nullability annotation for UL backing fields of private props (vor 3 Tagen) <Igor Yakovlev>
* a36d53e0865 - [ULC] Skip nullability annotation for backing field of lateinit property (vor 3 Tagen) <Igor Yakovlev>
* cd32cf78287 - [ULC] Add PsiElement overrides for UL elements with source (vor 3 Tagen) <Igor Yakovlev>
* 131c14626c0 - [ULC] Fix invalid alias search for UL classes (vor 3 Tagen) <Igor Yakovlev>
* 2c16ae968db - [ULC] Add support @receiver annotation site to UL classes (vor 3 Tagen) <Igor Yakovlev>
* dbb4337ac40 - [ULC] Fix invalid annotation resolve for KtUltraLightParameterForSetterParameter (vor 3 Tagen) <Igor Yakovlev>
* db6aa9140da - [ULC] Refactor for lightAnnotations classes (vor 3 Tagen) <Igor Yakovlev>
* c4cee35ccaa - [ULC] Fixed invalid UL facade annotations (vor 3 Tagen) <Igor Yakovlev>
* 6542ea9ba13 - [ULC] Add constant evaluation to light classes service (vor 3 Tagen) <Igor Yakovlev>
* 55bb8f24e39 - [ULC] Move UltraLightSupport to service provided bridge (vor 3 Tagen) <Igor Yakovlev>
* 7cb2631991b - [ULC] Fix light class Coherence test (vor 3 Tagen) <Igor Yakovlev>
* 7b0eb51f8db - [ULC] Add annotation support for UL facades (vor 3 Tagen) <Igor Yakovlev>
* a5e304f5205 - [ULC] Better nullability annotations for light classes (vor 3 Tagen) <Igor Yakovlev>
* c3810dc223c - [ULC] Fixed UL backing field initializers (vor 3 Tagen) <Igor Yakovlev>
* 129979b0ff8 - [ULC] Improve UL facades for private properties without accessors (vor 3 Tagen) <Igor Yakovlev>
* 025e2f2fe99 - [ULC] Better support for UL MultifileFacade classes (vor 3 Tagen) <Igor Yakovlev>
* bc12fb0d6b2 - [ULC] Enable UL for script classes (vor 3 Tagen) <Igor Yakovlev>
* 1d248f1a00d - [ULC] Fixed invalid fqName for script inner classes (vor 3 Tagen) <Igor Yakovlev>
* 236e41e024b - [ULC] Fixed invalid super type for UL scripts (vor 3 Tagen) <Igor Yakovlev>
* 6accc8fcf9e - [ULC] Fixed invalid constructor parameter list for UL script (vor 3 Tagen) <Igor Yakovlev>
* bf91ada06c7 - (tag: build-1.4.30-dev-86) [NI] Suppress false positive IDEA warnings in NewConstraintSystemImpl (vor 3 Tagen) <Dmitriy Novozhilov>
* 178cef56318 - [FIR] Don't create synchronized lazy for constraint system in candidate (vor 3 Tagen) <Dmitriy Novozhilov>
* a528deef0aa - [FIR] Update testdata due to previous commit and KT-37638 (vor 3 Tagen) <Dmitriy Novozhilov>
* 1dc3c93efa8 - [FIR] Don't assume types with not found symbol as error types (vor 3 Tagen) <Dmitriy Novozhilov>
* 7f692be11ec - [FIR] Properly detect callable reference type according conversions (vor 3 Tagen) <Dmitriy Novozhilov>
* ec93e5886ae - (tag: build-1.4.30-dev-85) [FIR2IR] Fix generation of accessors' extension receiver (f/o case) (vor 3 Tagen) <Mikhail Glukhikh>
* 36d2129fd3f - (tag: build-1.4.30-dev-81) Move common deserialization classes from :core:metadata modules (vor 3 Tagen) <Dmitriy Novozhilov>
* 07a3009d43d - Introduce new modules for common parts of deserialization (vor 3 Tagen) <Dmitriy Novozhilov>
* 2f4bd626fc6 - [FIR] Make constant values in fir serialization internal (vor 3 Tagen) <Dmitriy Novozhilov>
* 9e1e525343d - Fix circular dependency between :core:compiler:common.jvm and :core:metadata.jvm (vor 3 Tagen) <Dmitriy Novozhilov>
* c82d9ea9f49 - Remove dependency on :compiler:frontend.java from :compiler:fir:java (vor 3 Tagen) <Dmitriy Novozhilov>
* 1417fcecb87 - Move more common parts from :compiler:descriptors.jvm (vor 3 Tagen) <Dmitriy Novozhilov>
* 192e07a07bf - [FIR] Remove dependency on FE 1.0 modules form :compiler:fir:fir-deserialization (vor 3 Tagen) <Dmitriy Novozhilov>
* 5d4d07066b9 - Move common deserialization components to :core:metadata and :core:metadata.jvm (vor 3 Tagen) <Dmitriy Novozhilov>
* cdab00fdc89 - [FIR] Remove dependency on :core:deserialization from :compiler:fir:fir-serialization (vor 3 Tagen) <Dmitriy Novozhilov>
* 9beeb512273 - [FIR] Implement fir-specific contract values and fix annotations serialization (vor 3 Tagen) <Dmitriy Novozhilov>
* e1ad1aabc4b - Move RequireKotlinConstants to :core:compiler.common (vor 3 Tagen) <Dmitriy Novozhilov>
* 8d2e89a9eab - Move ProtoEnumFlags to :core:metadata (vor 3 Tagen) <Dmitriy Novozhilov>
* e39ce912535 - (tag: build-1.4.30-dev-76) [IR] Fixed fake override builder for lowerings (vor 3 Tagen) <Igor Chevdar>
* 7f4bda0d523 - (tag: build-1.4.30-dev-70) Enable FUS internal mode on IDE launching (vor 4 Tagen) <Andrey Uskov>
* ae9c1af8839 - (tag: build-1.4.30-dev-66) Do not use erroneous unsigned/signed comparison in UnsignedArraysTest (vor 4 Tagen) <Alexander Udalov>
* bcd33da6f83 - (tag: build-1.4.30-dev-63) Don't check an argument type during passing it to vararg in the named form to avoid false positives if the argument type is type variable yet (vor 4 Tagen) <Victor Petukhov>
* 2c4c8cdf011 - (tag: build-1.4.30-dev-62) [Wizard] Update versions in wizard (vor 4 Tagen) <Ilya Goncharov>
* 38854ce40b1 - (tag: build-1.4.30-dev-56) Disable profilerConfig for AHeavyInspectionsPerformanceTest (vor 4 Tagen) <Vladimir Dolzhenko>
* e3b07120bb4 - (tag: build-1.4.30-dev-54) Build: Don't retry tests in local builds (vor 4 Tagen) <Vyacheslav Gerasimov>
* 29f3811bab6 - (tag: build-1.4.30-dev-49) Update gradle tooling (vor 4 Tagen) <Kirill Shmakov>
* 60b812f4520 - Reorder arguments in KotlinNativeTest for better debug (vor 4 Tagen) <Kirill Shmakov>
* ef58e0cd717 - (tag: build-1.4.30-dev-24) FIR2IR: refactor adapter generation (vor 4 Tagen) <Jinseong Jeon>
* 5fdd06676f6 - FIR: discriminate candidates with suspend conversion (vor 4 Tagen) <Jinseong Jeon>
* 6de8ba40c1c - FIR: initial support of suspend conversion on arguments (vor 4 Tagen) <Jinseong Jeon>
* 49679f31455 - (tag: build-1.4.30-dev-23) FIR: map arguments for overloading indexed access operator (vor 4 Tagen) <Jinseong Jeon>
* a73856be666 - (tag: build-1.4.30-dev-22) Add warn message to ReplaceWithIgnoreCaseEquals inspection. (vor 4 Tagen) <Vladimir Dolzhenko>
* 50366731872 - (tag: build-1.4.30-dev-21, tag: build-1.4.30-dev-18) Improve package caching in KotlinJavaPsiFacade (vor 4 Tagen) <Vladimir Dolzhenko>
* 05d3e48564d - (tag: build-1.4.30-dev-11) Implemented collecting statistics about JS target mode (vor 4 Tagen) <Andrey Uskov>
* 47162285004 - Add js generate executable default collecting statistics (vor 4 Tagen) <Ilya Goncharov>
* 405e271b689 - Add js generate externals collecting statistics (vor 4 Tagen) <Ilya Goncharov>
* 6f03e42ef76 - (tag: build-1.4.30-dev-10) Revert back Inspection: convert initialized val to non-null type (vor 4 Tagen) <Vladimir Dolzhenko>
* 12ebd429bc9 - (tag: build-1.4.30-dev-3) Revert "Light classes support for declarations in multipart classes." (vor 5 Tagen) <Vladimir Ilmov>
* d324ae6cda3 - (tag: build-1.4.20-eap-2, tag: build-1.4.20-dev-4619) Fix AS 4.0 compilation (vor 5 Tagen) <Vladimir Dolzhenko>
* 0492a52a6a8 - (tag: build-1.4.20-dev-4617) Minor. Regenerate tests (vor 5 Tagen) <Ilmir Usmanov>
* 52f9569d332 - Generate CHECKCAST Object inside the markers (vor 5 Tagen) <Ilmir Usmanov>
* e8a451072e6 - Minor. Add tests with same JvmType in covariant override (vor 5 Tagen) <Ilmir Usmanov>
* 7cbd0674606 - Add tests with resume path (vor 5 Tagen) <Ilmir Usmanov>
* 1c97eafea8a - Check for COROUTINE_SUSPENDED inside callable reference (vor 5 Tagen) <Ilmir Usmanov>
* 4303e8126f0 - Do not generate suspend markers inside callable reference (vor 5 Tagen) <Ilmir Usmanov>
* ccc5b7afe00 - Box inline class in resume path of suspend call (vor 5 Tagen) <Ilmir Usmanov>
* 023cdd7cd42 - Support not boxing inline class of reference class (vor 5 Tagen) <Ilmir Usmanov>
* 5c011bc954f - (tag: build-1.4.20-dev-4615) Don't report when property is multi-line and action is MOVE (vor 5 Tagen) <Toshiaki Kameyama>
* 4569b85a163 - MoveVariableDeclarationIntoWhenInspection: report it if initializer is single line even if property is multi line (vor 5 Tagen) <Toshiaki Kameyama>
* 75d4c7e91ca - Find stdlib usages test case (vor 5 Tagen) <Vladimir Ilmov>
* 8b239d89b6a - SourceNavigationHelper multifile classes support (vor 5 Tagen) <Vladimir Ilmov>
* 3764eeba25b - (tag: build-1.4.20-dev-4613) Build: Setup gradle.test-retry plugin for all test tasks in the project (vor 5 Tagen) <Vyacheslav Gerasimov>
* 3d7619421fc - JVM IR: fix exception on star projection in type parameter upper bound (vor 5 Tagen) <Alexander Udalov>
* 685d16ec68e - (tag: build-1.4.20-dev-4610) NI: don't do substitution for unsupported callable descriptors to use as callable references (vor 5 Tagen) <Victor Petukhov>
* 668098f3a86 - (tag: build-1.4.20-dev-4606) [Gradle, JS] Add simple files without kotlinx.html (vor 5 Tagen) <Ilya Goncharov>
* 3ea51a982ce - (tag: build-1.4.20-eap-1, tag: build-1.4.20-dev-4602) Light classes support for declarations in multipart classes. (vor 5 Tagen) <Vladimir Ilmov>
* a5d91339b52 - (lightClass) multifile classes facade in libraries added (vor 5 Tagen) <Vladimir Ilmov>
* ac22232b8dd - (tag: build-1.4.20-dev-4601) Register disposable startup items in PluginStartupService (vor 5 Tagen) <Vladimir Dolzhenko>
* e5985ad98b2 - Rename PluginStartupService to PluginStartupApplicationService (vor 5 Tagen) <Vladimir Dolzhenko>
* c1ebd338331 - (tag: build-1.4.20-dev-4598) Capture flexible intersection types properly: take into account both bounds and use the same captured arguments for them (vor 5 Tagen) <Victor Petukhov>
* 140edb2215d - Consider intersection with ILT subtype of ILT (vor 5 Tagen) <Victor Petukhov>
* 7bd9c527324 - (tag: build-1.4.20-dev-4595) FIR Completion: Fix completion in function calls (`foo.bar<caret>()`) (vor 5 Tagen) <Roman Golyshev>
* 2d4d48b401c - FIR IDE: Invert the order of the scopes for completion (vor 5 Tagen) <Roman Golyshev>
* f748d8cf706 - (tag: build-1.4.20-dev-4592) [FIR] Extract ResolutionContext to separate file (vor 5 Tagen) <Dmitriy Novozhilov>
* 1a84ec9677c - [FIR] Mark all session components respectively to they have mutable state or not (vor 5 Tagen) <Dmitriy Novozhilov>
* 8686e3779e5 - [FIR] Make all session components abstract classes (vor 5 Tagen) <Dmitriy Novozhilov>
* caf325934c0 - [FIR] Unmake FirSamResolver as session component (vor 5 Tagen) <Dmitriy Novozhilov>
* 29addd2a2b7 - [FIR] Make InferenceComponents session component (vor 5 Tagen) <Dmitriy Novozhilov>
* 41b395b0aaa - [FIR] Extract mutable state from InferenceComponents (vor 5 Tagen) <Dmitriy Novozhilov>
* d70858edfae - [FIR] Get rid of inference components in CheckerSink (vor 5 Tagen) <Dmitriy Novozhilov>
* 912676d8687 - [FIR] Introduce ResolutionContext and get rid of components in Candidate (vor 5 Tagen) <Dmitriy Novozhilov>
* c53ffca34f6 - [FIR] Extract BodyResolveContext from FirAbstractBodyResolveTransformer (vor 5 Tagen) <Dmitriy Novozhilov>
* edb1273355d - [FIR] Report ResolutionDiagnostics instead of applicability in resolve (vor 5 Tagen) <Dmitriy Novozhilov>
* a148db9d814 - [FIR] Get rid of CandidateApplicability.SYNTHETIC_RESOLVED (vor 5 Tagen) <Dmitriy Novozhilov>
* 19707667fda - [FIR] Cleanup detection that applicability is successful (vor 5 Tagen) <Dmitriy Novozhilov>
* 68f3d84e22f - [FIR] Use CandidateApplicability from FE 1.0 (vor 5 Tagen) <Dmitriy Novozhilov>
* cd557ad1781 - Change order of enum entries in CandidateApplicability (vor 5 Tagen) <Dmitriy Novozhilov>
* d1568c1ce63 - Rename `ResolutionCandidateApplicability` to `CandidateApplicability` (vor 5 Tagen) <Dmitriy Novozhilov>
* db2e3f219ff - [FIR] Keep bare type for type alias case (vor 5 Tagen) <Mikhail Glukhikh>
* 3a5d0ab4271 - (tag: build-1.4.20-dev-4581) JVM IR: fix HashCode intrinsic for generics substituted with primitives (vor 5 Tagen) <Alexander Udalov>
* c46c80822c6 - JVM IR: fix enclosing constructor for lambdas in inner classes (vor 5 Tagen) <Alexander Udalov>
* 228e329d1ff - JVM IR: generate enclosing constructor only for lambdas in initializers (vor 5 Tagen) <Alexander Udalov>
* 2ab68b3245f - (tag: build-1.4.20-dev-4580) Wizard: move boolean setting description to the bottom (vor 6 Tagen) <Ilya Kirillov>
* ce00366c7fd - Wizard: fix when first selected template cannot be applied (vor 6 Tagen) <Ilya Kirillov>
* 3a6011fae9b - Wizard: always generate android MPP tests (vor 6 Tagen) <Ilya Kirillov>
* 553c525701a - Wizard: fix Gradle buildscript formatting (vor 6 Tagen) <Ilya Kirillov>
* 0f799d593df - Wizard: specify test platform to use on JVM (vor 6 Tagen) <Ilya Kirillov>
* 7002e86d6bf - Wizard: fix path & artifactId updating on name update (vor 6 Tagen) <Ilya Kirillov>
* 929b5f727d3 - (tag: build-1.4.20-dev-4575) Build: add :compiler:fir:entrypoint to compilerModules (vor 6 Tagen) <Alexander Udalov>
* 7fb7dc02103 - Fix deprecation warnings related to Project extensions (vor 6 Tagen) <Alexander Udalov>
* 196893bc4dd - Build: fix more warnings about deprecated/Alpha MPP plugins (vor 6 Tagen) <Alexander Udalov>
* 06680452dcb - (tag: build-1.4.20-dev-4571) [JVM_IR] Always look for default lambdas in the inliner. (vor 6 Tagen) <Mads Ager>
* a12e22bba42 - (tag: build-1.4.20-dev-4556) [Spec tests] Fix dependencies for spec tests generator (vor 6 Tagen) <anastasiia.spaseeva>
* 9d3426486b9 - (tag: build-1.4.20-dev-4549) [Gradle, JS] Support explicitApi in js plugin (vor 6 Tagen) <Ilya Goncharov>
* 28a83b04cd4 - [FIR] Minor. Fix code style (vor 6 Tagen) <Dmitriy Novozhilov>
* 67604dcb668 - [FIR] Add generator for checkers aliases and sets of checkers (vor 6 Tagen) <Dmitriy Novozhilov>
* 4de57fcac26 - [FIR] Initialize module for checkers generator (vor 6 Tagen) <Dmitriy Novozhilov>
* 6656669551a - [FIR] Fix typo (vor 6 Tagen) <Dmitriy Novozhilov>
* 3b9e86ccbf1 - [FIR] Remove empty file (vor 6 Tagen) <Dmitriy Novozhilov>
* a8a5ed3cd3a - [FIR] Get rid of `runCheck` in checkers components (vor 6 Tagen) <Dmitriy Novozhilov>
* 71a855112e2 - [FIR] Get rid of ParallelDiagnosticsCollector (vor 6 Tagen) <Dmitriy Novozhilov>
* 20a1ea0413b - [Wizard, JS] Change js compiler default (vor 6 Tagen) <Ilya Goncharov>
* 6746bd81d5d - (tag: build-1.4.20-dev-4548) PSI2IR tests for KT-41735 (vor 6 Tagen) <Dmitry Petrov>
* aa04c0b5df1 - Parent call already on KotlinBuiltInDecompiler.kt:79 (vor 6 Tagen) <Vladimir Ilmov>
* 44ffb1fb3e3 - (tag: build-1.4.20-dev-4543) Psi2Ir: Fix SAM conversion with new inference (vor 6 Tagen) <Steven Schäfer>
* 75891e860b3 - (tag: build-1.4.20-dev-4539) FIR2IR: split getIrPropertyOrFieldSymbol, handle locals there (vor 6 Tagen) <pyos>
* f198a19ab02 - FIR2IR: add local delegated property generation (vor 6 Tagen) <pyos>
* 4792be25229 - (tag: build-1.4.20-dev-4530) JVM IR: Optimize static property references (KT-36975) (vor 7 Tagen) <Steven Schäfer>
* 669fda6b778 - (tag: build-1.4.20-dev-4527) Do not add duplicate $completion when compiling JVM against JVM_IR (vor 7 Tagen) <Alexander Udalov>
* ae448ececb5 - Minor, add compileKotlinAgainstKotlin test case for KT-41374 (vor 7 Tagen) <Alexander Udalov>
* 9e357354fb4 - Add JVM/JVM_IR mixed compilation tests for compileKotlinAgainstKotlin/boxInline (vor 7 Tagen) <Alexander Udalov>
* e324733b016 - Tests: accept TargetBackend in KotlinBaseTest.createConfiguration (vor 7 Tagen) <Alexander Udalov>
* 0dea6b94c6c - JVM IR: unmute boxInline tests on enclosing method/class (vor 7 Tagen) <Alexander Udalov>
* 985088a3f1b - (tag: build-1.4.20-dev-4524) [Gradle, JS] Add test on dukat with both mode (vor 7 Tagen) <Ilya Goncharov>
* b694e3b009f - [Gradle, JS] Dukat with both create externals only once (vor 7 Tagen) <Ilya Goncharov>
* 210cd982f04 - (tag: build-1.4.20-dev-4521) [Gradle, JS] Use webpack config's required dependencies in karma (vor 7 Tagen) <Ilya Goncharov>
* b5aca450b14 - (tag: build-1.4.20-dev-4520) Make cancellation checks when building resolution anchor caches (vor 7 Tagen) <Pavel Kirpichenkov>
* 54811613f46 - Minor: drop unnecessary wrapper for utility function (vor 7 Tagen) <Pavel Kirpichenkov>
* 1ff064d98db - Make Kotlin OOCBM updater for modules internal again (vor 7 Tagen) <Pavel Kirpichenkov>
* 9d6bdc6fc46 - Support modification tracking for source-dependent LibraryInfo (vor 7 Tagen) <Pavel Kirpichenkov>
* 6abd708d429 - Preserve order entry to module info mapping in IdeaModelInfosCache (vor 7 Tagen) <Pavel Kirpichenkov>
* 24d8aee2bb6 - Prioritize resolution anchors during resolution (vor 7 Tagen) <Pavel Kirpichenkov>
* f8ee9767203 - Use union of all available descriptors in composite importing scope (vor 7 Tagen) <Pavel Kirpichenkov>
* 5892bdf3f49 - Extend import resolution for library-to-source analysis (vor 7 Tagen) <Pavel Kirpichenkov>
* 8c876e46218 - (tag: build-1.4.20-dev-4518) FIR IDE: Get rid of `originalPosition` in `KtFirCompletionCandidateChecker` (vor 7 Tagen) <Roman Golyshev>
* 828fc2520c4 - FIR IDE: Refactor `KtFirCompletionCandidateChecker` (vor 7 Tagen) <Roman Golyshev>
* 33ac487a427 - (tag: build-1.4.20-dev-4509) [FIR-IDE] Fix leaking KtAnalysisSession (vor 7 Tagen) <Pavel Kirpichenkov>
* 909d418dd15 - (tag: build-1.4.20-dev-4508) Improve diagnostics in `KtElementImplStub::getContainingKtFile` (vor 7 Tagen) <Roman Golyshev>
* 5b53663eb88 - (tag: build-1.4.20-dev-4505) PSI2IR KT-41181 don't generate deep trees in hashCode (vor 7 Tagen) <Dmitry Petrov>
* ade1a346e13 - JVM: add test for KT-40123 (vor 7 Tagen) <Dmitry Petrov>
* 45c67a90c28 - (tag: build-1.4.20-dev-4502) (CoroutineDebugger) Disposing under IW lock. (vor 7 Tagen) <Vladimir Ilmov>
* 01143f24a48 - (tag: build-1.4.20-dev-4494) Add KotlinClassConstructorInfoHandler for showing parameter info of parameterized super class constructor. (vor 7 Tagen) <Sebastian Kaspari>
* d674f519fd1 - (tag: build-1.4.20-dev-4491) [FIR-IDE] Fix completion check for generic extensions (vor 7 Tagen) <Pavel Kirpichenkov>
* 60dfa8cc840 - (tag: build-1.4.20-dev-4488) Ignore ProcessCancelledException in VirtualFileKotlinClass (vor 7 Tagen) <Vladimir Ilmov>
* 3de32e13ea0 - (tag: build-1.4.20-dev-4487) Clean up declarationAccessorNames debug check in UnusedSymbolInspection (vor 7 Tagen) <Vladimir Dolzhenko>
* 127257aa27c - Provide setter-method for LC for private property setter (vor 7 Tagen) <Vladimir Dolzhenko>
* b5b319803ba - Add more diagnostics to tackle exception in KotlinFunctionParameterInfoHandler (vor 7 Tagen) <Vladimir Dolzhenko>
* 87e70cf6904 - Handle project disposed in ScriptDefinitionsManager (vor 7 Tagen) <Vladimir Dolzhenko>
* 4e3b1f141ea - Use runReadActionInSmartMode instead of runReadAction in ConfigureKotlinInProjectUtils (vor 7 Tagen) <Vladimir Dolzhenko>
* 02be470e918 - Check if vFile is still valid in ScriptClassRootsUpdater#updateHighlighting (vor 7 Tagen) <Vladimir Dolzhenko>
* ba027a785c2 - Fix NPE in GradleScriptInfo (vor 7 Tagen) <Vladimir Dolzhenko>
* 698f51079f2 - Perform paste reference resolve in smart mode (vor 7 Tagen) <Vladimir Dolzhenko>
* b00ce872ea3 - (tag: build-1.4.20-dev-4486) JVM: record JVM signature for equals/hashCode/toString in inline classes (vor 7 Tagen) <Dmitry Petrov>