### PR TITLE
[kotlin compiler][update] 1.4.30-dev-374

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -45,6 +45,7 @@ import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
 object KonanFakeOverrideClassFilter : PlatformFakeOverrideClassFilter {
@@ -67,6 +68,7 @@ object KonanFakeOverrideClassFilter : PlatformFakeOverrideClassFilter {
 internal class KonanIrLinker(
         private val currentModule: ModuleDescriptor,
         override val functionalInterfaceFactory: IrAbstractFunctionFactory,
+        override val translationPluginContext: TranslationPluginContext?,
         logger: LoggingContext,
         builtIns: IrBuiltIns,
         symbolTable: SymbolTable,
@@ -219,4 +221,11 @@ internal class KonanIrLinker(
                     .filter { !it.key.isForwardDeclarationModule && it.value.moduleDescriptor !== currentModule }
                     .forEach { this.put(it.key.konanLibrary!!.libraryName, it.value.moduleFragment) }
         }
+    class KonanPluginContext(
+            override val moduleDescriptor: ModuleDescriptor,
+            override val bindingContext: BindingContext,
+            override val symbolTable: ReferenceSymbolTable,
+            override val typeTranslator: TypeTranslator,
+            override val irBuiltIns: IrBuiltIns
+    ):TranslationPluginContext
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -92,8 +92,6 @@ internal class KonanIrLinker(
     override fun isBuiltInModule(moduleDescriptor: ModuleDescriptor): Boolean = moduleDescriptor.isNativeStdlib()
 
     override val fakeOverrideBuilder = FakeOverrideBuilder(symbolTable, IdSignatureSerializer(KonanManglerIr), builtIns, KonanFakeOverrideClassFilter)
-    override val translationPluginContext: TranslationPluginContext?
-        get() = TODO("Not yet implemented")
 
     private val forwardDeclarationDeserializer = forwardModuleDescriptor?.let { KonanForwardDeclarationModuleDeserializer(it) }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-148,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-148
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-148,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-148
-kotlinStdlibTestsVersion=1.4.30-dev-148
-testKotlinCompilerVersion=1.4.30-dev-148
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-374,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-374
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-374,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-374
+kotlinStdlibTestsVersion=1.4.30-dev-374
+testKotlinCompilerVersion=1.4.30-dev-374
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 769c741d876 - (tag: build-1.4.30-dev-374, origin/rr/yunir/KTI-277) Revert "Pack jvm builtins into kotlin-stdlib shipped with idea plugin" (vor 3 Tagen) <Dmitry Savvinov>
* 6db70bb97d1 - (tag: build-1.4.30-dev-370) Minor: fix forgotten testdata after 6a554753922636c73f35ae00d61a577ee7d46f6d (vor 3 Tagen) <Dmitry Savvinov>
* 0b5aedb0a2c - (tag: build-1.4.30-dev-367) Pack jvm builtins into kotlin-stdlib shipped with idea plugin (vor 3 Tagen) <Ilya Gorbunov>
* f2cf64aec7a - (tag: build-1.4.30-dev-365) Create plugin context before launching actual psi2ir process. (vor 3 Tagen) <Leonid Startsev>
* ee3ada4e556 - (tag: build-1.4.30-dev-364) JVM_IR KT-40304 KT-41998 special handling for 'removeAt' (vor 3 Tagen) <Dmitry Petrov>
* 90089448601 - (tag: build-1.4.30-dev-361, tag: build-1.4.30-dev-359) Use target of the test in rerun dialog (vor 3 Tagen) <Kirill Shmakov>
* b406022315c - (tag: build-1.4.30-dev-357, tag: build-1.4.30-dev-344) Mark Unit unspillable if it is merged with unspillable Unit (vor 4 Tagen) <Ilmir Usmanov>
* f6e4705d9cf - (tag: build-1.4.30-dev-342) Regenerate KotlinSteppingTestGenerated (vor 4 Tagen) <Alexander Udalov>
* a62ffbf9923 - (tag: build-1.4.30-dev-341) [JVM_IR] Ignore fwBackingField stepping test. (vor 4 Tagen) <Mads Ager>
* 8343ca093c7 - (tag: build-1.4.30-dev-338, origin/rr/gogabr/remove-descriptors3) IR: bugfix in wrapped, IR-based descriptors (vor 4 Tagen) <Georgy Bronnikov>
* c2bdedfbaef - JVM_IR: remove descriptor usage from JvmSignatureClashDetector (vor 4 Tagen) <Georgy Bronnikov>
* c7f10c272a9 - JVM_IR: remove .toKotlinType() from PromisedValue (vor 4 Tagen) <Georgy Bronnikov>
* 7c5e255fa33 - JVM_IR: remove .toKotlinType() from IrInlineIntrinsicsSupport (vor 4 Tagen) <Georgy Bronnikov>
* 991a832d8c7 - JVM_IR: remove KotlinType reference from jvm/ir/IrUtils.kt (vor 4 Tagen) <Georgy Bronnikov>
* 3c0fbd5f45f - IR: remove .toKotlinType() usage from coerceToUnit calls in lowerings (vor 4 Tagen) <Georgy Bronnikov>
* 6a554753922 - (tag: build-1.4.30-dev-329) Dont show warning for KT-21515 with LV>=1.3 (vor 4 Tagen) <Dmitry Savvinov>
* 57ceb0fa20f - (tag: build-1.4.30-dev-324) [FIR] Don't create call to this in generated provideDelegate for top-level extension properies (vor 4 Tagen) <Dmitriy Novozhilov>
* a666eee67b9 - [FIR] Properly deserialize annotations on typealias and underlying type (vor 4 Tagen) <Dmitriy Novozhilov>
* 748049daa37 - [FIR] Don't call inline lambda twice in `withFullBodyResolve` (vor 4 Tagen) <Dmitriy Novozhilov>
* f9de2621b2b - [FIR] Minor, fix TODO in `constantValues` (vor 4 Tagen) <Dmitriy Novozhilov>
* 535de7bdc86 - [FIR] Cleanup code of FirTypeDeserializer.kt (vor 4 Tagen) <Dmitriy Novozhilov>
* 8deab3559ee - [FIR] Get rid of FirDeserializationComponents (vor 4 Tagen) <Dmitriy Novozhilov>
* d4cc98fab12 - [FIR] Safe VersionRequirementTable in deserialized declarations (vor 4 Tagen) <Dmitriy Novozhilov>
* 7c5160a968e - [FIR] Remove meaningless TODO's (vor 4 Tagen) <Dmitriy Novozhilov>
* 73c80598843 - [FIR] Properly deserialize arrays in annotation arguments (vor 4 Tagen) <Dmitriy Novozhilov>
* ae819ff0596 - [FIR] Add configurable typeRef to FirArrayOfCallBuilder (vor 4 Tagen) <Dmitriy Novozhilov>
* d4891cb4648 - [FIR] Move Jsr305State from FirSession to separate component (vor 4 Tagen) <Dmitriy Novozhilov>
* 93d63f7c66e - [FIR] Get rid of FirResolvedFunctionTypeRef (vor 4 Tagen) <Dmitriy Novozhilov>
* edab50ac61b - [FIR] Get rid of FirResolvedTypeRef.isSuspend (vor 4 Tagen) <Dmitriy Novozhilov>
* 6c5cf8eda35 - [FIR] Cleanup code in body resolve (vor 4 Tagen) <Dmitriy Novozhilov>
* d4038f35b6f - [FIR] Make BodyResolveComponents an abstract class (vor 4 Tagen) <Dmitriy Novozhilov>
* dfd7f33bd33 - Minor. Add test with reified type parameter (vor 4 Tagen) <Ilmir Usmanov>
* 9ecf5dc9af9 - Support is/as operations on suspend callable reference conversion (vor 4 Tagen) <Ilmir Usmanov>
* dfe6c42f631 - (tag: build-1.4.30-dev-309) Remove 203 version from idea range for kotlin plugin 1.4.20 (vor 4 Tagen) <Vladimir Dolzhenko>
* 985f2b839c2 - (tag: build-1.4.30-dev-308) Add regression tests to cover Unused symbol with private anonymous object property (vor 4 Tagen) <Vladimir Dolzhenko>
* d1ba69044e0 - (tag: build-1.4.30-dev-305) FIR: update the type of anonymous function as SAM (vor 4 Tagen) <Jinseong Jeon>
* f960201f529 - (tag: build-1.4.30-dev-302) Ignore type parameters of inline class (vor 4 Tagen) <Ilmir Usmanov>
* fbfe56e0cce - (tag: build-1.4.30-dev-301) JVM_IR KT-41915 compare Kotlin signatures when adding collection stubs (vor 4 Tagen) <Dmitry Petrov>
* 0e4bd70c297 - (tag: build-1.4.30-dev-300) Redundant nullable return type: fix false positive with elvis return (vor 4 Tagen) <Toshiaki Kameyama>
* 51d405e9508 - (tag: build-1.4.30-dev-298) Add json output for IDE performance tests (vor 4 Tagen) <Vladimir Dolzhenko>
* 72dea058542 - (tag: build-1.4.30-dev-296) FIR2IR: approximate type argument if reified (vor 4 Tagen) <Jinseong Jeon>
* 721248f8830 - FIR: migrate type-related utils to relevant file (vor 4 Tagen) <Jinseong Jeon>
* 0436a555d54 - [FIR serializer] Support type approximation (vor 4 Tagen) <Mikhail Glukhikh>
* 94a30ff9046 - [FIR] Drop redundant type check (vor 4 Tagen) <Mikhail Glukhikh>
* 4da7e762fe6 - (tag: build-1.4.30-dev-288, tag: build-1.4.30-dev-287) [IR] Skip hidden parameters in WrappedDescriptors (vor 5 Tagen) <Roman Artemev>
* 1da2830e2b6 - [IR] Support hidden parameters in ir builder (vor 5 Tagen) <Roman Artemev>
* b84084d54e1 - [IR] Support hidden parameters in IrMangler (vor 5 Tagen) <Roman Artemev>
* 8209b70a2f4 - [KLIB] Support `isHidden` flag in deserialization (vor 5 Tagen) <Roman Artemev>
* 83d62552944 - [KLIB] Support `isHidden` in proto flags (vor 5 Tagen) <Roman Artemev>
* f01941d1dd7 - [IR] Support `isHidden` is IrFactory API (vor 5 Tagen) <Roman Artemev>
* 79e2886da11 - [IR] Add `isHidden` flag into IrValueParameter (vor 5 Tagen) <Roman Artemev>
* be16fa76ab6 - (tag: build-1.4.30-dev-285) Wizard: fix not auto-updated artifactId on project name change (vor 5 Tagen) <Ilya Kirillov>
* ca3b3275922 - Wizard: add missing jvm target version for tests in Groovy DSL (vor 5 Tagen) <Ilya Kirillov>
* ee2f0f45fc6 - Wizard: ignore Kotlin repo in tests (vor 5 Tagen) <Ilya Kirillov>
* 9b157fd291d - (tag: build-1.4.30-dev-276, origin/build-1.4.20-dev-2960) JVM_IR: remove a descriptor-related hack from InterfaceLowering (vor 5 Tagen) <pyos>
* dd913ef4508 - JVM_IR: move common metadata serialization code to ClassCodegen (vor 5 Tagen) <pyos>
* a06181771f9 - IR: make DescriptorMetadataSource a subtype of MetadataSource (vor 5 Tagen) <pyos>
* 86cc5840ed3 - (tag: build-1.4.30-dev-275, tag: build-1.4.30-dev-272) JVM IR: unmute stepping test noParameterExtensionLambdaArgumentCallInInline3.kt (vor 5 Tagen) <Alexander Udalov>
* 0cccc61654d - JVM IR: unmute stepping test smartStepIntoInterfaceImpl.kt (vor 5 Tagen) <Alexander Udalov>
* e943d762662 - (tag: build-1.4.30-dev-271) [JVM_IR] Rebase fwBackingField stepping test. (vor 5 Tagen) <Mads Ager>
* cfc1ebb4bec - (tag: build-1.4.30-dev-264) [FIR] Support several annotation argument diagnostics (vor 5 Tagen) <Лихолетов Михаил>
* 0c13d3197ce - [FIR] Fix non-serializable type argument at the end of resolve (vor 5 Tagen) <Mikhail Glukhikh>
* 54d5494ecd5 - (tag: build-1.4.30-dev-259) JVM_IR special handling for 'remove' collection method stub (vor 5 Tagen) <Dmitry Petrov>
* e6e47f8848a - (tag: build-1.4.30-dev-257) Make watchOS test runnable on another bitness (vor 5 Tagen) <Kirill Shmakov>
* c56952a01eb - (tag: build-1.4.30-dev-252) Provide message collector for Java IC analysis (vor 5 Tagen) <Alexey Tsvetkov>
* 17db188b0ef - (tag: build-1.4.30-dev-251) Add regression test for already fixed issue KT-41396 (vor 5 Tagen) <Victor Petukhov>
* b202cf0f557 - Apply suggestions from code review (vor 11 Tagen) <1anisim>
* 33d3e1f13ec - Update ReadMe.md (vor 11 Tagen) <1anisim>
* cf9f120d550 - Update ReadMe.md (vor 13 Tagen) <1anisim>
* 57ebd0e13aa - (tag: build-1.4.30-dev-243) [FIR IDE] Remove unused code and add logging to LightClassProvider (vor 5 Tagen) <Igor Yakovlev>
* be4fcd626c0 - [FIR IDE] Separate searchers from descriptor usage (vor 5 Tagen) <Igor Yakovlev>
* 36e62471256 - (tag: build-1.4.30-dev-237) Add more details about bit shift operations #KT-41112 (vor 5 Tagen) <Abduqodiri Qurbonzoda>
* 1c0ac850e85 - Incorrect documentation for `rangeTo` function #KT-41356 (vor 5 Tagen) <Abduqodiri Qurbonzoda>
* 56c4a278874 - (tag: build-1.4.30-dev-231) Android Synthetics: Resolve unbound symbols in the AndroidIrExtension (vor 6 Tagen) <Steven Schäfer>
* fe466f3dc6b - Android Synthetics: Update test infrastructure (vor 6 Tagen) <Steven Schäfer>
* fb183ec3f80 - (tag: build-1.4.30-dev-222) Never use JVM IR to compile coroutines-experimental (vor 6 Tagen) <Alexander Udalov>
* f6187b9d649 - Remove dependency of fir:tree:tree-generator on kotlin-reflect (vor 6 Tagen) <Alexander Udalov>
* 58146c4452e - (tag: build-1.4.30-dev-221) Keep DebugMetadata annotation when regenerate lambda with state-machine (vor 6 Tagen) <Ilmir Usmanov>
* 12489ef1b46 - (tag: build-1.4.30-dev-219) Show run test gutters only when appropriate (vor 6 Tagen) <Kirill Shmakov>
* 8cabfda832f - (tag: build-1.4.30-dev-218) Add regression test for already fixed issue KT-41885 (vor 6 Tagen) <Victor Petukhov>
* 7c360c0068e - (tag: build-1.4.30-dev-211) Kotlin Gradle plugin - use build service to share incremental compilation info (vor 6 Tagen) <Ivan Gavrilovic>
* 16d51eb5106 - (tag: build-1.4.30-dev-207) [FIR IDE] Add ReadWriteAccessChecker FIR stub (vor 6 Tagen) <Igor Yakovlev>
* 7a19bc32a79 - [FIR IDE] Add base implementation of find usages of overrides (vor 6 Tagen) <Igor Yakovlev>
* f05630fcabf - [FIR IDE] Enabled search services and added services stubs (vor 6 Tagen) <Igor Yakovlev>
* 1a10275d0de - [FIR IDE] Enabled usages services and added services stubs (vor 6 Tagen) <Igor Yakovlev>
* 75347d06b9c - [FIR IDE] Move IconProvider in fir independed module (vor 6 Tagen) <Igor Yakovlev>
* e30f09d513b - [FIR IDE] Separate find usages logic from descriptors (vor 6 Tagen) <Igor Yakovlev>
* b102042dd87 - (tag: build-1.4.30-dev-206) Minor: add regression test for KT-41806 (vor 6 Tagen) <Pavel Kirpichenkov>
* 2fad935ce23 - (tag: build-1.4.30-dev-205) FIR deserializer: load inline/external flags properly (vor 6 Tagen) <Jinseong Jeon>
* 2154c941006 - (tag: build-1.4.30-dev-204) [Native] Add tests for resolvable properties (vor 6 Tagen) <Sergey Bogolepov>
* 5a0a853d9bc - [Native] Add simple symbol mechanism to konan.properties (vor 6 Tagen) <Sergey Bogolepov>
* fc35b5398c7 - (tag: build-1.4.30-dev-196) Mute test in Native (vor 7 Tagen) <Pavel Punegov>
* 0b2d05ee301 - (tag: build-1.4.30-dev-193) Minor: dereference `archiveFile` when logging it (vor 7 Tagen) <Nikita Bobko>
* c64c3192315 - (tag: build-1.4.30-dev-190) JPS. Suppress "Add new files to git" during portable artifacts extraction (vor 7 Tagen) <Aleksei Cherepanov>
* 7e2269a3cfd - (tag: build-1.4.30-dev-186) Update `completion-ranking-kotlin` dependency (0.1.2 -> 0.1.3) (vor 7 Tagen) <Roman Golyshev>
* 97ebf2867a3 - (tag: build-1.4.30-dev-184) [FIR] Get rid of type mismatch suppression during diagnostic casting (vor 7 Tagen) <Mikhail Glukhikh>
* 6fd3b011ca6 - [FIR] Simplify substitution for unsafe-variant type parameter types (vor 7 Tagen) <Mikhail Glukhikh>
* e1b4108e4a1 - [FIR2IR] Mute some tests due to captured type problems (vor 7 Tagen) <Mikhail Glukhikh>
* aa897db132e - [FIR] Introduce UnsafeVariance attribute (see KT-41792) (vor 7 Tagen) <Mikhail Glukhikh>
* e4aaae9ae78 - FIR call completion: approximate type argument types (vor 7 Tagen) <Mikhail Glukhikh>
* 3b828ac62b6 - [FIR] Bad test data fixes (around captured types) (vor 7 Tagen) <Mikhail Glukhikh>
* cf5480a398a - [FIR] Questionable test data fixes (around captured types) (vor 7 Tagen) <Mikhail Glukhikh>
* 4605a65f415 - [FIR] Good test data fixes (around captured types) (vor 7 Tagen) <Mikhail Glukhikh>
* c2d9fc469a3 - Get rid of exception at ConeKotlinType.varargElementType (vor 7 Tagen) <Mikhail Glukhikh>
* 2f61a2f56f5 - [FIR] Provide correct comparison of captured types (vor 7 Tagen) <Mikhail Glukhikh>
* b5f8fec2133 - FIR substitution: use standard approximation to remove captured types (vor 7 Tagen) <Mikhail Glukhikh>
* 7a737876806 - [FIR] Use captureFromArguments in createSubstitution (vor 7 Tagen) <Mikhail Glukhikh>
* e83f3bbf043 - Introduce substitution to ConeTypeContext.captureFromArguments (vor 7 Tagen) <Mikhail Glukhikh>
* 414842343d8 - [FIR2IR] Add another problematic test with captured type argument (vor 7 Tagen) <Mikhail Glukhikh>
* 267382d86b0 - [FIR2IR] Add problematic test with incorrect type argument (vor 7 Tagen) <Mikhail Glukhikh>
* b395771d01c - (tag: build-1.4.30-dev-178) KT-37050 don't generate redundant special bridges (vor 7 Tagen) <Dmitry Petrov>
* f0282bcfdfe - (tag: build-1.4.30-dev-172) JVM IR: add module name for internal functions before "$default" (vor 7 Tagen) <Alexander Udalov>
* 93f38e1c619 - JVM IR: minor, use more specific types in MethodSignatureMapper (vor 7 Tagen) <Alexander Udalov>
* 2a0f64ebcb8 - JVM IR: do not generate Deprecated(HIDDEN) class as synthetic (vor 7 Tagen) <Alexander Udalov>
* 162dc3aa0c6 - (tag: build-1.4.30-dev-166) KT-41295: Friend paths and compiler options compatible with conf caching (vor 7 Tagen) <Ivan Gavrilovic>
* be916e556a1 - (tag: build-1.4.30-dev-165) [FIR] Properly update type of block after postponed analysis of it's content (vor 7 Tagen) <Dmitriy Novozhilov>
* 535898c8a4b - [FIR] Fix processing integer operator calls for not integer types (vor 7 Tagen) <Dmitriy Novozhilov>
* def647c0941 - [FIR] Don't constraints for return expressions of lambda if it has Unit return type (vor 7 Tagen) <Dmitriy Novozhilov>
* 8e0d0d2fd86 - Remove redundant safe call to fix FIR compilation (vor 7 Tagen) <Dmitriy Novozhilov>
* 4929417aea1 - Remove redundant type arguments to fix compilation with FIR (vor 7 Tagen) <Dmitriy Novozhilov>
* 324aaaddad8 - [FIR] Rename `createArrayOf` to `createArrayType` (vor 7 Tagen) <Dmitriy Novozhilov>
* 3b941a8f437 - [FIR] Complete types of array literals in annotations (vor 7 Tagen) <Dmitriy Novozhilov>
* fbe964c0742 - [FIR] Transform annotations on safe calls (vor 7 Tagen) <Dmitriy Novozhilov>
* 0bd7de158c5 - (tag: build-1.4.30-dev-154, tag: build-1.4.30-dev-149) FIR: update suspend lambda type during declaration resolution (vor 7 Tagen) <Jinseong Jeon>