### PR TITLE
Use Files API for creating temp files and directories

### DIFF
--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/ModuleSupport.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/ModuleSupport.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlin.native.interop.indexer
 
 import clang.*
 import kotlinx.cinterop.*
+import java.nio.file.Files
 
 data class ModulesInfo(val topLevelHeaders: List<String>, val ownHeaders: Set<String>)
 
@@ -39,13 +40,13 @@ internal open class ModularCompilation(compilation: Compilation): Compilation by
     }
 
     private val moduleCacheDirectory = if (compilation.compilerArgs.none { it.startsWith(moduleCacheFlag) }) {
-        createTempDir("ModuleCache")
+        Files.createTempDirectory("ModuleCache").toAbsolutePath().toFile()
     } else {
         null
     }
 
     override val compilerArgs: List<String> = compilation.compilerArgs +
-            listOfNotNull("-fmodules", moduleCacheDirectory?.let { "$moduleCacheFlag${it.absolutePath}" })
+            listOfNotNull("-fmodules", moduleCacheDirectory?.let { "$moduleCacheFlag${it}" })
 
     override fun dispose() {
         moduleCacheDirectory?.deleteRecursively()

--- a/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt
+++ b/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt
@@ -98,7 +98,7 @@ fun loadKonanLibrary(name: String) {
         try {
             System.load("$dir/$fullLibraryName")
         } catch (e: UnsatisfiedLinkError) {
-            val tempDir = createTempDir(directory = File(dir)).absolutePath
+            val tempDir = Files.createTempDirectory(Paths.get(dir), null).toAbsolutePath().toString()
             Files.createLink(Paths.get(tempDir, fullLibraryName), Paths.get(dir, fullLibraryName))
             // TODO: Does not work on Windows. May be use FILE_FLAG_DELETE_ON_CLOSE?
             File(tempDir).deleteOnExit()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/VerifyModule.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/VerifyModule.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlin.backend.konan.llvm
 import kotlinx.cinterop.*
 import llvm.*
 import java.io.File
+import java.nio.file.Files
 
 internal fun verifyModule(llvmModule: LLVMModuleRef, current: String = "") = memScoped {
     val errorRef = allocPointerTo<ByteVar>()
@@ -49,7 +50,7 @@ private fun StringBuilder.appendModuleVerificationFailureDetails(
 
     appendVerificationError(verificationError)
 
-    val moduleDumpFile = createTempFile("kotlin_native_llvm_module_dump", ".ll")
+    val moduleDumpFile = Files.createTempFile("kotlin_native_llvm_module_dump", ".ll").toFile()
 
     dumpModuleAndAppendDetails(llvmModule, moduleDumpFile)
 

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.konan.KonanExternalToolFailure
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.lang.ProcessBuilder.Redirect
+import java.nio.file.Files
 
 
 open class Command(initialCommand: List<String>) {
@@ -83,7 +84,7 @@ open class Command(initialCommand: List<String>) {
     fun getResult(withErrors: Boolean, handleError: Boolean = false): Result {
         log()
 
-        val outputFile = createTempFile()
+        val outputFile = Files.createTempFile(null, null).toFile()
         outputFile.deleteOnExit()
 
         try {

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/KonanToolRunner.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/KonanToolRunner.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.konan.target.Family
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import java.nio.file.Files
 
 internal interface KonanToolRunner: Named {
     val mainClass: String
@@ -135,16 +136,12 @@ internal class KonanCompilerRunner(
             return args
         }
 
-        val argFile = createTempFile(prefix = "konancArgs", suffix = ".lst").apply {
-            deleteOnExit()
+        val argFile = Files.createTempFile("konancArgs", ".lst").toAbsolutePath().apply {
+            toFile().deleteOnExit()
         }
-        argFile.printWriter().use { writer ->
-            args.forEach {
-                writer.println(it)
-            }
-        }
+        Files.write(argFile, args)
 
-        return listOf("@${argFile.absolutePath}")
+        return listOf("@${argFile}")
     }
 }
 

--- a/utilities/cli-runner/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/GeneratePlatformLibraries.kt
+++ b/utilities/cli-runner/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/GeneratePlatformLibraries.kt
@@ -25,6 +25,8 @@ import org.jetbrains.kotlin.native.interop.tool.CommonInteropArguments.Companion
 import org.jetbrains.kotlin.native.interop.tool.SHORT_MODULE_NAME
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.system.exitProcess
 import java.io.File as JFile
@@ -175,11 +177,11 @@ private class DefFile(val name: String, val depends: MutableList<DefFile>) {
 }
 
 private fun createTempDir(prefix: String, parent: File): File =
-        File(createTempDir(prefix, directory = JFile(parent.absolutePath)).absolutePath)
+        File(Files.createTempDirectory(Paths.get(parent.absolutePath), prefix).toString())
 
 private fun File.deleteAtomicallyIfPossible(tmpDirectory: File) {
     // Try to atomically delete the old directory.
-    val tmpToDelete = createTempFile(directory = JFile(tmpDirectory.absolutePath))
+    val tmpToDelete = Files.createTempFile(Paths.get(tmpDirectory.absolutePath), null, null).toFile()
     if (renameAtomic(this.absolutePath, tmpToDelete.absolutePath, replaceExisting = true)) {
         tmpToDelete.deleteRecursively()
     } else {


### PR DESCRIPTION
To avoid build failures due to `-Werror` this PR replaces usages of `createTempFile`/`createTempDir` to `java.nio.file.Files` API in case of deprecation of the former.