### PR TITLE
[kotlin compiler][update] 1.4.30-dev-1638

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1514,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-1514
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1514,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-1514
-kotlinStdlibTestsVersion=1.4.30-dev-1514
-testKotlinCompilerVersion=1.4.30-dev-1514
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1638,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-1638
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1638,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-1638
+kotlinStdlibTestsVersion=1.4.30-dev-1638
+testKotlinCompilerVersion=1.4.30-dev-1638
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* cc4d93ac714 - (HEAD -> master, tag: build-1.4.30-dev-1638, origin/master, origin/HEAD) [IR] Eliminated expensive calculating of fqNames (#3815) (vor 3 Tagen) <LepilkinaElena>
* 4f5b2b8e22a - (tag: build-1.4.30-dev-1637) Uncomment accidentally commented code in debugger tests (vor 3 Tagen) <Ilya Kirillov>
* 318d11dcecd - (tag: build-1.4.30-dev-1633, origin/rr/gorshenev/tmp_rebase) [JVM_IR] Remove muting of fwBackingField. (vor 3 Tagen) <Mads Ager>
* 0505bd958a8 - [JVM] Fix the nop removal optimization. (vor 3 Tagen) <Mads Ager>
* 69127445a37 - (tag: build-1.4.30-dev-1631) JVM_IR: refine the condition for caching method nodes (vor 3 Tagen) <pyos>
* d6e0d2a55b3 - (tag: build-1.4.30-dev-1618) [Gradle, JS] Fix K/JS project build with configuration cache (part 2) (vor 3 Tagen) <Alexander.Likhachev>
* d7db6434223 - (tag: build-1.4.30-dev-1615) Add box test for KT-33992 (vor 3 Tagen) <Roman Artemev>
* 023a62395a3 - Add box test for KT-36897 (vor 3 Tagen) <Roman Artemev>
* 5e406e8803a - (tag: build-1.4.30-dev-1613) [FIR-IDE] Unmute passing test (vor 3 Tagen) <Dmitriy Novozhilov>
* 9f5191f2a1d - [FIR-IDE] Regenerate tests (vor 3 Tagen) <Dmitriy Novozhilov>
* 8cb08139e1b - [FIR-IDE] Add example flag for enabling fir ide to gradle.properties (vor 3 Tagen) <Dmitriy Novozhilov>
* 0e47d32587b - [FIR] Properly set type of constants for java declarations (vor 3 Tagen) <Dmitriy Novozhilov>
* 5f641a25523 - [FIR] Add wrapping scopes with forced calculator in checkers and fir2ir (vor 3 Tagen) <Dmitriy Novozhilov>
* e75f218f87b - [FIR] Rename FirDeclarationOrigin.FakeOverride to SubstitutionOverride (vor 3 Tagen) <Dmitriy Novozhilov>
* 739ebf772c3 - [FIR] Add configuring FakeOverrideTypeCalculator into ConeKotlinType.scope (vor 3 Tagen) <Dmitriy Novozhilov>
* fc23cf76d40 - [FIR] Force calculation of return type of fake overrides in return type calculator (vor 3 Tagen) <Dmitriy Novozhilov>
* f9faa5be644 - [FIR] Don't force calculation of return type in substitution scope (vor 3 Tagen) <Dmitriy Novozhilov>
* 06981fc0af0 - [FIR] Move functions for fake override creating to separate objects (vor 3 Tagen) <Dmitriy Novozhilov>
* 1c2fdf7e3f5 - [FIR] Remove scope session from FirClassSubstitutionScope constructor (vor 3 Tagen) <Dmitriy Novozhilov>
* 9e863c90fc2 - [FIR] Remove redundant default values for functions in FirClassSubstitutionScope (vor 3 Tagen) <Dmitriy Novozhilov>
* e07f63d26c7 - [FIR] Move declaration attributes to declaration builders (vor 3 Tagen) <Dmitriy Novozhilov>
* 0b51fd03e20 - [FIR] Add failing test for incorrect type calculation of implicit types (vor 3 Tagen) <Dmitriy Novozhilov>
* 23f1cc6b07d - [FIR] Get rid of ReturnTypeCalculator in ScopeSession (vor 3 Tagen) <Dmitriy Novozhilov>
* fae1b706051 - [FIR] Fix type of this reference in `copy` funciton of data class (vor 3 Tagen) <Dmitriy Novozhilov>
* 0616f948c7d - (tag: build-1.4.30-dev-1612) Use actual form of decodeSerializableElement function in 'decodeSequentially' (vor 3 Tagen) <Leonid Startsev>
* 1bb2eefcaa9 - (tag: build-1.4.30-dev-1610) Fix find usages test testdata adding FIR_COMPARISON directive (vor 3 Tagen) <Ilya Kirillov>
* 1bc52c195c9 - (tag: build-1.4.30-dev-1609) [Gradle, JS] Uninternal _target in js extension (vor 3 Tagen) <Ilya Goncharov>
* 0b6959ee3d8 - (tag: build-1.4.30-dev-1606) [Gradle, K/N] Deprecate K/N compile classpath prop in favor of libraries (vor 3 Tagen) <Alexander.Likhachev>
* f4da283ffb0 - [Gradle, K/N] Move build cache tests into appropriate class (vor 3 Tagen) <Alexander.Likhachev>
* a0f48980093 - [Gradle, K/N] Make compile and link tasks cacheable (vor 3 Tagen) <Alexander.Likhachev>
* a9b53adc50a - (tag: build-1.4.30-dev-1604) JVM_IR: make `primitive == object` slightly less lazy. (vor 3 Tagen) <pyos>
* 4c099062358 - (tag: build-1.4.30-dev-1603) Build: add kotlin.build.useIRForLibraries to enable JVM IR for libraries separately (vor 3 Tagen) <Alexander Udalov>
* 29d8730964f - Build: when using JVM IR, produce stable binaries (vor 3 Tagen) <Alexander Udalov>
* 04a4f9cde65 - (tag: build-1.4.30-dev-1600) Minor: cover negative cases with test +m (vor 3 Tagen) <Pavel Kirpichenkov>
* 9669ab14683 - Report warning on @JvmStatic in private companion objects (vor 3 Tagen) <Pavel Kirpichenkov>
* d769ca06ab0 - Add test for KT-25114 (vor 3 Tagen) <Pavel Kirpichenkov>
* c6da2a1138c - (tag: build-1.4.30-dev-1597) Reuse built functional types for postponed arguments by expected types and paths from a top level type variable (vor 3 Tagen) <Victor Petukhov>
* ee5edf4caa2 - (tag: build-1.4.30-dev-1596, origin/rr/pdn_jvmir_abi_ic_remove_int) JVM_IR fix 'remove' in inline class implementing MutableCollection (vor 3 Tagen) <Dmitry Petrov>
* 95edcea9a97 - (tag: build-1.4.30-dev-1579) Build: fix kotlinx-metadata-jvm publication (vor 4 Tagen) <Alexander Udalov>
* 8dd80fe3c9b - (tag: build-1.4.30-dev-1578) Wizard: fix maven testdata (vor 4 Tagen) <Ilya Kirillov>
* 394245ba4c5 - Wizard: do not run compose tests for Groovy dsl (vor 4 Tagen) <Ilya Kirillov>
* ec1528e7422 - Wizard: use custom Kotlin version for compose project (vor 4 Tagen) <Ilya Kirillov>
* b0bb03d7615 - Wizard: return junit back to android target (vor 4 Tagen) <Ilya Kirillov>
* 42914b4046b - Wizard: add resolutionStrategy for mpp library template (vor 4 Tagen) <Ilya Kirillov>
* f5d638eb8f7 - Wizard: do not create empty local.properties file (vor 4 Tagen) <Ilya Kirillov>
* aeff3c26823 - Wizard: regenerate tests (vor 4 Tagen) <Ilya Kirillov>
* b7017c233ec - Wizard: use different Kotlin version for compose templates (vor 4 Tagen) <Ilya Kirillov>
* 1cc007fcbf4 - Wizard: introduce Compose MPP template (vor 4 Tagen) <Ilya Kirillov>
* 7422690ea19 - Wizard: fix InvalidModuleDependencyError error message (vor 4 Tagen) <Ilya Kirillov>
* 2a5679e0c60 - Wizard: make project templates list scrollable (vor 4 Tagen) <Ilya Kirillov>
* db069c3264c - Wizard: add compose desktop template (vor 4 Tagen) <Ilya Kirillov>
* d547cb9ee68 - Wizard: introduce mobile mpp module template & allow module templates for mpp modules (vor 4 Tagen) <Ilya Kirillov>
* ac6b9e4aa0c - Wizard: add android extensions plugin only by flag (vor 4 Tagen) <Ilya Kirillov>
* ed924a1c99f - Wizard: change custom maven repositories rendering (vor 4 Tagen) <Ilya Kirillov>
* 31dac65a394 - Wizard: remove extra line break in build files (vor 4 Tagen) <Ilya Kirillov>
* 9948c265df9 - Wizard: add setting to hide version & groupId in gradle (vor 4 Tagen) <Ilya Kirillov>
* d3e99bd7a79 - Wizard: simplify custom maven repository syntax for Gradle (vor 4 Tagen) <Ilya Kirillov>
* 3ef12e32eeb - Wizard: update libraries versions (vor 4 Tagen) <Ilya Kirillov>
* fa8951c19e6 - Wizard: move common repositories to the allprojects section (vor 4 Tagen) <Ilya Kirillov>
* e824199169e - Wizard: remove resolutionStrategy from settings.gradle (vor 4 Tagen) <Ilya Kirillov>
* 8b89eb5dc86 - Wizard: clean activity_main.xml & AndroidManifest.xml files (vor 4 Tagen) <Ilya Kirillov>
* 733cd8891a8 - Wizard: simplify android configuration (vor 4 Tagen) <Ilya Kirillov>
* 4858b72a8d8 - (tag: build-1.4.30-dev-1577) Bump junit from 4.11 to 4.13.1 in /libraries (vor 4 Tagen) <dependabot[bot]>
* f69928d2b11 - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 845d6ae0632 - Bump junit in /libraries/tools/kotlin-maven-plugin/src/it/simple (vor 4 Tagen) <dependabot[bot]>
* b7782984860 - Bump junit (vor 4 Tagen) <dependabot[bot]>
* f3c26af0c7c - Bump junit (vor 4 Tagen) <dependabot[bot]>
* c2ed625f25e - Bump junit (vor 4 Tagen) <dependabot[bot]>
* e9255c8f17b - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 41123be3a27 - (tag: build-1.4.30-dev-1575) Bump junit (vor 4 Tagen) <dependabot[bot]>
* 3f27bb374a1 - Bump junit (vor 4 Tagen) <dependabot[bot]>
* fb7736377ca - Bump junit (vor 4 Tagen) <dependabot[bot]>
* df202c9b3ff - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 7fe9966e024 - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 046ed1e08cd - (tag: build-1.4.30-dev-1573) Bump junit (vor 4 Tagen) <dependabot[bot]>
* 0396ed29ccf - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 2a9e6df9b1b - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 1bf2a6b013a - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 797c02e1cb4 - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 916f9766ad5 - (tag: build-1.4.30-dev-1572) Bump junit (vor 4 Tagen) <dependabot[bot]>
* c012b16430c - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 74ad4eb00ef - Bump junit (vor 4 Tagen) <dependabot[bot]>
* e888f54ae8b - Bump junit (vor 4 Tagen) <dependabot[bot]>
* 1ca5bef7e6c - (origin/dependabot/maven/libraries/tools/kotlin-maven-plugin-test/src/it/test-helloworld/junit-junit-4.13.1) Bump junit (vor 6 Tagen) <dependabot[bot]>
* 209d5fd6c94 - Bump junit (vor 4 Tagen) <dependabot[bot]>
* c8e84f82eb3 - (tag: build-1.4.30-dev-1564) Proper check NON_JVM_DEFAULT_OVERRIDES_JAVA_DEFAULT in new jvm-default modes (vor 4 Tagen) <Mikhael Bogdanov>
* b6dc99b98e8 - Skip java defaults in EXPLICIT_OVERRIDE_REQUIRED_IN_MIXED_MODE check (vor 4 Tagen) <Mikhael Bogdanov>
* a60febbdfbb - (tag: build-1.4.30-dev-1559) KotlinMPPGradleProjectResolver: Ensure that artifactsMap is populated when Android plugin applied (vor 4 Tagen) <sebastian.sellmair>
* b42795a9eaf - (tag: build-1.4.30-dev-1557) Bump 'com.gradle.plugin-publish' from 0.11.0 to 0.12.0 (#3853) (vor 4 Tagen) <Victor Turansky>
* 09acea5548c - (tag: build-1.4.30-dev-1555) [FIR]: Set proper classId to enum entries (vor 4 Tagen) <Juan Chen>
* ed188204b4f - (tag: build-1.4.30-dev-1551) FIR checker: make property init analyzer path-sensitive (vor 4 Tagen) <Jinseong Jeon>
* 6fc3f7e776b - FIR CFG: label edges from try-enter through finally block to exit target (vor 4 Tagen) <Jinseong Jeon>
* 43852ad7ab5 - FIR CFG: add edges from try/catch to finally (vor 4 Tagen) <Jinseong Jeon>
* ea2f773e54e - FIR checker: reproduce KT-42350 (vor 4 Tagen) <Jinseong Jeon>
* da69e3db7cf - (tag: build-1.4.30-dev-1550) kotlinx-metadata-jvm: report error on using metadata version < 1.4 in writers (vor 4 Tagen) <Alexander Udalov>
* 5d7d9beb0d9 - kotlinx-metadata-jvm: remove bytecodeVersion from write methods (vor 4 Tagen) <Alexander Udalov>
* 90d66b0ba5c - kotlinx-metadata: reformat, cleanup, fix inspections (vor 4 Tagen) <Alexander Udalov>
* c89c31cd295 - (tag: build-1.4.30-dev-1549) [KLIB] Fix package name (js -> common) (vor 4 Tagen) <Roman Artemev>
* 07a1124b994 - [KLIB] Support error code in metadata (vor 4 Tagen) <Roman Artemev>
* f4830c88b95 - [JS IR] Make error code tests modular (vor 4 Tagen) <Roman Artemev>
* 0f7032051be - [JS IR] Fix klib generation (proper order of flags) (vor 4 Tagen) <Roman Artemev>
* a4945878aa3 - [KLIB] Pass `containsErrorCode` flag from library/IC cache into deserializer (vor 4 Tagen) <Roman Artemev>
* 28c6d17ab42 - [KLIB] Mark klib that contains error with special flag (vor 4 Tagen) <Roman Artemev>
* 98e55108717 - [KLIB] Support IrError* nodes in serialization (vor 4 Tagen) <Roman Artemev>
* 934141f8af4 - [KLIB] Support IrError* nodes in klib proto (vor 4 Tagen) <Roman Artemev>
* 8ce497c7ef0 - [IR] Add wrapped descriptor for error declaration (vor 4 Tagen) <Roman Artemev>
* eacc94a89dc - (tag: build-1.4.30-dev-1533) Do not hide synthetic properties except `isEmpty` from Java (vor 4 Tagen) <Mikhail Zarechenskiy>
* 4227e2dc40e - (tag: build-1.4.30-dev-1519) [Cocoapods] Fix task and directory naming to avoid subspecs collision (vor 4 Tagen) <Yaroslav Chernyshev>
* b8817d58842 - (tag: build-1.4.30-dev-1517) FIR2IR: clean up dead code regarding overriding utils (vor 4 Tagen) <Jinseong Jeon>
* 5f64d6ec765 - FIR2IR: add support for callable reference to Java field (vor 4 Tagen) <Jinseong Jeon>
* 65545a10c48 - FIR: reproduce KT-42656 (vor 4 Tagen) <Jinseong Jeon>