### PR TITLE
[kotlin compiler][update] 1.4.30-dev-1260

### DIFF
--- a/Interop/StubGenerator/build.gradle
+++ b/Interop/StubGenerator/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     api "org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"
     api "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
-    api "org.jetbrains.kotlinx:kotlinx-metadata-klib:0.0.1-dev-9"
+    api "org.jetbrains.kotlinx:kotlinx-metadata-klib:0.0.1-dev-10"
 
     testImplementation "junit:junit:4.12"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$buildKotlinVersion"

--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrMetadataEmitter.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/StubIrMetadataEmitter.kt
@@ -359,7 +359,7 @@ private class MappingExtensions(
 
     val ConstructorStub.flags: Flags
         get() = flagsOfNotNull(
-                isSecondaryConstructorFlag.takeIf { !isPrimary },
+                Flag.Constructor.IS_SECONDARY.takeIf { !isPrimary },
                 Flag.HAS_ANNOTATIONS.takeIf { annotations.isNotEmpty() }
         ) or visibility.flags
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/common/AbstractValueUsageTransformer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/common/AbstractValueUsageTransformer.kt
@@ -61,6 +61,9 @@ internal abstract class AbstractValueUsageTransformer(
     private fun IrExpression.useForVariable(variable: IrVariable): IrExpression =
             this.useAsValue(variable)
 
+    private fun IrExpression.useForValue(value: IrValueDeclaration) =
+            this.useAsValue(value)
+
     private fun IrExpression.useForField(field: IrField): IrExpression =
             this.useAs(field.type)
 
@@ -144,10 +147,10 @@ internal abstract class AbstractValueUsageTransformer(
         return expression
     }
 
-    override fun visitSetVariable(expression: IrSetVariable): IrExpression {
+    override fun visitSetValue(expression: IrSetValue): IrExpression {
         expression.transformChildrenVoid(this)
 
-        expression.value = expression.value.useForVariable(expression.symbol.owner)
+        expression.value = expression.value.useForValue(expression.symbol.owner)
 
         return expression
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -217,7 +217,7 @@ internal val tailrecPhase = makeKonanFileLoweringPhase(
 
 internal val defaultParameterExtentPhase = makeKonanFileOpPhase(
         { context, irFile ->
-            DefaultArgumentStubGenerator(context, skipInlineMethods = false).lower(irFile)
+            KonanDefaultArgumentStubGenerator(context).lower(irFile)
             DefaultParameterCleaner(context, replaceDefaultValuesWithStubs = true).lower(irFile)
             KonanDefaultParameterInjector(context).lower(irFile)
         },

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/KonanSharedVariablesManager.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/KonanSharedVariablesManager.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
 import org.jetbrains.kotlin.ir.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
-import org.jetbrains.kotlin.ir.expressions.IrSetVariable
+import org.jetbrains.kotlin.ir.expressions.IrSetValue
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrCompositeImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
@@ -87,7 +87,7 @@ internal class KonanSharedVariablesManager(val context: KonanBackendContext) : S
                 )
             }
 
-    override fun setSharedValue(sharedVariableSymbol: IrVariableSymbol, originalSet: IrSetVariable) =
+    override fun setSharedValue(sharedVariableSymbol: IrVariableSymbol, originalSet: IrSetValue) =
             IrCallImpl(originalSet.startOffset, originalSet.endOffset, context.irBuiltIns.unitType,
                     elementProperty.setter!!.symbol).apply {
                 dispatchReceiver = IrGetValueImpl(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumByValueFunctionGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumByValueFunctionGenerator.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.irCall
 import org.jetbrains.kotlin.psi2ir.generators.GeneratorContext
+import org.jetbrains.kotlin.util.OperatorNameConventions
 
 /**
  * Generate IR for function that returns appropriate enum entry for the provided integral value.
@@ -58,7 +59,7 @@ internal class CEnumByValueFunctionGenerator(
                     irCall.dispatchReceiver = irGet(values)
                 }
                 val getElementFn = symbols.arrayGet.getValue(arrayClass)
-                val plusFun = symbols.intPlusInt
+                val plusFun = symbols.getBinaryOperator(OperatorNameConventions.PLUS, irBuiltIns.intType, irBuiltIns.intType)
                 val lessFunctionSymbol = irBuiltIns.lessFunByOperandType.getValue(irBuiltIns.intClass)
                 +irWhile().also { loop ->
                     loop.condition = irCall(lessFunctionSymbol, irBuiltIns.booleanType).also { irCall ->

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/IrToBitcode.kt
@@ -9,6 +9,7 @@ import kotlinx.cinterop.*
 import llvm.*
 import org.jetbrains.kotlin.backend.common.ir.ir2string
 import org.jetbrains.kotlin.backend.common.ir.allParameters
+import org.jetbrains.kotlin.backend.common.ir.allParametersCount
 import org.jetbrains.kotlin.backend.common.lower.inline.InlinerExpressionLocationHint
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.descriptors.*
@@ -2013,7 +2014,7 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
     private fun getContinuation(): LLVMValueRef {
         val caller = functionGenerationContext.irFunction!!
         return if (caller.isSuspend)
-            codegen.param(caller, caller.allParameters.size)    // The last argument.
+            codegen.param(caller, caller.allParametersCount)    // The last argument.
         else {
             // Suspend call from non-suspend function - must be [invokeSuspend].
             assert ((caller as IrSimpleFunction).overrides(context.ir.symbols.invokeSuspendFunction.owner),
@@ -2033,10 +2034,10 @@ internal class CodeGeneratorVisitor(val context: Context, val lifetimes: Map<IrE
         val result = expression.getArgumentsWithIr().map { (_, argExpr) ->
             evaluateExpression(argExpr)
         }
-        val explicitParametersSize = expression.symbol.owner.explicitParameters.size
-        if (result.size != explicitParametersSize) {
+        val explicitParametersCount = expression.symbol.owner.explicitParametersCount
+        if (result.size != explicitParametersCount) {
             error("Number of arguments explicitly represented in the IR ${result.size} differs from expected " +
-                    "$explicitParametersSize in ${ir2string(expression)}")
+                    "$explicitParametersCount in ${ir2string(expression)}")
         }
         return result
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/VariableManager.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/VariableManager.kt
@@ -33,7 +33,7 @@ internal class VariableManager(val functionGenerationContext: FunctionGeneration
 
     inner class ParameterRecord(val address: LLVMValueRef, val refSlot: Boolean) : Record {
         override fun load() : LLVMValueRef = functionGenerationContext.loadSlot(address, false)
-        override fun store(value: LLVMValueRef) = throw Error("writing to parameter")
+        override fun store(value: LLVMValueRef) = functionGenerationContext.store(value, address)
         override fun address() : LLVMValueRef = this.address
         override fun toString() = (if (refSlot) "refslot" else "slot") + " for ${address}"
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.backend.konan.llvm.objcexport
 
 import llvm.*
 import org.jetbrains.kotlin.backend.common.ir.allParameters
+import org.jetbrains.kotlin.backend.common.ir.allParametersCount
 import org.jetbrains.kotlin.backend.common.ir.simpleFunctions
 import org.jetbrains.kotlin.backend.konan.*
 import org.jetbrains.kotlin.backend.konan.descriptors.*
@@ -982,7 +983,7 @@ private fun ObjCExportCodeGenerator.generateKotlinToObjCBridge(
                     }
 
                 MethodBridgeValueParameter.SuspendCompletion -> {
-                    val continuation = param(irFunction.allParameters.size) // The last argument.
+                    val continuation = param(irFunction.allParametersCount) // The last argument.
                     // TODO: consider placing interception into the converter to reduce code size.
                     val intercepted = callFromBridge(
                             context.ir.symbols.objCExportInterceptedContinuation.owner.llvmFunction,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -121,7 +121,6 @@ private class AutoboxingTransformer(val context: Context) : AbstractValueUsageTr
 
             else -> this.type
         }
-
         return this.adaptIfNecessary(actualType, type)
     }
 
@@ -466,6 +465,12 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
                         }
 
                         parameterMapping[expression.symbol]?.let { return irGet(it) }
+                        return expression
+                    }
+
+                    override fun visitSetValue(expression: IrSetValue): IrExpression {
+                        expression.transformChildrenVoid()
+                        parameterMapping[expression.symbol]?.let { return irSet(it.symbol, expression.value) }
                         return expression
                     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -98,7 +98,8 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                                 type = context.irBuiltIns.anyNType,
                                 varargElementType = null,
                                 isCrossinline = arg.isCrossinline,
-                                isNoinline = arg.isNoinline
+                                isNoinline = arg.isNoinline,
+                                isAssignable = arg.isAssignable
                         ).apply { it.bind(this) }
                     }
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -351,6 +351,14 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
                             loweredParameter.symbol, expression.origin)
                 }
             }
+
+            override fun visitSetValue(expression: IrSetValue): IrExpression {
+                expression.transformChildrenVoid()
+                return loweredEnumConstructorParameters[expression.symbol.owner]?.let {
+                    IrSetValueImpl(expression.startOffset, expression.endOffset, it.type,
+                            it.symbol, expression.value, expression.origin)
+                } ?: expression
+            }
         }
     }
 }
@@ -372,6 +380,22 @@ private class ParameterMapper(superConstructor: IrConstructor,
                     expression.startOffset, expression.endOffset,
                     parameter.type,
                     parameter.symbol)
+        }
+        return expression
+    }
+
+    override fun visitSetValue(expression: IrSetValue): IrExpression {
+        expression.transformChildrenVoid()
+        val superParameter = expression.symbol.owner as? IrValueParameter ?: return expression
+        if (valueParameters.contains(superParameter)) {
+            val index = if (useLoweredIndex) superParameter.loweredIndex else superParameter.index
+            val parameter = constructor.valueParameters[index]
+            return IrSetValueImpl(
+                    expression.startOffset, expression.endOffset,
+                    parameter.type,
+                    parameter.symbol,
+                    expression.value,
+                    expression.origin)
         }
         return expression
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/KonanDefaultArgumentStubGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/KonanDefaultArgumentStubGenerator.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.lower
+
+import org.jetbrains.kotlin.backend.common.lower.DefaultArgumentStubGenerator
+import org.jetbrains.kotlin.backend.konan.Context
+import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+
+internal class KonanDefaultArgumentStubGenerator(override val context: Context)
+    : DefaultArgumentStubGenerator(context, skipInlineMethods = false)
+{
+    override fun IrBlockBodyBuilder.selectArgumentOrDefault(
+            defaultFlag: IrExpression,
+            parameter: IrValueParameter,
+            default: IrExpression
+    ): IrValueDeclaration {
+        val value = irIfThenElse(parameter.type, irNotEquals(defaultFlag, irInt(0)), default, irGet(parameter))
+        return createTmpVariable(value, nameHint = parameter.name.asString())
+    }
+}

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
@@ -147,7 +147,9 @@ internal class VarargInjectionLowering constructor(val context: KonanBackendCont
     }
 
     private val symbols = context.ir.symbols
-    private val intPlusInt = symbols.intPlusInt.owner
+    private val intPlusInt = symbols.getBinaryOperator(
+            OperatorNameConventions.PLUS, context.irBuiltIns.intType, context.irBuiltIns.intType
+    ).owner
 
     private fun arrayType(type: IrType): ArrayHandle {
         val arrayClass = type.classifierOrFail

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
@@ -165,7 +165,7 @@ internal class VarargInjectionLowering constructor(val context: KonanBackendCont
     }
 
     private fun IrBuilderWithScope.incrementVariable(variable: IrVariable, value: IrExpression): IrExpression {
-        return irSetVar(variable.symbol, intPlus().apply {
+        return irSet(variable.symbol, intPlus().apply {
             dispatchReceiver = irGet(variable)
             putValueArgument(0, value)
         })

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
@@ -1401,12 +1401,12 @@ internal object Devirtualization {
                     callSite.origin,
                     actualCallee.parentAsClass.symbol
             )
-            if (actualCallee.explicitParameters.size == arguments.size) {
+            if (actualCallee.explicitParametersCount == arguments.size) {
                 arguments.forEachIndexed { index, argument -> call.putArgument(index, argument) }
                 return call
             }
-            assert(actualCallee.isSuspend && actualCallee.explicitParameters.size == arguments.size - 1) {
-                "Incorrect number of arguments: expected [${actualCallee.explicitParameters.size}] but was [${arguments.size - 1}]\n" +
+            assert(actualCallee.isSuspend && actualCallee.explicitParametersCount == arguments.size - 1) {
+                "Incorrect number of arguments: expected [${actualCallee.explicitParametersCount}] but was [${arguments.size - 1}]\n" +
                         actualCallee.dump()
             }
             val continuation = arguments.last()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -259,7 +259,7 @@ fun IrBuilderWithScope.irCallOp(
         }
 
 fun IrBuilderWithScope.irSetVar(variable: IrVariable, value: IrExpression) =
-        irSetVar(variable.symbol, value)
+        irSet(variable.symbol, value)
 
 fun IrBuilderWithScope.irCatch(type: IrType) =
         IrCatchImpl(

--- a/build-tools/build.gradle.kts
+++ b/build-tools/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
     api("org.jetbrains.kotlin:kotlin-native-shared:$konanVersion")
     implementation("com.github.jengelman.gradle.plugins:shadow:5.1.0")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-klib:0.0.1-dev-9")
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-klib:0.0.1-dev-10")
 }
 
 sourceSets["main"].withConvention(KotlinSourceSet::class) {

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/klib/metadata/KmComparator.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/klib/metadata/KmComparator.kt
@@ -143,7 +143,7 @@ internal class KmComparator(private val configuration: ComparisonConfig) {
     )(flags1, flags2)
 
     private fun compareConstructorFlags(flags1: Flags, flags2: Flags): MetadataCompareResult = serialComparator(
-            checkFlag(Flag.Constructor.IS_PRIMARY) to "IS_PRIMARY mismatch"
+            checkFlag(Flag.Constructor.IS_SECONDARY) to "IS_SECONDARY mismatch"
     )(flags1, flags2)
 
     private fun compare(constructor1: KmConstructor, constructor2: KmConstructor): MetadataCompareResult = serialComparator(

--- a/build.gradle
+++ b/build.gradle
@@ -315,7 +315,7 @@ task detectJarCollision(type: CollisionDetector) {
         resolvingRules["META-INF/compiler.version"] = "kotlin-compiler"
         resolvingRules["kotlinManifest.properties"] = "kotlin-compiler"
         librariesWithIgnoredClassCollisions.addAll(["util", "container", "resolution.common", "resolution", "serialization", "psi",
-                                                    "deserialization.common", "deserialization.common.jvm",
+                                                    "deserialization.common", "deserialization.common.jvm", "compiler.backend.common.jvm"
         											"frontend", "config", "config.jvm", "js.config", "javac-wrapper",
                                                     "frontend.common", "frontend.java", "cli-common", "ir.tree",
                                                     "ir.tree.impl", "ir.tree.persisting",

--- a/build.gradle
+++ b/build.gradle
@@ -308,6 +308,7 @@ task detectJarCollision(type: CollisionDetector) {
     resolvingRules["org/jetbrains/kotlin/builtins/konan/KonanBuiltIns.class"] = "kotlin-compiler"
     resolvingRules["org/jetbrains/kotlin/resolve/konan/platform/NativeInliningRule.class"] = "kotlin-compiler"
     resolvingRules["org/jetbrains/kotlin/resolve/konan/platform/NativePlatformAnalyzerServices.class"] = "kotlin-compiler"
+    resolvingRules["org/jetbrains/annotations/Nls.class"] = "kotlin-compiler"
     librariesWithIgnoredClassCollisions.addAll(["kotlin-util-klib", "kotlin-util-io", "kotlinx-metadata-klib", "kotlin-native-utils"])
     if (project.hasProperty('kotlinProjectPath')) {
         resolvingRulesWithRegexes[new Regex("META-INF/.+\\.kotlin_module")] = "kotlin-compiler"

--- a/build.gradle
+++ b/build.gradle
@@ -315,7 +315,7 @@ task detectJarCollision(type: CollisionDetector) {
         resolvingRules["META-INF/compiler.version"] = "kotlin-compiler"
         resolvingRules["kotlinManifest.properties"] = "kotlin-compiler"
         librariesWithIgnoredClassCollisions.addAll(["util", "container", "resolution.common", "resolution", "serialization", "psi",
-                                                    "deserialization.common", "deserialization.common.jvm", "compiler.backend.common.jvm"
+                                                    "deserialization.common", "deserialization.common.jvm", "compiler.backend.common.jvm",
         											"frontend", "config", "config.jvm", "js.config", "javac-wrapper",
                                                     "frontend.common", "frontend.java", "cli-common", "ir.tree",
                                                     "ir.tree.impl", "ir.tree.persisting",

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-374,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-374
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-374,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-374
-kotlinStdlibTestsVersion=1.4.30-dev-374
-testKotlinCompilerVersion=1.4.30-dev-374
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1260,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-1260
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1260,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-1260
+kotlinStdlibTestsVersion=1.4.30-dev-1260
+testKotlinCompilerVersion=1.4.30-dev-1260
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 5e5712afbb5 - (HEAD -> master, tag: build-1.4.30-dev-1260, origin/master, origin/HEAD) [JS IR] Make JsExport not fail on companion objects (KT-37829) (vor 2 Stunden) <Svyatoslav Kuzmich>
* 9f716ba37c0 - (tag: build-1.4.30-dev-1259) Jspecify: Rename DefaultNotNull to DefaultNonNull (vor 3 Stunden) <Victor Petukhov>
* c3bada44cf6 - Jspecify: Rename NullnessUnknown to NullnessUnspecified (vor 3 Stunden) <Victor Petukhov>
* 2685c7efce8 - Jspecify: Rename codeanalysis annotations to jspecify ones (vor 3 Stunden) <Victor Petukhov>
* 59bd7364ab3 - Enhance bounds for type parameters after loops disconnection (vor 3 Stunden) <Denis Zharkov>
* 6661814e403 - Do not enhance star projections for bounds of raw types (vor 3 Stunden) <Denis Zharkov>
* 16b4a2c4653 - Do not enhance type parameter bounds if they contain a raw type (vor 3 Stunden) <Denis Zharkov>
* c1b34a83e91 - Fix enhancement behavior in case of error-typed upper bounds (vor 3 Stunden) <Denis Zharkov>
* 2964d526400 - Add test case for codeanalysis annotation (vor 3 Stunden) <Denis Zharkov>
* dfb1cb86427 - Minor. Rename UnknownNullness -> NullnessUnknown (vor 3 Stunden) <Denis Zharkov>
* 0b958c8ac56 - Fix annotation name in test data to DefaultNullnessUnknown (vor 3 Stunden) <Denis Zharkov>
* f3a490ee16f - Support compiler flag -Xcodeanalysis-annotations (vor 3 Stunden) <Denis Zharkov>
* c734bac6768 - Minor. Reformat JavaNullabilityChecker.kt (vor 3 Stunden) <Denis Zharkov>
* ce2b7bded67 - Minor. Reformat AbstractForeignAnnotationsTest.kt (vor 3 Stunden) <Denis Zharkov>
* 90a9ca6cb36 - Minor. Rename flag in JvmAnalysisFlags: jsr305 -> javaTypeEnhancementState (vor 3 Stunden) <Denis Zharkov>
* 93d93018477 - Minor. Extract JavaTypeEnhancementStateParser::parseJsr305State (vor 3 Stunden) <Denis Zharkov>
* e7208f0c05d - Rename Jsr305Parser -> JavaTypeEnhancementStateParser (vor 3 Stunden) <Denis Zharkov>
* 6c37574fcef - Rename Jsr305State -> JavaTypeEnhancementState (vor 3 Stunden) <Denis Zharkov>
* 2f04a1505d1 - Support enhancement for unbounded wildcards from codeanalysis annotations (vor 3 Stunden) <Denis Zharkov>
* 392ef9aa2b3 - Support type arguments enhancement from type parameters bounds (vor 3 Stunden) <Denis Zharkov>
* e9e05c53e15 - Support enhancement for type parameter based types (vor 3 Stunden) <Denis Zharkov>
* fa2578c795a - Prepare type enhancement for codeanalysis annotations (vor 3 Stunden) <Denis Zharkov>
* e27501497b4 - Support codeanalysis annotations on type parameters bounds (vor 3 Stunden) <Denis Zharkov>
* 82d39dd86ae - Add basic support for default codeanalysis annotations (vor 3 Stunden) <Denis Zharkov>
* 517cc84f4d5 - Add initial support for codeanalysis annotations (vor 3 Stunden) <Denis Zharkov>
* 165a147dd80 - (tag: build-1.4.30-dev-1256, origin/rr/fir-ide-perf/fir-completion-handler-test) Improved IDE performance tests vega specs (vor 3 Stunden) <Vladimir Dolzhenko>
* 0682084ca33 - (tag: build-1.4.30-dev-1248) [FIR Completion] Generate part of performance tests for FIR completion (vor 5 Stunden) <Roman Golyshev>
* beac3757bc6 - (tag: build-1.4.30-dev-1243) [IR text test] Minor: add forgotten .fir.txt file (vor 6 Stunden) <Mikhail Glukhikh>
* 46535bbd9d2 - (tag: build-1.4.30-dev-1242, tag: build-1.4.30-dev-1235) Add IDE performance tests vega specs (vor 15 Stunden) <Vladimir Dolzhenko>
* 280fcb5c4ba - (tag: build-1.4.30-dev-1234) IDE: IndexNotReadyException while creating new Kotlin file in Dumb mode (vor 18 Stunden) <Dmitriy Dolovov>
* 2f003bdcb5b - (tag: build-1.4.30-dev-1233) Minor, add regression test (vor 18 Stunden) <Alexander Udalov>
* af98720720b - JVM_IR: move MoveOrCopyCompanionObjectFields down a bit (vor 18 Stunden) <pyos>
* dd1682510f9 - (tag: build-1.4.30-dev-1232) JVM_IR: generate accessors for inherited abstract members too (vor 18 Stunden) <pyos>
* 68157f09fa1 - (tag: build-1.4.30-dev-1226) Minor, add temporary workaround for KT-42492 (vor 20 Stunden) <Alexander Udalov>
* 7833698038a - (tag: build-1.4.30-dev-1223) [FIR IDE] Fix `idea-fir-performance-tests` module references (vor 21 Stunden) <Roman Golyshev>
* efef18c2ca7 - FIR IDE: mute not passing highlighting test (vor 21 Stunden) <Ilya Kirillov>
* 96422ea3fe7 - FIR IDE: introduce highlighting performance test (vor 21 Stunden) <Ilya Kirillov>
* 5cc12b49fca - (tag: build-1.4.30-dev-1219) Hide java.lang.CharSequence::isEmpty from Kotlin built-in class (vor 23 Stunden) <Denis Zharkov>
* 90044f9672a - Use correct naming for additional built-in member lists (vor 23 Stunden) <Denis Zharkov>
* 98088f739d5 - (tag: build-1.4.30-dev-1215) PSI2IR: do not generate when subjects multiple times (vor 23 Stunden) <pyos>
* e280416fe24 - (tag: build-1.4.30-dev-1212, tag: build-1.4.30-dev-1209) Minor, add regression test (vor 25 Stunden) <Alexander Udalov>
* 8ef0fdf021a - JVM_IR: remove two outdated comments (vor 25 Stunden) <pyos>
* f7441813a96 - JVM_IR: move SuspendLambdaLowering to a separate file (vor 25 Stunden) <pyos>
* a6c62d3339e - JVM_IR: do not inherit delegated property trackers (vor 25 Stunden) <pyos>
* 05c856f1f77 - JVM_IR: move SuspendLambdaLowering next to FunctionReferenceLowering (vor 25 Stunden) <pyos>
* 44e0bfe90b9 - JVM_IR: split AddContinuationLowering (vor 25 Stunden) <pyos>
* 4f171a9eb51 - JVM_IR: move FunctionReference lowering before PropertyReference (vor 25 Stunden) <pyos>
* 11904577599 - (tag: build-1.4.30-dev-1202) JVM_IR: fix copying of receivers when unboxing inline class parameters (vor 26 Stunden) <pyos>
* adcbfc7b4cd - (tag: build-1.4.30-dev-1200) IR: add an emptiness check to all unsigned `until` loops (vor 27 Stunden) <pyos>
* 4a030061627 - Generate min/max constants as non-const in ranges tests (vor 27 Stunden) <pyos>
* 260f66183cd - (tag: build-1.4.30-dev-1196, origin/rr/ddol/work3) Don't ignore the test on JS backend as it doesn't fail any more. (vor 28 Stunden) <Pavel Punegov>
* 93b2ea2febe - Regenerate tests (vor 28 Stunden) <Pavel Punegov>
* a439860e129 - Replace IGNORE_BACKENDs to TARGET_BACKEND for the Java test (vor 28 Stunden) <Pavel Punegov>
* 4d8ca074bcc - Ignore test for the full reflection in Native (vor 28 Stunden) <Pavel Punegov>
* 33d28b44fa4 - Unmute typeOf tests in Native backend (vor 28 Stunden) <Pavel Punegov>
* d92aa94c6d6 - (tag: build-1.4.30-dev-1195) [Usages] Provide BWC change for 1.4.20 and mark it as deprecated (vor 28 Stunden) <Igor Yakovlev>
* 23d33f51a25 - (tag: build-1.4.30-dev-1193) Open build tool window on Gradle DSL errors (vor 29 Stunden) <Vladimir Dolzhenko>
* 0e29f6f48b0 - (tag: build-1.4.30-dev-1191) DELEGATE_SPECIAL_FUNCTION_NONE_APPLICABLE: is -> are (vor 29 Stunden) <KotlinIsland>
* 9a0c3c47c87 - [inspections] fix false positive "Redundant Unit" inspection in lambda with dynamic return type (vor 29 Stunden) <Dmitry Gridin>
* 26d03295cf6 - (tag: build-1.4.30-dev-1187) [Cocoapods] Remove hierarchical PodInstall dependsOn to `Podspec`s (vor 29 Stunden) <Yaroslav Chernyshev>
* e49f881e7fa - (tag: build-1.4.30-dev-1186) [FIR2IR] Add more clear exception about absent setter (see KT-42496) (vor 30 Stunden) <Mikhail Glukhikh>
* aa4a0426122 - [FIR2IR] Use deepest matching symbol also for synthetic properties (vor 30 Stunden) <Mikhail Glukhikh>
* fb4f27e136f - [FIR2IR] Add test for problematic KT-42359 (vor 30 Stunden) <Mikhail Glukhikh>
* 49307e243c5 - (tag: build-1.4.30-dev-1185) FIR deserializer: load annotations on default accessors (vor 31 Stunden) <Jinseong Jeon>
* c25742c91a7 - (tag: build-1.4.30-dev-1184) kotlinx-metadata: Fix tests for Flag.Constructor.IS_SECONDARY flag (vor 31 Stunden) <Dmitriy Dolovov>
* 52e56ca070e - kotlinx-metadata: Wrong interpretation of Flag.Constructor.IS_PRIMARY (vor 31 Stunden) <Dmitriy Dolovov>
* 3a5ffe479eb - (tag: build-1.4.30-dev-1172) General fixes for composite builds in HMPP (vor 2 Tagen) <Sergey Igushkin>
* 7d1a3a137b7 - Publish MPP -metadata artifact in the root module, drop separate module (vor 2 Tagen) <Sergey Igushkin>
* a0fbf54d11a - Simplify matching of Kotlin variant name and Gradle configuration name (vor 2 Tagen) <Sergey Igushkin>
* 16d493558ef - HMPP resolution fixes (vor 2 Tagen) <Sergey Igushkin>
* 5963b079871 - Use JSON as the format for the Kotlin project structure metadata (vor 2 Tagen) <Sergey Igushkin>
* f19ef0184c3 - Cleanup GranularMetadataTransformation after refactoring (vor 2 Tagen) <Sergey Igushkin>
* 3817aa32a18 - (tag: build-1.4.30-dev-1170) [IR] Move isAssignable to IrValueDeclaration. (vor 2 Tagen) <Mads Ager>
* af0999ec6f1 - [IR] Support isAssignable in builders and serialization. (vor 2 Tagen) <Mads Ager>
* 37145fb055c - [JS_IR] Fix exponential behavior accidentally introduced. (vor 2 Tagen) <Mads Ager>
* 1f2ca606a55 - [IR] Add isAssignable property to IrValueParameter. (vor 2 Tagen) <Mads Ager>
* 8d791ca98ec - [IR] Update naming, but not binary format for IrSetValue. (vor 2 Tagen) <Mads Ager>
* 33ab2299f99 - [IR] Fix the type of the default argument mask condition. (vor 2 Tagen) <Mads Ager>
* 87f17dec4a1 - [JS_IR] Use IrSetValue for default argument handling for JS backend. (vor 2 Tagen) <Mads Ager>
* 9a93bb3f090 - [IR] Add IR support for setting parameters. (vor 2 Tagen) <Mads Ager>
* db23460fd59 - Implement proper script runtime exception rendering with tests (vor 2 Tagen) <Ilya Chernikov>
* d5ad424e8fa - (tag: build-1.4.30-dev-1166) FIR: introduce source element mappings tests for raw FIR (vor 2 Tagen) <Ilya Kirillov>
* a8ca2f8065c - FIR IDE: fix diagnostics collection (vor 2 Tagen) <Ilya Kirillov>
* 551864d8c19 - FIR: fix source element of FirQualifiedAccessExpression (vor 2 Tagen) <Ilya Kirillov>
* c6de9834769 - (tag: build-1.4.30-dev-1165) Keep class members of the ExtensionPoint interface instead of its implementation for easier usage (vor 2 Tagen) <Yan Zhulanow>
* 0dc243d74cb - Parcelize: Don't activate both 'kotlin-parcelize' and 'kotlin-android-extensions' in IDE (KT-42267) (vor 2 Tagen) <Yan Zhulanow>
* 4c540152fee - Parcelize: Forbid applying both 'kotlin-parcelize' and 'kotlin-android-extensions' (KT-42342) (vor 2 Tagen) <Yan Zhulanow>
* a37f16d7a25 - (tag: build-1.4.30-dev-1159) [IR] Do not generate line numbers for synthesized data class members. (vor 2 Tagen) <Mads Ager>
* 5048471835c - (tag: build-1.4.30-dev-1153) Properly check default kind on inheriting from old DefaultImpls scheme (vor 2 Tagen) <Mikhael Bogdanov>
* 714d17ac63d - (tag: build-1.4.30-dev-1151) Parcelize, JVM IR: Handle star projected and nullable arrays. (vor 2 Tagen) <Steven Schäfer>
* a6d5c02d9bb - (tag: build-1.4.30-dev-1148) JVM_IR: add a transformChildren call to PropertyReferenceLowering (vor 2 Tagen) <pyos>
* b1bd138afb4 - JVM_IR fix inline class <-> collection stubs issues (vor 2 Tagen) <Dmitry Petrov>
* 2573eaa77fb - (tag: build-1.4.30-dev-1139) IR: do not crash renderer on functions with uninitialized return type (vor 2 Tagen) <Alexander Udalov>
* 06f1bd6101e - Reformat IR tree declarations and implementations (vor 2 Tagen) <Alexander Udalov>
* b47e0e861b0 - (tag: build-1.4.30-dev-1130) [PSI2IR] Use SYNTHETIC_OFFSET for delegated brigdes. (vor 2 Tagen) <Mads Ager>
* ed5c2b0565b - (tag: build-1.4.30-dev-1128) Add tests for data class runtime string concatenation (vor 2 Tagen) <Mikhael Bogdanov>
* eb32a6ddbd3 - Add test for for kt42457 wrong behaviour. Align runtime concatenation with it (vor 2 Tagen) <Mikhael Bogdanov>
* 64fb114c30e - (tag: build-1.4.30-dev-1123) FIR Java annotations: create vararg or Array depending on parameter name (vor 2 Tagen) <Mikhail Glukhikh>
* f6b49a2c9a9 - FirAnnotationArgumentChecker: handle conversion calls properly (vor 2 Tagen) <Mikhail Glukhikh>
* 6f432ea5ddc - [FIR] Add problematic test for KT-42346 (double vararg in annotation) (vor 2 Tagen) <Mikhail Glukhikh>
* 862fb6a4053 - FIR Java: make annotation parameters not-null (vor 2 Tagen) <Mikhail Glukhikh>
* bcdc53d1c46 - (tag: build-1.4.30-dev-1118) [Gradle, JS] Consider GString in npm dependencies parse in root dependencies (vor 2 Tagen) <Ilya Goncharov>
* 39cde978d0e - (tag: build-1.4.30-dev-1104) Minor. Rename test folder (vor 2 Tagen) <Mikhael Bogdanov>
* d2c4be18a0e - Rename `runtime-string-concat` option into 'string-concat' (vor 2 Tagen) <Mikhael Bogdanov>
* 402f7df0d47 - (tag: build-1.4.30-dev-1103) [IR] Save several last calculated line numbers not to recalculate them several times during code and debug info generation (#3792) (vor 2 Tagen) <LepilkinaElena>
* a52e045c917 - (tag: build-1.4.30-dev-1091) [IR BE] Remap references in default arg value in inner class constructor (vor 3 Tagen) <Roman Artemev>
* f597585ffb0 - [IR BE] Refactor DefaultArgumentStubGenerator a bit (vor 3 Tagen) <Roman Artemev>
* d7e0649d93b - (tag: build-1.4.30-dev-1090) Automatically add -- after script/expression in kotlin runner (vor 3 Tagen) <Ilya Chernikov>
* 153217ae2e8 - (tag: build-1.4.30-dev-1088) Clean up muted tests (vor 3 Tagen) <Vladimir Dolzhenko>
* b27955d2680 - (tag: build-1.4.30-dev-1081) Wrong specialization diagnostic is reported on java default inheritance (vor 3 Tagen) <Mikhael Bogdanov>
* 2d001a46fc0 - (tag: build-1.4.30-dev-1073) FIR CFG traverser: do not skip graph enter node (vor 3 Tagen) <Jinseong Jeon>
* a154cf4c45c - FIR checker: reproduce KT-42348 (vor 3 Tagen) <Jinseong Jeon>
* be84110ada4 - (tag: build-1.4.30-dev-1070) Clean up muted tests (vor 3 Tagen) <Vladimir Dolzhenko>
* 71d76bdb4b2 - (tag: build-1.4.30-dev-1069) Revert "Perform shorten references under modal dialog" (vor 3 Tagen) <Vladimir Dolzhenko>
* dcf18ec500f - (tag: build-1.4.30-dev-1060, tag: build-1.4.30-dev-1055) [Gradle, Cocoapods] Fix false-negative `testCinteropExtraOpts` failing (vor 3 Tagen) <Yaroslav Chernyshev>
* 76c5d036a85 - (tag: build-1.4.30-dev-1053) Do not pack source of invisible runtime helpers to stdlib-js (vor 3 Tagen) <Ilya Gorbunov>
* 4a9819bf9e7 - (tag: build-1.4.30-dev-1048) Build: Upgrade gradle-enterprise plugin to 3.4.1 (vor 3 Tagen) <Vyacheslav Gerasimov>
* 0b822aa4925 - (tag: build-1.4.30-dev-1043) Perform shorten references under modal dialog (vor 3 Tagen) <Vladimir Dolzhenko>
* 36b3a8e0e32 - (tag: build-1.4.30-dev-1039) Revert "Open build tool window on Gradle DSL errors" (vor 3 Tagen) <Vladimir Dolzhenko>
* 5eac949b43a - (tag: build-1.4.30-dev-1036) Report EXPLICIT_DELEGATION_CALL_REQUIRED on relevant element (vor 3 Tagen) <Vladimir Dolzhenko>
* 7af564c9f20 - (tag: build-1.4.30-dev-1035) FIR: fix vararg remapping that merged named vararg (vor 3 Tagen) <Jinseong Jeon>
* 29b23e79f32 - (tag: build-1.4.30-dev-1032) Register EXPRESSION_CODE_FRAGMENT, BLOCK_CODE_FRAGMENT in KtStubElementTypes (vor 3 Tagen) <Vladimir Dolzhenko>
* 3cd552cb43d - [FIR2IR] Process anonymous object nested classes correctly (vor 3 Tagen) <Mikhail Glukhikh>
* 76cdf97b6d2 - [FIR2IR] Set facade class for backing field properly #KT-42384 Fixed (vor 3 Tagen) <Mikhail Glukhikh>
* ad7ad98738b - (tag: build-1.4.30-dev-1031) [Gradle, Cocoapods] Custom packageName and extraOpts for pods cinterop (vor 3 Tagen) <Yaroslav Chernyshev>
* b0b971cd0a2 - (tag: build-1.4.30-dev-1029) IR: Remove unused class (vor 3 Tagen) <Georgy Bronnikov>
* 80b7194799c - IR: remove KotlinType usage from Ir.kt (vor 3 Tagen) <Georgy Bronnikov>
* 7afad9a91d1 - Use wrapped descriptors in IrReturnableBlock (vor 3 Tagen) <Georgy Bronnikov>
* 38ee182f51f - IR: remove unused AbstractClosureAnnotator (vor 3 Tagen) <Georgy Bronnikov>
* 5e02a4efd78 - (tag: build-1.4.30-dev-1027) Mark implicit receiver as captured if the function is expression (vor 3 Tagen) <Ilmir Usmanov>
* 3078bd7b67f - (tag: build-1.4.30-dev-1026) [formatter] line indent provider: fix indent for empty braces (vor 3 Tagen) <Dmitry Gridin>
* 380226cba08 - (tag: build-1.4.30-dev-1021) FIR2IR: correct dispatch receiver inside inner class constructor (vor 3 Tagen) <Jinseong Jeon>
* aa488eabc93 - (tag: build-1.4.30-dev-1020) FIR2IR: distinguish constructor when picking return target (vor 3 Tagen) <Jinseong Jeon>
* 5ab822be36d - (tag: build-1.4.30-dev-995) Import scope of the imported script (vor 6 Tagen) <Ilya Chernikov>
* a71eab89e79 - Remove unused code... (vor 6 Tagen) <Ilya Chernikov>
* bdbf8d79802 - (tag: build-1.4.30-dev-994) Use correct class type when creating class references (vor 6 Tagen) <Leonid Startsev>
* d4bdb0eedc0 - Remove requirement on 'Serializable class must have single primary constructor' (vor 6 Tagen) <Leonid Startsev>
* de8776ec1d3 - (tag: build-1.4.30-dev-993) [Gradle, JS] Support for groovy dsl and Pair in kotlin dsl (vor 6 Tagen) <Ilya Goncharov>
* 6c1dc43d259 - (tag: build-1.4.30-dev-992) Add check already fixed variables in `PostponedArgumentInputTypesResolver` during adding constraints on them and using inside a functional type (vor 6 Tagen) <Victor Petukhov>
* 96ccf037945 - (tag: build-1.4.30-dev-991) [Gradle, JS] Test: Add yarn resolution by version shortcut (vor 6 Tagen) <Ilya Goncharov>
* 18ec9f10f90 - [Gradle, JS] Add yarn resolution by version shortcut (vor 6 Tagen) <Ilya Goncharov>
* 07f78f5ab81 - (tag: build-1.4.30-dev-982, origin/rr/kishmakov/showbinary) [Commonizer] Drop "kind" from CirClassConstructor (vor 6 Tagen) <Dmitriy Dolovov>
* abc4aef4033 - (tag: build-1.4.30-dev-981) Store kotlin-script-cache-dependencies as project file attribute (vor 6 Tagen) <Vladimir Dolzhenko>
* 941a5068858 - (tag: build-1.4.30-dev-980, origin/rr/pdn_jvmir_abi_ic_collections) Add test for inline classes implementing collection interfaces (vor 6 Tagen) <Dmitry Petrov>
* 2828f0a814b - (tag: build-1.4.30-dev-965) Fix restoring script configuration from file attributes (vor 6 Tagen) <Ilya Chernikov>
* d88e87aaac1 - Fix ScriptDefinition subtyping after earlier refactorings (vor 6 Tagen) <Ilya Chernikov>
* adcfca3f982 - Treat classpath extraction problems on script definition loading as warnings (vor 6 Tagen) <Ilya Chernikov>
* 741df42c186 - (tag: build-1.4.30-dev-959) Open build tool window on Gradle DSL errors (vor 6 Tagen) <Vladimir Dolzhenko>
* e018f2bd3e1 - (tag: build-1.4.30-dev-957) JVM_IR more precise check for special bridges in super class (vor 6 Tagen) <Dmitry Petrov>
* cf5bd38becb - JVM_IR. Support runtime string concatenation (vor 6 Tagen) <Mikhael Bogdanov>
* 1938f9459f4 - Support indy concatenation (vor 6 Tagen) <Mikhael Bogdanov>
* 942e1962d9b - Properly process constants (vor 6 Tagen) <Mikhael Bogdanov>
* 8a1f7c58598 - Add TODO (vor 6 Tagen) <Mikhael Bogdanov>
* c329c226301 - Add runtime string concat options. Some renaming (vor 6 Tagen) <Mikhael Bogdanov>
* 04012951c11 - Basic invokedynamic string concatenation support (vor 6 Tagen) <Mikhael Bogdanov>
* 88892ec65de - Introduce StringAppendGenerator (vor 6 Tagen) <Mikhael Bogdanov>
* bf35818438b - Minor. Reformat (vor 6 Tagen) <Mikhael Bogdanov>
* b58d75440b7 - (tag: build-1.4.30-dev-954) [FIR] Fix tests for vararg execution order after rebase. (vor 6 Tagen) <Mark Punzalan>
* e175e87225e - [FIR] Change type of argumentMapping properties and parameters from Map to LinkedHashMap, to signify that the order is important and we don't assume that mutableMapOf() will always return a LinkedHashMap. (vor 6 Tagen) <Mark Punzalan>
* 6b83f2d70e3 - [FIR] Remove Candidate.oldToNewArgumentMapping and use Candidate.argumentMapping instead of the Fir*Call's argumentList to remap vararg arguments to a FirVarargArgumentExpression. (vor 6 Tagen) <Mark Punzalan>
* a2a4d948347 - [FIR] Capture array and indices for postfix/prefix increment/decrement of array element (including overloaded indexed access operators, e.g., `a[b, c]++`). (vor 6 Tagen) <Mark Punzalan>
* eb631bc4296 - [FIR] Keep vararg argument order in resolved calls (KT-17691). (vor 6 Tagen) <Mark Punzalan>
* f6ce2d893cc - [FIR] Handle varargs in overloaded indexed access operator. (vor 6 Tagen) <Mark Punzalan>
* c471a7735e2 - (tag: build-1.4.30-dev-953) Keep all variants of ExtensionPointImpl.registerExtension() in the pro-guarded compiler (KT-42103) (vor 6 Tagen) <Yan Zhulanow>
* bcbb90dd81f - (tag: build-1.4.30-dev-950) "Receiver parameter is never used" inspection: don't report it when anonymous function is called with receiver (vor 6 Tagen) <Toshiaki Kameyama>
* 112e07814e6 - (tag: build-1.4.30-dev-948) [FIR] Mute test after rebase (vor 6 Tagen) <Mikhail Glukhikh>
* cc88374fd71 - [FIR] Add compile Kotlin against Kotlin test group (vor 6 Tagen) <Mikhail Glukhikh>
* 582f8fe287c - FIR: recursive transform annotation if it has annotation as argument (vor 6 Tagen) <Mikhail Glukhikh>
* 2fd752f8f69 - IR interpreter: fix calculation of constant Java fields (vor 6 Tagen) <Mikhail Glukhikh>
* 44ebec05bb9 - FIR Java: support read of field constant initializers (vor 6 Tagen) <Mikhail Glukhikh>
* fafb4a79148 - (tag: build-1.4.30-dev-943) Use regex for case-insensitive String.replace (vor 7 Tagen) <Ilya Gorbunov>
* 4a0109cf44a - Use StringBuilder in String.replace (2x faster) (vor 7 Tagen) <Francesco Vasco>
* 51a37bffffd - (tag: build-1.4.30-dev-942, tag: build-1.4.30-dev-940) Incorrect package name for multipart classes (vor 7 Tagen) <Vladimir Ilmov>
* dc2845df107 - (tag: build-1.4.30-dev-939) [IR] Avoid extra lists creation during getting explicit/all parameters (#3769) (vor 7 Tagen) <LepilkinaElena>
* 6d7744a9215 - (tag: build-1.4.30-dev-925, tag: build-1.4.30-dev-923) FIR2IR: Use correct origin for lazily created fake overrides (vor 7 Tagen) <Denis Zharkov>
* 26a43b253fd - FIR2IR: Avoid recreation of declarations (vor 7 Tagen) <Denis Zharkov>
* ff4b6a0bf9a - FIR: Fix modality computation for corner cases in FirTypeIntersectionScope (vor 7 Tagen) <Denis Zharkov>
* de3df799bc9 - FIR: Fix implicit return type computation for synthetic property+intersection (vor 7 Tagen) <Denis Zharkov>
* 754e17a28fa - FIR2IR: Fix checking if accessor is allowed to have fake override (vor 7 Tagen) <Denis Zharkov>
* 70bf7063c94 - FIR2IR: Add hack for delegate combinated with intersection (vor 7 Tagen) <Denis Zharkov>
* 85b86734341 - FIR: Fix overload resolution with defaults (vor 7 Tagen) <Denis Zharkov>
* 4964ff00195 - FIR2IR: Refine definition if we need a fake override (vor 7 Tagen) <Denis Zharkov>
* 3dfbd36f152 - FIR: Unmute passing blackbox tests (vor 7 Tagen) <Denis Zharkov>
* be6bef13d31 - FIR2IR: Drop some unused declarations (vor 7 Tagen) <Denis Zharkov>
* 5c9187b2708 - FIR2IR: Rework fake overrides generation (vor 7 Tagen) <Denis Zharkov>
* b241161c359 - FIR2IR: Rework DelegatedMemberGenerator (vor 7 Tagen) <Denis Zharkov>
* e311a60055f - FIR: Refine FirDelegatedMemberScope (vor 7 Tagen) <Denis Zharkov>
* 28c536e511a - FIR: Add temporary workaround to avoid changes in test data (vor 7 Tagen) <Denis Zharkov>
* ff835557296 - Minor. Optimize imports (vor 7 Tagen) <Denis Zharkov>
* fd9c6479bfa - FIR: Do not call withReplacedConeType if type is unresolved (vor 7 Tagen) <Denis Zharkov>
* cb07ffc4fd4 - FIR: Clarify contracts for two versions FirClass<*>::scope (vor 7 Tagen) <Denis Zharkov>
* 1adf731fc50 - FIR: Minor. Use buildValueParameterCopy (vor 7 Tagen) <Denis Zharkov>
* 9696fecab50 - FIR: Use refined visibility/modality for intersection overrides (vor 7 Tagen) <Denis Zharkov>
* 20bf238c277 - FIR2IR: Fix signature computed for fake-overrides (vor 7 Tagen) <Denis Zharkov>
* 9914b487b72 - FIR: Do not load hashCode/toString/equals methods from Java interface (vor 7 Tagen) <Denis Zharkov>
* 7c7c5336f9d - FIR: Reuse callables copying parts in FirClassSubstitutionScope (vor 7 Tagen) <Denis Zharkov>
* 0297be1fa86 - FIR: Replace callableId for intersection overrides (vor 7 Tagen) <Denis Zharkov>
* 11bc0e3225a - FIR: Extract FirTypeScope.getDirectOverridden* (vor 7 Tagen) <Denis Zharkov>
* 73c6eb2793f - FIR2IR: Extract common parts in FakeOverrideGenerator (vor 7 Tagen) <Denis Zharkov>
* d67a1f91236 - FIR: Rework default parameters propagation through overrides (vor 7 Tagen) <Denis Zharkov>
* ac666187b01 - FIR: Use correct session in FirJvmMangleComputer (vor 7 Tagen) <Denis Zharkov>
* c8afa8f7150 - FIR2IR: Remove unused FakeOverrideMode (vor 7 Tagen) <Denis Zharkov>
* 2b76fe8a726 - (tag: build-1.4.30-dev-910, origin/rr/yunirj/check-rr-push, origin/pushj/yunir/check-rr-push, origin/auto-push-check) [FIR Completion] Enable basic insertion handler tests for FIR completion (vor 7 Tagen) <Roman Golyshev>
* 39736868bf1 - (tag: build-1.4.30-dev-909) JVM IR: Allow debugger to evaluate expressions involving IR dependencies (vor 7 Tagen) <Steven Schäfer>
* 48b736e551b - JVM IR: Enable evaluate expression tests for the JVM IR backend (vor 7 Tagen) <Steven Schäfer>
* 33969c5f9ab - (tag: build-1.4.30-dev-908) Redundant semicolon: fix false negative on start of line (vor 7 Tagen) <Toshiaki Kameyama>
* 02c31a711cd - (tag: build-1.4.30-dev-907) Avoid iterating over all idea modules. (vor 7 Tagen) <Nikita Skvortsov>
* 713f6e1ed35 - (tag: build-1.4.30-dev-905) Load artifactory in root script to workaround conflicts (vor 7 Tagen) <Florian Kistner>
* 4c9d3b4668b - (tag: build-1.4.30-dev-904) [Gradle, Cocoapods] Add Podfile missing info to podInstall error report (vor 7 Tagen) <Yaroslav Chernyshev>
* 6c79040cfbd - (tag: build-1.4.30-dev-901) [FIR Completion] Enable passing tests (vor 7 Tagen) <Roman Golyshev>
* 12cd5fb43af - [FIR Completion] Refactor FIR completion tests (vor 7 Tagen) <Roman Golyshev>
* 31de584d14a - (tag: build-1.4.30-dev-900, tag: build-1.4.30-dev-899) [Spec tests] Generate sections json map (vor 7 Tagen) <anastasiia.spaseeva>
* d02432cf93d - (tag: build-1.4.30-dev-898) Introduce warning for the changing arguments execution order for named varargs (KT-17691) (vor 7 Tagen) <Victor Petukhov>
* d62c665e996 - Introduce language feature to enable the correct arguments execution order for named varargs (KT-17691) (vor 7 Tagen) <Victor Petukhov>
* 485ada7b906 - (tag: build-1.4.30-dev-891) Move getColon from KtClass to KtClassOrObject (vor 7 Tagen) <Bart van Helvert>
* 4d5b32b140d - (tag: build-1.4.30-dev-889) Clean up perf tests TC stats output (vor 7 Tagen) <Vladimir Dolzhenko>
* 986ee11aabb - (tag: build-1.4.30-dev-887, tag: build-1.4.30-dev-881, tag: build-1.4.30-dev-880) Fix failing spec test (vor 8 Tagen) <Victor Petukhov>
* 4f513671969 - (tag: build-1.4.30-dev-879, tag: build-1.4.30-dev-876) Remove build settings of CLion plugin (vor 8 Tagen) <Kirill Shmakov>
* f03b9578125 - (tag: build-1.4.30-dev-870) Build: Check ivy repository by empty marker file instead of directory (vor 8 Tagen) <Vyacheslav Gerasimov>
* d0a1f18c7d9 - (tag: build-1.4.30-dev-868) Fix failing test after fcfabb70d57c90d0aee9560e7307fc522c0a771c (vor 8 Tagen) <Victor Petukhov>
* 60cf3b57407 - (tag: build-1.4.30-dev-859) Upgradle agp version for ConfigurationCacheForAndroidIT (vor 8 Tagen) <Bingran>
* af86c521014 - (tag: build-1.4.30-dev-856) JVM_IR merge annotations when substituting types (vor 8 Tagen) <Dmitry Petrov>
* 4b152a635eb - (tag: build-1.4.30-dev-855) multiplatformUtil; Module.implementedModules: Extend Android M2 fallback to also include M3 relevant modules (vor 8 Tagen) <sebastian.sellmair>
* f9b8bc0edb6 - (tag: build-1.4.30-dev-853) Move KotlinAndroidDependsOnEdgesTest.kt to new `functionalTest` source set (vor 8 Tagen) <sebastian.sellmair>
* 1173c4380ad - KotlinPlugin: Setup default 'dependsOn' edges for Android source sets (vor 8 Tagen) <sebastian.sellmair>
* dbf34205ffb - (tag: build-1.4.30-dev-850) Advance bootstrap to 1.4.30-dev-738 (vor 8 Tagen) <Dmitriy Novozhilov>
* fcfabb70d57 - (tag: build-1.4.30-dev-847) Report invisible setter error if it's resolved to synthetic property of base class with public getter and protected setter (vor 8 Tagen) <Victor Petukhov>
* fdd71c0bce3 - (tag: build-1.4.30-dev-846) Fix incorrect NULLABLE_TYPE_PARAMETER_AGAINST_NOT_NULL_TYPE_PARAMETER (vor 8 Tagen) <Denis Zharkov>
* d09ccdbe3cf - (tag: build-1.4.30-dev-837) FIR serializer: distinguish typealias classifier (vor 8 Tagen) <Jinseong Jeon>
* b4ac2f5b556 - FIR serializer: special handling of Continuation (vor 8 Tagen) <Jinseong Jeon>
* 5d2adce7abe - (tag: build-1.4.30-dev-832) as42: Add lost project parameter to CliLightClassGenerationSupport. (vor 8 Tagen) <Konstantin Tskhovrebov>
* 3212df6183e - (tag: build-1.4.30-dev-829) Reverted back occasional commenting of perf runs (vor 8 Tagen) <Vladimir Dolzhenko>
* 803463ac110 - (tag: build-1.4.30-dev-827) Revert "as42: Fix override." (vor 8 Tagen) <Konstantin Tskhovrebov>
* 646e6446f78 - (tag: build-1.4.30-dev-826) as41: Fix compile error in :compiler:tests-common:compileTestJava (vor 8 Tagen) <Nikolay Krasko>
* 6d2647c681b - Clean .bunch file (vor 8 Tagen) <Nikolay Krasko>
* ce1b388668f - (tag: build-1.4.30-dev-822) Add registry key kotlin.resolve.forceFullResolveOnHighlighting (vor 8 Tagen) <Vladimir Dolzhenko>
* 50a16aa9bcd - (tag: build-1.4.30-dev-813) Do not print metadata for perf tests (vor 9 Tagen) <Vladimir Dolzhenko>
* f79afd67f46 - (tag: build-1.4.30-dev-812) Add more tests for collections implemented by delegation (vor 9 Tagen) <Dmitry Petrov>
* 3c380faeb5d - (tag: build-1.4.30-dev-809) Added deprecated PackageFragmentProvider#getPackageFragments for BWC (vor 9 Tagen) <Vladimir Dolzhenko>
* a228206cf59 - (tag: build-1.4.30-dev-808) Minor. Regenerate tests (vor 9 Tagen) <Mikhael Bogdanov>
* 79a2d9858c0 - (tag: build-1.4.30-dev-803) JVM_IR emulate JVM stub generation scheme (vor 9 Tagen) <Dmitry Petrov>
* 6dc08cb2fde - (tag: build-1.4.30-dev-802) Add a bytecode test that checks inlining of adapted references (vor 9 Tagen) <pyos>
* 9a3507af597 - JVM_IR: treat adapted references as lambdas for inlining (vor 9 Tagen) <pyos>
* 0e8a664c9b7 - JVM_IR: fix bound suspend-converted references (vor 9 Tagen) <pyos>
* ac50433e177 - (tag: build-1.4.30-dev-796, tag: build-1.4.30-dev-793) Fix failing bytecode text test (vor 9 Tagen) <Mikhail Glukhikh>
* cfd90c85cb5 - (tag: build-1.4.30-dev-789) Kapt: Re-enable JDK 9/11 tests disabled by occasion (vor 9 Tagen) <Yan Zhulanow>
* b39af513900 - (tag: build-1.4.30-dev-788) [FIR] Extract language settings into a dedicated component (vor 9 Tagen) <Pavel Kirpichenkov>
* 8f31b1ca830 - [FIR] Use default language settings in inference components (vor 9 Tagen) <Pavel Kirpichenkov>
* dba1b50aed3 - (tag: build-1.4.30-dev-787) Parcelize: Don't write Parcelize model if the Parcelize plugin is disabled (vor 9 Tagen) <Yan Zhulanow>
* 9cdd6e9a8fe - Kapt: Support new @JvmDefault functionality (KT-25960) (vor 9 Tagen) <Yan Zhulanow>
* a44fd964cf9 - Kapt: Don't convert field initializers for enum fields inside companion objects (KT-37732) (vor 9 Tagen) <Yan Zhulanow>
* 86ac44c23e2 - "Replace 'if' with elvis operator": don't suggest if val initializer is a complex expression (vor 9 Tagen) <Toshiaki Kameyama>
* 653e20dcbab - Convert put to assignment: don't report when receiver object has custom 'set' method (vor 9 Tagen) <Toshiaki Kameyama>
* 5abb6bc7a54 - Add quickfix for SENSELESS_NULL_IN_WHEN to remove redundant when branch (vor 9 Tagen) <Toshiaki Kameyama>
* 668473c3379 - Add quickfix for CONST_VAL_NOT_TOP_LEVEL_OR_OBJECT to remove `const` modifier (vor 9 Tagen) <Toshiaki Kameyama>
* 5a3c6def8f9 - Join with assignment: fix false negative when local variable are used (vor 9 Tagen) <Toshiaki Kameyama>
* b56272dc642 - Add name to argument: do not remove necessary backticks (vor 9 Tagen) <Toshiaki Kameyama>
* a492fe77570 - "Put arguments/parameters on separate lines": respect code style settings (vor 9 Tagen) <Toshiaki Kameyama>
* 74ee68e57b3 - Remove redundant backticks: do not report if variable inside the string and isn't followed by space (vor 9 Tagen) <Toshiaki Kameyama>
* ad3ea9a36a8 - Replace with binary operator: don't highlight when receiver is platform type (vor 9 Tagen) <Toshiaki Kameyama>
* 93db78e7acc - JavaMapForEachInspection: report for expression with implicit receiver (vor 9 Tagen) <Toshiaki Kameyama>
* 85e8b56a025 - Minor: Simplify code (vor 9 Tagen) <Yan Zhulanow>
* 75e8849c94c - Add quick fix for INLINE_CLASS_CONSTRUCTOR_NOT_FINAL_READ_ONLY_PARAMETER (vor 9 Tagen) <Toshiaki Kameyama>
* 9f192ba85e2 - Fix false positive in +0.0 == -0.0 comparison simplification (KT-17735) (vor 9 Tagen) <Yan Zhulanow>
* 915dc6ce916 - FoldInitializerAndIfToElvisInspection: don't report when 'var' variable has no explicit type and it's used as not nullable type (vor 9 Tagen) <Toshiaki Kameyama>
* db140b2815e - Fix Pill debug IDEA run configurations (vor 9 Tagen) <Yan Zhulanow>
* 7b5fc191563 - Minor: Simplify replacement check logic in ReplaceJavaStaticMethodWithKotlinAnalogInspection (vor 9 Tagen) <Yan Zhulanow>
* ed2b5479738 - Minor: Extract suspend call check to a separate function (vor 9 Tagen) <Yan Zhulanow>
* ef5335ba99c - ReplaceJavaStaticMethodWithKotlinAnalogInspection: don't report for Character.toString(int) (vor 9 Tagen) <Toshiaki Kameyama>
* b008e6c9be0 - SimplifiableCallChainInspection: don't report if suspend function cannot be called correctly (vor 9 Tagen) <Toshiaki Kameyama>
* 1e9bb007446 - Debugger: Disable "missing dependency superclass" diagnostic in evaluator (KT-38659) (vor 9 Tagen) <Yan Zhulanow>
* 62affd8e0da - Kapt: Allow to strip @Metadata annotation from stubs (KT-36667) (vor 9 Tagen) <Yan Zhulanow>
* da16b8e5279 - (tag: build-1.4.30-dev-784, origin/rr/gradle/ilgonmic/included-range-only-version) [Gradle, JS] Add includedRange with version only (vor 9 Tagen) <Ilya Goncharov>
* 3075de917bf - (tag: build-1.4.30-dev-780) Add useAndroidX property into mobile library template KT-42123 (vor 9 Tagen) <Kirill Shmakov>
* ac9b5dabfc2 - Clarify test names to avoid clashes in resolve (vor 9 Tagen) <Kirill Shmakov>
* 31e7dd5fcc5 - (tag: build-1.4.30-dev-776) [Gradle, JS] Fix escaped characters in package.json (vor 9 Tagen) <Ilya Goncharov>
* 337a66f9062 - [Gradle, JS] Fix NpmRange string representation with concrete version (vor 9 Tagen) <Ilya Goncharov>
* 0fa4f0572be - [Gradle, JS] Add test for duplicated dependency with range version (vor 9 Tagen) <Ilya Goncharov>
* 024771028c6 - [Gradle, JS] Fix yarn.lock resolution in case of duplicated dependencies (vor 9 Tagen) <Ilya Goncharov>
* 34b6003371a - (tag: build-1.4.30-dev-775, tag: build-1.4.30-dev-774) as42: remove unused bunch files (vor 9 Tagen) <Konstantin Tskhovrebov>
* c8def4543da - Bump AS versions. (vor 9 Tagen) <Konstantin Tskhovrebov>
* 8a4aac53d88 - as42: Fix override. (vor 9 Tagen) <Konstantin Tskhovrebov>
* ddfb86c839c - KT-42014 ClassNotFoundException in Android Studio 4.2 (vor 9 Tagen) <Andrei Klunnyi>
* 8ff141357ea - as42: move plugin.xml to appropriate resource directy (vor 9 Tagen) <Mikhail Zarechenskiy>
* 11ac5bd32a1 - as42: Fix test about forgotten bunches (vor 9 Tagen) <Mikhail Zarechenskiy>
* 929fb1f1783 - as42: Fix compilation of tests (vor 9 Tagen) <Mikhail Zarechenskiy>
* 99b9bc83a1f - as42: Fix assertEqualsToFile usage (vor 9 Tagen) <Nikolay Krasko>
* d83355e4c42 - as42: Remove setupGradleSettings usage (vor 9 Tagen) <Nikolay Krasko>
* fa9368125f3 - as42: Remove clearing scratchesMapping in tests (vor 9 Tagen) <Nikolay Krasko>
* c5b70797e2e - as42: Fix compilation errors in AbstractJavaToKotlinConverterForWebDemoTest (vor 9 Tagen) <Nikolay Krasko>
* 1dc3cb59788 - as42: Fix compilation errors caused by 202 platform (vor 9 Tagen) <Nikolay Krasko>
* ecff2816acc - as42: Fix duplication registration for com.intellij.psi.classFileDecompiler in plugin (vor 9 Tagen) <Nikolay Krasko>
* a3bef10b97b - as42: Add fastutil library to dependency to make KtUsefulTestCase.<clinit> work (vor 9 Tagen) <Nikolay Krasko>
* 1f3602c4b7d - as42: Register DumbUtil service as it required in PsiElementFinderImpl (vor 9 Tagen) <Nikolay Krasko>
* 1b97511248e - as42: Register classFileDecompiler through xml (vor 9 Tagen) <Nikolay Krasko>
* 5ba70b2cbbf - as42: Additional fixes for AS42 and 202 platform (vor 9 Tagen) <Nikolay Krasko>
* 2df030f583a - as42: Apply 201 <-> AS41 diff (vor 9 Tagen) <Nikolay Krasko>
* 17e43aadaaf - Introduce AS42 bunch (vor 9 Tagen) <Nikolay Krasko>
* 1fc459ab4ca - (tag: build-1.4.30-dev-768) JVM_IR KT-42260 add abstract overrides for generated stubs (vor 9 Tagen) <Dmitry Petrov>
* 445b2d6eb1b - (tag: build-1.4.30-dev-764) JVM IR: minor, unmute bytecode text test (vor 9 Tagen) <Alexander Udalov>
* b497f39c29c - IR: do not try to render IrUninitializedType (vor 9 Tagen) <Alexander Udalov>
* 522fdb3e59c - (tag: build-1.4.30-dev-756) [Gradle, JS] Empty compiler plugin classpath for KotlinJsIrLink (vor 9 Tagen) <Ilya Goncharov>
* cebbd21a1e8 - (tag: build-1.4.30-dev-753) FIR2IR: simplify analysis of companion' callable references (vor 9 Tagen) <Mikhail Glukhikh>
* 3151fc85779 - FIR2IR: set dispatch receiver for companion member reference (vor 9 Tagen) <Jinseong Jeon>
* 01d852c006c - (tag: build-1.4.30-dev-751) FIR: carry annotations on delegated property accessors (vor 9 Tagen) <Jinseong Jeon>
* f1aa75fdf81 - [JPS] Fix startup environment for Android Studio (vor 9 Tagen) <Aleksei Cherepanov>
* 6ae29518503 - (tag: build-1.4.30-dev-750) Minor. Do not check suffix of function for tail-call optimization hit (vor 9 Tagen) <Ilmir Usmanov>
* 7d277b907fb - [FIR] Add new backend tests to "[JPS] Run fast FIR tests" configuration (vor 9 Tagen) <Dmitriy Novozhilov>
* 8f333aef3a5 - (tag: build-1.4.30-dev-748) Introduce warning about forbidden referencing to underscore named parameter of the catch block in a future release (KT-31567) (vor 9 Tagen) <Victor Petukhov>
* 09f1764f822 - Introduce warning for private inline functions which return anonymous objects without specified supertypes (KT-33917) (vor 9 Tagen) <Victor Petukhov>
* 63d825fa243 - Introduce warning for secondary constructor in enums without delegation to primary constructors (KT-35870) (vor 9 Tagen) <Victor Petukhov>
* 416874f9d0b - [FIR] Update BB test license comments (vor 9 Tagen) <Mikhail Glukhikh>
* 238cc7c257d - [FIR] Enable BytecodeText tests for FIR. (vor 9 Tagen) <Mark Punzalan>
* 69cd7295064 - [FIR] Enable BlackBoxAgainstJavaCodegen tests for FIR. (vor 9 Tagen) <Mark Punzalan>
* 348ba3e08c9 - [FIR] Enable BlackBoxInlineCodegen tests for FIR. (vor 9 Tagen) <Mark Punzalan>
* 53a7d69ca61 - [FIR] Make FirPropertyAccessor inherits FirCallableMemberDeclaration (vor 9 Tagen) <Dmitriy Novozhilov>
* 8f1062594fb - [FIR] Add ability to get scopes for declarations of TYPES resolve phase (vor 9 Tagen) <Dmitriy Novozhilov>
* cc4f72e032c - [FIR] Capture type from type parameter upper bound when needed (vor 9 Tagen) <Dmitriy Novozhilov>
* 393688ad827 - [FIR] Add extension to FirSession to get ConeTypeCheckerContext (vor 9 Tagen) <Dmitriy Novozhilov>
* 9e4623c52b9 - [FIR] Fix resolution of calls on `super` to avoid resolve to interface methods (vor 9 Tagen) <Dmitriy Novozhilov>
* fb871a55a39 - [FIR] Don't create backing field for property without explicit type (vor 9 Tagen) <Dmitriy Novozhilov>
* 0c0a8f9849a - [FIR] Properly pass type attributes for inference of lambda with type variable as expected type (vor 9 Tagen) <Dmitriy Novozhilov>
* d9906ae8da8 - (tag: build-1.4.30-dev-740) Minor: unmute some bytecode listing tests in JVM_IR (vor 10 Tagen) <Dmitry Petrov>
* 565c156ddb4 - Minor: reformat and cleanup warnings in CollectionStubMethodGenerator.kt (vor 10 Tagen) <Dmitry Petrov>
* af1ed77d15d - (tag: build-1.4.30-dev-738, tag: build-1.4.30-dev-735, tag: build-1.4.30-dev-733, origin/rr/yan.dep) Parcelize: Fix NPE on availability check (vor 10 Tagen) <Yan Zhulanow>
* 8c423729e42 - (tag: build-1.4.30-dev-726) JVM_IR: slightly refactor ClassCodegen (vor 10 Tagen) <pyos>
* 79e5177126c - (tag: build-1.4.30-dev-715) [KTIJ-145] Memory leak detected (vor 10 Tagen) <Andrei Klunnyi>
* 819e83b68b4 - (tag: build-1.4.30-dev-713) [Gradle, Cocoapods] Complete logging for corner-case pod configurations (vor 10 Tagen) <Yaroslav Chernyshev>
* 5f4aa4db27f - [Gradle, Cocoapods] Improve logging when deprecated podspec path is used (vor 10 Tagen) <Yaroslav Chernyshev>
* 330502a0a65 - (tag: build-1.4.30-dev-708) KT-22665 "Create object" quick fix produce wrong code for enum (#2883) (vor 10 Tagen) <Toshiaki Kameyama>
* 076eacb3d11 - (tag: build-1.4.30-dev-700) Check implicitly inferred Nothing inside special calls properly: compare constructors instead of types (vor 10 Tagen) <Victor Petukhov>
* 051d64742ce - (tag: build-1.4.30-dev-695) Make SpaceBootstrap as default bootstrap source (vor 10 Tagen) <Dmitriy Novozhilov>
* f39adfdf156 - Update version of kotlin-build-gradle-plugin dependency (vor 10 Tagen) <Dmitriy Novozhilov>
* 7aef253a36f - Add SpaceBootstrap option to kotlin-build-gradle-plugin (vor 10 Tagen) <Dmitriy Novozhilov>
* a149d38c98f - Register TYPE_CODE_FRAGMENT in KtStubElementTypes (vor 10 Tagen) <Vladimir Dolzhenko>
* 243db689afd - (tag: build-1.4.30-dev-691, tag: build-1.4.30-dev-678, origin/rr/gradle/zoldater/KT-42086) Build: fix "unknown enum constant" warning on Nls.Capitalization (vor 13 Tagen) <Alexander Udalov>
* cb5c317f91f - Gradle: support moduleName option in KotlinJvmOptions (vor 13 Tagen) <Alexander Udalov>
* 0edbdaf0c71 - (tag: build-1.4.30-dev-677) Wizard: use EAP Kotlin versions for running import tests (vor 13 Tagen) <Ilya Kirillov>
* bc580d2fd9a - (tag: build-1.4.30-dev-668) Introduce "Unused result of data class copy" inspection (vor 13 Tagen) <Toshiaki Kameyama>
* ae6d89b100a - (tag: build-1.4.30-dev-664) Minor, mute new test for FIR (vor 13 Tagen) <Alexander Udalov>
* bd6ead0467d - JVM_IR: check for null when converting unboxed inline classes to strings (vor 13 Tagen) <pyos>
* d2bdab2ef5e - (tag: build-1.4.30-dev-662) [FIR IDE] Add find usages tests for FIR plugin (vor 13 Tagen) <Igor Yakovlev>
* d534d92123c - [FIR IDE] Implement FIR for KotlinUsageTypeProvider (vor 13 Tagen) <Igor Yakovlev>
* 37ba9eccc4e - (tag: build-1.4.30-dev-661) KT-31553 Complete Statement: Wrong auto-insertion of closing curly brace for a code block (#2378) (vor 13 Tagen) <Toshiaki Kameyama>
* 14bdcb1e26f - (tag: build-1.4.30-dev-660) "Create enum constant" quick fix: suggest if expected type is Any (vor 13 Tagen) <Toshiaki Kameyama>
* 31ed5430ee9 - (tag: build-1.4.30-dev-658) Minor. Update test data (vor 13 Tagen) <Mikhael Bogdanov>
* f8f2be3d9fb - (tag: build-1.4.30-dev-655) Minor, improve test on suspend invoke function reference (vor 13 Tagen) <Alexander Udalov>
* 20a5c44e41f - JVM IR: Fix types in generated function reference constructor (vor 13 Tagen) <Steven Schäfer>
* f3db113a821 - (tag: build-1.4.30-dev-654) FIR2IR: use @Target to put annotations on either property or backing field (vor 13 Tagen) <Jinseong Jeon>
* b59832c5fd9 - FIR: refactor annotation-related utils (vor 13 Tagen) <Jinseong Jeon>
* c8170702c64 - FIR serializer: special version requirement for @JvmField property in interface companion (vor 13 Tagen) <Jinseong Jeon>
* dc2226b42fe - FIR2IR: put @JvmField on field, not property (vor 13 Tagen) <Jinseong Jeon>
* ae23adb6f59 - FIR Java: fix exception during synthetic property enhancement (vor 13 Tagen) <Mikhail Glukhikh>
* 368de436232 - FIR Java: support Java setters more properly in use-site scope (vor 13 Tagen) <Mikhail Glukhikh>
* 873ea560a9f - [FIR2IR] Fix conversion of flexible class reference (vor 13 Tagen) <Mikhail Glukhikh>
* fe8e3e99aba - [FIR Java] Hide function in scope in case it's an accessor by fact (vor 13 Tagen) <Mikhail Glukhikh>
* 70095712eb2 - (tag: build-1.4.30-dev-640) Minor: drop new bytecode listing test that passes only in JVM_IR (vor 13 Tagen) <Dmitry Petrov>
* a2f70dfc3da - KT-41298 "Remove redundant 'with' call" intention works incorrectly with non-local returns and single-expression functions (#3713) (vor 13 Tagen) <Toshiaki Kameyama>
* 8a58ada4cd0 - (tag: build-1.4.30-dev-637) Fix version parser for versions without status "1.4-M1-42-IJ2020.1-1". (vor 13 Tagen) <Konstantin Tskhovrebov>
* 945edfe9879 - (tag: build-1.4.30-dev-636) KT-41859 Place classes after typealiases in `DeserializedMemberScope` (vor 13 Tagen) <Roman Golyshev>
* cfd62c15bfc - (tag: build-1.4.30-dev-634) JVM_IR KT-36994 don't generate stub if present in superclass (vor 13 Tagen) <Dmitry Petrov>
* 1adce112571 - Add tests for KT-40191 (vor 13 Tagen) <Dmitry Petrov>
* a45b409e231 - Minor: update generated JS tests (vor 13 Tagen) <Dmitry Petrov>
* 4e518e77cad - (tag: build-1.4.30-dev-621) [JVM_IR] Fix expectations for parcelize tests. (vor 2 Wochen) <Mads Ager>
* 6d13fe8213a - (tag: build-1.4.30-dev-619) Minor, add explicit type argument to workaround KT-42175 (vor 2 Wochen) <Alexander Udalov>
* f30e564c90b - (tag: build-1.4.30-dev-615) JVM_IR: do not use fields' superQualifierSymbol to cast the receiver (vor 2 Wochen) <pyos>
* a57c95624df - (tag: build-1.4.30-dev-613, tag: build-1.4.30-dev-609) Add changelog for 1.4.20-M1 (vor 2 Wochen) <anastasiia.spaseeva>
* 0d954f11907 - (tag: build-1.4.30-dev-604) Change module :core:compiler.backend.common.jvm to :compiler:backend.common.jvm (vor 2 Wochen) <Dmitriy Novozhilov>
* b343d05e149 - [FIR] Implement JvmTypeMapper based on cone types (vor 2 Wochen) <Dmitriy Novozhilov>
* a28d0e0b7fb - Make IrTypeMapper delegate to AbstractTypeMapper (vor 2 Wochen) <Dmitriy Novozhilov>
* 86d4d320c4d - Introduce AbstractTypeMapper based on type markers (vor 2 Wochen) <Dmitriy Novozhilov>
* 7380abac139 - Split AsmUtils to descriptors dependent and independent parts (vor 2 Wochen) <Dmitriy Novozhilov>
* 54a5a066e84 - Introduce new module for common parts of backend utils (vor 2 Wochen) <Dmitriy Novozhilov>
* c3a89e25073 - Move common part of typeSignatureMapping.kt to :core:compiler.common.jvm (vor 2 Wochen) <Dmitriy Novozhilov>
* d215c413cc0 - Move TypeMappingMode to :core:compiler.common.jvm (vor 2 Wochen) <Dmitriy Novozhilov>
* 4ef57c120f9 - [FIR] Consider variance of type parameters during java type enhancement (vor 2 Wochen) <Dmitriy Novozhilov>
* a0db510e49a - [FIR] Split creating fir for java declarations to separate methods (vor 2 Wochen) <Dmitriy Novozhilov>
* 0d29d6d3615 - [FIR] Transform when conditions with boolean expected type (vor 2 Wochen) <Dmitriy Novozhilov>
* 68a47d6efb6 - [FIR] Add helpers for creating diagnostics on nullable source (vor 2 Wochen) <Dmitriy Novozhilov>
* 162d9744ff3 - (tag: build-1.4.30-dev-595) [JS IR] Fix export of constructor with default argument (KT-41275) (vor 2 Wochen) <Svyatoslav Kuzmich>
* 5b136516c4c - (tag: build-1.4.30-dev-594) FIR: utilize checking subtype of functional type and finding invoke symbol (vor 2 Wochen) <Jinseong Jeon>
* b10466f6a22 - FIR: extend suspend conversion to subtype of functional type (vor 2 Wochen) <Jinseong Jeon>
* 17176c00aee - (tag: build-1.4.30-dev-590) Move lambda out: don't remove block comments (vor 2 Wochen) <Toshiaki Kameyama>
* 6670e4b21da - (tag: build-1.4.30-dev-589) [JS IR] Fix callable reference to generic constructor (vor 2 Wochen) <Roman Artemev>
* 4da67bf0132 - (tag: build-1.4.30-dev-585) Minor. Unmute tests (vor 2 Wochen) <Ilmir Usmanov>
* f22f10febbb - JVM_IR: Unbox inline classes in suspend functions (vor 2 Wochen) <Ilmir Usmanov>
* ccc9b757c09 - (tag: build-1.4.30-dev-583) Fix failing MPP tests after 25ea3df5ca8ecbb6ad3b151cae3ea76ce8dc5342 through registering `InferenceCompatibilityCheckerImpl` instance (vor 2 Wochen) <Victor Petukhov>
* ac742123fd3 - (tag: build-1.4.30-dev-580) [JVM_IR] Generate line numbers in synthetic bridges. (vor 2 Wochen) <Mads Ager>
* acf1a15f3ee - (tag: build-1.4.30-dev-579) Parcelize: Add integration test for the new kotlin-parcelize plugin (vor 2 Wochen) <Yan Zhulanow>
* 2d158ffebd5 - Parcelize: Add tests for deprecated (kotlinx.android.parcel) annotations (vor 2 Wochen) <Yan Zhulanow>
* 1d5ab192f5a - Parcelize: Support old (kotlinx.android.parcel) annotations in Parcelize plugin (vor 2 Wochen) <Yan Zhulanow>
* f0b93bf352b - Parcelize: Move back annotations from kotlinx.android.parcel, deprecate them (vor 2 Wochen) <Yan Zhulanow>
* 75a1323974c - Parcelize: Add deprecation warning to Android Extensions Gradle plugin (KT-42121) (vor 2 Wochen) <Yan Zhulanow>
* 419c88d1f25 - Parcelize: Publish Parcelize compiler plugin to IDE dependencies repository (vor 2 Wochen) <Yan Zhulanow>
* 0ce9003ef7a - Parcelize: Add missing dependencies to Parcelize components in tests (vor 2 Wochen) <Yan Zhulanow>
* 4bd8e2f78c4 - Parcelize: Support the new Parcelize plugin in Gradle (KT-40030) (vor 2 Wochen) <Yan Zhulanow>
* 15b2850ee01 - Parcelize: Add IDE support for the Parcelize compiler plugin with sources extracted from Android Extensions plugin (KT-40030) (vor 2 Wochen) <Yan Zhulanow>
* b7796d63d86 - Parcelize: Add the Parcelize compiler plugin with sources extracted from Android Extensions plugin (KT-40030) (vor 2 Wochen) <Yan Zhulanow>
* c9bca165bcb - Update generated tests in android-extension-compiler (vor 2 Wochen) <Yan Zhulanow>
* aca9478998f - Parcelize: Recognize (suspend) function types as serializable (vor 2 Wochen) <Steven Schäfer>
* a2418484bbd - Parcelize: More robust code for locating layoutlib.jar (vor 2 Wochen) <Steven Schäfer>
* 9bf3f105d96 - Parcelize: Add a test for sealed Parcelable classes (vor 2 Wochen) <Steven Schäfer>
* 77fb0ddd329 - Parcelize: Update test expectations (vor 2 Wochen) <Steven Schäfer>
* 9d000529e70 - Fix JVM Parcelize use of Parceler (vor 2 Wochen) <rbares>
* 8ab6411b937 - Parcelize, JVM IR: Fix types in nested containers (vor 2 Wochen) <Steven Schäfer>
* eaa5d087368 - Move all sources for android-tests to the 'test' source set (vor 2 Wochen) <Yan Zhulanow>
* 3a7cc93c4e8 - (tag: build-1.4.30-dev-577) JVM IR: More precise check for calls to the implementation method in a default stub (vor 2 Wochen) <Steven Schäfer>
* 648bc9b1c4f - JVM IR: Check for cycles when inlining into default stubs (vor 2 Wochen) <Steven Schäfer>
* 111c550f3c2 - JVM IR: More tests for inlining in $default stubs (vor 2 Wochen) <Steven Schäfer>
* 5e27d9b0898 - JVM IR: Make inlining in $default stubs compatible with the JVM BE (vor 2 Wochen) <Steven Schäfer>
* bef0437edb9 - JVM IR: Generate LVT entries for parameters in inline $default methods (vor 2 Wochen) <Steven Schäfer>
* 347a984ce09 - (tag: build-1.4.30-dev-572) FIR IDE: fix tests compilation (vor 2 Wochen) <Ilya Kirillov>
* f36cd286964 - FIR IDE: introduce withFir function (vor 2 Wochen) <Ilya Kirillov>
* a516264923a - FIR IDE: introduce withFirDeclaration function (vor 2 Wochen) <Ilya Kirillov>
* ebc2ea59cde - FIR IDE: introduce WeakFirRef for low level (vor 2 Wochen) <Ilya Kirillov>
* 8ee4c4e0476 - FIR IDE: introduce scoped fir functions (vor 2 Wochen) <Ilya Kirillov>
* e19d2ecc738 - FIR IDE: make FirModuleResolveState functions to be internal (vor 2 Wochen) <Ilya Kirillov>
* 8e41384f6d5 - FIR IDE: separate LowLevelFirApiFacade from completion (vor 2 Wochen) <Ilya Kirillov>
* 7cc714c5986 - FIR IDE: move all public low level api to separate package (vor 2 Wochen) <Ilya Kirillov>
* a0337ec10d9 - FIR: fix invalid increasing inner array size in ArrayMapImpl (vor 2 Wochen) <Ilya Kirillov>
* 4238fd3842a - FIR IDE: fix compilation after rename registerJavaSpecificComponents -> registerJavaSpecificResolveComponents (vor 2 Wochen) <Ilya Kirillov>
* 65ef629ca73 - FIR: add ensureResolved to processConstructors (vor 2 Wochen) <Ilya Kirillov>
* a570be4e765 - FIR IDE: fix compilation of AbstractFirIdeDiagnosticsCollector.kt (vor 2 Wochen) <Ilya Kirillov>
* fa570710ee6 - FIR IDE: move diagnostic highlighting to separate pass (vor 2 Wochen) <Ilya Kirillov>
* 1f4aff9643d - FIR: add ensureResolved to FirSealedClassInheritorsTransformer (vor 2 Wochen) <Ilya Kirillov>
* 1c0bbaf225f - FIR: add ensureResolved to FirExposedVisibilityDeclarationChecker (vor 2 Wochen) <Ilya Kirillov>
* 04fca93b1e0 - FIR IDE: fix completion on parenthesized expression (vor 2 Wochen) <Ilya Kirillov>
* 879cf3b0498 - FIR IDE: do not fail whole completion on exception in lookup element creation (vor 2 Wochen) <Ilya Kirillov>
* e9fb79741a7 - FIR IDE: fix completion in initializer (vor 2 Wochen) <Ilya Kirillov>
* 1ab6595ae24 - FIR Completion: Use name filtering in completion contributor (vor 2 Wochen) <Roman Golyshev>
* 75d8710bf6e - FIR IDE: Add name filtering to scope `KtScope` and implementations (vor 2 Wochen) <Roman Golyshev>
* dc600e3caf3 - FIR IDE: Fix `buildKtType` for `ConeDefinitelyNotNullType` (vor 2 Wochen) <Roman Golyshev>
* 74298aae320 - FIR IDE: invalidate sessions on exception (vor 2 Wochen) <Ilya Kirillov>
* a743b80d17f - FIR IDE: reuse up-to-date fir sessions (vor 2 Wochen) <Ilya Kirillov>
* 22c2d34b14b - FIR IDE: add debug info when can not build KtType (vor 2 Wochen) <Ilya Kirillov>
* a52262bf976 - FIR IDE: run completion resolve under lock (vor 2 Wochen) <Ilya Kirillov>
* f1c808384e3 - FIR IDE: do not resolve symbols by transitive module dependencies (vor 2 Wochen) <Ilya Kirillov>
* 01875635db2 - FIR IDE: do not resolve whole firFile in completion (vor 2 Wochen) <Ilya Kirillov>
* 2cfbfabe049 - FIR IDE: do not recreate transformer phases & ScopeSession (vor 2 Wochen) <Ilya Kirillov>
* 9a99703f24c - FIR IDE: implement incremental function analysis (vor 2 Wochen) <Ilya Kirillov>
* 8bcba00bb78 - FIR IDE: do not resolve declarations if they are already resolved when we are inside lock (vor 2 Wochen) <Ilya Kirillov>
* fc64d8d5e82 - FIR IDE: reanalyse dependent modules only then they change (vor 2 Wochen) <Ilya Kirillov>
* 07be30c5db6 - FIR IDE: separate fir session for current module from dependent modules session (vor 2 Wochen) <Ilya Kirillov>
* ab897752de7 - FIR IDE: remove invalid comments from FirIdeSessionFactory (vor 2 Wochen) <Ilya Kirillov>
* 4045c8fbf42 - FIR IDE: fix invalid order of classes in classIdIfNonLocal (vor 2 Wochen) <Ilya Kirillov>
* 766063ba774 - FIR IDE: optimize search for FirDeclaration by KtDeclaration (vor 2 Wochen) <Ilya Kirillov>
* 36e57545e8c - FIR IDE: simplify psiModificationTrackerBasedCachedValue (vor 2 Wochen) <Ilya Kirillov>
* 73451b16169 - FIR IDE: reresolve libraries only when they change (vor 2 Wochen) <Ilya Kirillov>
* c48cc615dd0 - FIR IDE: use KtAnalysisSession as receiver (vor 2 Wochen) <Ilya Kirillov>
* d4786e06a9e - FIR IDE: ignore PCE when running lazy resolve phase (vor 2 Wochen) <Ilya Kirillov>
* 9130392eb96 - FIR IDE: resolve symbol to status to get it modality (vor 2 Wochen) <Ilya Kirillov>
* 0c47d426592 - FIR IDE: add failing multiModuleLazyResolve test (vor 2 Wochen) <Ilya Kirillov>
* a3a59131b57 - FIR IDE: fix passing whenWithHeiarchy test (vor 2 Wochen) <Ilya Kirillov>
* 6d0a5a0bb20 - (tag: build-1.4.30-dev-558) KT-41346 Implement `NoReorderImplementation` without reordering (vor 2 Wochen) <Roman Golyshev>
* bf371ff98ae - KT-41346 Refactor `computeNonDeclared*` (vor 2 Wochen) <Roman Golyshev>
* b1097c49d32 - KT-41346 Move `Implementation` to `DeserializedMemberScope` (vor 2 Wochen) <Roman Golyshev>
* 5596bf33d8b - KT-41346 Move related code to `OptimizedImplementation` (vor 2 Wochen) <Roman Golyshev>
* c8878f862d9 - KT-41346 Introduce inner `OptimizedImplementation` class (vor 2 Wochen) <Roman Golyshev>
* 683dd57f24c - KT-41346 Extract `Implementation` interface (vor 2 Wochen) <Roman Golyshev>
* 341a7478ed7 - KT-41346 Move removing non-available functions to protected method (vor 2 Wochen) <Roman Golyshev>
* 4f4c25ca5e6 - KT-41346 Cleanup `DeserializedMemberScope` (vor 2 Wochen) <Roman Golyshev>
* 622f71bd659 - Fix binary compatibility with AS (vor 2 Wochen) <Ilya Kirillov>
* 1c4567c999a - (tag: build-1.4.30-dev-557) Add tests for KT-40152 (vor 2 Wochen) <Dmitry Petrov>
* cd37301ea24 - Minor: TARGET_BACKEND=JVM in JVM-specific tests (vor 2 Wochen) <Dmitry Petrov>
* 99dbeecc40f - Some more bytecode listing tests for JVM_IR (vor 2 Wochen) <Dmitry Petrov>
* 25ea3df5ca8 - (tag: build-1.4.30-dev-553) Put fix in 9123c4f73baf77f8a50dede6c890c46f5ffafd6c under the inference compatibility flag (vor 2 Wochen) <Victor Petukhov>
* bfb46befa5f - Mark projection of a nullable captured type as not null during simplification constrains with it and a nullable type variable (vor 2 Wochen) <Victor Petukhov>
* 0f868ff83f5 - (tag: build-1.4.30-dev-552) [TEST] Regenerate tests (vor 2 Wochen) <Dmitriy Novozhilov>
* 84df9962049 - (tag: build-1.4.30-dev-550) JVM IR: fix "step over" for inline function calls in conditions (vor 2 Wochen) <Alexander Udalov>
* 4144adf4ee1 - (tag: build-1.4.30-dev-549) Make internal: don't suggest in interface (vor 2 Wochen) <Toshiaki Kameyama>
* 6e8565917e4 - (tag: build-1.4.30-dev-543) MapGetWithNotNullAssertionOperatorInspection: decrease severity to INFORMATION (vor 2 Wochen) <Toshiaki Kameyama>
* 5e73e28695c - (tag: build-1.4.30-dev-541) [FIR-TEST] Fix psi consistency test due to 5efd533f (vor 2 Wochen) <Dmitriy Novozhilov>
* 10e7c0f1b26 - [TEST] Fix long literal in testdata broken in 4374c06 (vor 2 Wochen) <Dmitriy Novozhilov>
* a2bde2ffb23 - (tag: build-1.4.30-dev-537) Redundant overriding method: do not report when super method is not called (vor 2 Wochen) <Toshiaki Kameyama>
* 76ed09482f9 - (tag: build-1.4.30-dev-534) [IR BE] Fix inline class lowering (vor 2 Wochen) <Roman Artemev>
* 5954db18cb1 - JVM_IR: fix lifting of arguments to object super constructors (vor 2 Wochen) <pyos>
* 4d5e54cab6e - (tag: build-1.4.30-dev-533) [FIR] Unwrap definitely not null when matching overrides (vor 2 Wochen) <Dmitriy Novozhilov>
* 08b5f3ddde9 - [FIR] Remove unused list with java.lang.Object member names (vor 2 Wochen) <Dmitriy Novozhilov>
* 896103b94b5 - [FIR] Properly resolve implicit invoke calls (vor 2 Wochen) <Dmitriy Novozhilov>
* a8e81e9ad1e - [FIR] Add special node for implicit invoke calls (vor 2 Wochen) <Dmitriy Novozhilov>
* 696c8f07b44 - [FIR] Add pretty `toString` to CallKind (vor 2 Wochen) <Dmitriy Novozhilov>
* 40a9bb6eac9 - [FIR] Assume nullable types as good types for ILT approximation (vor 2 Wochen) <Dmitriy Novozhilov>
* f0698574925 - [FIR] Cleanup annotations transform in FirExpressionsResolveTransformer (vor 2 Wochen) <Dmitriy Novozhilov>
* 0e91c8f0489 - [FIR] Create synthetic properties for members of java annotations (vor 2 Wochen) <Dmitriy Novozhilov>
* da3a676c2ae - [FIR] Get rid of FirIntegerLiteralTypeScope and corresponding stuff (vor 2 Wochen) <Dmitriy Novozhilov>
* 4374c065377 - [FIR] Approximate all integer literals which resolved in independent mode (vor 2 Wochen) <Dmitriy Novozhilov>
* 5efd533f55e - [FIR] Desugar unary plus and minus as part of integer literal (vor 2 Wochen) <Dmitriy Novozhilov>
* a018847f85c - [FIR] Properly deserialize type attributes for type arguments (vor 2 Wochen) <Dmitriy Novozhilov>
* a274216f14d - [FIR] Check that expected lambda type is extension function using cone expected type (vor 2 Wochen) <Dmitriy Novozhilov>
* 57a57d10da4 - [FIR] Add rendering for attribites of cone types (vor 2 Wochen) <Dmitriy Novozhilov>
* d48307ec34f - (tag: build-1.4.30-dev-528) JVM IR: do not copy type parameters into suspend lambda classes (vor 2 Wochen) <Alexander Udalov>
* bdf502edef9 - (tag: build-1.4.30-dev-523) Override/Implement members: don't add 'external' modifier (vor 2 Wochen) <Toshiaki Kameyama>
* 4e5c61cd2fa - (tag: build-1.4.30-dev-522) Notify if gradle points to invalid JDK (vor 2 Wochen) <Vladimir Dolzhenko>
* be20a8bd800 - (tag: build-1.4.30-dev-520) Configure modules Kotlin language settings in a background with a progress (vor 2 Wochen) <Vladimir Dolzhenko>
* f0cbd6b1a54 - (tag: build-1.4.30-dev-510) HMPP: Avoid NPE during Kotlin facet serialization (vor 2 Wochen) <Dmitriy Dolovov>
* 4653a164502 - (tag: build-1.4.30-dev-506) [FIR2IR] Add problematic test with in/out clash during approximation (vor 2 Wochen) <Mikhail Glukhikh>
* 3a57a541f41 - FIR mangler: support captured types (vor 2 Wochen) <Mikhail Glukhikh>
* b64b32e06b2 - FIR: keep captured types in substitution scope (vor 2 Wochen) <Mikhail Glukhikh>
* b7059a3eebb - FIR: perform type approximation when completion isn't required (vor 2 Wochen) <Mikhail Glukhikh>
* 03102727382 - FIR: perform more proper type approximation in completion (vor 2 Wochen) <Mikhail Glukhikh>
* 14cfc62745e - FIR: fix calculation of type arguments for bare types (vor 2 Wochen) <Mikhail Glukhikh>
* 3c3aa3210e1 - FIR: use FROM_EXPRESSION, not FOR_SUBTYPING capt. types in substitution (vor 2 Wochen) <Mikhail Glukhikh>
* 86d1a3be379 - FIR serializer: throw exception on getting ConeIntegerLiteralType (vor 2 Wochen) <Mikhail Glukhikh>
* 5a919cc827b - FIR element serializer: drop duplicated approximation code (vor 2 Wochen) <Mikhail Glukhikh>
* 104f088d4e1 - FIR serializer: throw exception on getting ConeCapturedType (vor 2 Wochen) <Mikhail Glukhikh>
* 83ee705c0ae - (tag: build-1.4.30-dev-499) IR: make IrClassReference.classType mutable (vor 2 Wochen) <Georgy Bronnikov>
* 9d22ef948c9 - IR: rework ScopeValidator (vor 2 Wochen) <Georgy Bronnikov>
* 377940a6ea2 - IR: handle IrVararg.varargElementType in RemapTypes (vor 2 Wochen) <Georgy Bronnikov>
* a542bb6af74 - IR: check IrClassReference.classType in ScopeValidator (vor 2 Wochen) <Georgy Bronnikov>
* 728c55973ab - IR: handle MemberAccessExpression type parameters in RemapTypes (vor 2 Wochen) <Georgy Bronnikov>
* 3041a2815c9 - IR: handle varargElementType in LocalDeclarationsLowering (vor 2 Wochen) <Georgy Bronnikov>
* 8990344bb29 - Varargs: add test (vor 2 Wochen) <Georgy Bronnikov>
* 67d7bf32690 - IR: take care of supertypes when copying IrTypeParameters (vor 2 Wochen) <Georgy Bronnikov>
* 916d66c2204 - IR: add ScopeValidator (vor 2 Wochen) <Georgy Bronnikov>
* 382f423ab94 - Mute a test under DCE (vor 2 Wochen) <Georgy Bronnikov>
* 33a2c691229 - IR: remap types in LocalDeclarationsLowering (vor 2 Wochen) <Georgy Bronnikov>
* 1f3d344835c - IR: add RemapTypes.kt (vor 2 Wochen) <Georgy Bronnikov>
* df1d9a01137 - IR: make IrTypeParameter.superTypes persistent mutable field (vor 2 Wochen) <Georgy Bronnikov>
* a409976d28d - IR: make IrValueParameter.varargElementType mutable (vor 2 Wochen) <Georgy Bronnikov>
* a3763e82766 - IR: make IrTypeAlias.expandedType mutable (vor 2 Wochen) <Georgy Bronnikov>
* 78fc690f299 - IR: make IrLocaldelegatedProperty.type mutable (vor 2 Wochen) <Georgy Bronnikov>
* 09a906cc9a7 - IR: make IrTypeOperatorCall.typeOperand mutable (vor 2 Wochen) <Georgy Bronnikov>
* d9681e535da - IR: make IrField.type mutable (vor 2 Wochen) <Georgy Bronnikov>
* 5065b1a4c61 - Make IrValueDeclaration.type mutable (vor 2 Wochen) <Georgy Bronnikov>
* 1f37795e08f - IR: make IrExpression.type mutable (vor 2 Wochen) <Georgy Bronnikov>
* fde7fc69518 - (tag: build-1.4.30-dev-495) JVM IR: use correct file for final test output check in debugger tests (vor 2 Wochen) <Alexander Udalov>
* 78483930bc2 - (tag: build-1.4.30-dev-494) [JVM_IR] Fix offsets in constant propagation optimization. (vor 2 Wochen) <Mads Ager>
* f273edeb8ec - Build: upgrade language to 1.3 in cli, compiler plugins and Gradle plugin (vor 2 Wochen) <Alexander Udalov>
* 5755c32c84c - Minor, fix appendln deprecation warnings in cli (vor 2 Wochen) <Alexander Udalov>
* f20a6b7fe1c - (tag: build-1.4.30-dev-492)  Change function signature: add/change receiver type (vor 2 Wochen) <Toshiaki Kameyama>
* 9f3ce099ee7 - (tag: build-1.4.30-dev-484) [JVM_IR] Fix line numbers for function reference invoke methods. (vor 2 Wochen) <Mads Ager>
* 16b2379cd72 - (tag: build-1.4.30-dev-481) [Gradle, JS] Use new npm versions (vor 2 Wochen) <Ilya Goncharov>
* 9f9cb4f57e9 - [Gradle, JS] Parallelize requests (vor 2 Wochen) <Ilya Goncharov>
* a86dd8b5ba7 - [Gradle, JS] Refactor with coroutines (vor 2 Wochen) <Ilya Goncharov>
* 4986e8c9ccb - [Gradle, JS] Fetch NPM package versions in separate module (vor 2 Wochen) <Ilya Goncharov>
* db90c9cc888 - [Gradle, JS] Move from NpmVersions (vor 2 Wochen) <Ilya Goncharov>
* 7d4a734791a - (tag: build-1.4.30-dev-478) Fix nullability of `typePath` parameter (vor 2 Wochen) <Mikhael Bogdanov>
* 0539b2b3896 - Mute some FIR->JVM_IR box tests (vor 2 Wochen) <Dmitry Petrov>
* c03573fc18c - (tag: build-1.4.30-dev-473) JVM_IR fix override equivalence check for collection stub generation (vor 2 Wochen) <Dmitry Petrov>
* fdc134ff666 - (tag: build-1.4.30-dev-471) [NI] Use compatibility mode for KT-41934 (vor 2 Wochen) <Pavel Kirpichenkov>
* 1465e10f128 - Add language feature for inference compatibility mode (vor 2 Wochen) <Pavel Kirpichenkov>
* 896fbbd1a3d - [NI] Add extra ordering for ready-for-fixation variables (vor 2 Wochen) <Pavel Kirpichenkov>
* ec8465859cd - (tag: build-1.4.30-dev-469) Support rerun of MPP tests for jvm target (vor 2 Wochen) <Kirill Shmakov>
* 23642d2f869 - Support rerun of common MPP tests (vor 2 Wochen) <Kirill Shmakov>
* c09c0468d4d - (tag: build-1.4.30-dev-457) Replace deprecated symbol usage: move named lambda argument outside parentheses (vor 2 Wochen) <Toshiaki Kameyama>
* d9cf4ee732a - (tag: build-1.4.30-dev-455) Add intention to evaluate compile time expression (vor 2 Wochen) <Toshiaki Kameyama>
* 8cac3f654cf - (tag: build-1.4.30-dev-451) [FIR] Handle pre/postfix dec/increment of labeled expression (vor 2 Wochen) <Mark Punzalan>
* f55ff8eb1b6 - [FIR] Capture receiver for pre/postfix dec/increment of qualified access (vor 2 Wochen) <Mark Punzalan>
* 393189db8d3 - (tag: build-1.4.30-dev-445) FIR JVM serializer: fix compilation after rebase (vor 2 Wochen) <Mikhail Glukhikh>
* 6e143a26562 - JVM_IR: collect free type parameters when serializing FIR metadata (vor 2 Wochen) <pyos>
* aa58ed92348 - JVM_IR: partially implement FIR local delegated property reflection (vor 2 Wochen) <pyos>
* 6f622920e71 - (tag: build-1.4.30-dev-430) Minor, deduplicate matching JVM_OLD/JVM_IR duplicateJvmSignature tests (vor 2 Wochen) <Alexander Udalov>
* 05c662ec554 - [JVM_IR] Remove line numbers from delegated member functions. (vor 2 Wochen) <Mads Ager>
* eea4ff33a01 - (tag: build-1.4.30-dev-425) Adapt serialization exceptions constructor calls to signature change (vor 2 Wochen) <Leonid Startsev>
* fe5dbf75fa9 - Add diagnostic to check whether provided custom serializer matches (vor 2 Wochen) <Leonid Startsev>
* bc432ecb852 - Improve remove/specify type intentions in Explicit API mode (vor 2 Wochen) <Leonid Startsev>
* 5f0e7c3c3fc - Check return type of `internal @PublishedApi` functions in Explicit API mode (vor 2 Wochen) <Leonid Startsev>
* a9972913a6e - (tag: build-1.4.30-dev-423) [FIR TEST] Add some FIR_IDENTICAL to fix recently changed tests (vor 2 Wochen) <Mikhail Glukhikh>
* c9054e7a04f - (tag: build-1.4.30-dev-409) Added possibility to split gradle-integration-tests locally (vor 2 Wochen) <Andrey Uskov>
* d151f0e573e - Fixed splitting gradle tests into different tasks (vor 2 Wochen) <Andrey Uskov>