### PR TITLE
Don't allow GC in BackRefFromAssociatedObject::tryAddRef

### DIFF
--- a/backend.native/tests/interop/objc/tests/tryRetainGC.h
+++ b/backend.native/tests/interop/objc/tests/tryRetainGC.h
@@ -1,0 +1,6 @@
+#import <Foundation/NSObject.h>
+
+@interface WeakRefHolder : NSObject
+@property (weak) id obj;
+-(void)loadManyTimes;
+@end;

--- a/backend.native/tests/interop/objc/tests/tryRetainGC.kt
+++ b/backend.native/tests/interop/objc/tests/tryRetainGC.kt
@@ -1,0 +1,25 @@
+import kotlinx.cinterop.*
+import kotlin.test.*
+import objcTests.*
+
+@Test
+fun testTryRetainGC() {
+    kotlin.native.internal.GC.collect()
+    val weakRefHolder = WeakRefHolder()
+    createGarbageNSObjects(weakRefHolder)
+    weakRefHolder.obj = object : NSObject() {}
+    // Loading weak ref takes a lock. If K/N runtime runs GC while the lock is taken,
+    // then it releases garbage objects and thus Obj-C runtime might take a recursive lock
+    // and abort in _os_unfair_lock_recursive_abort.
+    weakRefHolder.loadManyTimes()
+}
+
+private fun createGarbageNSObjects(weakRefHolder: WeakRefHolder) {
+    autoreleasepool {
+        repeat(100) {
+            // Assigning the object to a weak reference so Obj-C would take a lock when deallocating it:
+            weakRefHolder.obj = NSObject()
+        }
+        weakRefHolder.obj = null
+    }
+}

--- a/backend.native/tests/interop/objc/tests/tryRetainGC.m
+++ b/backend.native/tests/interop/objc/tests/tryRetainGC.m
@@ -1,0 +1,11 @@
+#import "tryRetainGC.h"
+#import <Foundation/NSArray.h>
+
+@implementation WeakRefHolder
+-(void)loadManyTimes {
+    NSMutableArray* array = [NSMutableArray new];
+    for (int i = 0; i < 10000; ++i) {
+        [array addObject:self.obj];
+    }
+}
+@end;

--- a/runtime/src/main/cpp/MemoryPrivate.hpp
+++ b/runtime/src/main/cpp/MemoryPrivate.hpp
@@ -24,6 +24,7 @@ extern "C" {
 bool TryAddHeapRef(const ObjHeader* object);
 
 MODEL_VARIANTS(void, ReleaseHeapRef, const ObjHeader* object);
+MODEL_VARIANTS(void, ReleaseHeapRefNoCollect, const ObjHeader* object);
 
 void Kotlin_ObjCExport_releaseAssociatedObject(void* associatedObject);
 

--- a/runtime/src/main/cpp/MemorySharedRefs.cpp
+++ b/runtime/src/main/cpp/MemorySharedRefs.cpp
@@ -153,7 +153,7 @@ bool BackRefFromAssociatedObject::tryAddRef() {
   RuntimeAssert(isForeignRefAccessible(obj_, context_), "Cannot be inaccessible because of the check above");
   // TODO: This is a very weird way to ask for "unsafe" addRef.
   addRef<ErrorPolicy::kIgnore>();
-  ReleaseHeapRef(obj); // Balance TryAddHeapRef.
+  ReleaseHeapRefNoCollect(obj); // Balance TryAddHeapRef.
   // TODO: consider optimizing for non-shared objects.
 
   return true;

--- a/runtime/src/relaxed/cpp/MemoryImpl.cpp
+++ b/runtime/src/relaxed/cpp/MemoryImpl.cpp
@@ -33,6 +33,10 @@ void ReleaseHeapRef(const ObjHeader* object) {
   ReleaseHeapRefRelaxed(object);
 }
 
+void ReleaseHeapRefNoCollect(const ObjHeader* object) {
+  ReleaseHeapRefNoCollectRelaxed(object);
+}
+
 void ZeroStackRef(ObjHeader** location) {
   ZeroStackRefRelaxed(location);
 }

--- a/runtime/src/strict/cpp/MemoryImpl.cpp
+++ b/runtime/src/strict/cpp/MemoryImpl.cpp
@@ -33,6 +33,10 @@ void ReleaseHeapRef(const ObjHeader* object) {
   ReleaseHeapRefStrict(object);
 }
 
+void ReleaseHeapRefNoCollect(const ObjHeader* object) {
+  ReleaseHeapRefNoCollectStrict(object);
+}
+
 void SetStackRef(ObjHeader** location, const ObjHeader* object) {
   SetStackRefStrict(location, object);
 }


### PR DESCRIPTION
This function is invoked while a non-recursive os_lock is taken,
and GC can provoke Obj-C object deallocation taking the same lock
recursively.