### PR TITLE
Add jcenter and maven central as backup repositories

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/maven-central'
         }
+        mavenCentral()
         maven {
             url buildKotlinCompilerRepo
         }

--- a/build-tools/build.gradle.kts
+++ b/build-tools/build.gradle.kts
@@ -39,6 +39,7 @@ repositories {
     maven(kotlinCompilerRepo)
     maven(buildKotlinCompilerRepo)
     maven("https://cache-redirector.jetbrains.com/maven-central")
+    mavenCentral()
     maven("https://kotlin.bintray.com/kotlinx")
     maven("https://dl.bintray.com/kotlin/kotlin-dev")
 }

--- a/build-tools/settings.gradle.kts
+++ b/build-tools/settings.gradle.kts
@@ -9,6 +9,7 @@ pluginManagement {
     repositories {
         maven(kotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
+        mavenCentral()
     }
 
     resolutionStrategy {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
         maven { url kotlinCompilerRepo }
         maven { url "https://kotlin.bintray.com/kotlinx" }
         maven { url "https://cache-redirector.jetbrains.com/maven-central" }
+        mavenCentral()
         maven { url "https://dl.bintray.com/kotlin/kotlin-dev" }
         jcenter()
     }
@@ -104,6 +105,7 @@ allprojects {
             maven {
                 url 'https://cache-redirector.jetbrains.com/jcenter'
             }
+            jcenter()
             maven { url "https://dl.bintray.com/kotlin/kotlin-dev" }
         }
     }
@@ -115,6 +117,7 @@ allprojects {
         maven {
             url 'https://cache-redirector.jetbrains.com/maven-central'
         }
+        mavenCentral()
         maven {
             url kotlinStdlibRepo
         }

--- a/endorsedLibraries/build.gradle
+++ b/endorsedLibraries/build.gradle
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.EndorsedLibraryInfo
 buildscript {
     repositories {
         maven { url 'https://cache-redirector.jetbrains.com/jcenter' }
+        jcenter()
     }
 
     dependencies {

--- a/endorsedLibraries/kotlinx.cli/build.gradle
+++ b/endorsedLibraries/kotlinx.cli/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/jcenter'
         }
+        jcenter()
         maven {
             url kotlinCompilerRepo
         }
@@ -22,6 +23,7 @@ repositories {
     maven {
         url 'https://cache-redirector.jetbrains.com/jcenter'
     }
+    jcenter()
     maven {
         url kotlinCompilerRepo
     }

--- a/gradle/kotlinGradlePlugin.gradle
+++ b/gradle/kotlinGradlePlugin.gradle
@@ -16,6 +16,7 @@ project.buildscript.repositories {
     maven {
         url 'https://cache-redirector.jetbrains.com/maven-central'
     }
+    mavenCentral()
 }
 
 project.buildscript.dependencies {

--- a/performance/KotlinVsSwift/build.gradle
+++ b/performance/KotlinVsSwift/build.gradle
@@ -4,6 +4,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/jcenter'
         }
+        jcenter()
     }
 }
 

--- a/performance/build.gradle
+++ b/performance/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/jcenter'
         }
+        jcenter()
     }
 }
 

--- a/performance/framework/build.gradle
+++ b/performance/framework/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/jcenter'
         }
+        jcenter()
     }
 }
 
@@ -19,6 +20,7 @@ repositories {
     maven {
         url 'https://cache-redirector.jetbrains.com/jcenter'
     }
+    jcenter()
     maven {
         url kotlinCompilerRepo
     }

--- a/platformLibs/build.gradle
+++ b/platformLibs/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/maven-central'
         }
+        mavenCentral()
         maven {
             url buildKotlinCompilerRepo
         }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -37,6 +37,7 @@ version = konanVersion
 
 repositories {
     maven("https://cache-redirector.jetbrains.com/maven-central")
+    mavenCentral()
     maven(kotlinCompilerRepo)
     maven(buildKotlinCompilerRepo)
 }

--- a/shared/settings.gradle.kts
+++ b/shared/settings.gradle.kts
@@ -9,6 +9,7 @@ pluginManagement {
     repositories {
         maven(kotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
+        mavenCentral()
     }
 
     resolutionStrategy {

--- a/tools/benchmarksAnalyzer/build.gradle
+++ b/tools/benchmarksAnalyzer/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/jcenter'
         }
+        jcenter()
         maven {
             url kotlinCompilerRepo
         }
@@ -24,6 +25,7 @@ repositories {
     maven {
         url 'https://cache-redirector.jetbrains.com/jcenter'
     }
+    jcenter()
     maven {
         url kotlinCompilerRepo
     }

--- a/tools/kotlin-native-gradle-plugin/build.gradle
+++ b/tools/kotlin-native-gradle-plugin/build.gradle
@@ -26,10 +26,11 @@ buildscript {
         maven {
             url = 'https://cache-redirector.jetbrains.com/jcenter'
         }
+        jcenter()
         maven {
             url "https://cache-redirector.jetbrains.com/plugins.gradle.org/m2/"
         }
-        jcenter()
+        gradlePluginPortal()
     }
 
     dependencies {

--- a/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/MultiplatformSpecification.groovy
+++ b/tools/kotlin-native-gradle-plugin/src/test/groovy/org/jetbrains/kotlin/gradle/plugin/test/MultiplatformSpecification.groovy
@@ -34,6 +34,7 @@ class MultiplatformSpecification extends BaseKonanSpecification {
                 maven {
                    url = 'https://cache-redirector.jetbrains.com/jcenter'
                 }
+                jcenter()
             }
             dependencies {
                 classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
@@ -49,6 +50,7 @@ class MultiplatformSpecification extends BaseKonanSpecification {
             maven {
                url = 'https://cache-redirector.jetbrains.com/jcenter'
             }
+            jcenter()
         }
 
         dependencies {

--- a/tools/performance-server/build.gradle
+++ b/tools/performance-server/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/jcenter'
         }
+        jcenter()
         maven {
             url kotlinCompilerRepo
         }
@@ -24,6 +25,7 @@ repositories {
     maven {
         url 'https://cache-redirector.jetbrains.com/jcenter'
     }
+    jcenter()
     maven {
         url kotlinCompilerRepo
     }

--- a/tools/performance-server/ui/build.gradle
+++ b/tools/performance-server/ui/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         maven {
             url 'https://cache-redirector.jetbrains.com/jcenter'
         }
+        jcenter()
         maven {
             url kotlinCompilerRepo
         }
@@ -30,6 +31,7 @@ repositories {
     maven {
         url 'https://cache-redirector.jetbrains.com/jcenter'
     }
+    jcenter()
     maven {
         url kotlinCompilerRepo
     }


### PR DESCRIPTION
While having a cache redirector for Maven repositories makes sense for JetBrains when working internally, it can be a burden on those contributing to kotlin-native. In my experience, sometimes the resolution of dependencies from the cache redirector fails where the original repositories would succeed. This pull request adds `mavenCentral()` and `jcenter()` *after* their respective cache redirector declarations where these redirectors are used, to allow resolution of these dependencies outside of JetBrains' network.