### PR TITLE
Show all errors in cInterop task

### DIFF
--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/Utils.kt
@@ -148,8 +148,11 @@ private fun Diagnostic.isError() = (severity == CXDiagnosticSeverity.CXDiagnosti
 internal fun CXTranslationUnit.hasCompileErrors() = (this.getCompileErrors().firstOrNull() != null)
 
 internal fun CXTranslationUnit.ensureNoCompileErrors(): CXTranslationUnit {
-    val firstError = this.getCompileErrors().firstOrNull() ?: return this
-    throw Error(firstError)
+    val errors = this.getCompileErrors()
+    if (errors.isEmpty()) return this
+    
+    val errorDescription = errors.joinToString { it.toString() } 
+    throw Error(errorDescription)
 }
 
 internal typealias CursorVisitor = (cursor: CValue<CXCursor>, parent: CValue<CXCursor>) -> CXChildVisitResult


### PR DESCRIPTION
Now when cInterop task failed in gradle log showed only first line. For example:
```
Exception in thread "main" java.lang.Error: /var/folders/c6/fcjx052j7jx6dn5jdygs4_h00000gp/T/tmp8468429452304852533.m:1:9: fatal error: could not build module 'MapboxNavigation'
	at org.jetbrains.kotlin.native.interop.indexer.UtilsKt.ensureNoCompileErrors(Utils.kt:152)
	at org.jetbrains.kotlin.native.interop.indexer.ModuleSupportKt.getModulesASTFiles(ModuleSupport.kt:67)
	at org.jetbrains.kotlin.native.interop.indexer.ModuleSupportKt.getModulesInfo(ModuleSupport.kt:13)
	at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.buildNativeLibrary(main.kt:499)
	at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.processCLib(main.kt:264)
	at org.jetbrains.kotlin.native.interop.gen.jvm.MainKt.interop(main.kt:72)
	at org.jetbrains.kotlin.cli.utilities.InteropCompilerKt.invokeInterop(InteropCompiler.kt:45)
	at org.jetbrains.kotlin.cli.utilities.MainKt.mainImpl(main.kt:19)
	at org.jetbrains.kotlin.cli.utilities.MainKt.main(main.kt:37)
Task :maps-mapbox:cinteropCocoapodMapboxNavigationIosX64 in maps Finished
```
only the first error may not be enough for analysis and fix. Will be better if all compile errors will be showed in error report - it is done in this PR.