### PR TITLE
Interop generators use symbol owner too early.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumCompanionGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumCompanionGenerator.kt
@@ -55,8 +55,8 @@ internal class CEnumCompanionGenerator(
                 +IrDelegatingConstructorCallImpl.fromSymbolDescriptor(
                         startOffset, endOffset, context.irBuiltIns.unitType,
                         superConstructorSymbol,
-                        superConstructorSymbol.owner.typeParameters.size,
-                        superConstructorSymbol.owner.valueParameters.size
+                        superConstructorSymbol.descriptor.typeParameters.size,
+                        superConstructorSymbol.descriptor.valueParameters.size
                 )
                 +irInstanceInitializer(symbolTable.referenceClass(companionObjectDescriptor))
             }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumVarClassGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumVarClassGenerator.kt
@@ -59,8 +59,8 @@ internal class CEnumVarClassGenerator(
         irConstructor.body = irBuilder(irBuiltIns, irConstructor.symbol, SYNTHETIC_OFFSET, SYNTHETIC_OFFSET).irBlockBody {
             +IrDelegatingConstructorCallImpl.fromSymbolDescriptor(
                     startOffset, endOffset, context.irBuiltIns.unitType, enumVarConstructorSymbol,
-                    enumVarConstructorSymbol.owner.typeParameters.size,
-                    enumVarConstructorSymbol.owner.valueParameters.size
+                    enumVarConstructorSymbol.descriptor.typeParameters.size,
+                    enumVarConstructorSymbol.descriptor.valueParameters.size
             ).also {
                 it.putValueArgument(0, irGet(irConstructor.valueParameters[0]))
             }
@@ -84,8 +84,8 @@ internal class CEnumVarClassGenerator(
                 +IrDelegatingConstructorCallImpl.fromSymbolDescriptor(
                         startOffset, endOffset, context.irBuiltIns.unitType,
                         superConstructorSymbol,
-                        superConstructorSymbol.owner.typeParameters.size,
-                        superConstructorSymbol.owner.valueParameters.size
+                        superConstructorSymbol.descriptor.typeParameters.size,
+                        superConstructorSymbol.descriptor.valueParameters.size
                 ).also {
                     it.putValueArgument(0, irInt(typeSize))
                 }


### PR DESCRIPTION
Interop generators use symbol owner too early.
We should take parameter list size from the descriptor