### PR TITLE
[kotlin compiler][update] 1.4.30-dev-1359

### DIFF
--- a/Interop/StubGenerator/build.gradle
+++ b/Interop/StubGenerator/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     api "org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion"
     api "org.jetbrains.kotlin:kotlin-native-shared:$konanVersion"
-    api "org.jetbrains.kotlinx:kotlinx-metadata-klib:0.0.1-dev-10"
+    api "org.jetbrains.kotlinx:kotlinx-metadata-klib:$metadataVersion"
 
     testImplementation "junit:junit:4.12"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$buildKotlinVersion"

--- a/build-tools/build.gradle.kts
+++ b/build-tools/build.gradle.kts
@@ -30,6 +30,10 @@ val kotlinCompilerRepo: String by rootProperties
 val buildKotlinVersion: String by rootProperties
 val buildKotlinCompilerRepo: String by rootProperties
 val konanVersion: String by rootProperties
+val slackApiVersion: String by rootProperties
+val ktorVersion: String by rootProperties
+val shadowVersion: String by rootProperties
+val metadataVersion: String by rootProperties
 
 group = "org.jetbrains.kotlin"
 version = konanVersion
@@ -50,19 +54,19 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    implementation("com.ullink.slack:simpleslackapi:1.2.0")
+    implementation("com.ullink.slack:simpleslackapi:$slackApiVersion")
 
-    implementation("io.ktor:ktor-client-auth:1.2.1")
-    implementation("io.ktor:ktor-client-core:1.2.1")
-    implementation("io.ktor:ktor-client-cio:1.2.1")
+    implementation("io.ktor:ktor-client-auth:$ktorVersion")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
 
     api("org.jetbrains.kotlin:kotlin-native-utils:$kotlinVersion")
 
     // Located in <repo root>/shared and always provided by the composite build.
     api("org.jetbrains.kotlin:kotlin-native-shared:$konanVersion")
-    implementation("com.github.jengelman.gradle.plugins:shadow:5.1.0")
+    implementation("com.github.jengelman.gradle.plugins:shadow:$shadowVersion")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-klib:0.0.1-dev-10")
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-klib:$metadataVersion")
 }
 
 sourceSets["main"].withConvention(KotlinSourceSet::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1260,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-1260
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1260,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-1260
-kotlinStdlibTestsVersion=1.4.30-dev-1260
-testKotlinCompilerVersion=1.4.30-dev-1260
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1359,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-1359
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1359,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-1359
+kotlinStdlibTestsVersion=1.4.30-dev-1359
+testKotlinCompilerVersion=1.4.30-dev-1359
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,10 @@ gtestRevision=07f4869221012b16b7f9ee685d94856e1fc9f361
 
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.workers.max=4
+slackApiVersion=1.2.0
+ktorVersion=1.2.1
+shadowVersion=5.1.0
+metadataVersion=0.0.1-dev-10
 
 # Uncomment to enable composite build
 #kotlinProjectPath=<insert the path to Kotlin project root here>


### PR DESCRIPTION
* 3eeaa07e0c9 - (tag: build-1.4.30-dev-1359) Sync up plugin.xml AS42 with 202 (vor 2 Stunden) <Vladimir Dolzhenko>
* f941733f13d - (tag: build-1.4.30-dev-1358) [JVM_IR] Rebase init blocks stepping test that is working as intended. (vor 2 Stunden) <Mads Ager>
* a9bc63dece0 - (tag: build-1.4.30-dev-1337) Drop redundant legacy_name from ide perf tests json stats (vor 35 Stunden) <Vladimir Dolzhenko>
* a4fb2a445f2 - (tag: build-1.4.30-dev-1328) Minor, add spaces to diagnostic message (vor 3 Tagen) <Alexander Udalov>
* ac39e4d89c0 - Minor, add regression test (vor 3 Tagen) <Alexander Udalov>
* 6f9f437f151 - IR: refuse to copy classes in InitializersLowering (vor 3 Tagen) <pyos>
* e6c0575d3a0 - JVM_IR: do not deep-copy suspend lambdas in initializers (vor 3 Tagen) <pyos>
* 8bc7370b92e - (tag: build-1.4.30-dev-1324) ForLoopsLowering: Add PLUSEQ origin to increment to use IINC instructions if possible. (vor 3 Tagen) <Mark Punzalan>
* 14137cb0139 - ForLoopsLowering: Remove `additionalNotEmptyCondition` as it is no longer used in UntilHandler. (vor 3 Tagen) <Mark Punzalan>
* ccbf7cc2ee2 - ForLoopsLowering: Use last-exclusive for-loops for optimized `until` progressions instead of decrementing "last". (vor 3 Tagen) <Mark Punzalan>
* 1adb130509a - ForLoopsLowering: Move `isLastInclusive` to HeaderInfo. (vor 3 Tagen) <Mark Punzalan>
* a093efde114 - Add blackbox test for KT-42533. (vor 3 Tagen) <Mark Punzalan>
* 375d92cf673 - (tag: build-1.4.30-dev-1319) Merge two consequent records in LVT (vor 3 Tagen) <Ilmir Usmanov>
* 91b8e32d431 - (tag: build-1.4.30-dev-1318, origin/rr/pdn_jvmir_abi_tests) Add ABI tests for classes extending Number and CharSequence (vor 3 Tagen) <Dmitry Petrov>
* 6dd2d8bbdb8 - (tag: build-1.4.30-dev-1312) JVM_IR drop 'SpecialMethodWithDefaultInfo#needsArgumentBoxing' (vor 3 Tagen) <Dmitry Petrov>
* a412596d8ef - JVM_IR emulate old back-end behavior in special bridges + inline classes (vor 3 Tagen) <Dmitry Petrov>
* 92fa13cbabe - Workaround for a possible compiler bug in object literals (vor 3 Tagen) <Dmitry Petrov>
* 23beaa5883a - [formatter] add tests for line indent after properties (vor 3 Tagen) <Dmitry Gridin>
* 434139d9864 - Revert "Add indent before accessor for extension property (KT-33131)" (vor 3 Tagen) <Dmitry Gridin>
* 852d705c71c - (tag: build-1.4.30-dev-1305) FIR: optimize converting string expressions in raw FIR builder (vor 3 Tagen) <Ilya Kirillov>
* 5937ffae4d5 - FIR: optimize checking if placeholder projection for raw FIR builder (vor 3 Tagen) <Ilya Kirillov>
* bbc641b390b - FIR: do not get statement text for every statement in raw FIR builder (vor 3 Tagen) <Ilya Kirillov>
* b1768d805f9 - (tag: build-1.4.30-dev-1298) [Gradle, JS] Rename dukatMode to externalsOutputFormat (vor 3 Tagen) <Ilya Goncharov>
* 3ad6d581531 - [Gradle, JS] Execute dukat on import in both mode (vor 3 Tagen) <Ilya Goncharov>
* 0a86beeb64b - [Gradle, JS] Add descriptors to dependencies in configurations phase (vor 3 Tagen) <Ilya Goncharov>
* af65365d6ae - [Gradle, JS] Move gradle post processing after executing of dukat (vor 3 Tagen) <Ilya Goncharov>
* 4eea52e4e73 - [Gradle, JS] Add TaskAction on overriden method for integrated task (vor 3 Tagen) <Ilya Goncharov>
* b37414ae0bd - [Gradle, JS] Add test on compilation with dukat binaries (vor 3 Tagen) <Ilya Goncharov>
* c1fe8defd23 - [Gradle, JS] Dukat descriptors (vor 3 Tagen) <Ilya Goncharov>
* 500fceb4389 - [Gradle, JS] Add binary dukat mode (vor 3 Tagen) <Ilya Goncharov>
* f50851a982e - (tag: build-1.4.30-dev-1297) Fix testdata after migrating to NewKotlinTypeCheckerImpl in OverrideResolver (vor 3 Tagen) <Dmitry Savvinov>
* f02593074f7 - Drop isEqualTypeConstructor in favour of areEqualTypeConstructors (vor 3 Tagen) <Dmitry Savvinov>
* fc4b488d436 - Use NewKotlinTypeChecker in OverridingUtil (vor 3 Tagen) <Dmitry Savvinov>
* 01d61810504 - Add test on overriding declaration with a composite type with expect declaration (vor 3 Tagen) <Dmitry Savvinov>
* f8b90116678 - Minor: unify error reporting for fun/properties overriding (vor 3 Tagen) <Dmitry Savvinov>
* ac63d8b3bf1 - Unify code for checking return type on override for fun/property (vor 3 Tagen) <Dmitry Savvinov>
* 736ecf3e9fb - Add test case on overriding property of expect-type (vor 3 Tagen) <Dmitry Savvinov>
* ac107f362e0 - Refine types of type parameters before checking their equality in OverridingUtil (vor 3 Tagen) <Dmitry Savvinov>
* 80f4061a3db - Add test on override with expect in return type (vor 3 Tagen) <Dmitry Savvinov>
* f8b8f94040b - (tag: build-1.4.30-dev-1296, tag: build-1.4.30-dev-1292) Adjust vega IDE performance test charts (vor 3 Tagen) <Vladimir Dolzhenko>
* a6efaf440aa - (tag: build-1.4.30-dev-1291) FIR supertypes: replace class phase even if it hasn't unresolved supers (vor 3 Tagen) <Mikhail Glukhikh>
* 94302614cd4 - [FIR] Add forgotten resolving status of enum entries (by Dmitry) (vor 3 Tagen) <Mikhail Glukhikh>
* 5fbe7158711 - [FIR] Add forgotten replacing resolve phase during type resolve (vor 3 Tagen) <Dmitriy Novozhilov>
* 1f5797e929d - Don't resolve annotation arguments in FirTypeResolveTransformer (vor 3 Tagen) <Mikhail Glukhikh>
* 6f89385aec0 - Transform forgotten property annotations in FirTypeResolveTransformer (vor 3 Tagen) <Mikhail Glukhikh>
* e5463be6ba5 - Don't transform parameter default values in FirTypeResolveTransformer (vor 3 Tagen) <Mikhail Glukhikh>
* bdec2454247 - Don't transform enum entry initializer in FirTypeResolveTransformer (vor 3 Tagen) <Mikhail Glukhikh>
* 880eb6da6ca - Don't transform delegated constructor args in FirTypeResolveTransformer (vor 3 Tagen) <Mikhail Glukhikh>
* 949952e766c - (tag: build-1.4.30-dev-1275) kotlinx-metadata: minor, remove incorrect ReplaceWith from IS_PRIMARY deprecation (vor 4 Tagen) <Alexander Udalov>
* afd710292a8 - [JVM_IR] Fix mangling of default argument stubs for internal methods. (vor 4 Tagen) <Mads Ager>
* 8c88670185d - (tag: build-1.4.30-dev-1270) FIR: copy constructor for typealias'ed inner/nested class (vor 4 Tagen) <Jinseong Jeon>