### PR TITLE
[kotlin compiler][update] 1.4.30-dev-2139

### DIFF
--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -4501,7 +4501,7 @@ if (isAppleTarget(project)) {
         framework(frameworkName) {
             sources = ['objcexport']
             library = libraryName
-            opts = ["-Xemit-lazy-objc-header=$lazyHeader", "-Xopt-in=kotlin.ExperimentalStdlibApi"]
+            opts = ["-Xemit-lazy-objc-header=$lazyHeader"]
         }
         swiftSources = ['objcexport']
     }
@@ -4532,7 +4532,6 @@ if (isAppleTarget(project)) {
             artifact = frameworkArtifactName
             library = libraryName
             isStatic = true
-            opts = ['-Xstatic-framework', "-Xopt-in=kotlin.ExperimentalStdlibApi"]
         }
         swiftSources = ['objcexport']
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1895,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-1895
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-1895,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-1895
-kotlinStdlibTestsVersion=1.4.30-dev-1895
-testKotlinCompilerVersion=1.4.30-dev-1895
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2139,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-2139
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2139,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-2139
+kotlinStdlibTestsVersion=1.4.30-dev-2139
+testKotlinCompilerVersion=1.4.30-dev-2139
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/coroutines/cancellation/CancellationException.kt
+++ b/runtime/src/main/kotlin/kotlin/coroutines/cancellation/CancellationException.kt
@@ -5,7 +5,6 @@
 
 package kotlin.coroutines.cancellation
 
-@ExperimentalStdlibApi
 @SinceKotlin("1.4")
 public actual open class CancellationException : IllegalStateException {
     actual constructor() : super()


### PR DESCRIPTION
* 7d0e9654bd6 - (HEAD -> master, tag: build-1.4.30-dev-2139, origin/master, origin/HEAD) Clean ups in IDE performance tests output (vor 16 Stunden) <Vladimir Dolzhenko>
* d36511c0948 - (tag: build-1.4.30-dev-2135) Clean ups in IDE performance tests output (vor 31 Stunden) <Vladimir Dolzhenko>
* 5fae769a906 - (tag: build-1.4.30-dev-2134) Wizard: use new compose icon (vor 2 Tagen) <Ilya Kirillov>
* 8eefcbb1d48 - Wizard: update compose templates (vor 2 Tagen) <Ilya Kirillov>
* 21928d8f512 - Wizard: do not allow creating compose projects with gradle groovy (vor 2 Tagen) <Ilya Kirillov>
* 4f6fa1059c5 - (tag: build-1.4.30-dev-2133) Add missed task dependency for IDE performance tests output (vor 2 Tagen) <Vladimir Dolzhenko>
* ceea57ab58f - (tag: build-1.4.30-dev-2132) Add missed task dependency for IDE performance tests output (vor 2 Tagen) <Vladimir Dolzhenko>
* 3c0d43dc0d9 - (tag: build-1.4.30-dev-2123) Rebuild IDE performance tests output (vor 2 Tagen) <Vladimir Dolzhenko>
* f87e46b5992 - (tag: build-1.4.30-dev-2117) Kx-serialization: generate wrapper type for reference array serializer (vor 3 Tagen) <Alexander Udalov>
* 42aef01d79f - Kx-serialization: support SerialInfo annotations from dependencies in JVM IR (vor 3 Tagen) <Alexander Udalov>
* 51ded98c4b9 - Kx-serialization: support SerialInfo for JVM IR (vor 3 Tagen) <Alexander Udalov>
* e4ba7870348 - (tag: build-1.4.30-dev-2115) JVM_IR KT-43066 Generate 'clone' in class implementing kotlin.Cloneable (vor 3 Tagen) <Dmitry Petrov>
* 7b4f781ea83 - (tag: build-1.4.30-dev-2113) [FIR] Split primary constructor parameter scope into two different (vor 3 Tagen) <Mikhail Glukhikh>
* 2d0535a713f - (tag: build-1.4.30-dev-2112) [JS_IR] Invoke companion init block while instantiating a class (vor 3 Tagen) <Shagen Ogandzhanian>
* 22117604f68 - (tag: build-1.4.30-dev-2105) Move script simple type remapper to the common utilities (vor 3 Tagen) <Ilya Chernikov>
* de340e9bc85 - Implement support for synthetic script params in IR: (vor 3 Tagen) <Ilya Chernikov>
* 7572b503852 - Expose script parameters from descriptor explicitly... (vor 3 Tagen) <Ilya Chernikov>
* 4cb0437145b - [minor] fix reflection usage in scripting tests (vor 3 Tagen) <Ilya Chernikov>
* 94f2813a8a0 - Add script main function generation to JVM IR backend (vor 3 Tagen) <Ilya Chernikov>
* 62b9d87bfc4 - [minor] scripting tests improvements (vor 3 Tagen) <Ilya Chernikov>
* af7102a5864 - Enable IR backend in script compiler (vor 3 Tagen) <Ilya Chernikov>
* 60246f22618 - Ignore temporarily the kt22029.kts codegen test for JVM IR: (vor 3 Tagen) <Ilya Chernikov>
* d7112a4500c - Implement JVM IR support for scripts (vor 3 Tagen) <Ilya Chernikov>
* 01d73ba0fcb - Make IrScript a statement container first, update JS support (vor 3 Tagen) <Ilya Chernikov>
* 55048f40abf - (tag: build-1.4.30-dev-2102) Disable "Incomplete destructuring declaration" (vor 3 Tagen) <Andrei Klunnyi>
* 3acb468d48a - (tag: build-1.4.30-dev-2100) Add a link to scope functions overview for takeIf and takeUnless (vor 3 Tagen) <Dominik Wuttke>
* f48f7c6dcab - (tag: build-1.4.30-dev-2099) Added samples for the kotlin.system package (measureTime* functions) (vor 3 Tagen) <Uzi Landsmann>
* 15381c46626 - (tag: build-1.4.30-dev-2098) Added samples for the kotlin.streams package (vor 3 Tagen) <Uzi Landsmann>
* 18672c99caf - (tag: build-1.4.30-dev-2097) KT-20357: Add a sample for requireNotNull (vor 3 Tagen) <Yuya Urano>
* 2b03c109414 - (tag: build-1.4.30-dev-2094) Correct small grammatical error in KDocs (vor 3 Tagen) <Ciaran Treanor>
* 28e148d35ab - (tag: build-1.4.30-dev-2090) Old JVM: support init blocks in inline classes (vor 3 Tagen) <Ilmir Usmanov>
* 999604541e1 - JVM_IR: Support init blocks in inline classes (vor 3 Tagen) <Ilmir Usmanov>
* 5804f73ebd9 - (tag: build-1.4.30-dev-2083, tag: build-1.4.30-dev-2081) JVM_IR. Deprecate public access to @JvmField/const fields in private companions (vor 4 Tagen) <Mikhael Bogdanov>
* 57c9afc73af - Deprecate public access to @JvmField/const fields in private companions (vor 4 Tagen) <Mikhael Bogdanov>
* 8be23df668b - (tag: build-1.4.30-dev-2079) Remove unneeded dependency of util on deserialization & reflect (vor 4 Tagen) <Alexander Udalov>
* 0d1bb9acaf0 - JVM IR: do not clear BindingContext in bytecode tool window (vor 4 Tagen) <Alexander Udalov>
* 08b761ae7a6 - (tag: build-1.4.30-dev-2073, origin/prr/yunir/check) PSI2IR don't copy annotations for properties implemented by delegation (vor 4 Tagen) <Dmitry Petrov>
* 53004f97b11 - (tag: build-1.4.30-dev-2070) Store processed metadata artifacts in `.gradle/` rather than `build/` (vor 4 Tagen) <Sergey Igushkin>
* dca1f4631c4 - (tag: build-1.4.30-dev-2067) [JVM_IR] Use line number 1 for multifile bridge methods. (vor 4 Tagen) <Mads Ager>
* c8a8410fc5c - (tag: build-1.4.30-dev-2048, origin/rr/kishmakov/bump, origin/rr/adudinsky/code-meta-info-tests) Fix MultiModuleLineMarkerTest on Windows (vor 4 Tagen) <Alexander Dudinsky>
* d4d93b70913 - (tag: build-1.4.30-dev-2036) Add change-notes for 1.4.20 (vor 4 Tagen) <Anton Yalyshev>
* ad5b6da273f - (tag: build-1.4.30-dev-2033, tag: build-1.4.30-dev-2031) JVM IR: substitute generic type for inline class replacement function calls (vor 5 Tagen) <Alexander Udalov>
* 4a3a2ef72a3 - (tag: build-1.4.30-dev-2028) [FIR2IR] Test data fix after rebase (regular + delegated supertype) (vor 5 Tagen) <Mikhail Glukhikh>
* 60141ccbaa3 - [FIR] Fix Substitution scope key to avoid accidental matches (vor 5 Tagen) <Mikhail Glukhikh>
* 2dc6467b5df - [FIR] Modify signatures also from ERASED_COLLECTION_PARAMETER_SIGNATURES (vor 5 Tagen) <Mikhail Glukhikh>
* 3a693e112b2 - (tag: build-1.4.30-dev-2022) Update ExperimentalPathApi annotation's SinceKotlin value to 1.4 (vor 5 Tagen) <Jake Wharton>
* 82984089f08 - (tag: build-1.4.30-dev-2017) KT-42274 Update `SOURCE_STUB_VERSION` (vor 5 Tagen) <Roman Golyshev>
* 80108444ec3 - (tag: build-1.4.30-dev-2015) FIR2IR: cleanup implicit cast inserter (vor 5 Tagen) <Mikhail Glukhikh>
* 2424f2438cb - FIR2IR: towards comprehensive visits in implicit cast inserter (vor 5 Tagen) <Jinseong Jeon>
* 5f6d2c53624 - FIR2IR: utilize argument conversions (vor 5 Tagen) <Jinseong Jeon>
* f1fd3d6b5dd - FIR2IR: avoid using constant -1 (vor 5 Tagen) <Jinseong Jeon>
* 707e94bab50 - FIR2IR: add test about coercion-to-Unit for nested when (vor 5 Tagen) <Jinseong Jeon>
* 318f4b5f023 - FIR2IR: refactor implicit cast insertion, part 3: implicit not_null (vor 5 Tagen) <Jinseong Jeon>
* 8708bdec0d5 - FIR2IR: refactor implicit cast insertion, part 2: coerce-to-Unit (vor 5 Tagen) <Jinseong Jeon>
* 8f8ee88957e - FIR2IR: refactor implicit cast insertion, part 1: implicit cast (vor 5 Tagen) <Jinseong Jeon>
* e9a7b64ca03 - FIR2IR: use AnnotationGenerator to convert file annotations (vor 5 Tagen) <Jinseong Jeon>
* ef6b643b9c5 - [FIR2IR] Don't set WHILE_LOOP origin for blocks (vor 5 Tagen) <Mikhail Glukhikh>
* eb9b5da82ba - (tag: build-1.4.30-dev-2013) Kapt: Never mark static methods 'default' (KT-42915) (vor 5 Tagen) <Yan Zhulanow>
* 09e1bed5c91 - (tag: build-1.4.30-dev-2010) Redundant 'inner' modifier: fix false positive/negative with constructor call (vor 5 Tagen) <Toshiaki Kameyama>
* e9669bf5cb7 - (tag: build-1.4.30-dev-2009, tag: build-1.4.30-dev-2001) fix unstable IncrementalFileToPathConverterTest tests (vor 5 Tagen) <nataliya.valtman>
* 2589de6c499 - (tag: build-1.4.30-dev-2000) FIR: Refine delegated members introduced to use-site scope (vor 5 Tagen) <Denis Zharkov>
* 2105a041a5f - FIR: Optimize usages of `containingClass` and its implementation (vor 5 Tagen) <Denis Zharkov>
* 923bb3b6740 - FIR2IR: Mute failing bb test (vor 5 Tagen) <Denis Zharkov>
* 2bdb21793f3 - FIR: Adjust test data (vor 5 Tagen) <Denis Zharkov>
* b6a312483a4 - FIR: Fix fir2symbol inconsistencies for imported properties (vor 5 Tagen) <Denis Zharkov>
* 09b7237ae5f - FIR: Introduce importedFromObjectClassId (vor 5 Tagen) <Denis Zharkov>
* 4d9ef4d414f - FIR: Get rid of CallableId::classId usages (vor 5 Tagen) <Denis Zharkov>
* 9996c983c90 - FIR: Initialize dispatchReceiverType and containingClassAttr for callable members (vor 5 Tagen) <Denis Zharkov>
* ecb89a66be2 - FIR: Copy `attributes` when copying declaration (vor 5 Tagen) <Denis Zharkov>
* 52c6aebec27 - FIR: Use copy-builders at FirObjectImportedCallableScope (vor 5 Tagen) <Denis Zharkov>
* 995b1aa1ebe - FIR: Add FirCallableMemberDeclaration::dispatchReceiverType (vor 5 Tagen) <Denis Zharkov>
* 0fa2cc15de9 - (tag: build-1.4.30-dev-1998, tag: build-1.4.30-dev-1994) Cleanup more test files and directories after tests (vor 5 Tagen) <Ilya Gorbunov>
* fe098ec8212 - Revise functions in PathReadWrite (vor 5 Tagen) <Ilya Gorbunov>
* a43cc0d1f9f - Implement additional Path extensions (vor 5 Tagen) <Ilya Gorbunov>
* 038f1cbd1e5 - Add glob filtering when listing directory entries (vor 5 Tagen) <Ilya Gorbunov>
* e7c888a2e6b - Avoid introducing Path.printWriter (vor 5 Tagen) <Ilya Gorbunov>
* 9f659d74df6 - Introduce dedicated experimental annotation for Path extensions (vor 5 Tagen) <Ilya Gorbunov>
* 997cd35e06a - Move Path extensions to the new package kotlin.io.path (vor 5 Tagen) <Ilya Gorbunov>
* 7d58a5e2f22 - Simplify Path.copyTo implementation (vor 5 Tagen) <Ilya Gorbunov>
* f6d24002082 - Workaround bugs in Path.relativize (vor 5 Tagen) <Ilya Gorbunov>
* b3a87356bd2 - Add java.nio.Path extensions to stdlib-jdk7: part 2 (vor 5 Tagen) <AJ>
* 03cc0bf6aa9 - Add java.nio.Path extensions to stdlib-jdk7 (vor 5 Tagen) <AJ>
* 008da87160c - (tag: build-1.4.30-dev-1975, tag: build-1.4.30-dev-1973) Minor: Update Android Extensions deprecation message in relevant test (vor 6 Tagen) <Yan Zhulanow>
* 9faf91f55d8 - Fix Parcelize settings serialization (KT-42958) (vor 6 Tagen) <Yan Zhulanow>
* 3386b930093 - (tag: build-1.4.30-dev-1971) [Gradle, Cocoapods] Added `useLibraries()` to allow static library pods (vor 6 Tagen) <Yaroslav Chernyshev>
* 21521aa397e - (tag: build-1.4.30-dev-1969, origin/rr/mb/kt21177) Deprecate protected constructors call from public inline function (vor 6 Tagen) <Mikhael Bogdanov>
* a72cdeabb4f - (tag: build-1.4.30-dev-1965) fix testData (vor 6 Tagen) <Dmitry Gridin>
* e6edb629119 - (tag: build-1.4.30-dev-1964) [Gradle, JS] Fix for IDEA import with dukat binaries (vor 6 Tagen) <Ilya Goncharov>
* bb2e9e2d562 - Extract new method from the publicly used interface for compatibility (vor 6 Tagen) <Mikhail Zarechenskiy>
* 0e7e657657c - (tag: build-1.4.30-dev-1963) Migrate `MultiModuleLineMarkerTest` to the new CodeMetaInfo test infrastructure (vor 6 Tagen) <Alexander Dudinsky>
* 94bf38a7b55 - Added support for various platforms for CodeMetaInfo tests. ^KT-41996 (vor 6 Tagen) <Alexander Dudinsky>
* 84d24e5b766 - Migrate `MultiplatformAnalysisTest` to new test runner (vor 6 Tagen) <Alexander Dudinsky>
* ac98bc98531 - New highlighting/line markers/diagnostics test infrastructure (vor 6 Tagen) <Alexander Dudinsky>
* 994cb6f28ee - (tag: build-1.4.30-dev-1960) Update deprecation message for the Android Extensions plugin (vor 6 Tagen) <Yan Zhulanow>
* 5e9333773ca - (tag: build-1.4.30-dev-1957) Remove explicit type arguments: don't report when type argument has annotations (vor 6 Tagen) <Toshiaki Kameyama>
* e1a380ec95b - (tag: build-1.4.30-dev-1953) KT-34862 use relative path for incremental build cache (vor 6 Tagen) <nataliya.valtman>
* 09043fb98df - (tag: build-1.4.30-dev-1950) [FIR] JvmMappedScope: add mutable methods or not depending on a class (vor 6 Tagen) <Mikhail Glukhikh>
* 5c3269f489e - [FIR] JvmMappedScope: don't add Java methods if Kotlin ones are here (vor 6 Tagen) <Mikhail Glukhikh>
* ce407471ec0 - (tag: build-1.4.30-dev-1947) Convert to secondary constructor: suggest on class name (vor 6 Tagen) <Toshiaki Kameyama>
* 2c5c15f5037 - (tag: build-1.4.30-dev-1945) Clean-up outputs on non-incremental run (vor 6 Tagen) <Ivan Gavrilovic>
* 2fd7d64db03 - (tag: build-1.4.30-dev-1940) Promote CancellationException to stable #KT-41837 (vor 6 Tagen) <Abduqodiri Qurbonzoda>
* caafe21e848 - (tag: build-1.4.30-dev-1932) [FIR] Add CheckLowPriorityStage to callable reference resolve (vor 7 Tagen) <Mikhail Glukhikh>
* a775fa195bd - (tag: build-1.4.30-dev-1930) Unbox inline class parameter of lambda if underlying type is Any or Any? (vor 7 Tagen) <Ilmir Usmanov>
* 752f6d8f720 - (tag: build-1.4.30-dev-1925, tag: build-1.4.30-dev-1922) Elvis -> if intention: don't introduce new variable when RHS type is Nothing (vor 7 Tagen) <Toshiaki Kameyama>
* f9f8fd055b0 - (tag: build-1.4.30-dev-1920) Convert receiver to parameter: place value argument list after type argument list (vor 7 Tagen) <Toshiaki Kameyama>
* b1629cc5f49 - (tag: build-1.4.30-dev-1919, origin/rr/pdn_kt22465) JVM KT-22465 don't generate accessor to private setter in other class (vor 7 Tagen) <Dmitry Petrov>
* 4d63ecd83cb - (tag: build-1.4.30-dev-1913) [JS IR] Do not copy prototype references of FO from super class (vor 7 Tagen) <Roman Artemev>
* 99a6bdeec7f - (tag: build-1.4.30-dev-1912) Fix KotlinCoreEnvironment projectCount disposable (vor 7 Tagen) <Matthew Gharrity>
* e9b51b42f95 - (tag: build-1.4.30-dev-1911) [FIR] Add test for both KT-10240 and KT-19446 (vor 7 Tagen) <Mikhail Glukhikh>
* 382a0bd2982 - (tag: build-1.4.30-dev-1908) JVM IR: clear BindingContext after psi2ir (vor 7 Tagen) <Alexander Udalov>
* bc76f1fec37 - Refactor test utilties to reuse GenerationState construction (vor 7 Tagen) <Alexander Udalov>
* dd813777b94 - Refactor Main-Class computation in CLI for JVM with .jar outputs (vor 7 Tagen) <Alexander Udalov>