### PR TITLE
Fix clang invocation in the tests: use linker with the same options as the build.

### DIFF
--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecClang.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecClang.kt
@@ -88,18 +88,15 @@ class ExecClang(private val project: Project) {
     }
 
     private fun execClang(defaultArgs: List<String>, action: Action<in ExecSpec>): ExecResult {
-        val extendedAction = object : Action<ExecSpec> {
-            override fun execute(execSpec: ExecSpec) {
-                action.execute(execSpec)
+        val extendedAction = Action<ExecSpec> { execSpec ->
+            action.execute(execSpec)
+            execSpec.apply {
+                executable = resolveExecutable(executable)
 
-                execSpec.apply {
-                    executable = resolveExecutable(executable)
-
-                    val hostPlatform = project.findProperty("hostPlatform") as Platform
-                    environment["PATH"] = project.files(hostPlatform.clang.clangPaths).asPath +
-                            java.io.File.pathSeparator + environment["PATH"]
-                    args(defaultArgs)
-                }
+                val hostPlatform = project.findProperty("hostPlatform") as Platform
+                environment["PATH"] = project.files(hostPlatform.clang.clangPaths).asPath +
+                        java.io.File.pathSeparator + environment["PATH"]
+                args = defaultArgs + args
             }
         }
         return project.exec(extendedAction)

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecClang.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/ExecClang.kt
@@ -96,7 +96,7 @@ class ExecClang(private val project: Project) {
                 val hostPlatform = project.findProperty("hostPlatform") as Platform
                 environment["PATH"] = project.files(hostPlatform.clang.clangPaths).asPath +
                         java.io.File.pathSeparator + environment["PATH"]
-                args = defaultArgs + args
+                args = args + defaultArgs
             }
         }
         return project.exec(extendedAction)


### PR DESCRIPTION
Compile to the `.o` file and then link it with all options.

Now the final binary has correct dependencies:
1. Before:
```
Pavel@win MINGW64 /d/Pavel/ws/kotlin-native (clang-invoke-fix)
$ ldd ./test.output/local/interop_cleaners_second_thread/mingw_x64/interop_cleaners_second_thread.exe
        ntdll.dll => /c/WINDOWS/SYSTEM32/ntdll.dll (0x7fff49840000)
        KERNEL32.DLL => /c/WINDOWS/System32/KERNEL32.DLL (0x7fff49740000)
        KERNELBASE.dll => /c/WINDOWS/System32/KERNELBASE.dll (0x7fff47350000)
        msvcrt.dll => /c/WINDOWS/System32/msvcrt.dll (0x7fff48860000)
        libstdc++-6.dll => /mingw64/bin/libstdc++-6.dll (0x6fc40000)
        libgcc_s_seh-1.dll => /mingw64/bin/libgcc_s_seh-1.dll (0x61440000)
        interop_cleaners_second_thread.dll => /d/Pavel/ws/kotlin-native/test.output/local/interop_cleaners_second_thread/mingw_x64/interop_cleaners_second_thread.dll (0x57390000)
        USER32.dll => /c/WINDOWS/System32/USER32.dll (0x7fff47fe0000)
        win32u.dll => /c/WINDOWS/System32/win32u.dll (0x7fff472c0000)
        GDI32.dll => /c/WINDOWS/System32/GDI32.dll (0x7fff48c90000)
        libwinpthread-1.dll => /mingw64/bin/libwinpthread-1.dll (0x64940000)
        ??? => ??? (0x180000)
        gdi32full.dll => /c/WINDOWS/System32/gdi32full.dll (0x7fff47120000)
        msvcp_win.dll => /c/WINDOWS/System32/msvcp_win.dll (0x7fff477d0000)
        ucrtbase.dll => /c/WINDOWS/System32/ucrtbase.dll (0x7fff467d0000)
```
2. After:
```
Pavel@win MINGW64 /d/Pavel/ws/kotlin-native (clang-invoke-fix)
$ ldd ./test.output/local/interop_cleaners_second_thread/mingw_x64/interop_cleaners_second_thread.exe
        ntdll.dll => /c/WINDOWS/SYSTEM32/ntdll.dll (0x7fff49840000)
        KERNEL32.DLL => /c/WINDOWS/System32/KERNEL32.DLL (0x7fff49740000)
        KERNELBASE.dll => /c/WINDOWS/System32/KERNELBASE.dll (0x7fff47350000)
        msvcrt.dll => /c/WINDOWS/System32/msvcrt.dll (0x7fff48860000)
        interop_cleaners_second_thread.dll => /d/Pavel/ws/kotlin-native/test.output/local/interop_cleaners_second_thread/mingw_x64/interop_cleaners_second_thread.dll (0x572a0000)
```