### PR TITLE
Advance LLDB bundles to 10th version

### DIFF
--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -80,7 +80,7 @@ osVersionMinFlagClang.macos_x64 = -mmacosx-version-min
 osVersionMin.macos_x64 = 10.11
 dependencies.macos_x64 = \
     libffi-3.2.1-3-darwin-macos \
-    lldb-2-macos
+    lldb-3-macos
 
 target-sysroot-xcode_11_5-macos_x64.default = \
   remote:internal
@@ -309,7 +309,7 @@ targetToolchain.linux_x64 = target-gcc-toolchain-3-linux-x86-64/x86_64-unknown-l
 dependencies.linux_x64 = \
     target-gcc-toolchain-3-linux-x86-64 \
     libffi-3.2.1-2-linux-x86-64 \
-    lldb-2-linux
+    lldb-3-linux
 
 gccToolchain.mingw_x64 = target-gcc-toolchain-3-linux-x86-64
 targetToolchain.mingw_x64-linux_x64 = msys2-mingw-w64-x86_64-clang-llvm-lld-compiler_rt-8.0.1
@@ -583,6 +583,7 @@ libffiDir.mingw_x64 = libffi-3.2.1-mingw-w64-x86-64
 
 targetToolchain.linux_x64-mingw_x64 = msys2-mingw-w64-x86_64-clang-llvm-lld-compiler_rt-8.0.1
 targetToolchain.macos_x64-mingw_x64 = msys2-mingw-w64-x86_64-clang-llvm-lld-compiler_rt-8.0.1
+# for Windows we are currently using LLDB 9
 dependencies.mingw_x64 = \
     libffi-3.2.1-mingw-w64-x86-64 \
     lldb-2-windows


### PR DESCRIPTION
Since we dont have 10th LLDB for Windows currently, only
MacOS and Linux are advanced.

This relates to #KT-41716