### PR TITLE
Add kotlin.build.useIR property to compile project with JVM IR

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
@@ -820,7 +820,7 @@ internal object Devirtualization {
                 val value = fromId.toLong() or (toId.toLong() shl 32)
                 // This is 64-bit extension of a hashing method from Knuth's "The Art of Computer Programming".
                 // The magic constant is the closest prime to 2^64 * phi, where phi is the golden ratio.
-                val bucketIdx = ((value.toULong() * 11400714819323198393UL) % bagOfEdges.size.toUInt()).toInt()
+                val bucketIdx = ((value.toULong() * 11400714819323198393UL) % bagOfEdges.size.toULong()).toInt()
                 val bucket = bagOfEdges[bucketIdx] ?: LongArrayList().also { bagOfEdges[bucketIdx] = it }
                 for (x in bucket)
                     if (x == value) return

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,15 @@ allprojects {
         }
     }
 
+    if (property("kotlin.build.useIR") == "true") {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                useIR = true
+                freeCompilerArgs += ["-Xir-binary-with-stable-abi"]
+            }
+        }
+    }
+
     setupHostAndTarget()
     loadCommandLineProperties()
     loadLocalProperties()

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ allprojects {
         }
     }
 
-    if (property("kotlin.build.useIR") == "true") {
+    if (findProperty("kotlin.build.useIR") == "true") {
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {
                 useIR = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,5 +42,8 @@ ktorVersion=1.2.1
 shadowVersion=5.1.0
 metadataVersion=0.0.1-dev-10
 
+# Uncomment to compile Kotlin/Native backend modules with JVM IR backend.
+# kotlin.build.useIR=true
+
 # Uncomment to enable composite build
 #kotlinProjectPath=<insert the path to Kotlin project root here>


### PR DESCRIPTION
The change in Devirtualization.kt is needed to workaround JVM IR issue
reported at KT-43286.