### PR TITLE
Add global accessors to companion objects.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -292,7 +292,6 @@ internal class Context(config: KonanConfig) : KonanBackendContext(config) {
                 throw Error("Another IrModule in the context.")
             }
             field = module!!
-            internalAbi.init(module)
             ir = KonanIr(this, module)
         }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InternalAbi.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InternalAbi.kt
@@ -10,7 +10,9 @@ import org.jetbrains.kotlin.backend.konan.llvm.llvmSymbolOrigin
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrModuleFragmentImpl
-import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.util.NaiveSourceBasedFileEntryImpl
+import org.jetbrains.kotlin.ir.util.addFile
+import org.jetbrains.kotlin.ir.util.fqNameForIrSerialization
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
@@ -22,22 +24,24 @@ import org.jetbrains.kotlin.name.Name
  */
 internal class InternalAbi(private val context: Context) {
     /**
-     * File that stores all internal ABI declarations.
+     * Files that stores all internal ABI declarations.
+     * We use per-module files so that global initializer will be stored
+     * in the appropriate modules.
      *
      * We have to store such declarations in top-level to avoid mangling that
      * makes referencing harder.
      * A bit better solution is to add files with proper packages, but it is impossible
      * during FileLowering (hello, ConcurrentModificationException).
      */
-    private lateinit var internalAbiFile: IrFile
+    private lateinit var internalAbiFiles: Map<ModuleDescriptor, IrFile>
 
     /**
      * Representation of ABI files from external modules.
      */
-    private val externalModules = mutableMapOf<ModuleDescriptor, IrFile>()
+    private val externalAbiFiles = mutableMapOf<ModuleDescriptor, IrFile>()
 
-    fun init(module: IrModuleFragment) {
-        internalAbiFile = createAbiFile(module)
+    fun init(modules: List<IrModuleFragment>) {
+        internalAbiFiles = modules.associate { it.descriptor to createAbiFile(it) }
     }
 
     private fun createAbiFile(module: IrModuleFragment): IrFile =
@@ -49,24 +53,16 @@ internal class InternalAbi(private val context: Context) {
     fun reference(function: IrFunction, module: ModuleDescriptor) {
         assert(function.isExternal) { "Function that represents external ABI should be marked as external" }
         context.llvmImports.add(module.llvmSymbolOrigin)
-        externalModules.getOrPut(module) {
+        externalAbiFiles.getOrPut(module) {
             createAbiFile(IrModuleFragmentImpl(module, context.irBuiltIns))
         }.addChild(function)
     }
 
     /**
-     * Generate name for declaration that will be a part of internal ABI.
+     * Adds [function] to a list of [module]'s publicly available symbols.
      */
-    fun getMangledNameFor(declarationName: String, parent: IrDeclarationParent): Name {
-        val prefix = parent.fqNameForIrSerialization
-        return "$prefix.$declarationName".synthesizedName
-    }
-
-    /**
-     * Adds [function] to a list of publicly available symbols.
-     */
-    fun declare(function: IrFunction) {
-        internalAbiFile.addChild(function)
+    fun declare(function: IrFunction, module: ModuleDescriptor) {
+        internalAbiFiles.getValue(module).addChild(function)
     }
 
     companion object {
@@ -74,5 +70,19 @@ internal class InternalAbi(private val context: Context) {
          * Allows to distinguish external declarations to internal ABI.
          */
         val INTERNAL_ABI_ORIGIN = object : IrDeclarationOriginImpl("INTERNAL_ABI") {}
+
+        fun getCompanionObjectAccessorName(companion: IrClass): Name =
+                getMangledNameFor("globalAccessor", companion)
+
+        fun getEnumValuesAccessorName(enum: IrClass): Name =
+                getMangledNameFor("getValues", enum)
+
+        /**
+         * Generate name for declaration that will be a part of internal ABI.
+         */
+        private fun getMangledNameFor(declarationName: String, parent: IrDeclarationParent): Name {
+            val prefix = parent.fqNameForIrSerialization
+            return "$prefix.$declarationName".synthesizedName
+        }
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
@@ -157,6 +157,8 @@ internal fun Context.psiToIr(symbolTable: SymbolTable) {
     // Note: coupled with [shouldLower] below.
     irModules = linker.modules.filterValues { llvmModuleSpecification.containsModule(it) }
 
+    internalAbi.init(irModules.values + irModule!!)
+
     ir.symbols = symbols
 
     functionIrClassFactory.module =


### PR DESCRIPTION
It fixes IrGetObjectValue evaluation in case of Lazy IR.