### PR TITLE
Improve compatibility with newer GCC+Clang, resolve some warnings

### DIFF
--- a/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Utils.kt
+++ b/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Utils.kt
@@ -523,7 +523,7 @@ public fun CPointer<ShortVar>.toKStringFromUtf16(): String {
         chars[index] = nativeBytes[index].toChar()
         ++index
     }
-    return String(chars)
+    return chars.concatToString()
 }
 
 /**
@@ -555,7 +555,7 @@ public fun CPointer<IntVar>.toKStringFromUtf32(): String {
             chars[toIndex++] = value.toChar()
         }
     }
-    return String(chars)
+    return chars.concatToString()
 }
 
 /**

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeMem.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeMem.kt
@@ -143,7 +143,7 @@ public fun CPointer<UShortVar>.toKStringFromUtf16(): String {
         chars[index] = nativeBytes[index].toShort().toChar()
         ++index
     }
-    return String(chars)
+    return chars.concatToString()
 }
 
 public fun CPointer<ShortVar>.toKString(): String = this.toKStringFromUtf16()

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/ObjectiveCImpl.kt
@@ -98,7 +98,7 @@ class ObjCNotImplementedVar<T : Any?>(rawPtr: NativePtr) : CVariable(rawPtr) {
 
 var <T : Any?> ObjCNotImplementedVar<T>.value: T
     get() = TODO()
-    set(value) = TODO()
+    set(_) = TODO()
 
 typealias ObjCStringVarOf<T> = ObjCNotImplementedVar<T>
 typealias ObjCBlockVar<T> = ObjCNotImplementedVar<T>

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -29,8 +29,16 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-native-gradle-plugin:$gradlePluginVersion"
     }
-    ext.useCustomDist = project.hasProperty("konan.home")
+    ext.useCustomDist = project.hasProperty("kotlin.native.home") ||
+            project.hasProperty("org.jetbrains.kotlin.native.home") ||
+            project.hasProperty("konan.home")
+    ext.kotlinNativeDist = project.findProperty("kotlin.native.home")
+            ?: project.findProperty("org.jetbrains.kotlin.native.home")
+            ?: project.findProperty("konan.home")
+            ?: distDir.absolutePath
     if (!useCustomDist) {
+        ext.setProperty("kotlin.native.home", distDir.absolutePath)
+        ext.setProperty("org.jetbrains.kotlin.native.home", distDir.absolutePath)
         ext.setProperty("konan.home", distDir.absolutePath)
     }
 }
@@ -96,7 +104,7 @@ externalStdlibTestsDir.mkdirs()
 ext.platformManager = project.rootProject.platformManager
 ext.target = platformManager.targetManager(project.testTarget).target
 
-ext.testLibraryDir = "${project.property("konan.home")}/klib/platform/${project.target.name}"
+ext.testLibraryDir = "${ext.kotlinNativeDist}/klib/platform/${project.target.name}"
 
 // Add executor to run tests depending on a target
 project.convention.plugins.executor = ExecutorServiceKt.create(project)

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecClang.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecClang.kt
@@ -39,8 +39,8 @@ class ExecClang(private val project: Project) {
         return konanArgs(target)
     }
 
-    fun resolveExecutable(executable: String?): String {
-        val executable = executable ?: "clang"
+    fun resolveExecutable(executableOrNull: String?): String {
+        val executable = executableOrNull ?: "clang"
 
         if (listOf("clang", "clang++").contains(executable)) {
             val llvmDir = project.findProperty("llvmDir")

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/MPPTools.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/MPPTools.kt
@@ -98,14 +98,14 @@ fun createJsonReport(projectProperties: Map<String, Any>): String {
     val machine = Environment.Machine(getValue("cpu"), getValue("os"))
     val jdk = Environment.JDKInstance(getValue("jdkVersion"), getValue("jdkVendor"))
     val env = Environment(machine, jdk)
-    val flags = (projectProperties["flags"] ?: emptyList<String>()) as List<String>
+    val flags: List<String> = (projectProperties["flags"] as? List<*>)?.filterIsInstance<String>() ?: emptyList()
     val backend = Compiler.Backend(Compiler.backendTypeFromString(getValue("type"))!! ,
                                     getValue("compilerVersion"), flags)
     val kotlin = Compiler(backend, getValue("kotlinVersion"))
     val benchDesc = getValue("benchmarks")
     val benchmarksArray = JsonTreeParser.parse(benchDesc)
     val benchmarks = parseBenchmarksArray(benchmarksArray)
-            .union(projectProperties["compileTime"] as List<BenchmarkResult>).union(
+            .union((projectProperties["compileTime"] as? List<*>)?.filterIsInstance<BenchmarkResult>() ?: emptyList()).union(
                     listOf(projectProperties["codeSize"] as? BenchmarkResult).filterNotNull()).toList()
     val report = BenchmarksReport(env, benchmarks, kotlin)
     return report.toJson()
@@ -184,7 +184,6 @@ fun sendUploadRequest(url: String, fileName: String, username: String? = null, p
 }
 
 // A short-cut to add a Kotlin/Native run task.
-@JvmOverloads
 fun createRunTask(
         subproject: Project,
         name: String,

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/RegressionsReporter.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/RegressionsReporter.kt
@@ -100,8 +100,7 @@ open class RegressionsReporter : DefaultTask() {
         val teamcityConfig = System.getenv("TEAMCITY_BUILD_PROPERTIES_FILE") ?:
             error("Can't load teamcity config!")
 
-        val buildProperties = Properties()
-        buildProperties.load(FileInputStream(teamcityConfig))
+        val buildProperties = Properties().apply { load(FileInputStream(teamcityConfig)) }
         val buildId = buildProperties.getProperty("teamcity.build.id")
         val buildTypeId = buildProperties.getProperty("teamcity.buildType.id")
         val buildNumber = buildProperties.getProperty("build.number")
@@ -115,7 +114,7 @@ open class RegressionsReporter : DefaultTask() {
         val testReportUrl = testReportUrl(buildId, buildTypeId)
 
         // Get previous build on branch.
-        val builds = getBuild(previousBuildLocator(buildTypeId,branch), user, password)
+        getBuild(previousBuildLocator(buildTypeId,branch), user, password)
 
         // Get changes description.
         val changesList = getCommits("id:$buildId", user, password)
@@ -135,7 +134,7 @@ open class RegressionsReporter : DefaultTask() {
         val target = System.getProperty("os.name").replace("\\s".toRegex(), "")
 
         // Generate comparison report.
-        val output = arrayOf("$analyzer", "-r", "html", "$currentBenchmarksReportFile", "artifactory:$compareToBuildNumber:$target:$artifactoryFileName", "-o", "$htmlReport")
+        val output = arrayOf(analyzer, "-r", "html", currentBenchmarksReportFile, "artifactory:$compareToBuildNumber:$target:$artifactoryFileName", "-o", htmlReport)
                 .runCommand()
 
         if (output.contains("Uncaught exception")) {

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/XcRunRuntimeUtils.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/XcRunRuntimeUtils.kt
@@ -10,14 +10,14 @@ import kotlin.math.min
  * Examples of numeric version strings: "12.4.1.2", "9", "0.5".
  */
 private fun compareStringsAsVersions(version1: String, version2: String): Int {
-    val version1 = version1.split('.').map { it.toInt() }
-    val version2 = version2.split('.').map { it.toInt() }
-    val minimalLength = min(version1.size, version2.size)
+    val splitVersion1 = version1.split('.').map { it.toInt() }
+    val splitVersion2 = version2.split('.').map { it.toInt() }
+    val minimalLength = min(splitVersion1.size, splitVersion2.size)
     for (index in 0 until minimalLength) {
-        if (version1[index] < version2[index]) return -1
-        if (version1[index] > version2[index]) return 1
+        if (splitVersion1[index] < splitVersion2[index]) return -1
+        if (splitVersion1[index] > splitVersion2[index]) return 1
     }
-    return version1.size.compareTo(version2.size)
+    return splitVersion1.size.compareTo(splitVersion2.size)
 }
 
 /**

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/CompileBenchmarkingPlugin.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/CompileBenchmarkingPlugin.kt
@@ -110,9 +110,7 @@ open class CompileBenchmarkingPlugin : Plugin<Project> {
     private fun getCompilerFlags(benchmarkExtension: CompileBenchmarkExtension) =
             benchmarkExtension.compilerOpts
 
-    private fun Project.configureJvmRun(
-        benchmarkExtension: CompileBenchmarkExtension
-    ) {
+    private fun Project.configureJvmRun() {
         val jvmRun = tasks.create("jvmRun") {
             it.group = BenchmarkingPlugin.BENCHMARKING_GROUP
             it.description = "Runs the compile only benchmark for Kotlin/JVM."
@@ -139,7 +137,7 @@ open class CompileBenchmarkingPlugin : Plugin<Project> {
         // Create tasks.
         configureUtilityTasks()
         configureKonanRun(benchmarkExtension)
-        configureJvmRun(benchmarkExtension)
+        configureJvmRun()
     }
 
     companion object {

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/SwiftBenchmarkingPlugin.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/benchmark/SwiftBenchmarkingPlugin.kt
@@ -79,7 +79,7 @@ open class SwiftBenchmarkingPlugin : BenchmarkingPlugin() {
         val nativeTarget = kotlin.targets.getByName(NATIVE_TARGET_NAME) as KotlinNativeTarget
         // Build executable from swift code.
         framework = nativeTarget.binaries.getFramework(nativeFrameworkName, benchmark.buildType)
-        val buildSwift = tasks.create("buildSwift") { task ->
+        tasks.create("buildSwift") { task ->
             task.dependsOn(framework.linkTaskName)
             task.doLast {
                 val frameworkParentDirPath = framework.outputDirectory.absolutePath

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/bitcode/CompileToBitcodePlugin.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/bitcode/CompileToBitcodePlugin.kt
@@ -35,7 +35,7 @@ open class CompileToBitcodePlugin: Plugin<Project> {
 open class CompileToBitcodeExtension @Inject constructor(val project: Project) {
 
     private val targetList = with(project) {
-        provider { rootProject.property("targetList") as List<String> } // TODO: Can we make it better?
+        provider { (rootProject.property("targetList") as? List<*>)?.filterIsInstance<String>() ?: emptyList() } // TODO: Can we make it better?
     }
 
     fun create(

--- a/runtime/src/legacymm/cpp/Memory.cpp
+++ b/runtime/src/legacymm/cpp/Memory.cpp
@@ -3190,17 +3190,17 @@ bool TryAddHeapRef(const ObjHeader* object) {
   return tryAddHeapRef(object);
 }
 
-void ReleaseHeapRefStrict(const ObjHeader* object) {
+RUNTIME_NOTHROW void ReleaseHeapRefStrict(const ObjHeader* object) {
   releaseHeapRef<true>(const_cast<ObjHeader*>(object));
 }
-void ReleaseHeapRefRelaxed(const ObjHeader* object) {
+RUNTIME_NOTHROW void ReleaseHeapRefRelaxed(const ObjHeader* object) {
   releaseHeapRef<false>(const_cast<ObjHeader*>(object));
 }
 
-void ReleaseHeapRefNoCollectStrict(const ObjHeader* object) {
+RUNTIME_NOTHROW void ReleaseHeapRefNoCollectStrict(const ObjHeader* object) {
   releaseHeapRef<true, /* CanCollect = */ false>(const_cast<ObjHeader*>(object));
 }
-void ReleaseHeapRefNoCollectRelaxed(const ObjHeader* object) {
+RUNTIME_NOTHROW void ReleaseHeapRefNoCollectRelaxed(const ObjHeader* object) {
   releaseHeapRef<false, /* CanCollect = */ false>(const_cast<ObjHeader*>(object));
 }
 
@@ -3273,60 +3273,60 @@ OBJ_GETTER(InitSharedInstanceRelaxed,
   RETURN_RESULT_OF(initSharedInstance<false>, location, typeInfo, ctor);
 }
 
-void SetStackRefStrict(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void SetStackRefStrict(ObjHeader** location, const ObjHeader* object) {
   setStackRef<true>(location, object);
 }
-void SetStackRefRelaxed(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void SetStackRefRelaxed(ObjHeader** location, const ObjHeader* object) {
   setStackRef<false>(location, object);
 }
 
-void SetHeapRefStrict(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void SetHeapRefStrict(ObjHeader** location, const ObjHeader* object) {
   setHeapRef<true>(location, object);
 }
-void SetHeapRefRelaxed(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void SetHeapRefRelaxed(ObjHeader** location, const ObjHeader* object) {
   setHeapRef<false>(location, object);
 }
 
-void ZeroHeapRef(ObjHeader** location) {
+RUNTIME_NOTHROW void ZeroHeapRef(ObjHeader** location) {
   zeroHeapRef(location);
 }
 
-void ZeroStackRefStrict(ObjHeader** location) {
+RUNTIME_NOTHROW void ZeroStackRefStrict(ObjHeader** location) {
   zeroStackRef<true>(location);
 }
-void ZeroStackRefRelaxed(ObjHeader** location) {
+RUNTIME_NOTHROW void ZeroStackRefRelaxed(ObjHeader** location) {
   zeroStackRef<false>(location);
 }
 
-void UpdateStackRefStrict(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateStackRefStrict(ObjHeader** location, const ObjHeader* object) {
   updateStackRef<true>(location, object);
 }
-void UpdateStackRefRelaxed(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateStackRefRelaxed(ObjHeader** location, const ObjHeader* object) {
   updateStackRef<false>(location, object);
 }
 
-void UpdateHeapRefStrict(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateHeapRefStrict(ObjHeader** location, const ObjHeader* object) {
   updateHeapRef<true>(location, object);
 }
-void UpdateHeapRefRelaxed(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateHeapRefRelaxed(ObjHeader** location, const ObjHeader* object) {
   updateHeapRef<false>(location, object);
 }
 
-void UpdateReturnRefStrict(ObjHeader** returnSlot, const ObjHeader* value) {
+RUNTIME_NOTHROW void UpdateReturnRefStrict(ObjHeader** returnSlot, const ObjHeader* value) {
   updateReturnRef<true>(returnSlot, value);
 }
-void UpdateReturnRefRelaxed(ObjHeader** returnSlot, const ObjHeader* value) {
+RUNTIME_NOTHROW void UpdateReturnRefRelaxed(ObjHeader** returnSlot, const ObjHeader* value) {
   updateReturnRef<false>(returnSlot, value);
 }
 
-void ZeroArrayRefs(ArrayHeader* array) {
+RUNTIME_NOTHROW void ZeroArrayRefs(ArrayHeader* array) {
   for (uint32_t index = 0; index < array->count_; ++index) {
     ObjHeader** location = ArrayAddressOfElementAt(array, index);
     zeroHeapRef(location);
   }
 }
 
-void UpdateHeapRefIfNull(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateHeapRefIfNull(ObjHeader** location, const ObjHeader* object) {
   updateHeapRefIfNull(location, object);
 }
 
@@ -3335,7 +3335,7 @@ OBJ_GETTER(SwapHeapRefLocked,
   RETURN_RESULT_OF(swapHeapRefLocked, location, expectedValue, newValue, spinlock, cookie);
 }
 
-void SetHeapRefLocked(ObjHeader** location, ObjHeader* newValue, int32_t* spinlock, int32_t* cookie) {
+RUNTIME_NOTHROW void SetHeapRefLocked(ObjHeader** location, ObjHeader* newValue, int32_t* spinlock, int32_t* cookie) {
   setHeapRefLocked(location, newValue, spinlock, cookie);
 }
 
@@ -3347,17 +3347,17 @@ OBJ_GETTER(ReadHeapRefNoLock, ObjHeader* object, KInt index) {
   RETURN_RESULT_OF(readHeapRefNoLock, object, index);
 }
 
-void EnterFrameStrict(ObjHeader** start, int parameters, int count) {
+RUNTIME_NOTHROW void EnterFrameStrict(ObjHeader** start, int parameters, int count) {
   enterFrame<true>(start, parameters, count);
 }
-void EnterFrameRelaxed(ObjHeader** start, int parameters, int count) {
+RUNTIME_NOTHROW void EnterFrameRelaxed(ObjHeader** start, int parameters, int count) {
   enterFrame<false>(start, parameters, count);
 }
 
-void LeaveFrameStrict(ObjHeader** start, int parameters, int count) {
+RUNTIME_NOTHROW void LeaveFrameStrict(ObjHeader** start, int parameters, int count) {
   leaveFrame<true>(start, parameters, count);
 }
-void LeaveFrameRelaxed(ObjHeader** start, int parameters, int count) {
+RUNTIME_NOTHROW void LeaveFrameRelaxed(ObjHeader** start, int parameters, int count) {
   leaveFrame<false>(start, parameters, count);
 }
 
@@ -3473,11 +3473,11 @@ OBJ_GETTER(Kotlin_native_internal_GC_findCycle, KRef, KRef root) {
 #endif
 }
 
-KNativePtr CreateStablePointer(KRef any) {
+RUNTIME_NOTHROW KNativePtr CreateStablePointer(KRef any) {
   return createStablePointer(any);
 }
 
-void DisposeStablePointer(KNativePtr pointer) {
+RUNTIME_NOTHROW void DisposeStablePointer(KNativePtr pointer) {
   disposeStablePointer(pointer);
 }
 
@@ -3489,7 +3489,7 @@ OBJ_GETTER(AdoptStablePointer, KNativePtr pointer) {
   RETURN_RESULT_OF(adoptStablePointer, pointer);
 }
 
-bool ClearSubgraphReferences(ObjHeader* root, bool checked) {
+RUNTIME_NOTHROW bool ClearSubgraphReferences(ObjHeader* root, bool checked) {
   return clearSubgraphReferences(root, checked);
 }
 
@@ -3506,7 +3506,7 @@ void MutationCheck(ObjHeader* obj) {
     ThrowInvalidMutabilityException(obj);
 }
 
-void CheckLifetimesConstraint(ObjHeader* obj, ObjHeader* pointee) {
+RUNTIME_NOTHROW void CheckLifetimesConstraint(ObjHeader* obj, ObjHeader* pointee) {
   if (!obj->local() && pointee != nullptr && pointee->local()) {
     konan::consolePrintf("Attempt to store a stack object %p into a heap object %p\n", pointee, obj);
     konan::consolePrintf("This is a compiler bug, please report it to https://kotl.in/issue\n");
@@ -3522,7 +3522,7 @@ void Kotlin_Any_share(ObjHeader* obj) {
   shareAny(obj);
 }
 
-void AddTLSRecord(MemoryState* memory, void** key, int size) {
+RUNTIME_NOTHROW void AddTLSRecord(MemoryState* memory, void** key, int size) {
   auto* tlsMap = memory->tlsMap;
   auto it = tlsMap->find(key);
   if (it != tlsMap->end()) {
@@ -3533,7 +3533,7 @@ void AddTLSRecord(MemoryState* memory, void** key, int size) {
   tlsMap->emplace(key, std::make_pair(start, size));
 }
 
-void ClearTLSRecord(MemoryState* memory, void** key) {
+RUNTIME_NOTHROW void ClearTLSRecord(MemoryState* memory, void** key) {
   auto* tlsMap = memory->tlsMap;
   auto it = tlsMap->find(key);
   if (it != tlsMap->end()) {
@@ -3547,7 +3547,7 @@ void ClearTLSRecord(MemoryState* memory, void** key) {
   }
 }
 
-KRef* LookupTLS(void** key, int index) {
+RUNTIME_NOTHROW KRef* LookupTLS(void** key, int index) {
   auto* state = memoryState;
   auto* tlsMap = state->tlsMap;
   // In many cases there is only one module, so this one element cache.
@@ -3564,19 +3564,19 @@ KRef* LookupTLS(void** key, int index) {
 }
 
 
-void GC_RegisterWorker(void* worker) {
+RUNTIME_NOTHROW void GC_RegisterWorker(void* worker) {
 #if USE_CYCLIC_GC
   cyclicAddWorker(worker);
 #endif  // USE_CYCLIC_GC
 }
 
-void GC_UnregisterWorker(void* worker) {
+RUNTIME_NOTHROW void GC_UnregisterWorker(void* worker) {
 #if USE_CYCLIC_GC
   cyclicRemoveWorker(worker, g_hasCyclicCollector);
 #endif  // USE_CYCLIC_GC
 }
 
-void GC_CollectorCallback(void* worker) {
+RUNTIME_NOTHROW void GC_CollectorCallback(void* worker) {
 #if USE_CYCLIC_GC
   if (g_hasCyclicCollector)
     cyclicCollectorCallback(worker);
@@ -3604,7 +3604,7 @@ bool Kotlin_Any_isShareable(KRef thiz) {
     return thiz == nullptr || isShareable(containerFor(thiz));
 }
 
-void PerformFullGC() {
+RUNTIME_NOTHROW void PerformFullGC() {
     garbageCollect(::memoryState, true);
 }
 

--- a/runtime/src/main/kotlin/kotlin/Throwable.kt
+++ b/runtime/src/main/kotlin/kotlin/Throwable.kt
@@ -69,7 +69,7 @@ public open class Throwable(open val message: String?, open val cause: Throwable
                 println(this)
                 clear()
             } else {
-                appendln()
+                appendLine()
             }
         }
 

--- a/runtime/src/main/kotlin/kotlin/native/concurrent/Lazy.kt
+++ b/runtime/src/main/kotlin/kotlin/native/concurrent/Lazy.kt
@@ -41,8 +41,7 @@ internal class FreezeAwareLazyImpl<out T>(initializer: () -> T) : Lazy<T> {
         }
         // Set value_ to actual one.
         value_.value = result
-        @Suppress("UNCHECKED_CAST")
-        return result as T
+        return result
     }
 
     override val value: T

--- a/runtime/src/main/kotlin/kotlin/text/regex/Lexer.kt
+++ b/runtime/src/main/kotlin/kotlin/text/regex/Lexer.kt
@@ -457,7 +457,7 @@ internal class Lexer(val patternString: String, flags: Int) {
             // Word/whitespace/digit.
             'w', 's', 'd', 'W', 'S', 'D' -> {
                 lookAheadSpecialToken = AbstractCharClass.getPredefinedClass(
-                        String(pattern, prevNonWhitespaceIndex, 1),
+                        pattern.concatToString(prevNonWhitespaceIndex, prevNonWhitespaceIndex + 1),
                         false
                 )
                 lookAhead = 0
@@ -724,12 +724,12 @@ internal class Lexer(val patternString: String, flags: Int) {
         val CHAR_PREVIOUS_MATCH       = 0x80000000.toInt() or 'G'.toInt()
         val CHAR_END_OF_INPUT         = 0x80000000.toInt() or 'z'.toInt()
         val CHAR_END_OF_LINE          = 0x80000000.toInt() or 'Z'.toInt()
-        
+
         // Quantifier modes.
         val QMOD_GREEDY     = 0xe0000000.toInt()
         val QMOD_RELUCTANT  = 0xc0000000.toInt()
         val QMOD_POSSESSIVE = 0x80000000.toInt()
-        
+
         // Quantifiers.
         val QUANT_STAR   = QMOD_GREEDY or '*'.toInt()
         val QUANT_STAR_P = QMOD_POSSESSIVE or '*'.toInt()

--- a/runtime/src/main/kotlin/kotlin/text/regex/Pattern.kt
+++ b/runtime/src/main/kotlin/kotlin/text/regex/Pattern.kt
@@ -794,7 +794,7 @@ internal class Pattern(val pattern: String, flags: Int = 0) {
         val isSupplCodePoint = Char.isSupplementaryCodePoint(ch)
 
         return when {
-            isSupplCodePoint -> SequenceSet(String(Char.toChars(ch), 0, 2), hasFlag(CASE_INSENSITIVE))
+            isSupplCodePoint -> SequenceSet(Char.toChars(ch).concatToString(0, 2), hasFlag(CASE_INSENSITIVE))
             ch.toChar().isLowSurrogate() ->  LowSurrogateCharSet(ch.toChar())
             ch.toChar().isHighSurrogate() -> HighSurrogateCharSet(ch.toChar())
             else -> CharSet(ch.toChar(), hasFlag(CASE_INSENSITIVE))

--- a/runtime/src/main/kotlin/kotlin/text/regex/sets/FSets.kt
+++ b/runtime/src/main/kotlin/kotlin/text/regex/sets/FSets.kt
@@ -67,7 +67,7 @@ open internal class FSet(val groupIndex: Int) : SimpleSet() {
     }
 
     companion object {
-        var possessiveFSet = PossessiveFSet()
+        val possessiveFSet = PossessiveFSet()
     }
 }
 

--- a/runtime/src/main/kotlin/kotlin/text/regex/sets/HangulDecomposedCharSet.kt
+++ b/runtime/src/main/kotlin/kotlin/text/regex/sets/HangulDecomposedCharSet.kt
@@ -43,7 +43,7 @@ internal class HangulDecomposedCharSet(
      * String representing syllable
      */
     private val decomposedCharUTF16: String by lazy {
-        String(decomposedChar, 0, decomposedChar.size)
+        decomposedChar.concatToString(0, decomposedChar.size)
     }
 
     override val name: String

--- a/runtime/src/main/kotlin/kotlin/text/regex/sets/SupplementaryCharSet.kt
+++ b/runtime/src/main/kotlin/kotlin/text/regex/sets/SupplementaryCharSet.kt
@@ -91,7 +91,7 @@ package kotlin.text.regex
  * Represents node accepting single supplementary codepoint.
  */
 internal class SupplementaryCharSet(val codePoint: Int, ignoreCase: Boolean)
-    : SequenceSet(String(Char.toChars(codePoint), 0, 2), ignoreCase) {
+    : SequenceSet(Char.toChars(codePoint).concatToString(0, 2), ignoreCase) {
 
     override val name: String
         get() = patternString

--- a/runtime/src/relaxed/cpp/MemoryImpl.cpp
+++ b/runtime/src/relaxed/cpp/MemoryImpl.cpp
@@ -29,43 +29,43 @@ OBJ_GETTER(InitSharedInstance,
   RETURN_RESULT_OF(InitSharedInstanceRelaxed, location, typeInfo, ctor);
 }
 
-void ReleaseHeapRef(const ObjHeader* object) {
+RUNTIME_NOTHROW void ReleaseHeapRef(const ObjHeader* object) {
   ReleaseHeapRefRelaxed(object);
 }
 
-void ReleaseHeapRefNoCollect(const ObjHeader* object) {
+RUNTIME_NOTHROW void ReleaseHeapRefNoCollect(const ObjHeader* object) {
   ReleaseHeapRefNoCollectRelaxed(object);
 }
 
-void ZeroStackRef(ObjHeader** location) {
+RUNTIME_NOTHROW void ZeroStackRef(ObjHeader** location) {
   ZeroStackRefRelaxed(location);
 }
 
-void SetStackRef(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void SetStackRef(ObjHeader** location, const ObjHeader* object) {
   SetStackRefRelaxed(location, object);
 }
 
-void SetHeapRef(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void SetHeapRef(ObjHeader** location, const ObjHeader* object) {
   SetHeapRefRelaxed(location, object);
 }
 
-void UpdateHeapRef(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateHeapRef(ObjHeader** location, const ObjHeader* object) {
   UpdateHeapRefRelaxed(location, object);
 }
 
-void UpdateReturnRef(ObjHeader** returnSlot, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateReturnRef(ObjHeader** returnSlot, const ObjHeader* object) {
   UpdateReturnRefRelaxed(returnSlot, object);
 }
 
-void EnterFrame(ObjHeader** start, int parameters, int count) {
+RUNTIME_NOTHROW void EnterFrame(ObjHeader** start, int parameters, int count) {
   EnterFrameRelaxed(start, parameters, count);
 }
 
-void LeaveFrame(ObjHeader** start, int parameters, int count) {
+RUNTIME_NOTHROW void LeaveFrame(ObjHeader** start, int parameters, int count) {
   LeaveFrameRelaxed(start, parameters, count);
 }
 
-void UpdateStackRef(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateStackRef(ObjHeader** location, const ObjHeader* object) {
     UpdateStackRefRelaxed(location, object);
 }
 

--- a/runtime/src/strict/cpp/MemoryImpl.cpp
+++ b/runtime/src/strict/cpp/MemoryImpl.cpp
@@ -29,43 +29,43 @@ OBJ_GETTER(InitSharedInstance,
   RETURN_RESULT_OF(InitSharedInstanceStrict, location, typeInfo, ctor);
 }
 
-void ReleaseHeapRef(const ObjHeader* object) {
+RUNTIME_NOTHROW void ReleaseHeapRef(const ObjHeader* object) {
   ReleaseHeapRefStrict(object);
 }
 
-void ReleaseHeapRefNoCollect(const ObjHeader* object) {
+RUNTIME_NOTHROW void ReleaseHeapRefNoCollect(const ObjHeader* object) {
   ReleaseHeapRefNoCollectStrict(object);
 }
 
-void SetStackRef(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void SetStackRef(ObjHeader** location, const ObjHeader* object) {
   SetStackRefStrict(location, object);
 }
 
-void SetHeapRef(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void SetHeapRef(ObjHeader** location, const ObjHeader* object) {
   SetHeapRefStrict(location, object);
 }
 
-void ZeroStackRef(ObjHeader** location) {
+RUNTIME_NOTHROW void ZeroStackRef(ObjHeader** location) {
   ZeroStackRefStrict(location);
 }
 
-void UpdateHeapRef(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateHeapRef(ObjHeader** location, const ObjHeader* object) {
   UpdateHeapRefStrict(location, object);
 }
 
-void UpdateReturnRef(ObjHeader** returnSlot, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateReturnRef(ObjHeader** returnSlot, const ObjHeader* object) {
   UpdateReturnRefStrict(returnSlot, object);
 }
 
-void EnterFrame(ObjHeader** start, int parameters, int count) {
+RUNTIME_NOTHROW void EnterFrame(ObjHeader** start, int parameters, int count) {
   EnterFrameStrict(start, parameters, count);
 }
 
-void LeaveFrame(ObjHeader** start, int parameters, int count) {
+RUNTIME_NOTHROW void LeaveFrame(ObjHeader** start, int parameters, int count) {
   LeaveFrameStrict(start, parameters, count);
 }
 
-void UpdateStackRef(ObjHeader** location, const ObjHeader* object) {
+RUNTIME_NOTHROW void UpdateStackRef(ObjHeader** location, const ObjHeader* object) {
     UpdateStackRefStrict(location, object);
 }
 


### PR DESCRIPTION
This PR includes three modifications:
- Resolve `kotlin.native.home` and `org.jetbrains.kotlin.native.home` in the `backend.native:tests` package
- Update C and C++ files to improve their compatibility with newer versions of GCC/Glibc and Clang, while retaining compatibility with the current versions
- Resolve several compiler warnings in Kotlin source files