### PR TITLE
Forbid subclasses of NativePointed to have backing fields 

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialBackendChecksTraversal.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialBackendChecksTraversal.kt
@@ -317,7 +317,7 @@ private class BackendChecker(val context: Context, val irFile: IrFile) : IrEleme
             )
         }
 
-        if (callee.returnType.getInlinedClassNative()?.descriptor == interop.nativePointed)
+        if (callee.returnType.isNativePointed(symbols))
             reportError(expression, "Native interop types constructors must not be called directly")
     }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialBackendChecksTraversal.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/SpecialBackendChecksTraversal.kt
@@ -321,6 +321,17 @@ private class BackendChecker(val context: Context, val irFile: IrFile) : IrEleme
             reportError(expression, "Native interop types constructors must not be called directly")
     }
 
+    override fun visitField(declaration: IrField) {
+        if (declaration.isFakeOverride) return // Can't happen now, just trying to be future-proof here.
+
+        val parent = declaration.parent
+
+        if (parent is IrClass && parent.defaultType.isNativePointed(symbols) && parent.symbol != symbols.nativePointed) {
+            val nativePointed = symbols.nativePointed.owner.name
+            reportError(declaration, "Subclasses of $nativePointed cannot have properties with backing fields")
+        }
+    }
+
     override fun visitCall(expression: IrCall) {
         expression.acceptChildrenVoid(this)
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -4030,6 +4030,10 @@ task interop_convert(type: KonanLocalTest) {
     source = "codegen/intrinsics/interop_convert.kt"
 }
 
+task interop_sourceCodeStruct(type: KonanLocalTest) {
+    source = "codegen/intrinsics/interop_sourceCodeStruct.kt"
+}
+
 /*
 TODO: This test isn't run automatically
 task interop_echo_server(type: RunInteropKonanTest) {

--- a/backend.native/tests/codegen/intrinsics/interop_sourceCodeStruct.kt
+++ b/backend.native/tests/codegen/intrinsics/interop_sourceCodeStruct.kt
@@ -1,0 +1,40 @@
+package codegen.intrinsics.interop_sourceCodeStruct
+
+import kotlinx.cinterop.*
+import kotlinx.cinterop.internal.*
+import kotlin.test.*
+
+// Just making sure this doesn't get accidentally forbidden or otherwise broken.
+// (however defining structs this way is still strongly discouraged, please define
+// structs in C headers or .def files instead).
+
+@CStruct("struct { int p0; int p1; }")
+class S(rawPtr: NativePtr) : CStructVar(rawPtr) {
+
+    companion object : CStructVar.Type(8, 4)
+
+    var x: Int
+        get() = memberAt<IntVar>(0).value
+        set(value) {
+            memberAt<IntVar>(0).value = value
+        }
+
+    var y: Int
+        get() = memberAt<IntVar>(4).value
+        set(value) {
+            memberAt<IntVar>(4).value = value
+        }
+}
+
+@Test
+fun test() = memScoped {
+    val s = alloc<S>()
+
+    s.x = 123
+    assertEquals(123, s.x)
+    assertEquals(123, s.ptr.reinterpret<IntVar>()[0])
+
+    s.y = 321
+    assertEquals(321, s.y)
+    assertEquals(321, s.ptr.reinterpret<IntVar>()[1])
+}

--- a/backend.native/tests/compilerChecks/t60.kt
+++ b/backend.native/tests/compilerChecks/t60.kt
@@ -1,0 +1,10 @@
+import kotlinx.cinterop.*
+
+class Vertex constructor(rawPtr: NativePtr) : CStructVar(rawPtr) {
+    var x: Float = 0f
+    var y: Float = 0f
+    var r: Float = 0f
+    var g: Float = 0f
+    var b: Float = 0f
+    companion object : CStructVar.Type(40, 8)
+}


### PR DESCRIPTION
(this crashes the compiler otherwise)