### PR TITLE
[psi2ir] Clear FE bindingContext after initial analysis

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.ir.visitors.acceptVoid
 import org.jetbrains.kotlin.psi2ir.Psi2IrConfiguration
 import org.jetbrains.kotlin.psi2ir.Psi2IrTranslator
 import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.CleanableBindingContext
 import org.jetbrains.kotlin.utils.DFS
 
 internal fun Context.psiToIr(
@@ -194,4 +195,10 @@ internal fun Context.psiToIr(
         internalAbi.init(irModules.values + irModule!!)
         functionIrClassFactory.module = (modules.values + irModule!!).single { it.descriptor.isNativeStdlib() }
     }
+
+    val originalBindingContext = bindingContext as? CleanableBindingContext
+            ?: error("BindingContext should be cleanable in K/N IR to avoid leaking memory: $bindingContext")
+    originalBindingContext.clear()
+
+    this.bindingContext = BindingContext.EMPTY
 }


### PR DESCRIPTION
It should not be used anywhere in the BE