### PR TITLE
Use non-local ObjC-export mapping and naming in ObjcExportHeaderGeneratorMobile

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjcExportHeaderGeneratorMobile.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjcExportHeaderGeneratorMobile.kt
@@ -19,11 +19,12 @@ class ObjcExportHeaderGeneratorMobile internal constructor(
                 warningCollector: ObjCExportWarningCollector,
                 builtIns: KotlinBuiltIns,
                 moduleDescriptors: List<ModuleDescriptor>,
-                deprecationResolver: DeprecationResolver? = null): ObjCExportHeaderGenerator {
+                deprecationResolver: DeprecationResolver? = null,
+                local: Boolean = false): ObjCExportHeaderGenerator {
 
-            val mapper = ObjCExportMapper(deprecationResolver, local = false)
+            val mapper = ObjCExportMapper(deprecationResolver, local)
             val namerConfiguration = createNamerConfiguration(configuration)
-            val namer = ObjCExportNamerImpl(namerConfiguration, builtIns, mapper, local = false)
+            val namer = ObjCExportNamerImpl(namerConfiguration, builtIns, mapper, local)
 
             return ObjcExportHeaderGeneratorMobile(
                     moduleDescriptors,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjcExportHeaderGeneratorMobile.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjcExportHeaderGeneratorMobile.kt
@@ -21,9 +21,9 @@ class ObjcExportHeaderGeneratorMobile internal constructor(
                 moduleDescriptors: List<ModuleDescriptor>,
                 deprecationResolver: DeprecationResolver? = null): ObjCExportHeaderGenerator {
 
-            val mapper = ObjCExportMapper(deprecationResolver, local = true)
+            val mapper = ObjCExportMapper(deprecationResolver, local = false)
             val namerConfiguration = createNamerConfiguration(configuration)
-            val namer = ObjCExportNamerImpl(namerConfiguration, builtIns, mapper, local = true)
+            val namer = ObjCExportNamerImpl(namerConfiguration, builtIns, mapper, local = false)
 
             return ObjcExportHeaderGeneratorMobile(
                     moduleDescriptors,


### PR DESCRIPTION
We're getting duplicate stubs in local mode, but the problem does not seem to occur in non-local mode.