### PR TITLE
[kotlin compiler][update] 1.4.30-dev-1895

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -88,7 +88,7 @@ internal data class ExternalLoweredEnum(
         override val entriesMap: Map<Name, Int>
 ) : LoweredEnumAccess {
     override fun getValuesField(startOffset: Int, endOffset: Int): IrExpression =
-            IrCallImpl(startOffset, endOffset, valuesGetter.returnType, valuesGetter.symbol)
+            IrCallImpl(startOffset, endOffset, valuesGetter.returnType, valuesGetter.symbol, valuesGetter.typeParameters.size, valuesGetter.valueParameters.size)
 }
 
 internal class EnumSpecialDeclarationsFactory(val context: Context) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InlineClasses.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/InlineClasses.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
+import org.jetbrains.kotlin.ir.symbols.isPublicApi
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.makeNullable

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLoweringPhases.kt
@@ -92,10 +92,8 @@ internal val arrayConstructorPhase = makeKonanModuleLoweringPhase(
 
 internal val lateinitPhase = makeKonanModuleOpPhase(
         { context, irModule ->
-            NullableFieldsForLateinitCreationLowering(context)
-                    .runPostfix(true).toFileLoweringPass().lower(irModule)
-            NullableFieldsDeclarationLowering(context)
-                    .runPostfix(true).toFileLoweringPass().lower(irModule)
+            NullableFieldsForLateinitCreationLowering(context).lower(irModule)
+            NullableFieldsDeclarationLowering(context).lower(irModule)
             LateinitUsageLowering(context).lower(irModule)
         },
         name = "Lateinit",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ObjCInterop.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.symbols.isPublicApi
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.getPublicSignature
 import org.jetbrains.kotlin.ir.util.*

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -368,7 +368,7 @@ internal val useInternalAbiPhase = makeKonanModuleOpPhase(
                             context.internalAbi.reference(it, irClass.module)
                         }
                     }
-                    return IrCallImpl(expression.startOffset, expression.endOffset, expression.type, accessor.symbol)
+                    return IrCallImpl(expression.startOffset, expression.endOffset, expression.type, accessor.symbol, accessor.typeParameters.size, accessor.valueParameters.size)
                 }
             }
             module.transformChildrenVoid(transformer)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -164,7 +164,7 @@ internal val copyDefaultValuesToActualPhase = konanUnitPhase(
 
 internal val serializerPhase = konanUnitPhase(
         op = {
-            val expectActualLinker = config.configuration.get(CommonConfigurationKeys.EXPECT_ACTUAL_LINKER)?:false
+            val expectActualLinker = config.configuration.get(CommonConfigurationKeys.EXPECT_ACTUAL_LINKER) ?: false
 
             serializedIr = irModule?.let { ir ->
                 KonanIrModuleSerializer(
@@ -175,6 +175,7 @@ internal val serializerPhase = konanUnitPhase(
             val serializer = KlibMetadataMonolithicSerializer(
                 this.config.configuration.languageVersionSettings,
                 config.configuration.get(CommonConfigurationKeys.METADATA_VERSION)!!,
+                config.project,
                 !expectActualLinker)
             serializedMetadata = serializer.serializeModule(moduleDescriptor)
         },

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -553,6 +553,7 @@ internal fun KotlinStubs.generateCFunctionPointer(
             expression.type,
             fakeFunction.symbol,
             typeArgumentsCount = 0,
+            fakeFunction.valueParameters.size,
             reflectionTarget = null
     )
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -319,8 +319,9 @@ internal fun KotlinStubs.generateObjCCall(
 
     val callBuilder = KotlinToCCallBuilder(builder, this@generateObjCCall, isObjCMethod = true, exceptionMode)
 
-    val superClass = irTemporaryVar(
-            superQualifier?.let { getObjCClass(symbols, it) } ?: irNullNativePtr(symbols)
+    val superClass = irTemporary(
+            superQualifier?.let { getObjCClass(symbols, it) } ?: irNullNativePtr(symbols),
+            isMutable = true
     )
 
     val messenger = irCall(if (isStret) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/KonanSharedVariablesManager.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/KonanSharedVariablesManager.kt
@@ -64,7 +64,8 @@ internal class KonanSharedVariablesManager(val context: KonanBackendContext) : S
 
         val sharedVariableInitialization =
                 IrCallImpl(initializer.startOffset, initializer.endOffset,
-                        context.irBuiltIns.unitType, elementProperty.setter!!.symbol)
+                        context.irBuiltIns.unitType, elementProperty.setter!!.symbol,
+                        elementProperty.setter!!.typeParameters.size, elementProperty.setter!!.valueParameters.size)
 
         sharedVariableInitialization.dispatchReceiver =
                 IrGetValueImpl(initializer.startOffset, initializer.endOffset,
@@ -80,7 +81,8 @@ internal class KonanSharedVariablesManager(val context: KonanBackendContext) : S
 
     override fun getSharedValue(sharedVariableSymbol: IrVariableSymbol, originalGet: IrGetValue) =
             IrCallImpl(originalGet.startOffset, originalGet.endOffset,
-                    originalGet.type, elementProperty.getter!!.symbol).apply {
+                    originalGet.type, elementProperty.getter!!.symbol,
+                    elementProperty.getter!!.typeParameters.size, elementProperty.getter!!.valueParameters.size).apply {
                 dispatchReceiver = IrGetValueImpl(
                         originalGet.startOffset, originalGet.endOffset,
                         sharedVariableSymbol.owner.type, sharedVariableSymbol
@@ -89,7 +91,8 @@ internal class KonanSharedVariablesManager(val context: KonanBackendContext) : S
 
     override fun setSharedValue(sharedVariableSymbol: IrVariableSymbol, originalSet: IrSetValue) =
             IrCallImpl(originalSet.startOffset, originalSet.endOffset, context.irBuiltIns.unitType,
-                    elementProperty.setter!!.symbol).apply {
+                    elementProperty.setter!!.symbol, elementProperty.setter!!.typeParameters.size,
+                    elementProperty.setter!!.valueParameters.size).apply {
                 dispatchReceiver = IrGetValueImpl(
                         originalSet.startOffset, originalSet.endOffset,
                         sharedVariableSymbol.owner.type, sharedVariableSymbol

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
@@ -7,8 +7,6 @@ package org.jetbrains.kotlin.backend.konan.ir
 
 import org.jetbrains.kotlin.backend.common.atMostOne
 import org.jetbrains.kotlin.backend.konan.DECLARATION_ORIGIN_INLINE_CLASS_SPECIAL_FUNCTION
-import org.jetbrains.kotlin.builtins.KotlinBuiltIns
-import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.declarations.*

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.isPublicApi
 import org.jetbrains.kotlin.ir.types.IdSignatureValues
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.isMarkedNullable

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumByValueFunctionGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumByValueFunctionGenerator.kt
@@ -52,8 +52,8 @@ internal class CEnumByValueFunctionGenerator(
         // throw NPE
         byValueIrFunction.body = irBuilder(irBuiltIns, byValueIrFunction.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
             +irReturn(irBlock {
-                val values = irTemporaryVar(irCall(valuesIrFunctionSymbol))
-                val inductionVariable = irTemporaryVar(irInt(0))
+                val values = irTemporary(irCall(valuesIrFunctionSymbol), isMutable = true)
+                val inductionVariable = irTemporary(irInt(0), isMutable = true)
                 val arrayClass = values.type.classOrNull!!
                 val valuesSize = irCall(symbols.arraySize.getValue(arrayClass), irBuiltIns.intType).also { irCall ->
                     irCall.dispatchReceiver = irGet(values)
@@ -67,10 +67,10 @@ internal class CEnumByValueFunctionGenerator(
                         irCall.putValueArgument(1, valuesSize)
                     }
                     loop.body = irBlock {
-                        val entry = irTemporaryVar(irCall(getElementFn, byValueIrFunction.returnType).also { irCall ->
+                        val entry = irTemporary(irCall(getElementFn, byValueIrFunction.returnType).also { irCall ->
                             irCall.dispatchReceiver = irGet(values)
                             irCall.putValueArgument(0, irGet(inductionVariable))
-                        })
+                        }, isMutable = true)
                         val valueGetter = entry.type.getClass()!!.getPropertyGetter("value")!!
                         val entryValue = irGet(irValueParameter.type, irGet(entry), valueGetter)
                         +irIfThenElse(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumClassGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumClassGenerator.kt
@@ -120,7 +120,7 @@ internal class CEnumClassGenerator(
                 SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                 IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB, entryDescriptor
         ).also { enumEntry ->
-            enumEntry.initializerExpression = IrExpressionBodyImpl(IrEnumConstructorCallImpl(
+            enumEntry.initializerExpression = IrExpressionBodyImpl(IrEnumConstructorCallImpl.fromSymbolDescriptor(
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                     type = irBuiltIns.unitType,
                     symbol = symbolTable.referenceConstructor(enumDescriptor.unsubstitutedPrimaryConstructor!!),
@@ -147,7 +147,7 @@ internal class CEnumClassGenerator(
         val irConstructor = createConstructor(descriptor.unsubstitutedPrimaryConstructor!!)
         val enumConstructor = context.builtIns.enum.constructors.single()
         irConstructor.body = irBuilder(irBuiltIns, irConstructor.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
-            +IrEnumConstructorCallImpl(
+            +IrEnumConstructorCallImpl.fromSymbolDescriptor(
                     startOffset, endOffset,
                     context.irBuiltIns.unitType,
                     symbolTable.referenceConstructor(enumConstructor),

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumCompanionGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumCompanionGenerator.kt
@@ -54,7 +54,9 @@ internal class CEnumCompanionGenerator(
             it.body = irBuilder(irBuiltIns, it.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
                 +IrDelegatingConstructorCallImpl(
                         startOffset, endOffset, context.irBuiltIns.unitType,
-                        superConstructorSymbol
+                        superConstructorSymbol,
+                        superConstructorSymbol.owner.typeParameters.size,
+                        superConstructorSymbol.owner.valueParameters.size
                 )
                 +irInstanceInitializer(symbolTable.referenceClass(companionObjectDescriptor))
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumVarClassGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumVarClassGenerator.kt
@@ -58,7 +58,9 @@ internal class CEnumVarClassGenerator(
         )
         irConstructor.body = irBuilder(irBuiltIns, irConstructor.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
             +IrDelegatingConstructorCallImpl(
-                    startOffset, endOffset, context.irBuiltIns.unitType, enumVarConstructorSymbol
+                    startOffset, endOffset, context.irBuiltIns.unitType, enumVarConstructorSymbol,
+                    enumVarConstructorSymbol.owner.typeParameters.size,
+                    enumVarConstructorSymbol.owner.valueParameters.size
             ).also {
                 it.putValueArgument(0, irGet(irConstructor.valueParameters[0]))
             }
@@ -81,7 +83,9 @@ internal class CEnumVarClassGenerator(
             it.body = irBuilder(irBuiltIns, it.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
                 +IrDelegatingConstructorCallImpl(
                         startOffset, endOffset, context.irBuiltIns.unitType,
-                        superConstructorSymbol
+                        superConstructorSymbol,
+                        superConstructorSymbol.owner.typeParameters.size,
+                        superConstructorSymbol.owner.valueParameters.size
                 ).also {
                     it.putValueArgument(0, irInt(typeSize))
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cstruct/CStructVarClassGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cstruct/CStructVarClassGenerator.kt
@@ -64,7 +64,9 @@ internal class CStructVarClassGenerator(
             irConstructor.body = irBuilder(irBuiltIns, irConstructor.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
                 +IrDelegatingConstructorCallImpl(
                         startOffset, endOffset,
-                        context.irBuiltIns.unitType, enumVarConstructorSymbol
+                        context.irBuiltIns.unitType, enumVarConstructorSymbol,
+                        irConstructor.typeParameters.size,
+                        1
                 ).also {
                     it.putValueArgument(0, irGet(irConstructor.valueParameters[0]))
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cstruct/CStructVarCompanionGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cstruct/CStructVarCompanionGenerator.kt
@@ -48,7 +48,9 @@ internal class CStructVarCompanionGenerator(
             irConstructor.body = irBuilder(irBuiltIns, irConstructor.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
                 +IrDelegatingConstructorCallImpl(
                         startOffset, endOffset, context.irBuiltIns.unitType,
-                        superConstructorSymbol
+                        superConstructorSymbol,
+                        irConstructor.typeParameters.size,
+                        2
                 ).also {
                     it.putValueArgument(0, irLong(size))
                     it.putValueArgument(1, irInt(align))

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/RTTIGenerator.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.backend.konan.isExternalObjCClassMethod
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.symbols.isPublicApi
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.util.isAnnotationClass

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -97,7 +97,9 @@ private class AutoboxingTransformer(val context: Context) : AbstractValueUsageTr
                     startOffset,
                     endOffset,
                     symbols.getNativeNullPtr.owner.returnType,
-                    symbols.getNativeNullPtr
+                    symbols.getNativeNullPtr,
+                    symbols.getNativeNullPtr.owner.typeParameters.size,
+                    symbols.getNativeNullPtr.owner.valueParameters.size
             ).uncheckedCast(type)
         }
 
@@ -164,7 +166,8 @@ private class AutoboxingTransformer(val context: Context) : AbstractValueUsageTr
             val parameter = conversion.owner.explicitParameters.single()
             val argument = this.uncheckedCast(parameter.type)
 
-            IrCallImpl(startOffset, endOffset, conversion.owner.returnType, conversion).apply {
+            IrCallImpl(startOffset, endOffset, conversion.owner.returnType, conversion,
+                    conversion.owner.typeParameters.size, conversion.owner.valueParameters.size).apply {
                 addArguments(mapOf(parameter to argument))
             }.uncheckedCast(this.type) // Try not to bring new type incompatibilities.
         }
@@ -273,7 +276,9 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
             IrBlockImpl(startOffset, endOffset, irBuiltIns.unitType).apply {
                 statements.addIfNotNull(expression.receiver)
                 statements += expression.value
-                statements += IrCallImpl(startOffset, endOffset, irBuiltIns.nothingType, symbols.throwNullPointerException)
+                statements += IrCallImpl(startOffset, endOffset, irBuiltIns.nothingType, symbols.throwNullPointerException,
+                        symbols.throwNullPointerException.owner.typeParameters.size,
+                        symbols.throwNullPointerException.owner.valueParameters.size)
                 statements += IrGetObjectValueImpl(startOffset, endOffset, irBuiltIns.unitType, irBuiltIns.unitClass)
             }
         } else {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.ir.util.transformFlat
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import org.jetbrains.kotlin.load.java.BuiltinMethodsWithSpecialGenericSignature
+import org.jetbrains.kotlin.load.java.SpecialGenericSignatures
 
 internal class WorkersBridgesBuilding(val context: Context) : DeclarationContainerLoweringPass, IrElementTransformerVoid() {
 
@@ -200,7 +201,7 @@ private fun IrBuilderWithScope.irConst(value: Any?) = when (value) {
 
 private fun IrBlockBodyBuilder.buildTypeSafeBarrier(function: IrFunction,
                                                     originalFunction: IrFunction,
-                                                    typeSafeBarrierDescription: BuiltinMethodsWithSpecialGenericSignature.TypeSafeBarrierDescription) {
+                                                    typeSafeBarrierDescription: SpecialGenericSignatures.TypeSafeBarrierDescription) {
     val valueParameters = function.valueParameters
     val originalValueParameters = originalFunction.valueParameters
     for (i in valueParameters.indices) {
@@ -209,7 +210,7 @@ private fun IrBlockBodyBuilder.buildTypeSafeBarrier(function: IrFunction,
         val type = originalValueParameters[i].type
         if (!type.isNullableAny()) {
             +returnIfBadType(irGet(valueParameters[i]), type,
-                    if (typeSafeBarrierDescription == BuiltinMethodsWithSpecialGenericSignature.TypeSafeBarrierDescription.MAP_GET_OR_DEFAULT)
+                    if (typeSafeBarrierDescription == SpecialGenericSignatures.TypeSafeBarrierDescription.MAP_GET_OR_DEFAULT)
                         irGet(valueParameters[2])
                     else irConst(typeSafeBarrierDescription.defaultValue)
             )

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -119,6 +119,7 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                         type          = job.type,
                         symbol        = bridge.symbol,
                         typeArgumentsCount = 0,
+                        valueArgumentsCount = bridge.symbol.owner.valueParameters.size,
                         reflectionTarget = null)
                 )
                 return expression
@@ -238,6 +239,8 @@ private fun Context.buildBridge(startOffset: Int, endOffset: Int,
                 endOffset,
                 targetSymbol.owner.returnType,
                 targetSymbol,
+                typeArgumentsCount = targetSymbol.owner.typeParameters.size,
+                valueArgumentsCount = targetSymbol.owner.valueParameters.size,
                 superQualifierSymbol = superQualifierSymbol /* Call non-virtually */
         ).apply {
             bridge.dispatchReceiverParameter?.let {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BuiltinOperatorLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BuiltinOperatorLowering.kt
@@ -58,7 +58,9 @@ internal class BuiltinOperatorLowering(val context: Context) : FileLoweringPass,
 
             irBuiltins.noWhenBranchMatchedExceptionSymbol -> IrCallImpl(expression.startOffset, expression.endOffset,
                     context.ir.symbols.throwNoWhenBranchMatchedException.owner.returnType,
-                    context.ir.symbols.throwNoWhenBranchMatchedException)
+                    context.ir.symbols.throwNoWhenBranchMatchedException,
+                    context.ir.symbols.throwNoWhenBranchMatchedException.owner.typeParameters.size,
+                    context.ir.symbols.throwNoWhenBranchMatchedException.owner.valueParameters.size)
 
             else -> expression
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DataClassOperatorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DataClassOperatorsLowering.kt
@@ -5,73 +5,76 @@
 
 package org.jetbrains.kotlin.backend.konan.lower
 
-import org.jetbrains.kotlin.backend.common.FunctionLoweringPass
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.backend.common.lower.irBlock
 import org.jetbrains.kotlin.backend.konan.Context
-import org.jetbrains.kotlin.ir.util.isSimpleTypeWithQuestionMark
+import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.util.irCall
-import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
-import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.ir.util.isSimpleTypeWithQuestionMark
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
 
-internal class DataClassOperatorsLowering(val context: Context): FunctionLoweringPass {
-
+internal class DataClassOperatorsLowering(val context: Context) : FileLoweringPass, IrElementTransformer<IrFunction?> {
     private val irBuiltins = context.irModule!!.irBuiltins
 
-    override fun lower(irFunction: IrFunction) {
-        irFunction.transformChildrenVoid(object: IrElementTransformerVoid() {
-            override fun visitCall(expression: IrCall): IrExpression {
-                expression.transformChildrenVoid(this)
+    override fun lower(irFile: IrFile) {
+        irFile.transformChildren(this, null)
+    }
 
-                if (expression.symbol != irBuiltins.dataClassArrayMemberToStringSymbol
-                        && expression.symbol != irBuiltins.dataClassArrayMemberHashCodeSymbol)
-                    return expression
+    override fun visitFunction(declaration: IrFunction, data: IrFunction?): IrStatement =
+        super.visitFunction(declaration, declaration)
 
-                val argument = expression.getValueArgument(0)!!
-                val argumentClassifier = argument.type.classifierOrFail
+    override fun visitCall(expression: IrCall, data: IrFunction?): IrExpression {
+        expression.transformChildren(this, data)
 
-                val isToString = expression.symbol == irBuiltins.dataClassArrayMemberToStringSymbol
-                val newCalleeSymbol = if (isToString)
-                                    context.ir.symbols.arrayContentToString[argumentClassifier]!!
-                                else
-                                    context.ir.symbols.arrayContentHashCode[argumentClassifier]!!
+        if (expression.symbol != irBuiltins.dataClassArrayMemberToStringSymbol
+            && expression.symbol != irBuiltins.dataClassArrayMemberHashCodeSymbol)
+            return expression
 
-                val newCallee = newCalleeSymbol.owner
+        val argument = expression.getValueArgument(0)!!
+        val argumentClassifier = argument.type.classifierOrFail
 
-                val startOffset = expression.startOffset
-                val endOffset = expression.endOffset
-                val irBuilder = context.createIrBuilder(irFunction.symbol, startOffset, endOffset)
+        val isToString = expression.symbol == irBuiltins.dataClassArrayMemberToStringSymbol
+        val newCalleeSymbol = if (isToString)
+            context.ir.symbols.arrayContentToString[argumentClassifier]!!
+        else
+            context.ir.symbols.arrayContentHashCode[argumentClassifier]!!
 
-                return irBuilder.run {
-                    // TODO: use more precise type arguments.
-                    val typeArguments = (0 until newCallee.typeParameters.size).map { irBuiltins.anyNType }
+        val newCallee = newCalleeSymbol.owner
 
-                    if (!argument.type.isSimpleTypeWithQuestionMark) {
-                        irCall(newCallee, typeArguments).apply {
-                            extensionReceiver = argument
-                        }
-                    } else {
-                        irBlock(argument) {
-                            val tmp = irTemporary(argument)
-                            val call = irCall(newCallee, typeArguments).apply {
-                                extensionReceiver = irGet(tmp)
-                            }
-                            +irIfThenElse(call.type,
-                                    irEqeqeq(irGet(tmp), irNull()),
-                                    if (isToString)
-                                        irString("null")
-                                    else
-                                        irInt(0),
-                                    call)
-                        }
+        val startOffset = expression.startOffset
+        val endOffset = expression.endOffset
+        val irBuilder = context.createIrBuilder(data!!.symbol, startOffset, endOffset)
+
+        return irBuilder.run {
+            // TODO: use more precise type arguments.
+            val typeArguments = (0 until newCallee.typeParameters.size).map { irBuiltins.anyNType }
+
+            if (!argument.type.isSimpleTypeWithQuestionMark) {
+                irCall(newCallee, typeArguments).apply {
+                    extensionReceiver = argument
+                }
+            } else {
+                irBlock(argument) {
+                    val tmp = irTemporary(argument)
+                    val call = irCall(newCallee, typeArguments).apply {
+                        extensionReceiver = irGet(tmp)
                     }
+                    +irIfThenElse(call.type,
+                        irEqeqeq(irGet(tmp), irNull()),
+                        if (isToString)
+                            irString("null")
+                        else
+                            irInt(0),
+                        call)
                 }
             }
-        })
+        }
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumClassLowering.kt
@@ -113,9 +113,12 @@ internal class EnumUsageLowering(val context: Context)
         return IrCallImpl(
                 startOffset, endOffset, enumClass.defaultType,
                 loweredEnum.itemGetterSymbol.owner.symbol,
-                typeArgumentsCount = 0
+                typeArgumentsCount = 0,
+                loweredEnum.itemGetterSymbol.owner.valueParameters.size
         ).apply {
-            dispatchReceiver = IrCallImpl(startOffset, endOffset, loweredEnum.valuesGetter.returnType, loweredEnum.valuesGetter.symbol)
+            dispatchReceiver = IrCallImpl(startOffset, endOffset, loweredEnum.valuesGetter.returnType,
+                    loweredEnum.valuesGetter.symbol, loweredEnum.valuesGetter.typeParameters.size,
+                    loweredEnum.valuesGetter.valueParameters.size)
             putValueArgument(0, IrConstImpl.int(startOffset, endOffset, context.irBuiltIns.intType, ordinal))
         }
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -179,7 +179,9 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
                 val result = IrDelegatingConstructorCallImpl(
                         startOffset, endOffset,
                         context.irBuiltIns.unitType,
-                        enumConstructorCall.symbol)
+                        enumConstructorCall.symbol,
+                        enumConstructorCall.symbol.owner.typeParameters.size,
+                        enumConstructorCall.symbol.owner.valueParameters.size)
 
                 assert(result.symbol.owner.valueParameters.size == 2) {
                     "Enum(String, Int) constructor call expected:\n${result.dump()}"
@@ -214,7 +216,9 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
                 val result = IrDelegatingConstructorCallImpl(
                         startOffset, endOffset,
                         context.irBuiltIns.unitType,
-                        loweredDelegatingConstructor.symbol)
+                        loweredDelegatingConstructor.symbol,
+                        loweredDelegatingConstructor.symbol.owner.typeParameters.size,
+                        loweredDelegatingConstructor.symbol.owner.valueParameters.size)
 
                 val firstParameter = enumClassConstructor.valueParameters[0]
                 result.putValueArgument(0,
@@ -268,7 +272,8 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
 
         private inner class InEnumEntryClassConstructor(enumEntry: IrEnumEntry) : InEnumEntry(enumEntry) {
             override fun createConstructorCall(startOffset: Int, endOffset: Int, loweredConstructor: IrConstructorSymbol) =
-                    IrDelegatingConstructorCallImpl(startOffset, endOffset, context.irBuiltIns.unitType, loweredConstructor)
+                    IrDelegatingConstructorCallImpl(startOffset, endOffset, context.irBuiltIns.unitType, loweredConstructor,
+                    loweredConstructor.owner.typeParameters.size, loweredConstructor.owner.valueParameters.size)
         }
 
         private inner class InEnumEntryInitializer(enumEntry: IrEnumEntry) : InEnumEntry(enumEntry) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
@@ -188,7 +188,9 @@ internal class InitializersLowering(val context: CommonBackendContext) : ClassLo
                                     val startOffset = it.startOffset
                                     val endOffset = it.endOffset
                                     listOf(IrCallImpl(startOffset, endOffset,
-                                            context.irBuiltIns.unitType, initializeMethodSymbol
+                                            context.irBuiltIns.unitType, initializeMethodSymbol,
+                                            initializeMethodSymbol.owner.typeParameters.size,
+                                            initializeMethodSymbol.owner.valueParameters.size
                                     ).apply {
                                         dispatchReceiver = IrGetValueImpl(
                                                 startOffset, endOffset,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -655,7 +655,8 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
                         endOffset,
                         context.irBuiltIns.unitType,
                         superConstructor,
-                        0
+                        0,
+                        superConstructor.owner.valueParameters.size
                 )
 
                 +irCall(symbols.interopObjCObjectSuperInitCheck).apply {
@@ -1213,6 +1214,7 @@ private class InteropTransformer(val context: Context, override val irFile: IrFi
                             symbols.executeImpl.owner.valueParameters[3].type,
                             targetSymbol,
                             typeArgumentsCount = 0,
+                            targetSymbol.owner.valueParameters.size,
                             reflectionTarget = null)
 
                     builder.irCall(symbols.executeImpl).apply {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -767,7 +767,8 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
             // Special case: bridge from Objective-C method implementation template to Kotlin method;
             // handled in CodeGeneratorVisitor.callVirtual.
             val useKotlinDispatch = isInteropStubsFile &&
-                    builder.scope.scopeOwner.annotations.hasAnnotation(FqName("kotlin.native.internal.ExportForCppRuntime"))
+                    (builder.scope.scopeOwnerSymbol.owner as? IrAnnotationContainer)
+                            ?.hasAnnotation(FqName("kotlin.native.internal.ExportForCppRuntime")) == true
 
             if (!useKotlinDispatch) {
                 val arguments = callee.valueParameters.map { expression.getValueArgument(it.index) }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeInlineFunctionResolver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeInlineFunctionResolver.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.backend.common.lower.inline.DefaultInlineFunctionRes
 import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesExtractionFromInlineFunctionsLowering
 import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesInInlineFunctionsLowering
 import org.jetbrains.kotlin.backend.common.lower.inline.LocalClassesInInlineLambdasLowering
-import org.jetbrains.kotlin.backend.common.runPostfix
 import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
@@ -50,7 +49,7 @@ internal class NativeInlineFunctionResolver(override val context: Context) : Def
     }
 
     private fun DeclarationTransformer.lowerWithLocalDeclarations(function: IrFunction) {
-        if (runPostfix(true).transformFlat(function) != null)
+        if (transformFlat(function) != null)
             error("Unexpected transformation of function ${function.dump()}")
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/RedundantCoercionsCleaner.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/RedundantCoercionsCleaner.kt
@@ -41,7 +41,7 @@ internal class RedundantCoercionsCleaner(val context: Context) : FileLoweringPas
                                 typeOperand, expression)
                     }
             with (coercion) {
-                return IrCallImpl(startOffset, endOffset, type, symbol, typeArgumentsCount, origin).apply {
+                return IrCallImpl(startOffset, endOffset, type, symbol, typeArgumentsCount, symbol.owner.valueParameters.size, origin).apply {
                     putValueArgument(0, castedExpression)
                 }
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOperatorLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TypeOperatorLowering.kt
@@ -6,59 +6,34 @@
 package org.jetbrains.kotlin.backend.konan.lower
 
 import org.jetbrains.kotlin.backend.common.CommonBackendContext
-import org.jetbrains.kotlin.backend.common.FunctionLoweringPass
-import org.jetbrains.kotlin.backend.common.lower.at
-import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
-import org.jetbrains.kotlin.backend.common.lower.irBlock
-import org.jetbrains.kotlin.ir.util.isSimpleTypeWithQuestionMark
+import org.jetbrains.kotlin.backend.common.FileLoweringPass
+import org.jetbrains.kotlin.backend.common.lower.*
 import org.jetbrains.kotlin.backend.konan.ir.containsNull
 import org.jetbrains.kotlin.backend.konan.ir.isSubtypeOf
-import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
-import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
-import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.makeNotNull
 import org.jetbrains.kotlin.ir.types.makeNullable
 import org.jetbrains.kotlin.ir.util.irCall
-import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.util.isSimpleTypeWithQuestionMark
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
-import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.TypeUtils
 
-/**
- * This lowering pass lowers some [IrTypeOperatorCall]s.
- */
-internal class TypeOperatorLowering(val context: CommonBackendContext) : FunctionLoweringPass {
-    override fun lower(irFunction: IrFunction) {
-        val transformer = TypeOperatorTransformer(context, irFunction.symbol)
-        irFunction.transformChildrenVoid(transformer)
-    }
-}
-
-
-private class TypeOperatorTransformer(val context: CommonBackendContext, val function: IrFunctionSymbol) : IrElementTransformerVoid() {
-
-    private val builder = context.createIrBuilder(function)
-
-    val throwNullPointerException = context.ir.symbols.throwNullPointerException
-
-    override fun visitFunction(declaration: IrFunction): IrStatement {
-        // ignore inner functions during this pass
-        return declaration
+internal class TypeOperatorLowering(val context: CommonBackendContext) : FileLoweringPass, IrBuildingTransformer(context) {
+    override fun lower(irFile: IrFile) {
+        irFile.transformChildren(this, null)
     }
 
     private fun IrType.erasure(): IrType {
         if (this !is IrSimpleType) return this
 
-        val classifier = this.classifier
-        return when (classifier) {
+        return when (val classifier = classifier) {
             is IrClassSymbol -> this
             is IrTypeParameterSymbol -> {
                 val upperBound = classifier.owner.superTypes.firstOrNull() ?:
@@ -87,7 +62,7 @@ private class TypeOperatorTransformer(val context: CommonBackendContext, val fun
             expression.argument.type.isSubtypeOf(typeOperand) -> expression.argument
 
             expression.argument.type.containsNull() -> {
-                with (builder) {
+                with(builder) {
                     irLetS(expression.argument) { argument ->
                         irIfThenElse(
                                 type = expression.type,
@@ -96,7 +71,7 @@ private class TypeOperatorTransformer(val context: CommonBackendContext, val fun
                                 thenPart = if (typeOperand.isSimpleTypeWithQuestionMark)
                                     irNull()
                                 else
-                                    irCall(throwNullPointerException.owner),
+                                    irCall(this@TypeOperatorLowering.context.ir.symbols.throwNullPointerException.owner),
 
                                 elsePart = irAs(irGet(argument.owner), typeOperand.makeNotNull())
                         )
@@ -111,8 +86,6 @@ private class TypeOperatorTransformer(val context: CommonBackendContext, val fun
             else -> builder.irAs(expression.argument, typeOperand)
         }
     }
-
-    private fun KotlinType.isNullable() = TypeUtils.isNullableType(this)
 
     private fun lowerSafeCast(expression: IrTypeOperatorCall): IrExpression {
         val typeOperand = expression.typeOperand.erasure()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/VarargLowering.kt
@@ -103,18 +103,19 @@ internal class VarargInjectionLowering constructor(val context: KonanBackendCont
                     val arrayHandle = arrayType(expression.type)
 
                     val vars = expression.elements.map {
-                        it to irTemporaryVar(
+                        it to irTemporary(
                                 (it as? IrSpreadElement)?.expression ?: it as IrExpression,
-                                "elem".synthesizedString
+                                "elem".synthesizedString,
+                                isMutable = true
                         )
                     }.toMap()
                     val arraySize = calculateArraySize(arrayHandle, hasSpreadElement, scope, expression, vars)
                     val array = arrayHandle.createArray(this, expression.varargElementType, arraySize)
 
-                    val arrayTmpVariable = irTemporaryVar(array, "array".synthesizedString)
+                    val arrayTmpVariable = irTemporary(array, "array".synthesizedString, isMutable = true)
                     lateinit var indexTmpVariable: IrVariable
                     if (hasSpreadElement)
-                        indexTmpVariable = irTemporaryVar(kIntZero, "index".synthesizedString)
+                        indexTmpVariable = irTemporary(kIntZero, "index".synthesizedString, isMutable = true)
                     expression.elements.forEachIndexed { i, element ->
                         irBuilder.at(element.startOffset, element.endOffset)
                         log { "element:$i> ${ir2string(element)}" }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DFGBuilder.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/DFGBuilder.kt
@@ -334,7 +334,9 @@ internal class ModuleDFGBuilder(val context: Context, val irModule: IrModuleFrag
                 // Producer and job of executeImpl are called externally, we need to reflect this somehow.
                 val producerInvocation = IrCallImpl(expression.startOffset, expression.endOffset,
                         executeImplProducerInvoke.returnType,
-                        executeImplProducerInvoke.symbol)
+                        executeImplProducerInvoke.symbol,
+                        executeImplProducerInvoke.symbol.owner.typeParameters.size,
+                        executeImplProducerInvoke.symbol.owner.valueParameters.size)
                 producerInvocation.dispatchReceiver = expression.getValueArgument(2)
 
                 expressions += producerInvocation to currentLoop
@@ -343,7 +345,9 @@ internal class ModuleDFGBuilder(val context: Context, val irModule: IrModuleFrag
                         ?: error("A function reference expected")
                 val jobInvocation = IrCallImpl(expression.startOffset, expression.endOffset,
                         jobFunctionReference.symbol.owner.returnType,
-                        jobFunctionReference.symbol as IrSimpleFunctionSymbol)
+                        jobFunctionReference.symbol as IrSimpleFunctionSymbol,
+                        jobFunctionReference.symbol.owner.typeParameters.size,
+                        jobFunctionReference.symbol.owner.valueParameters.size)
                 jobInvocation.putValueArgument(0, producerInvocation)
 
                 expressions += jobInvocation to currentLoop
@@ -355,7 +359,9 @@ internal class ModuleDFGBuilder(val context: Context, val irModule: IrModuleFrag
                     && expression.typeOperand.isObjCObjectType()) {
                 val objcObjGetter = IrCallImpl(expression.startOffset, expression.endOffset,
                         objCObjectRawValueGetter.owner.returnType,
-                        objCObjectRawValueGetter
+                        objCObjectRawValueGetter,
+                        objCObjectRawValueGetter.owner.typeParameters.size,
+                        objCObjectRawValueGetter.owner.valueParameters.size
                 ).apply {
                     extensionReceiver = expression.argument
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
-import org.jetbrains.kotlin.ir.descriptors.IrTemporaryVariableDescriptorImpl
+import org.jetbrains.kotlin.ir.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
@@ -1318,13 +1318,13 @@ internal object Devirtualization {
         }
 
         fun <T : IrElement> IrStatementsBuilder<T>.irTemporary(value: IrExpression, tempName: String, type: IrType): IrVariable {
-            val originalKotlinType = type.originalKotlinType ?: type.toKotlinType()
-            val descriptor = IrTemporaryVariableDescriptorImpl(scope.scopeOwner, Name.identifier(tempName), originalKotlinType, false)
+            val descriptor = WrappedVariableDescriptor()
 
             val temporary = IrVariableImpl(
                 value.startOffset, value.endOffset, IrDeclarationOrigin.IR_TEMPORARY_VARIABLE, IrVariableSymbolImpl(descriptor),
-                descriptor.name, type, isVar = false, isConst = false, isLateinit = false
+                Name.identifier(tempName), type, isVar = false, isConst = false, isLateinit = false
             ).apply {
+                descriptor.bind(this)
                 this.initializer = value
             }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
@@ -29,5 +29,5 @@ class KonanIrFileSerializer(
         return node.annotations.hasAnnotation(fqn)
     }
 
-    override fun backendSpecificSerializeAllMembers(irClass: IrClass) = !KonanFakeOverrideClassFilter.constructFakeOverrides(irClass)
+    override fun backendSpecificSerializeAllMembers(irClass: IrClass) = !KonanFakeOverrideClassFilter.needToConstructFakeOverrides(irClass)
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -58,7 +58,7 @@ object KonanFakeOverrideClassFilter : FakeOverrideClassFilter {
     private fun IrClass.hasInteropSuperClass() = this.superTypes
         .mapNotNull { it.classOrNull }
         .filter { it is IrPublicSymbolBase<*> }
-        .any { it.signature.isInteropSignature() }
+        .any { it.signature?.isInteropSignature() ?: false }
 
     override fun needToConstructFakeOverrides(clazz: IrClass): Boolean {
         return !clazz.hasInteropSuperClass()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -18,7 +18,7 @@ package org.jetbrains.kotlin.backend.konan.serialization
 
 import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideBuilder
-import org.jetbrains.kotlin.backend.common.overrides.PlatformFakeOverrideClassFilter
+import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideClassFilter
 import org.jetbrains.kotlin.backend.common.serialization.*
 import org.jetbrains.kotlin.backend.common.serialization.encodings.BinarySymbolData
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureSerializer
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
-object KonanFakeOverrideClassFilter : PlatformFakeOverrideClassFilter {
+object KonanFakeOverrideClassFilter : FakeOverrideClassFilter {
     private fun IdSignature.isInteropSignature(): Boolean = with(this) {
         IdSignature.Flags.IS_NATIVE_INTEROP_LIBRARY.test()
     }
@@ -60,7 +60,7 @@ object KonanFakeOverrideClassFilter : PlatformFakeOverrideClassFilter {
         .filter { it is IrPublicSymbolBase<*> }
         .any { it.signature.isInteropSignature() }
 
-    override fun constructFakeOverrides(clazz: IrClass): Boolean {
+    override fun needToConstructFakeOverrides(clazz: IrClass): Boolean {
         return !clazz.hasInteropSuperClass()
     }
 }
@@ -91,9 +91,8 @@ internal class KonanIrLinker(
 
     override fun isBuiltInModule(moduleDescriptor: ModuleDescriptor): Boolean = moduleDescriptor.isNativeStdlib()
 
-    override val fakeOverrideBuilder = FakeOverrideBuilder(symbolTable, IdSignatureSerializer(KonanManglerIr), builtIns, KonanFakeOverrideClassFilter)
-
     private val forwardDeclarationDeserializer = forwardModuleDescriptor?.let { KonanForwardDeclarationModuleDeserializer(it) }
+    override val fakeOverrideBuilder = FakeOverrideBuilder(this, symbolTable, IdSignatureSerializer(KonanManglerIr), builtIns, KonanFakeOverrideClassFilter)
 
     override fun createModuleDeserializer(moduleDescriptor: ModuleDescriptor, klib: IrLibrary?, strategy: DeserializationStrategy): IrModuleDeserializer {
         if (moduleDescriptor === forwardModuleDescriptor) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -241,7 +241,7 @@ fun IrBuilderWithScope.irCall(irFunction: IrFunction, typeArguments: List<IrType
 internal fun irCall(startOffset: Int, endOffset: Int, irFunction: IrSimpleFunction, typeArguments: List<IrType>): IrCall =
         IrCallImpl(
                 startOffset, endOffset, irFunction.substitutedReturnType(typeArguments),
-                irFunction.symbol, typeArguments.size
+                irFunction.symbol, typeArguments.size, irFunction.valueParameters.size
         ).apply {
             typeArguments.forEachIndexed { index, irType ->
                 this.putTypeArgument(index, irType)

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -4395,6 +4395,18 @@ standaloneTest("fake_override_0") {
     goldValue = "Moved\nMoved\nChild\nSuper\n"
 }
 
+linkTest("private_fake_overrides_0") {
+    source = "link/private_fake_overrides/inherit_main.kt"
+    lib = "link/private_fake_overrides/inherit_lib.kt"
+    goldValue = "PASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\n"
+}
+
+linkTest("private_fake_overrides_1") {
+    source = "link/private_fake_overrides/override_main.kt"
+    lib = "link/private_fake_overrides/override_lib.kt"
+    goldValue = "PASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\nPASS\n"
+}
+
 Task frameworkTest(String name, Closure<FrameworkTest> configurator) {
     return KotlinNativeTestKt.createTest(project, name, FrameworkTest) { task ->
         configurator.delegate = task

--- a/backend.native/tests/link/private_fake_overrides/inherit_lib.kt
+++ b/backend.native/tests/link/private_fake_overrides/inherit_lib.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+// Private classes
+private open class A {
+    public fun foo1() = println("PASS")
+    internal fun foo2() = println("PASS")
+    protected fun foo3() = println("PASS")
+}
+
+private class B:A() {
+    fun foo4() = foo3()
+}
+
+// Private interfaces
+private interface C {
+    fun foo() = println("PASS")
+}
+
+private class D: C 
+
+fun runner() {
+   B().foo1()
+   B().foo2()
+   B().foo4()
+
+   D().foo()
+
+   // Objects
+   object : A(){
+       fun foo4() = foo3()
+   }.apply {
+       foo1()
+       foo2()
+       foo4()
+   }
+
+   // Function local classes
+   abstract class E {
+       public open fun foo1() = println("PASS")
+       internal open fun foo2() = println("PASS")
+       protected open fun foo3() = println("PASS")
+   }
+   class F : E() {
+       fun foo4() = foo3()
+   }
+   F().foo1()
+   F().foo2()
+   F().foo4()
+}
+

--- a/backend.native/tests/link/private_fake_overrides/inherit_main.kt
+++ b/backend.native/tests/link/private_fake_overrides/inherit_main.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+fun main() {
+    runner()
+}
+

--- a/backend.native/tests/link/private_fake_overrides/override_lib.kt
+++ b/backend.native/tests/link/private_fake_overrides/override_lib.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+// Private classes
+private open class A {
+    public open fun foo1() = println("FAIL")
+    internal open fun foo2() = println("FAIL")
+    protected open fun foo3() = println("FAIL")
+    private fun foo4() = println("FAIL")
+}
+
+private class B:A() {
+    override public fun foo1() = println("PASS")
+    override internal fun foo2() = println("PASS")
+    override protected fun foo3() = println("PASS")
+    private fun foo4() = println("PASS")
+    fun foo5() = foo3()
+    fun foo6() = foo4()
+}
+
+private abstract class G {
+    public abstract fun foo1()
+    internal abstract fun foo2()
+    protected abstract fun foo3()
+    private fun foo4() = println("FAIL")
+}
+
+private class H:A() {
+    override public fun foo1() = println("PASS")
+    override internal fun foo2() = println("PASS")
+    override protected fun foo3() = println("PASS")
+    private fun foo4() = println("PASS")
+    fun foo5() = foo3()
+    fun foo6() = foo4()
+}
+
+
+// Private interfaces
+private interface C {
+    fun foo() = println("FAIL")
+}
+
+private class D: C {
+    override fun foo() = println("PASS")
+}
+
+fun runner() {
+   B().foo1()
+   B().foo2()
+   B().foo5()
+   B().foo6()
+
+   H().foo1()
+   H().foo2()
+   H().foo5()
+   H().foo6()
+
+   D().foo()
+
+   // Objects
+   object : A(){
+        override public fun foo1() = println("PASS")
+        override internal fun foo2() = println("PASS")
+        override protected fun foo3() = println("PASS")
+        private fun foo4() = println("PASS")
+        fun foo5() = foo3()
+        fun foo6() = foo4()
+   }.apply {
+       foo1()
+       foo2()
+       foo5()
+       foo6()
+   }
+
+   // Function local classes
+   open class E {
+       public open fun foo1() = println("FAIL")
+       internal open fun foo2() = println("FAIL")
+       protected open fun foo3() = println("FAIL")
+       private fun foo4() = println("FAIL")
+   }
+   class F : E() {
+       public override fun foo1() = println("PASS")
+       internal override fun foo2() = println("PASS")
+       protected override fun foo3() = println("PASS")
+       private fun foo4() = println("PASS")
+       fun foo5() = foo3()
+       fun foo6() = foo4()
+   }
+   F().foo1()
+   F().foo2()
+   F().foo5()
+   F().foo6()
+}
+

--- a/backend.native/tests/link/private_fake_overrides/override_main.kt
+++ b/backend.native/tests/link/private_fake_overrides/override_main.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+fun main() {
+    runner()
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1638,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-1638
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1638,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-1638
-kotlinStdlibTestsVersion=1.4.30-dev-1638
-testKotlinCompilerVersion=1.4.30-dev-1638
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1895,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-1895
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1895,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-1895
+kotlinStdlibTestsVersion=1.4.30-dev-1895
+testKotlinCompilerVersion=1.4.30-dev-1895
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 0a18be62e59 - (HEAD -> master, tag: build-1.4.30-dev-1895, origin/master, origin/HEAD) Add prefix for inner test classes in ide perf tests to avoid metric name clashes (vor 17 Stunden) <Vladimir Dolzhenko>
* 08b8939b80b - (tag: build-1.4.30-dev-1887) IR: make IrSymbol.isPublicApi an extension (vor 3 Tagen) <Alexander Udalov>
* 4bd08e5e0cb - IR: clear callToSubstitutedDescriptorMap for each file to avoid leaking memory (vor 3 Tagen) <Alexander Udalov>
* 7ac981d4d37 - Psi2ir: refactor ModuleGenerator.generateModuleFragment (vor 3 Tagen) <Alexander Udalov>
* 7b53d668ab2 - (tag: build-1.4.30-dev-1883) Fix test after 4f061624464a0fa2f643ec88dbab3a061dd1b9e6 (vor 3 Tagen) <Victor Petukhov>
* c07f25fa44f - (tag: build-1.4.30-dev-1882) Revert "FoldInitializerAndIfToElvisInspection: don't add explicit type if var is used as non-nullable" (vor 3 Tagen) <Yan Zhulanow>
* 87574dddd9b - Revert "ReplaceWith: suggest for "invoke" extension" (vor 3 Tagen) <Yan Zhulanow>
* 04457e92d0a - Revert ""Put/Join arguments/parameters" intention: don't suggest on nested argument list" (vor 3 Tagen) <Yan Zhulanow>
* 3321ce63252 - Revert ""Code Cleanup": don't remove deprecated imports when file has `@file:Suppress("DEPRECATION")` annotation" (vor 3 Tagen) <Yan Zhulanow>
* 839c30d04b7 - Revert "Additional minor fixes for KT-33594: avoid using hard-coded annotation name, simplify hasAnnotationToSuppressDeprecation()" (vor 3 Tagen) <Yan Zhulanow>
* 9320637efea - Revert "Redundant companion reference: do not report 'values/valueOf' function in enum" (vor 3 Tagen) <Yan Zhulanow>
* 383190f25e3 - Revert "Replace with ordinary assignment: do not suggest when operator is augmented assignment operator function" (vor 3 Tagen) <Yan Zhulanow>
* 7fccd0153be - Revert "Refactoring: Remove hard-coded augmented assignment check with a Name check" (vor 3 Tagen) <Yan Zhulanow>
* 0ae21a157f2 - Revert ""Change to return with label" quick fix: apply for type mismatch" (vor 3 Tagen) <Yan Zhulanow>
* 601198634dc - Revert "Minor: Extract lambda return expression handling" (vor 3 Tagen) <Yan Zhulanow>
* b18de1e3ff2 - Revert "Provide quickfix for specifying type of variable initialized with null" (vor 3 Tagen) <Yan Zhulanow>
* 4327bc4ac30 - Revert "KT-23394: Add a test with a property" (vor 3 Tagen) <Yan Zhulanow>
* fe64fcf8a35 - Revert "Minor: update order in IntentionTestGenerated" (vor 3 Tagen) <Yan Zhulanow>
* c4a48598c0a - Revert ""Add parameter to function" for TYPE_MISMATCH: fix it works correctly for extension function" (vor 3 Tagen) <Yan Zhulanow>
* 16dbf7ba74c - Revert "Convert to range check: don't report it if recursive call will be created" (vor 3 Tagen) <Yan Zhulanow>
* d735637f1ea - Revert "RemoveBracesIntention: add new line for long expression" (vor 3 Tagen) <Yan Zhulanow>
* f615ed2f26e - Revert ""Use destructuring declaration": fix it works correctly if variable name is shadowed" (vor 3 Tagen) <Yan Zhulanow>
* ab70cc35ead - Revert "Add quick fix for 'JAVA_CLASS_ON_COMPANION'" (vor 3 Tagen) <Yan Zhulanow>
* 6cc4d70b073 - Revert "Minor: Remove hard-coded 'Companion' name" (vor 3 Tagen) <Yan Zhulanow>
* 19f518c037c - Revert "IfThenToSafeAccessInspection: fix it works correctly for variable/operator call" (vor 3 Tagen) <Yan Zhulanow>
* 19896f96166 - Revert "Minor: Use second pattern argument instead of explicit `callee.text`" (vor 3 Tagen) <Yan Zhulanow>
* 519f92599ca - Revert "Minor: Import DebuggerUtils" (vor 3 Tagen) <Yan Zhulanow>
* 9b2aa0951b5 - (tag: build-1.4.30-dev-1880) [box-tests] Turned on tests on typeof for K/N (vor 3 Tagen) <Igor Chevdar>
* 9d1cb6a2c0f - Turned off TypeOfChecker for K/N (vor 3 Tagen) <Igor Chevdar>
* 4f061624464 - (tag: build-1.4.30-dev-1879) Get a callable reference expression to report an error on it properly, taking into account possible wrapping (vor 3 Tagen) <Victor Petukhov>
* cb020fb9f4e - (tag: build-1.4.30-dev-1873) Change repository adding logic (vor 3 Tagen) <Ilya Muradyan>
* 7062bf5737a - (tag: build-1.4.30-dev-1872) [JS_IR] Additional check on loop label to not persist name for labeled loop (vor 3 Tagen) <Ilya Goncharov>
* 1a9e516dc02 - (tag: build-1.4.30-dev-1871) [ir-plugin] Referenced binary operators with the new API (vor 3 Tagen) <Igor Chevdar>
* 23d12a717ed - (tag: build-1.4.30-dev-1866) [box-tests] Added a test (vor 3 Tagen) <Igor Chevdar>
* 27aed0ccbc9 - [IR] Inliner: erase non-reified parameters for casts (vor 3 Tagen) <Igor Chevdar>
* 27fb46712ae - (tag: build-1.4.30-dev-1865) [JVM+IR] Unify new debugger tests expectations (vor 3 Tagen) <Kristoffer Andersen>
* e19ecdfb3d7 - [Tests] Suspend Codegen Tests Improvements (vor 3 Tagen) <pyos>
* 3291f8455b5 - [JVM+IR] Update straight-forward LVT tests (vor 3 Tagen) <Kristoffer Andersen>
* 2c9bf952272 - [JVM+IR] New LVT debugging test harness improvements (vor 3 Tagen) <Kristoffer Andersen>
* 4479bf09331 - (tag: build-1.4.30-dev-1862) [JS_IR] Enum constructor copy parameters with mapping by index (vor 3 Tagen) <Ilya Goncharov>
* 2790bc1105a - (tag: build-1.4.30-dev-1856) Split perf test json reports in a separate files/docs (vor 3 Tagen) <Vladimir Dolzhenko>
* d7a783e077c - Add prefix for inner test classes (vor 3 Tagen) <Vladimir Dolzhenko>
* 58f606e1f5b - (tag: build-1.4.30-dev-1854) Minor: Import DebuggerUtils (vor 3 Tagen) <Yan Zhulanow>
* 55e36fa1abd - Minor: Use second pattern argument instead of explicit `callee.text` (vor 3 Tagen) <Yan Zhulanow>
* 5095caee504 - IfThenToSafeAccessInspection: fix it works correctly for variable/operator call (vor 3 Tagen) <Toshiaki Kameyama>
* 871ad2b9093 - Minor: Remove hard-coded 'Companion' name (vor 3 Tagen) <Yan Zhulanow>
* 15a615d63bc - Add quick fix for 'JAVA_CLASS_ON_COMPANION' (vor 3 Tagen) <Toshiaki Kameyama>
* d61158a1765 - "Use destructuring declaration": fix it works correctly if variable name is shadowed (vor 3 Tagen) <Toshiaki Kameyama>
* f4b9c4777f2 - RemoveBracesIntention: add new line for long expression (vor 3 Tagen) <Toshiaki Kameyama>
* 731848849ea - Convert to range check: don't report it if recursive call will be created (vor 3 Tagen) <Toshiaki Kameyama>
* 03e725d5da8 - "Add parameter to function" for TYPE_MISMATCH: fix it works correctly for extension function (vor 3 Tagen) <Toshiaki Kameyama>
* 6515d53b94f - Minor: update order in IntentionTestGenerated (vor 3 Tagen) <Yan Zhulanow>
* f2dc132d5d9 - KT-23394: Add a test with a property (vor 3 Tagen) <Yan Zhulanow>
* cdf7f46ce14 - Provide quickfix for specifying type of variable initialized with null (vor 3 Tagen) <Toshiaki Kameyama>
* 55038e19ec6 - Minor: Extract lambda return expression handling (vor 3 Tagen) <Yan Zhulanow>
* f76e98868c0 - "Change to return with label" quick fix: apply for type mismatch (vor 3 Tagen) <Toshiaki Kameyama>
* 016e78e4833 - Refactoring: Remove hard-coded augmented assignment check with a Name check (vor 3 Tagen) <Yan Zhulanow>
* 73e319ca7ae - Replace with ordinary assignment: do not suggest when operator is augmented assignment operator function (vor 3 Tagen) <Toshiaki Kameyama>
* 55d55446c8d - Redundant companion reference: do not report 'values/valueOf' function in enum (vor 3 Tagen) <Toshiaki Kameyama>
* 2a841550d46 - Additional minor fixes for KT-33594: avoid using hard-coded annotation name, simplify hasAnnotationToSuppressDeprecation() (vor 3 Tagen) <Yan Zhulanow>
* cf5a6274e28 - "Code Cleanup": don't remove deprecated imports when file has `@file:Suppress("DEPRECATION")` annotation (vor 3 Tagen) <Toshiaki Kameyama>
* 4a328981c60 - "Put/Join arguments/parameters" intention: don't suggest on nested argument list (vor 3 Tagen) <Toshiaki Kameyama>
* be194c3460e - ReplaceWith: suggest for "invoke" extension (vor 3 Tagen) <Toshiaki Kameyama>
* bb7d4c224fb - FoldInitializerAndIfToElvisInspection: don't add explicit type if var is used as non-nullable (vor 3 Tagen) <Toshiaki Kameyama>
* 3e632d074ef - Enable Parcelize IDE plugin in Android Studio 4.2 (KT-42859) (vor 3 Tagen) <Yan Zhulanow>
* 47a4bd17014 - (tag: build-1.4.30-dev-1852) [FIR Java] Look into type arguments during dependent type parameter search (vor 3 Tagen) <Mikhail Glukhikh>
* 7f3d0af4f75 - [FIR Java] Soften rules for matching types for may-be-special-builtins (vor 3 Tagen) <Mikhail Glukhikh>
* 81529a835ba - Drop FirAbstractOverrideChecker.isEqualTypes (vor 3 Tagen) <Mikhail Glukhikh>
* abc28669028 - [FIR] Fold flexible types after substitution if possible (vor 3 Tagen) <Mikhail Glukhikh>
* acb03cb28c9 - [FIR2IR] Expand type during super qualifier search (vor 3 Tagen) <Mikhail Glukhikh>
* c50aa5f2ec7 - [FIR TEST] Bad test data changes due to Java signature transformation (vor 3 Tagen) <Mikhail Glukhikh>
* d3e85dbce0d - [FIR] Implement replacing Object with type parameters for specials builtins (vor 3 Tagen) <Mikhail Glukhikh>
* d40248cb53c - [FIR] Extract computeJvmDescriptorReplacingKotlinToJava (vor 3 Tagen) <Mikhail Glukhikh>
* f866eff93ea - Extract special generic signatures to compiler.common.jvm to reuse in FIR (vor 3 Tagen) <Mikhail Glukhikh>
* 0e7acd6e8b5 - [FIR Java] Add better type parameter erasure for override matching (vor 3 Tagen) <Mikhail Glukhikh>
* 17de486c239 - [FIR Java] Drop nasty code providing type parameter erasure (vor 3 Tagen) <Mikhail Glukhikh>
* 999627952a7 - (tag: build-1.4.30-dev-1851) [Gradle, K/N] Add proper assumptions for Mac only integration tests (vor 4 Tagen) <Alexander Likhachev>
* ac7b7abcc0a - [Gradle, JS] Fix K/JS project build with configuration cache (part 3) (vor 4 Tagen) <Alexander Likhachev>
* 97d39c102a2 - (tag: build-1.4.30-dev-1835) Fix BWC for Search utils (vor 4 Tagen) <Igor Yakovlev>
* 71023cd596c - (tag: build-1.4.30-dev-1834) [KT-40688] Inlay Hints: inlay hints are duplicated on code editing (vor 4 Tagen) <Andrei Klunnyi>
* b7a07fdf034 - (tag: build-1.4.30-dev-1832) Review fix: unify irTemporary variants (vor 4 Tagen) <Georgy Bronnikov>
* 8e331c8afeb - IR: relax type cast for WrappedVariableDescriptor.containingDeclaration (vor 4 Tagen) <Georgy Bronnikov>
* b5888397520 - EnumConstructorCall.fromSymbolDescriptor (vor 4 Tagen) <Georgy Bronnikov>
* 887dd10764a - IR: remove descriptor usage (vor 4 Tagen) <Georgy Bronnikov>
* e5cf7a1be77 - Remove descriptor usage from Scope.kt (vor 4 Tagen) <Georgy Bronnikov>
* 8d999a2c13b - Disable kx.ser plugin inside descriptors serialization in the IDE (vor 4 Tagen) <Leonid Startsev>
* 4ec90b18bcb - Rework DescriptorSerializerPlugin to be a part of Project's extensions (vor 4 Tagen) <Leonid Startsev>
* ef907e0c462 - (tag: build-1.4.30-dev-1821) Fix FIR IDE test broken by Jinseong commit (vor 4 Tagen) <Mikhail Glukhikh>
* ad12cc296b7 - (tag: build-1.4.30-dev-1816) [FIR] Expand type before adding equality constraint (vor 4 Tagen) <Mikhail Glukhikh>
* 7815529eedf - (tag: build-1.4.30-dev-1811) [Private fake overrides] Tests for private fake overrides construction (vor 4 Tagen) <Alexander Gorshenev>
* 294e7dd902b - [Private fake overrides] Renamed FakeOverrideBuilder object to FakeOverrideBuilderForLowering (vor 4 Tagen) <Alexander Gorshenev>
* 81c06b24f75 - [Private fake overrides] Private fake overrides linkage (vor 4 Tagen) <Alexander Gorshenev>
* 223d1dd5e67 - [Private fake overrides] Private fake override construction (vor 4 Tagen) <Alexander Gorshenev>
* c90556a8830 - [Private fake overrides] FakeOverrideDeclarationTable for private fake override construction (vor 4 Tagen) <Alexander Gorshenev>
* 623f9a54c64 - [Private fake overrides] Tweak DeclarationTable to be open (vor 4 Tagen) <Alexander Gorshenev>
* c7ea8b1ab6e - [Private fake overrides] Prepare IdSignature for private fake override construction (vor 4 Tagen) <Alexander Gorshenev>
* 91089f5f7a7 - (tag: build-1.4.30-dev-1810) IrValidator: add more details to duplicate message for type parameter (vor 4 Tagen) <Mikhail Glukhikh>
* 44bb12480b3 - [FIR2IR] Forbid private fake overrides in generator (vor 4 Tagen) <Mikhail Glukhikh>
* 3663bc6be35 - FirClassSubstitutionScope: eliminate second constructor to simplify code (vor 4 Tagen) <Mikhail Glukhikh>
* 80f8b5b234f - IrValidator: mention file in exception message (vor 4 Tagen) <Mikhail Glukhikh>
* 23e7468e577 - [FIR2IR] Cache Java field-based properties more correctly #KT-42805 Fixed (vor 4 Tagen) <Mikhail Glukhikh>
* 3576cbf0d8e - [FIR] Add test for KT-42805 (vor 4 Tagen) <Mikhail Glukhikh>
* f2c651ec9cc - [FIR2IR] Don't generate Any delegated members for data class (vor 4 Tagen) <Mikhail Glukhikh>
* 44459e8ac79 - FIR mangler: fix alias-based type handling #KT-42770 Fixed (vor 4 Tagen) <Mikhail Glukhikh>
* 6251568e177 - (tag: build-1.4.30-dev-1807) Fix test after 84129098cb6fc86dfb3be8618a76195de2a757f1 (vor 4 Tagen) <Victor Petukhov>
* 289efd47b26 - (tag: build-1.4.30-dev-1805) [FIR2IR] Cleanup code around implicit casts (vor 4 Tagen) <Mikhail Glukhikh>
* 620a5d404df - [FIR2IR] Keep redundant cast on 'this' for local anonymous function (vor 4 Tagen) <Juan Chen>
* f4531b0f34c - FIR: set missed source in various FirElements (vor 4 Tagen) <Jinseong Jeon>
* 46cc01602e9 - FIR2IR: add implicit NOT_NULL cast if needed (vor 4 Tagen) <Jinseong Jeon>
* eeda48e63ed - (tag: build-1.4.30-dev-1803) Allow prefix and relative path in resolvable properties. (vor 4 Tagen) <Sergey Bogolepov>
* 84129098cb6 - (tag: build-1.4.30-dev-1792) Add equality constraints without subtyping (vor 5 Tagen) <Victor Petukhov>
* b1b87becc84 - (tag: build-1.4.30-dev-1791) PSI2IR more JVM-like exhaustive when behavior KT-36840 (vor 5 Tagen) <Dmitry Petrov>
* 7edeccbdc7d - (tag: build-1.4.30-dev-1787) Move labeling into NameTables with labeling loops which contain escaped break (vor 5 Tagen) <Ilya Goncharov>
* 400a15e3d6c - Add lowering on switch in loop (vor 5 Tagen) <Ilya Goncharov>
* 14d9aa16601 - Add test on break in when without label (vor 5 Tagen) <Ilya Goncharov>
* a4b67f007f7 - (tag: build-1.4.30-dev-1784) JVM_IR: treat suspend-converted references as lambdas for inlining (vor 5 Tagen) <pyos>
* 12bec7cca26 - JVM_IR: when convering references to lambdas, bind the receiver (vor 5 Tagen) <pyos>
* 95fb597da07 - PSI2IR / FIR2IR: bind FunctionN as receiver when suspend-converting (vor 5 Tagen) <pyos>
* ccf921510d7 - PSI2IR / FIR2IR: do not create temporaries for adapted references (vor 5 Tagen) <pyos>
* 369056ca5d1 - Minor, add explicit type argument to workaround KT-42175 (vor 5 Tagen) <Alexander Udalov>
* 29aaf70d211 - (tag: build-1.4.30-dev-1783) Launch common tests on local JVM via run gutter (vor 5 Tagen) <Kirill Shmakov>
* 1c1e8f7beb6 - (tag: build-1.4.30-dev-1777) FIR CFG: revise edge kind between local func node and fun enter node (vor 5 Tagen) <Jinseong Jeon>
* ce8d983b2a2 - (tag: build-1.4.30-dev-1776) Fix test after the fix for KT-17691 (vor 5 Tagen) <Pavel Punegov>
* 0b34526321b - JVM_IR remove lambda hack required for odd JVM+OI behavior in KT-35849 (vor 5 Tagen) <Dmitry Petrov>
* ad88c60fd87 - (tag: build-1.4.30-dev-1772) [JVM_IR] Copy offsets from the original function to invokeSuspend. (vor 5 Tagen) <Mads Ager>
* 800bfe2cdbb - (tag: build-1.4.30-dev-1770) [TEST] Update testdata broken in c2d3a252 (vor 5 Tagen) <Dmitriy Novozhilov>
* c2d3a252a88 - (tag: build-1.4.30-dev-1767) Mute very strange failing of FIR find usages test (vor 5 Tagen) <Dmitriy Novozhilov>
* 0484ab8cca4 - Don't unwrap captured types in IDE descriptors renderers (vor 5 Tagen) <Dmitriy Novozhilov>
* 3068d79d2b5 - [FIR-IDE] Add lock for status resolve (vor 5 Tagen) <Dmitriy Novozhilov>
* 6550bd09b19 - [FIR] Ensure class resolve phase in status resolve (vor 5 Tagen) <Dmitriy Novozhilov>
* 699dd54be96 - [FIR] Don't inherit some declaration modifiers (like `tailrec`) (vor 5 Tagen) <Dmitriy Novozhilov>
* bf1a00c73af - [FIR] Rework resolution of declaration statuses (vor 5 Tagen) <Dmitriy Novozhilov>
* 0b8116dff03 - [FIR] Change some phase requirements: STATUS -> DECLARATIONS (vor 5 Tagen) <Mikhail Glukhikh>
* 275260720d1 - Add replacePhase in FirTypeResolveTransformer.transformEnumEntry (vor 5 Tagen) <Mikhail Glukhikh>
* c171dafd91c - FIR serializer: always normalize visibility (vor 5 Tagen) <Mikhail Glukhikh>
* 1ff5da5f413 - [FIR] Add forgotten fake override type calculation (vor 5 Tagen) <Dmitriy Novozhilov>
* 5c55f679237 - (tag: build-1.4.30-dev-1748) JVM_IR: generate shorter names for classes in delegate initializers (vor 6 Tagen) <pyos>
* b786cf75590 - [IR] Made signature nullable (#3860) (vor 6 Tagen) <LepilkinaElena>
* 6a9c72e77c2 - IR: use one traversal instead of two for DeclarationContainerLoweringPass (vor 6 Tagen) <Alexander Udalov>
* b5695188f90 - IR: remove FunctionLoweringPass, refactor usages to FileLoweringPass (vor 6 Tagen) <Alexander Udalov>
* c1100319353 - IR: refactor DeclarationTransformer (vor 6 Tagen) <Alexander Udalov>
* 2be7afc7f99 - IR: minor, give names to anonymous lowering visitors (vor 6 Tagen) <Alexander Udalov>
* 3979cde7386 - (tag: build-1.4.30-dev-1743) Add box and PSI2IR tests for special cases listed in KT-35849 (vor 6 Tagen) <Dmitry Petrov>
* efee3228301 - (tag: build-1.4.30-dev-1731) [Gradle, JS] Update Dukat on 0.5.8-rc.3 (vor 6 Tagen) <Ilya Goncharov>
* 4d4aabab8de - (tag: build-1.4.30-dev-1728) [JS BE] Make properties configurable when implementing an interface by delegation (vor 6 Tagen) <Victor Turansky>
* 2ad13847d13 - (tag: build-1.4.30-dev-1715) [KT-40670] Allow to override konan.properties from CLI (vor 6 Tagen) <Sergey Bogolepov>
* ea34a588f39 - (tag: build-1.4.30-dev-1709) Update KMM project wizard. (vor 6 Tagen) <Konstantin Tskhovrebov>
* 47c784f0234 - (tag: build-1.4.30-dev-1695) JVM_IR fix Java wildcard types translation (vor 7 Tagen) <Dmitry Petrov>
* 19ed04e3fe7 - (tag: build-1.4.30-dev-1680) Bad capitalization fixed (vor 7 Tagen) <zhelenskiy>
* ba08cbbb204 - Other typos fixed (vor 7 Tagen) <zhelenskiy>
* 6e0aa007da1 - Typos fixed (vor 7 Tagen) <zhelenskiy>
* 0367dec035a - [Gradle, JS] Dukat change default mode onto source (vor 7 Tagen) <Ilya Goncharov>
* 0ce6d694b7c - (tag: build-1.4.30-dev-1679) Fix tests for as42. (vor 7 Tagen) <Konstantin Tskhovrebov>
* 48cd86b7171 - (tag: build-1.4.30-dev-1678) Add JVM target bytecode version 15 (vor 7 Tagen) <Alexander Udalov>
* 819d64a2ef9 - (tag: build-1.4.30-dev-1676) Box inline class returned from suspend lambda non-locally in JVM_IR (vor 7 Tagen) <Ilmir Usmanov>
* 70a4ed3ebc8 - Box inline class returned from suspend lambda non-locally (vor 7 Tagen) <Ilmir Usmanov>
* c1765a5306b - (tag: build-1.4.30-dev-1668) Add changelog for 1.4.20-M2 (vor 7 Tagen) <anastasiia.spaseeva>
* b70a1735957 - (tag: build-1.4.30-dev-1666) Formatting changes (vor 7 Tagen) <Georgy Bronnikov>
* 44893e09c13 - IR: remove unneeded ObsoleteDescriptorBasedAPI uses from backend.common (vor 7 Tagen) <Georgy Bronnikov>
* a0a6a4b0f10 - JVM_IR: make ObsoleteDescriptorBasedApi use explicit in all of backend.jvm (vor 7 Tagen) <Georgy Bronnikov>
* 305da8ee10c - IR: IrFunctionReference.fromSymbolDescriptor (vor 7 Tagen) <Georgy Bronnikov>
* 14b3beefb3d - IR: IrDelegatingConstructorCall.fromSymbolDescriptor (vor 7 Tagen) <Georgy Bronnikov>
* b28c85f5eaa - IR: IrCall.fromSymbolDescriptor (vor 7 Tagen) <Georgy Bronnikov>
* ab3ef3a7e97 - IR: remove descriptor usage (vor 7 Tagen) <Georgy Bronnikov>
* 065edac64b9 - IR: remove unused functions (vor 7 Tagen) <Georgy Bronnikov>
* 726282c1eeb - IR: remove a descriptor usage (vor 7 Tagen) <Georgy Bronnikov>
* c69402c8006 - (tag: build-1.4.30-dev-1665) [Commonizer] Fix computing underlyingType and expandedType in CirTypeAlias (vor 7 Tagen) <Dmitriy Dolovov>