### PR TITLE
[kotlin compiler][update] 1.4.30-dev-1514

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1359,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-1359
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1359,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-1359
-kotlinStdlibTestsVersion=1.4.30-dev-1359
-testKotlinCompilerVersion=1.4.30-dev-1359
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1514,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-1514
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1514,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-1514
+kotlinStdlibTestsVersion=1.4.30-dev-1514
+testKotlinCompilerVersion=1.4.30-dev-1514
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 96834d6f4cc - (tag: build-1.4.30-dev-1514) Update example for default buildList to not use capacity KT-41136 (#3688) (vor 7 Stunden) <Derek Bodin>
* d9b3f91d730 - (tag: build-1.4.30-dev-1513) Support hasError in ide perf tests vega charts (vor 8 Stunden) <Vladimir Dolzhenko>
* 051d9149966 - (tag: build-1.4.30-dev-1508) Align ide perf tests vega charts with json reports camelCase propNames (vor 11 Stunden) <Vladimir Dolzhenko>
* 98efdaa5237 - (tag: build-1.4.30-dev-1507) FIR IDE: fix KtTypeRendererTest (vor 11 Stunden) <Ilya Kirillov>
* 5cda4b5ab33 - fix test generator compilation (vor 11 Stunden) <Ilya Kirillov>
* 29151665e15 - FIR IDE: add fir ide plugin tests task (vor 11 Stunden) <Ilya Kirillov>
* bd68b937e53 - FIR: ignore `testdata` directory in testPsiConsistency test (vor 11 Stunden) <Ilya Kirillov>
* 5c798d4e132 - FIR IDE: fix test data in fir-ide module (vor 11 Stunden) <Ilya Kirillov>
* 6086b54a061 - FIR IDE: do preliminary highlighting in completion tests considering exceptions (vor 11 Stunden) <Ilya Kirillov>
* b9cf9d8bc53 - FIR IDE: add missing test dependency (vor 11 Stunden) <Ilya Kirillov>
* 2f093e76b01 - FIR IDE: render resolve phase for lazy resolve tests (vor 11 Stunden) <Ilya Kirillov>
* 9c53c66bb56 - FIR IDE: actualize testdata for idea-frontend-fir module (vor 11 Stunden) <Ilya Kirillov>
* a585d206392 - FIR IDE: fix bodies calculator for property acessors (vor 11 Stunden) <Ilya Kirillov>
* ab4faa52f05 - FIR IDE: add missing IdeSessionComponents for FirIdeBuiltinsAndCloneableSession (vor 11 Stunden) <Ilya Kirillov>
* a22514cf8e5 - FIR IDE: separate lazy phase into 3 phases, add contracts phase (vor 11 Stunden) <Ilya Kirillov>
* c418140bef7 - FIR IDE: fix test dependencies (vor 11 Stunden) <Ilya Kirillov>
* dc467f7d6c5 - FIR: add test which checks that we do not access lazy bodies & lazy expressions till contract phase (vor 11 Stunden) <Ilya Kirillov>
* 7611135a4ad - FIR: add raw fir building delegate expression test (vor 11 Stunden) <Ilya Kirillov>
* 971e551bae3 - FIR IDE: implement lazy delegate initializers (vor 11 Stunden) <Ilya Kirillov>
* 3f9735dd5d8 - FIR: use enum in RawFirBuilder to indicate its mode: normals, stubs, or lazy bodies (vor 11 Stunden) <Ilya Kirillov>
* 81d4371685e - FIR IDE: generate lazy initializers for properties (vor 11 Stunden) <Ilya Kirillov>
* 7c1170722ff - FIR: add FirLazyExpression node (vor 11 Stunden) <Ilya Kirillov>
* 71b5b6df7c1 - FIR IDE: add tests for lazy resolving single declaration in file (vor 11 Stunden) <Ilya Kirillov>
* f4199a07299 - FIR: add ability to render declaration phase in FirRenderer (vor 11 Stunden) <Ilya Kirillov>
* bbf450703f4 - FIR: introduce stub bodies raw fir test case (vor 11 Stunden) <Ilya Kirillov>
* d2d330c3be2 - FIR IDE: implement lazy functions, constructors & accessors bodies building for raw fir (vor 11 Stunden) <Ilya Kirillov>
* 4fae9cbdb07 - FIR: introduce FirLazyBlock node (vor 11 Stunden) <Ilya Kirillov>
* 864800902bd - FIR IDE: introduce WeakFirByPsiRef (vor 11 Stunden) <Ilya Kirillov>
* 17748b44994 - (tag: build-1.4.30-dev-1506) [JVM_IR] Fix off-by-one line number error in CoroutineCodegen. (vor 11 Stunden) <Mads Ager>
* 13def12731a - (tag: build-1.4.30-dev-1505) IR: remove unnecessary calls to deepCopyWithSymbols (vor 12 Stunden) <pyos>
* 45a0850d95f - (tag: build-1.4.30-dev-1503) Fix KotlinType.isNullabilityFlexible for types based on type parameters (vor 13 Stunden) <Alexander Udalov>
* fbf56c054bc - JVM IR: fix names of $annotations methods for internal properties (vor 13 Stunden) <Alexander Udalov>
* 3f73be391fc - JVM IR: fix names of $annotations methods with inline classes in signature (vor 13 Stunden) <Alexander Udalov>
* 1df3bafbaf2 - (tag: build-1.4.30-dev-1498) Minor, fix and unmute fieldNameClash.kt test (vor 15 Stunden) <Alexander Udalov>
* ec877843fc0 - (tag: build-1.4.30-dev-1495) [Gradle, K/N] Increase Xmx for MPP tests with native (vor 16 Stunden) <Alexander.Likhachev>
* babc7845afa - (tag: build-1.4.30-dev-1489) FirSyntheticPropertiesScope: support case with derived getter (vor 17 Stunden) <Mikhail Glukhikh>
* 2f9b7495fcf - [FIR2IR] Make safe call result always nullable (vor 17 Stunden) <Mikhail Glukhikh>
* d623f4d1d64 - (tag: build-1.4.30-dev-1488) Add test for KT-40190 (vor 17 Stunden) <Dmitry Petrov>
* d3f98923dc4 - (tag: build-1.4.30-dev-1487) [Gradle, JS] Fix K/JS project build with configuration cache enabled (vor 18 Stunden) <Alexander.Likhachev>
* 82a66bc6590 - [Gradle, K/N] Remove wasm from VariantAwareDependenciesIT (vor 18 Stunden) <Alexander.Likhachev>
* e505c6473d2 - [Gradle, K/N] Remove check for export API from libraries producing test (vor 18 Stunden) <Alexander.Likhachev>
* 72ad581fe42 - [Gradle, K/N] Change prefix of apple-specific tests to native-* (vor 18 Stunden) <Alexander.Likhachev>
* 3ab99c1f96d - [Gradle, K/N] Reduce number of targets in MPP tests (vor 18 Stunden) <Alexander.Likhachev>
* 3dda02459df - [Gradle, K/N] Add more cases for cinterop test (vor 18 Stunden) <Alexander.Likhachev>
* be7cc32c10e - [Gradle, K/N] Add export API test for frameworks (vor 18 Stunden) <Alexander.Likhachev>
* 7c2339bcad7 - [Gradle, K/N] Move compiler version change to separate test (vor 18 Stunden) <Alexander.Likhachev>
* f0aa4a59e3c - [Gradle, K/N] Tests cleanup (vor 18 Stunden) <Alexander.Likhachev>
* 4b68678a364 - [Gradle, K/N] Add release binaries to generate binaries tests (vor 18 Stunden) <Alexander.Likhachev>
* 08ee702d19d - Update Kotlin/Native: 1.4.30-dev-16766 (vor 18 Stunden) <Alexander.Likhachev>
* 5dd1e75793d - [Gradle, K/N] Configure memory properties for tests in single place (vor 18 Stunden) <Alexander.Likhachev>
* 780b85e3ec6 - [Gradle, K/N] Simplify testNativeTests test by reducing number of targets (vor 18 Stunden) <Alexander.Likhachev>
* 882f4428482 - [Gradle, K/N] Simplify native cinterop test (vor 18 Stunden) <Alexander.Likhachev>
* 7523b401c32 - [Gradle, K/N] Remove wasm32 from mpp tests compile tasks (vor 18 Stunden) <Alexander.Likhachev>
* 79ba6df7b81 - [Gradle, K/N] Remove "kotlinx.html" maven repository from tests (vor 18 Stunden) <Alexander.Likhachev>
* 03ee0f60eac - [Gradle, K/N] Add workaround for iOS simulator warning report check (vor 18 Stunden) <Alexander.Likhachev>
* 00cbfa9eb4f - [Gradle, K/N] Simplify native binaries DSL test (vor 18 Stunden) <Alexander.Likhachev>
* 4f8503dc304 - [Gradle, K/N] Reduce number of targets in tests (vor 18 Stunden) <Alexander.Likhachev>
* 8aa9ef50492 - [Gradle, K/N] Enable compiler daemon in tests (vor 18 Stunden) <Alexander.Likhachev>
* 923e7f7de5e - [Gradle, K/N] Create new framework producing test (vor 18 Stunden) <Alexander.Likhachev>
* 76e03842ae4 - [Gradle, K/N] Refactor native-specific Gradle tests (vor 18 Stunden) <Ilya Matveev>
* 71fe60f4a2e - [Gradle, K/N] Rename native native-specific test projects (vor 18 Stunden) <Ilya Matveev>
* 174e390d2c2 - [Gradle, K/N] Add separate tasks for native-specific Gradle tests (vor 18 Stunden) <Ilya Matveev>
* d971817c32e - [Gradle, K/N] Move native-specific tests to a separate class from MPP (vor 18 Stunden) <Ilya Matveev>
* 4d28463f1a9 - (tag: build-1.4.30-dev-1486) FIR CLI: initialize module and dependencies (vor 18 Stunden) <Jinseong Jeon>
* 01ba1cded73 - (tag: build-1.4.30-dev-1481) [Cocoapods] Minor. Fix `CocoaPodsIT`, test data update (vor 21 Stunden) <Yaroslav Chernyshev>
* 36dd883768e - (tag: build-1.4.30-dev-1479) Update testData of testKt28385 for 202 version (vor 21 Stunden) <Alexander Dudinsky>
* 9ef7273641d - (tag: build-1.4.30-dev-1478) Unmute stdlib tests after bootstrap advance. (vor 21 Stunden) <Roman Artemev>
* 3d8b6147785 - (tag: build-1.4.30-dev-1472) [Commonizer] Allow debugging through "runCommonizer" Gradle task (vor 24 Stunden) <Dmitriy Dolovov>
* f49f5cb3d5a - [Commonizer] Fix classpath for "runCommonizer" Gradle task (vor 24 Stunden) <Dmitriy Dolovov>
* f27bf049117 - (tag: build-1.4.30-dev-1460) Perf test: remove info markers in testdata before test (vor 31 Stunden) <Ilya Kirillov>
* 4b3455dfa16 - (tag: build-1.4.30-dev-1444) Set backend for the test (vor 35 Stunden) <Pavel Punegov>
* 58ed1bbb64b - (tag: build-1.4.30-dev-1441) Can't use configure action from Immutable state (vor 2 Tagen) <nataliya.valtman>
* 9147aa76b50 - (tag: build-1.4.30-dev-1440) Advance bootstrap to 1.4.30-dev-1423 (vor 2 Tagen) <Dmitriy Novozhilov>
* 052f345a178 - (tag: build-1.4.30-dev-1439) JVM_IR no generic signatures for abstract stubs KT-42609 (vor 2 Tagen) <Dmitry Petrov>
* c8bf74c7d5a - Bytecode listing test fails if JVM and JVM_IR have same testData (vor 2 Tagen) <Dmitry Petrov>
* 51e2b9d33da - (tag: build-1.4.30-dev-1435) Enable signing using gpg in KotlinBuildPublishingPlugin (KTI-355) (vor 2 Tagen) <Nikolay Krasko>
* 1b39a235d84 - (tag: build-1.4.30-dev-1430) JVM IR: sort multifile part names in metadata (vor 2 Tagen) <Alexander Udalov>
* b257b031521 - JVM IR: do not generate JvmName on multifile parts (vor 2 Tagen) <Alexander Udalov>
* 0eccb9661f7 - JVM IR: simplify staticDefaultFunctionPhase (vor 2 Tagen) <Alexander Udalov>
* 1859d4d3402 - JVM IR: avoid quadratic complexity in InheritedDefaultMethodsOnClassesLowering (vor 2 Tagen) <Alexander Udalov>
* 5ca4c2ce1ad - (tag: build-1.4.30-dev-1428) Use camelCase propNames in ide perf tests json stats; report hasError (vor 2 Tagen) <Vladimir Dolzhenko>
* bc6693fa6ed - (tag: build-1.4.30-dev-1425) FIR2IR: element-wise SAM conversion for vararg (vor 2 Tagen) <Jinseong Jeon>
* 5d394528f6d - (tag: build-1.4.30-dev-1423) Fix double publication of javadoc in kotlin-osgi-bundle (KTI-356) (vor 2 Tagen) <Nikolay Krasko>
* e06ae01c0cb - (tag: build-1.4.30-dev-1419) Restore nullability after type refinement along with annotations (vor 2 Tagen) <Dmitry Savvinov>
* ee794f86641 - (tag: build-1.4.30-dev-1414) FIR IDE: add check canceled between diagnostics (vor 2 Tagen) <Ilya Kirillov>
* 9dd3d8fb14b - (tag: build-1.4.30-dev-1409) [NI] Fix extension function check after commonization (vor 2 Tagen) <Pavel Kirpichenkov>
* c53011dd04c - [FIR] mute builder inference test (vor 2 Tagen) <Pavel Kirpichenkov>
* 39a87435ee7 - [FIR/NI] Refactor type variable gathering from lambda types (vor 2 Tagen) <Pavel Kirpichenkov>
* ef44077cb7c - [FIR] Restore variable fixation direction in call completion (vor 2 Tagen) <Pavel Kirpichenkov>
* 712a2ce1abe - [FIR] Improved lambda completion: initial implementation (vor 2 Tagen) <Pavel Kirpichenkov>
* 5eae6f2f4ec - [FIR] Move PostponedArgumentInputTypesResolver to resolution.common (vor 2 Tagen) <Pavel Kirpichenkov>
* 3822a32fce7 - [FIR] Prepare commonization of PostponedArgumentInputTypesResolver (vor 2 Tagen) <Pavel Kirpichenkov>
* 0685beb7657 - (tag: build-1.4.30-dev-1406, tag: build-1.4.30-dev-1405) NI: do substitution type variables during updating trace for lambda (these type variables can appear after the builder inference) (vor 2 Tagen) <Victor Petukhov>
* e399b4cd12e - (tag: build-1.4.30-dev-1396) JVM IR: minor, sort ElementType fields as in the old backend (vor 2 Tagen) <Alexander Udalov>
* 1daeebcdd32 - Minor, add regression test (vor 2 Tagen) <Alexander Udalov>
* 2ff011af175 - (tag: build-1.4.30-dev-1394) JVM_IR: add an assertion and a comment about property references (vor 2 Tagen) <pyos>
* 16636196061 - JVM_IR: add local delegated property metadata to non-synthetic classes (vor 2 Tagen) <pyos>
* 2974004de42 - JVM_IR: make PropertyReferenceLowering less quadratic (vor 2 Tagen) <pyos>
* d7b9920ebab - (tag: build-1.4.30-dev-1392, tag: build-1.4.30-dev-1390) Treat field initializer as class initializer (vor 3 Tagen) <Ilmir Usmanov>
* 3b5706972ed - Extract effect from lambda argument if it is in parentheses (vor 3 Tagen) <Ilmir Usmanov>
* df64bb3eb72 - JVM_IR emulate JVM hack for generic signatures in KT-18189 (vor 3 Tagen) <Dmitry Petrov>
* f20a695c0e1 - (tag: build-1.4.30-dev-1386) Minor: Rebase testGenericConstructorCallWithTypeArguments (vor 3 Tagen) <Steven Schäfer>
* c89461e654a - (tag: build-1.4.30-dev-1383) JSpecify: add gradle task to download JSpecify test suite (vor 3 Tagen) <Victor Petukhov>
* d0cd7a4008c - JSpecify: exclude test running from the common `test` task (vor 3 Tagen) <Victor Petukhov>
* 9dab052266f - JSpecify: implement tests generator and test runner with checking compliance of kotlin diagnostics and jspecify marks (vor 3 Tagen) <Victor Petukhov>
* f39e2d4a2d0 - JSpecify: convert java use sites for existing tests to kotlin ones (vor 3 Tagen) <Victor Petukhov>
* ce44f7d4d38 - JSpecify: implement kotlin use sites to java ones converter (vor 3 Tagen) <Victor Petukhov>
* 520e35baaf6 - JSpecify: rework tests – replace kotlin use sites to java ones with future j2k conversion (vor 3 Tagen) <Victor Petukhov>
* 8974128be4f - JSpecify: remove annotations unsupported yet (vor 3 Tagen) <Victor Petukhov>
* fb8bba4dfb7 - Include kotlin reflect test runtime dependency for `tests-java8` module to make jps tests running work (vor 3 Tagen) <Victor Petukhov>
* 677f5ca4e39 - (tag: build-1.4.30-dev-1379) Don't keep ref to ABSENT_KOTLIN_INJECTION in companion object (vor 3 Tagen) <Vladimir Dolzhenko>
* 7c2112d0140 - Prepare for KT dynamic plugin: make EP dynamic (vor 3 Tagen) <Vladimir Dolzhenko>
* 0e7e24c4983 - (tag: build-1.4.30-dev-1378) Add more diagnostics to address invalid module (vor 3 Tagen) <Vladimir Dolzhenko>
* fa7104213c6 - (tag: build-1.4.30-dev-1377) Temporary disable test until bootstrap is updated (vor 3 Tagen) <Roman Artemev>
* f824bb69870 - [JS BE] Merge Legacy and IR BE exceptions-related test data (vor 3 Tagen) <Roman Artemev>
* c16b11a1242 - [JS IR BE] Fix throwable stuff to make exceptions similar to JVM (vor 3 Tagen) <Roman Artemev>
* ff093d363a3 - [JS IR BE] Fix Throwable ancestor transformation (vor 3 Tagen) <Roman Artemev>
* 383146f836a -  [JS IR BE] Add compiler instrinsic to express `undefined` value in BE (vor 3 Tagen) <Roman Artemev>
* f794ced8881 - (tag: build-1.4.30-dev-1373, origin/push/demiurg906/fir-cfg-dump-fix) [FIR] Fix incorrect cluster creating in CFG dumps (vor 3 Tagen) <Dmitriy Novozhilov>
* 3495ec198d3 - (tag: build-1.4.30-dev-1360) Minor. Small clean-up in KLIB decompiler (vor 3 Tagen) <Dmitriy Dolovov>