### PR TITLE
[kotlin compiler][update] 1.4.30-dev-2395

### DIFF
--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -191,9 +191,6 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                         arguments.disablePhases.toNonNullList())
                 put(LIST_PHASES, arguments.listPhases)
 
-                put(COMPATIBLE_COMPILER_VERSIONS,
-                    arguments.compatibleCompilerVersions.toNonNullList())
-
                 put(ENABLE_ASSERTIONS, arguments.enableAssertions)
 
                 put(MEMORY_MODEL, when (arguments.memoryModel) {

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -121,9 +121,6 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     @Argument(value="-Xcheck-dependencies", deprecatedName = "--check_dependencies", description = "Check dependencies and download the missing ones")
     var checkDependencies: Boolean = false
 
-    @Argument(value="-Xcompatible-compiler-version", valueDescription = "<version>", description = "Assume the given compiler version to be binary compatible")
-    var compatibleCompilerVersions: Array<String>? = null
-
     @Argument(value = EMBED_BITCODE_FLAG, description = "Embed LLVM IR bitcode as data")
     var embedBitcode: Boolean = false
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -14,8 +14,6 @@ class KonanConfigKeys {
         // Keep the list lexically sorted.
         val CHECK_DEPENDENCIES: CompilerConfigurationKey<Boolean>
                 = CompilerConfigurationKey.create("check dependencies and download the missing ones")
-        val COMPATIBLE_COMPILER_VERSIONS: CompilerConfigurationKey<List<String>>
-                = CompilerConfigurationKey.create("compatible compiler versions")
         val DEBUG: CompilerConfigurationKey<Boolean>
                 = CompilerConfigurationKey.create("add debug information")
         val DISABLE_FAKE_OVERRIDE_VALIDATOR: CompilerConfigurationKey<Boolean>

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLibrariesResolveSupport.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanLibrariesResolveSupport.kt
@@ -53,15 +53,11 @@ class KonanLibrariesResolveSupport(
                 }
             }
 
-    private val compatibleCompilerVersions: List<CompilerVersion> =
-            configuration.getList(KonanConfigKeys.COMPATIBLE_COMPILER_VERSIONS).map { it.parseCompilerVersion() }
-
     private val resolver = defaultResolver(
             repositories,
             libraryNames.filter { it.contains(File.separator) },
             target,
             distribution,
-            compatibleCompilerVersions,
             resolverLogger
     ).libraryResolver()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2139,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-2139
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2139,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-2139
-kotlinStdlibTestsVersion=1.4.30-dev-2139
-testKotlinCompilerVersion=1.4.30-dev-2139
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2395,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-2395
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2395,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-2395
+kotlinStdlibTestsVersion=1.4.30-dev-2395
+testKotlinCompilerVersion=1.4.30-dev-2395
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/SearchPathResolver.kt
+++ b/shared/src/library/kotlin/org/jetbrains/kotlin/konan/library/SearchPathResolver.kt
@@ -11,31 +11,27 @@ import org.jetbrains.kotlin.library.impl.createKotlinLibrary
 import org.jetbrains.kotlin.util.DummyLogger
 import org.jetbrains.kotlin.util.Logger
 
-interface SearchPathResolverWithTarget<L: KotlinLibrary>: SearchPathResolverWithAttributes<L> {
+interface SearchPathResolverWithTarget<L: KotlinLibrary>: SearchPathResolver<L> {
     val target: KonanTarget
 }
 
 fun defaultResolver(
         repositories: List<String>,
         target: KonanTarget,
-        distribution: Distribution,
-        compatibleCompilerVersions: List<CompilerVersion> = emptyList()
-): SearchPathResolverWithTarget<KonanLibrary> = defaultResolver(repositories, emptyList(), target, distribution, compatibleCompilerVersions)
+        distribution: Distribution
+): SearchPathResolverWithTarget<KonanLibrary> = defaultResolver(repositories, emptyList(), target, distribution)
 
 fun defaultResolver(
     repositories: List<String>,
     directLibs: List<String>,
     target: KonanTarget,
     distribution: Distribution,
-    compatibleCompilerVersions: List<CompilerVersion> = emptyList(),
     logger: Logger = DummyLogger,
     skipCurrentDir: Boolean = false
 ): SearchPathResolverWithTarget<KonanLibrary> = KonanLibraryProperResolver(
         repositories,
         directLibs,
         target,
-        listOf(KotlinAbiVersion.CURRENT),
-        compatibleCompilerVersions,
         distribution.klib,
         distribution.localKonanDir.absolutePath,
         skipCurrentDir,
@@ -65,16 +61,12 @@ internal class KonanLibraryProperResolver(
     repositories: List<String>,
     directLibs: List<String>,
     override val target: KonanTarget,
-    knownAbiVersions: List<KotlinAbiVersion>?,
-    knownCompilerVersions: List<CompilerVersion>?,
     distributionKlib: String?,
     localKonanDir: String?,
     skipCurrentDir: Boolean,
     override val logger: Logger
 ) : KotlinLibraryProperResolverWithAttributes<KonanLibrary>(
     repositories, directLibs,
-    knownAbiVersions,
-    knownCompilerVersions,
     distributionKlib,
     localKonanDir,
     skipCurrentDir,


### PR DESCRIPTION
* 0e8cf58a35c - (HEAD -> master, tag: build-1.4.30-dev-2395, origin/master, origin/HEAD) Minor: reformat (vor 16 Stunden) <Pavel Kirpichenkov>
* b79b94fe75e - [MPP] Allow smart casts for properties from dependsOn modules (vor 16 Stunden) <Pavel Kirpichenkov>
* 778bbd76cb5 - [MPP] Add test for KT-42754 (vor 16 Stunden) <Pavel Kirpichenkov>
* 9f0cec34435 - (tag: build-1.4.30-dev-2389) Native, Gradle IT: Add verbosity to IT (vor 2 Tagen) <Dmitriy Dolovov>
* 9adc1a6e9bd - (tag: build-1.4.30-dev-2381) JVM IR: generate 'main' wrappers as non-final (vor 2 Tagen) <Alexander Udalov>
* 791be7c2dcc - JVM IR: improve ABI of properties in multifile facades (vor 2 Tagen) <Alexander Udalov>
* 55974b4eda2 - JVM IR: do not generate InlineOnly property accessors in multifile facade (vor 2 Tagen) <Alexander Udalov>
* 500b1cfbd3a - JVM IR: fix flags of $default methods in multi-file facades (vor 2 Tagen) <Alexander Udalov>
* d326d6a6936 - Specify module name via moduleName option instead of freeCompilerArgs (vor 2 Tagen) <Alexander Udalov>
* bdb8a58b3b7 - JVM IR: merge JvmBackendFacade into JvmIrCodegenFactory (vor 2 Tagen) <Alexander Udalov>
* 5c2c2591a1c - Minor, rename file to keep git history (vor 2 Tagen) <Alexander Udalov>
* 624204c7b48 - JVM IR: remove outdated code in JvmIrCodegenFactory (vor 2 Tagen) <Alexander Udalov>
* b2d49e96150 - Minor, fix whitespace in toString (vor 2 Tagen) <Alexander Udalov>
* c1a292b01b4 - Psi2ir: improve exception stack traces (vor 2 Tagen) <Alexander Udalov>
* 3cb202f5766 - (tag: build-1.4.30-dev-2373) Gradle IT: Fix Gradle output checks in Kotlin/Native ITs (vor 3 Tagen) <Dmitriy Dolovov>
* e3db96354d5 - (tag: build-1.4.30-dev-2361) Add javadoc and sources artifacts to kotlin-gradle-build-metrics module (vor 3 Tagen) <Alexander Likhachev>
* 5f2a9630069 - Better wording and comments for klib compatibility code (vor 3 Tagen) <Alexander Gorshenev>
* 891a4c46218 - Dropped outdated klib version compatibility mechanisms (vor 3 Tagen) <Alexander Gorshenev>
* 8b2b36d61f9 - Enabled klib abi version compatibility (vor 3 Tagen) <Alexander Gorshenev>
* e434a1c8920 - (tag: build-1.4.30-dev-2355) FIR: Drop unused AbstractFirOverrideScope::create*Copy (vor 3 Tagen) <Denis Zharkov>
* 2e4c41c0d82 - FIR: Drop PossiblyFirFakeOverrideSymbol (vor 3 Tagen) <Denis Zharkov>
* 7b48625b582 - FIR: Remove FirCallableSymbol::overriddenSymbol (vor 3 Tagen) <Denis Zharkov>
* 78b374ec88f - FIR: Do not set overriddenSymbol for KFunction::invoke (vor 3 Tagen) <Denis Zharkov>
* a11b488c824 - FIR: Add workaround for combination of intersection + delegated members (vor 3 Tagen) <Denis Zharkov>
* 41f878e104e - FIR: Adjust test data for type alias constructors (vor 3 Tagen) <Denis Zharkov>
* 96c3436e73e - FIR: Temporary adjust diagnostics test data (vor 3 Tagen) <Denis Zharkov>
* d58e66e79a9 - FIR: Merge both synthetic type alias constructor kinds (vor 3 Tagen) <Denis Zharkov>
* f9aab77ce5a - FIR: Simplify ConstructorProcessing relevant to type aliases (vor 3 Tagen) <Denis Zharkov>
* 8a949b0dcfa - FIR: Use attribute instead of overriddenSymbol for synthetic type alias constructor (vor 3 Tagen) <Denis Zharkov>
* 4282e27d738 - FIR: Get rid of usages of FirCallableSymbol::overriddenSymbol (vor 3 Tagen) <Denis Zharkov>
* 728c2a808f0 - FIR: Do not propagate overriddenSymbol at FirObjectImportedCallableScope (vor 3 Tagen) <Denis Zharkov>
* 037ba4d973b - FIR: Simplify VariableStorage::isStable (vor 3 Tagen) <Denis Zharkov>
* 317d9814728 - FIR: Do not use overriddenSymbol for imported from object (vor 3 Tagen) <Denis Zharkov>
* 65119adb6a2 - FIR: Adjust test data. FakeOverride -> SubssitutionOverride (vor 3 Tagen) <Denis Zharkov>
* 3e37995004e - FIR: Get rid of FirCallableSymbol::isFakeOverride and isIntersectionOverride (vor 3 Tagen) <Denis Zharkov>
* 36387d97ad1 - (tag: build-1.4.30-dev-2323) Add IC metrics reporting (vor 3 Tagen) <Alexey Tsvetkov>
* 5bde6457b18 - Metrics reporting utils (vor 3 Tagen) <Alexey Tsvetkov>
* 97a09680d56 - Remove CompositeICReporterAsync (vor 3 Tagen) <Alexey Tsvetkov>
* 2c1e4c17694 - (tag: build-1.4.30-dev-2319) [IR] Use more specific type (IrSimpleFunction) for accessors in IrLocalDelegatedProperty (vor 3 Tagen) <Zalim Bashorov>
* 11bc1c07537 - (tag: build-1.4.30-dev-2316) Revert "Fix configuration cache issue in AbstractKotlinTarget" (vor 3 Tagen) <Sergey Igushkin>
* 8ca9e792e92 - (tag: build-1.4.30-dev-2314) [KLIB] Make sure that referenced local anonymous class is deserialzied. (vor 3 Tagen) <Roman Artemev>
* 0dd329d3d4c - (tag: build-1.4.30-dev-2306) Gradle IT: Intercept and log Gradle process output on import failures (vor 4 Tagen) <Dmitriy Dolovov>
* 4de1bf8d350 - Gradle IT: Move GradleProcessOutputInterceptor to the test framework (vor 4 Tagen) <Dmitriy Dolovov>
* fae3ba35e96 - Gradle, Native: More verbose logging in KotlinToolRunner (vor 4 Tagen) <Dmitriy Dolovov>
* 734dff62822 - [Commonizer] Use compact variants of collections to reduce memory footprint (vor 4 Tagen) <Dmitriy Dolovov>
* 30bf7b87fea - Minor. Code formatted (vor 4 Tagen) <Dmitriy Dolovov>
* f5bb60f7cd6 - [Commonizer] Refactor CIR type representation (vor 4 Tagen) <Dmitriy Dolovov>
* 2764550bbe7 - [Commonizer] Relax conditions for TA lifting-up (vor 4 Tagen) <Dmitriy Dolovov>
* cb2e94df164 - [Commonizer] Minor. Convert approximation keys back to data classes (vor 4 Tagen) <Dmitriy Dolovov>
* 45ce0c6c116 - (tag: build-1.4.30-dev-2293) avoid failing KotlinGradleIT.testInternalTest for Windows agent (vor 4 Tagen) <nataliya.valtman>
* 6d29bb5814e - Fix configuration cache issue in AbstractKotlinTarget (vor 10 Tagen) <Hung Nguyen>
* 90ea64a0e5c - (tag: build-1.4.30-dev-2289) Don't report warning about changing execution order for varargs if it's inside an annotation (vor 4 Tagen) <Victor Petukhov>
* f052bc341c0 - Don't report warning about implicitly inferred Nothing for call arguments if there is non-Nothing return type (vor 4 Tagen) <Victor Petukhov>
* 78592873372 - (tag: build-1.4.30-dev-2288) [KT-40688] Inlay Hints: lambda hints removal on editing (vor 4 Tagen) <Andrei Klunnyi>
* b3b09ea9b72 - (tag: build-1.4.30-dev-2271) FIR: adjust spec testData after DFA changes: (vor 5 Tagen) <Jinseong Jeon>
* a5389b067bd - FIR DFA: use element-wise join everywhere (vor 5 Tagen) <Jinseong Jeon>
* 771c839d742 - FIR DFA: element-wise join at merging points of try expression (vor 5 Tagen) <Jinseong Jeon>
* bd173ebebcc - FIR DFA: isolate effects between blocks in try expression (vor 5 Tagen) <Jinseong Jeon>
* 1f1e1828a70 - FIR CFG: reconfigure exception throwing paths in try expression (vor 5 Tagen) <Jinseong Jeon>
* 146036010c9 - FIR DFA: add tests about smartcasts in/after try-catch-finally (vor 5 Tagen) <Jinseong Jeon>
* 2c8c47399af - (tag: build-1.4.30-dev-2263) [JVM_IR] Enable KotlinAgainstJava and remaining JavaAgainstKotlin test. (vor 5 Tagen) <Mads Ager>
* 24345bb6b3e - (tag: build-1.4.30-dev-2262) Prevent NPE while fetching muted tests from Teamcity server (vor 5 Tagen) <Yunir Salimzyanov>
* bc2b396ecd9 - (tag: build-1.4.30-dev-2257) kotlin.native.cocoapods.targets can be a custom list of architectures (#3861) (vor 5 Tagen) <MikeKulasinski-visa>
* 02790682140 - (tag: build-1.4.30-dev-2255) [JVM_IR] Follow old backend in bridge visibility and varargs marking. (vor 5 Tagen) <Mads Ager>
* 326768e8b5f - (tag: build-1.4.30-dev-2251) Minor. Update test data (vor 5 Tagen) <Ilmir Usmanov>
* bd4e2a283cb - (tag: build-1.4.30-dev-2247) JVM IR: Don't generate null checks on value parameters of private operator functions (vor 5 Tagen) <Steven Schäfer>
* d4cb5214332 - (tag: build-1.4.30-dev-2239) JVM IR: Fix names for SAM callable references with inline class return types (vor 5 Tagen) <Steven Schäfer>
* aa81041415d - (tag: build-1.4.30-dev-2235) FIR: Fix DiagnosticsTestGenerated when FIR starts requesting light classes (vor 6 Tagen) <Denis Zharkov>
* a936386e53a - FIR: Add more complicated workaround for OverloadResolutionByLambdaReturnType (vor 6 Tagen) <Denis Zharkov>
* 4612f26bfb0 - FIR: Add workaround for OverloadResolutionByLambdaReturnType (vor 6 Tagen) <Denis Zharkov>
* 07ed89b02bf - Move OVERLOAD_RESOLUTION_BY_LAMBDA_ANNOTATION to compiler.common (vor 6 Tagen) <Denis Zharkov>
* a444618c275 - FIR: Correctly handle Java annotations from deserialization (vor 6 Tagen) <Denis Zharkov>
* f2b0d057b9e - (tag: build-1.4.30-dev-2231) JVM IR: minor optimizations in IrTypeMapper.classInternalName (vor 6 Tagen) <Alexander Udalov>
* b3e79d36df1 - (tag: build-1.4.30-dev-2223) Fix compiler warnings and some inspections (vor 6 Tagen) <Alexander Udalov>
* e5d5c204735 - Minor, suppress deprecation warnings in parcelize plugin (vor 6 Tagen) <Alexander Udalov>
* ee8db2f7607 - (tag: build-1.4.30-dev-2221) Escape resolving same library several times in K/N (#3880) (vor 6 Tagen) <LepilkinaElena>
* 1376fed1d47 - (tag: build-1.4.30-dev-2210) Support non-public inline class constructors (vor 6 Tagen) <Ilmir Usmanov>
* 88bbeea7f6a - (tag: build-1.4.30-dev-2208) Fix deprecated gradle api usage in artifact transform (vor 6 Tagen) <Bingran>
* 94145f880c4 - (tag: build-1.4.30-dev-2199) [IR] Inliner: supported recursion in default arguments (vor 6 Tagen) <Igor Chevdar>
* 5f8fabed61d - (tag: build-1.4.30-dev-2196) Minor. Update test data (vor 6 Tagen) <Ilmir Usmanov>
* 497b7ee266a - (tag: build-1.4.30-dev-2183) [minor] fix accidental addition of FirScriptCodegenTestGenerated (vor 6 Tagen) <Ilya Chernikov>
* 89836a2c9a1 - (tag: build-1.4.30-dev-2173) Minor, test-data-only: Remove unused "IGNORE_BACKEND_FIR" directives in asmLike test-data. (vor 6 Tagen) <Mark Punzalan>
* c02e92a5e06 - JVM IR: minor, use createJvmIrBuilder to simplify code (vor 6 Tagen) <Alexander Udalov>
* dd33ed92978 - Fix suspend function with inline class types in reflection (vor 6 Tagen) <Alexander Udalov>
* 56f7e34e3eb - (tag: build-1.4.30-dev-2171) [Gradle, K/N] Revert change of AbstractKotlinNativeCompile supertype (vor 6 Tagen) <Alexander Likhachev>
* 369b1ef5df9 - (tag: build-1.4.30-dev-2166) Fix compilation in perfTests (vor 7 Tagen) <Vladimir Dolzhenko>
* 2bffce2259b - (tag: build-1.4.30-dev-2163) Revert Open build tool window on Gradle DSL errors (vor 7 Tagen) <Vladimir Dolzhenko>
* 1a57794e820 - (tag: build-1.4.30-dev-2162) Clean ups in IDE performance tests output (vor 7 Tagen) <Vladimir Dolzhenko>
* 617279310e8 - (tag: build-1.4.30-dev-2159) [JVM_IR] Rebase inline function and defaults args stepping test. (vor 7 Tagen) <Mads Ager>
* 7b315a8b525 - (tag: build-1.4.30-dev-2150) JVM_IR: Do not box inline class in methods (vor 7 Tagen) <Ilmir Usmanov>
* e20093d762e - (tag: build-1.4.30-dev-2145) Support @JvmStatic and @JvmOverload in annotation companion (vor 7 Tagen) <Mikhael Bogdanov>
* 7ec2d036ae8 - Don't generate `final` modifier on static interface methods produced by @JvmStatic+@JvmOverloads from interface companion (vor 7 Tagen) <Mikhael Bogdanov>