### PR TITLE
Set code style to default IDE code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ gradle-app.setting
 
 # local project files
 lib/
-.idea/
+.idea/*
 proto/compiler/protoc-artifacts
 proto/compiler/tests
 
@@ -72,3 +72,6 @@ compile_commands.json
 
 # googletest framework used by runtime tests
 runtime/googletest/
+
+# code style
+!.idea/codeStyles/

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>


### PR DESCRIPTION
Always apply IDE default code style instead of whatever is configured on the user's machine until formal decision about `kotlin-native` is made.