### PR TITLE
Allow registering zero events in test run statistics

### DIFF
--- a/runtime/src/main/kotlin/kotlin/native/internal/test/GTestLogger.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/test/GTestLogger.kt
@@ -19,12 +19,12 @@ internal class GTestLogger : TestLoggerWithStatistics() {
         }
         super.startIteration(runner, iteration, suites)
         println("[==========] Running ${suites.totalTestsNotIgnored} tests from ${suites.totalNotIgnored} test cases.")
-        // Just hack to deal with the Clion parser. TODO: Remove it after changes in the parser.
+        // Just hack to deal with GTest output parsers.
         println("[----------] Global test environment set-up.")
     }
 
     private fun printResults(timeMillis: Long) = with (statistics) {
-        println("[----------] Global test environment tear-down") // Just hack to deal with the Clion parser.
+        println("[----------] Global test environment tear-down") // Just hack to deal with GTest output parsers.
         println("[==========] $total tests from $totalSuites test cases ran. ($timeMillis ms total)")
         println("[  PASSED  ] $passed tests.")
         if (hasFailedTests) {

--- a/runtime/src/main/kotlin/kotlin/native/internal/test/TestStatistics.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/test/TestStatistics.kt
@@ -36,12 +36,12 @@ internal class MutableTestStatistics: TestStatistics {
         get() = _failedTests
 
     fun registerSuite(count: Int = 1) {
-        require(count > 0)
+        require(count >= 0)
         totalSuites += count
     }
 
     fun registerPass(count: Int = 1) {
-        require(count > 0)
+        require(count >= 0)
         total += count
         passed += count
     }
@@ -54,7 +54,7 @@ internal class MutableTestStatistics: TestStatistics {
     fun registerFail(testCase: TestCase) = registerFail(listOf(testCase))
 
     fun registerIgnore(count: Int = 1) {
-        require(count > 0)
+        require(count >= 0)
         total += count
         ignored += count
     }


### PR DESCRIPTION
We represent an ignored test suite in tests statistics just by
registering all its test cases as ignored. The registering method
expects a non-zero number of ignored tests. But a suite may contain
zero test cases, e.g. when all of them were filtered out by CLI options.

In this case the registering will fail (see #3817).

This patch fixes it by allowing registering zero events in all statistics
methods.