### PR TITLE
Add facility to restrict extra classes in Mobile ObjC Generator

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -6,8 +6,10 @@
 package org.jetbrains.kotlin.backend.konan.objcexport
 
 import org.jetbrains.kotlin.backend.konan.*
+import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.backend.konan.descriptors.getPackageFragments
 import org.jetbrains.kotlin.backend.konan.descriptors.isInterface
+import org.jetbrains.kotlin.backend.konan.getExportedDependencies
 import org.jetbrains.kotlin.backend.konan.llvm.CodeGenerator
 import org.jetbrains.kotlin.backend.konan.llvm.objcexport.ObjCExportBlockCodeGenerator
 import org.jetbrains.kotlin.backend.konan.llvm.objcexport.ObjCExportCodeGenerator
@@ -18,10 +20,7 @@ import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.konan.exec.Command
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.file.createTempFile
-import org.jetbrains.kotlin.konan.target.AppleConfigurables
-import org.jetbrains.kotlin.konan.target.CompilerOutputKind
-import org.jetbrains.kotlin.konan.target.Family
-import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.target.*
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.isSubpackageOf
@@ -33,12 +32,6 @@ internal class ObjCExportedInterface(
         val headerLines: List<String>,
         val namer: ObjCExportNamer,
         val mapper: ObjCExportMapper
-)
-
-data class ObjCExportedStubs(
-    val classForwardDeclarations: Set<String>,
-    val protocolForwardDeclarations: Set<String>,
-    val stubs: List<Stub<*>>
 )
 
 internal class ObjCExport(val context: Context, symbolTable: SymbolTable) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -6,10 +6,8 @@
 package org.jetbrains.kotlin.backend.konan.objcexport
 
 import org.jetbrains.kotlin.backend.konan.*
-import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.backend.konan.descriptors.getPackageFragments
 import org.jetbrains.kotlin.backend.konan.descriptors.isInterface
-import org.jetbrains.kotlin.backend.konan.getExportedDependencies
 import org.jetbrains.kotlin.backend.konan.llvm.CodeGenerator
 import org.jetbrains.kotlin.backend.konan.llvm.objcexport.ObjCExportBlockCodeGenerator
 import org.jetbrains.kotlin.backend.konan.llvm.objcexport.ObjCExportCodeGenerator
@@ -20,7 +18,10 @@ import org.jetbrains.kotlin.ir.util.SymbolTable
 import org.jetbrains.kotlin.konan.exec.Command
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.file.createTempFile
-import org.jetbrains.kotlin.konan.target.*
+import org.jetbrains.kotlin.konan.target.AppleConfigurables
+import org.jetbrains.kotlin.konan.target.CompilerOutputKind
+import org.jetbrains.kotlin.konan.target.Family
+import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.isSubpackageOf
@@ -32,6 +33,12 @@ internal class ObjCExportedInterface(
         val headerLines: List<String>,
         val namer: ObjCExportNamer,
         val mapper: ObjCExportMapper
+)
+
+data class ObjCExportedStubs(
+    val classForwardDeclarations: Set<String>,
+    val protocolForwardDeclarations: Set<String>,
+    val stubs: List<Stub<*>>
 )
 
 internal class ObjCExport(val context: Context, symbolTable: SymbolTable) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -1128,7 +1128,9 @@ abstract class ObjCExportHeaderGenerator internal constructor(
 
     private fun translateExtraClasses() {
         while (extraClassesToTranslate.isNotEmpty()) {
-            val descriptor = extraClassesToTranslate.iterator().run { next().also { remove() } }
+            val descriptor = extraClassesToTranslate.first()
+            extraClassesToTranslate -= descriptor
+
             assert(shouldTranslateExtraClass(descriptor)) { "Shouldn't be queued for translation: $descriptor" }
             if (descriptor.isInterface) {
                 generateInterface(descriptor)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -1059,23 +1059,19 @@ abstract class ObjCExportHeaderGenerator internal constructor(
         // TODO: make the translation order stable
         // to stabilize name mangling.
         translateBaseDeclarations()
+        translateModuleDeclarations()
+    }
+
+    fun translateBaseDeclarations() {
+        stubs += translator.generateBaseDeclarations()
+    }
+
+    fun translateModuleDeclarations() {
         translatePackageFragments()
         translateExtraClasses()
     }
 
-    fun translateExtraClasses() {
-        while (extraClassesToTranslate.isNotEmpty()) {
-            val descriptor = extraClassesToTranslate.iterator().run { next().also { remove() } }
-            assert(shouldTranslateExtraClass(descriptor)) { "Shouldn't be queued for translation: $descriptor" }
-            if (descriptor.isInterface) {
-                generateInterface(descriptor)
-            } else {
-                generateClass(descriptor)
-            }
-        }
-    }
-
-    fun translatePackageFragments() {
+    private fun translatePackageFragments() {
         val packageFragments = moduleDescriptors.flatMap { it.getPackageFragments() }
 
         packageFragments.forEach { packageFragment ->
@@ -1130,8 +1126,16 @@ abstract class ObjCExportHeaderGenerator internal constructor(
         }
     }
 
-    fun translateBaseDeclarations() {
-        stubs += translator.generateBaseDeclarations()
+    private fun translateExtraClasses() {
+        while (extraClassesToTranslate.isNotEmpty()) {
+            val descriptor = extraClassesToTranslate.iterator().run { next().also { remove() } }
+            assert(shouldTranslateExtraClass(descriptor)) { "Shouldn't be queued for translation: $descriptor" }
+            if (descriptor.isInterface) {
+                generateInterface(descriptor)
+            } else {
+                generateClass(descriptor)
+            }
+        }
     }
 
     private fun generateFile(sourceFile: SourceFile, declarations: List<CallableMemberDescriptor>) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -1126,6 +1126,17 @@ abstract class ObjCExportHeaderGenerator internal constructor(
         }
     }
 
+    /**
+     * Translates additional classes referenced from the module's declarations, such as parameter types, return types,
+     * thrown exception types, and underlying enum types.
+     *
+     * This is required for classes from dependencies to be exported correctly. However, we also currently rely on this
+     * for a few edge cases, such as some inner classes. Sub classes may reject certain descriptors to be translated.
+     * Some referenced descriptors may be translated early for ordering reasons.
+     * @see shouldTranslateExtraClass
+     * @see generateExtraClassEarly
+     * @see generateExtraInterfaceEarly
+     */
     private fun translateExtraClasses() {
         while (extraClassesToTranslate.isNotEmpty()) {
             val descriptor = extraClassesToTranslate.first()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportedStubs.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportedStubs.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package org.jetbrains.kotlin.backend.konan.objcexport
+
+data class ObjCExportedStubs(
+    val classForwardDeclarations: Set<String>,
+    val protocolForwardDeclarations: Set<String>,
+    val stubs: List<Stub<*>>
+)


### PR DESCRIPTION
- Implement way to restrict extra classes from other modules in Mobile ObjC generator
- Split generation into smaller steps
- Add API to retrieve stubs and foundation imports