### PR TITLE
[kotlin compiler][update] 1.4.30-dev-2687 

### DIFF
--- a/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/ModuleSupport.kt
+++ b/Interop/Indexer/src/main/kotlin/org/jetbrains/kotlin/native/interop/indexer/ModuleSupport.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlin.native.interop.indexer
 
 import clang.*
 import kotlinx.cinterop.*
+import java.nio.file.Files
 
 data class ModulesInfo(val topLevelHeaders: List<String>, val ownHeaders: Set<String>)
 
@@ -39,13 +40,13 @@ internal open class ModularCompilation(compilation: Compilation): Compilation by
     }
 
     private val moduleCacheDirectory = if (compilation.compilerArgs.none { it.startsWith(moduleCacheFlag) }) {
-        createTempDir("ModuleCache")
+        Files.createTempDirectory("ModuleCache").toAbsolutePath().toFile()
     } else {
         null
     }
 
     override val compilerArgs: List<String> = compilation.compilerArgs +
-            listOfNotNull("-fmodules", moduleCacheDirectory?.let { "$moduleCacheFlag${it.absolutePath}" })
+            listOfNotNull("-fmodules", moduleCacheDirectory?.let { "$moduleCacheFlag${it}" })
 
     override fun dispose() {
         moduleCacheDirectory?.deleteRecursively()

--- a/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt
+++ b/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt
@@ -98,7 +98,7 @@ fun loadKonanLibrary(name: String) {
         try {
             System.load("$dir/$fullLibraryName")
         } catch (e: UnsatisfiedLinkError) {
-            val tempDir = createTempDir(directory = File(dir)).absolutePath
+            val tempDir = Files.createTempDirectory(Paths.get(dir), null).toAbsolutePath().toString()
             Files.createLink(Paths.get(tempDir, fullLibraryName), Paths.get(dir, fullLibraryName))
             // TODO: Does not work on Windows. May be use FILE_FLAG_DELETE_ON_CLOSE?
             File(tempDir).deleteOnExit()

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
@@ -72,8 +72,6 @@ internal fun Context.psiToIr(
         val irProviderForCEnumsAndCStructs =
                 IrProviderForCEnumAndCStructStubs(generatorContext, interopBuiltIns, symbols)
 
-        val deserializeFakeOverrides = config.configuration.getBoolean(CommonConfigurationKeys.DESERIALIZE_FAKE_OVERRIDES)
-
         val translationContext = object : TranslationPluginContext {
             override val moduleDescriptor: ModuleDescriptor
                 get() = generatorContext.moduleDescriptor
@@ -98,7 +96,6 @@ internal fun Context.psiToIr(
                 stubGenerator,
                 irProviderForCEnumsAndCStructs,
                 exportedDependencies,
-                deserializeFakeOverrides,
                 config.cachedLibraries
         ).also { linker ->
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/VerifyModule.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/VerifyModule.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlin.backend.konan.llvm
 import kotlinx.cinterop.*
 import llvm.*
 import java.io.File
+import java.nio.file.Files
 
 internal fun verifyModule(llvmModule: LLVMModuleRef, current: String = "") = memScoped {
     val errorRef = allocPointerTo<ByteVar>()
@@ -49,7 +50,7 @@ private fun StringBuilder.appendModuleVerificationFailureDetails(
 
     appendVerificationError(verificationError)
 
-    val moduleDumpFile = createTempFile("kotlin_native_llvm_module_dump", ".ll")
+    val moduleDumpFile = Files.createTempFile("kotlin_native_llvm_module_dump", ".ll").toFile()
 
     dumpModuleAndAppendDetails(llvmModule, moduleDumpFile)
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -78,9 +78,8 @@ internal class KonanIrLinker(
         private val stubGenerator: DeclarationStubGenerator,
         private val cenumsProvider: IrProviderForCEnumAndCStructStubs,
         exportedDependencies: List<ModuleDescriptor>,
-        deserializeFakeOverrides: Boolean,
         private val cachedLibraries: CachedLibraries
-) : KotlinIrLinker(currentModule, logger, builtIns, symbolTable, exportedDependencies, deserializeFakeOverrides) {
+) : KotlinIrLinker(currentModule, logger, builtIns, symbolTable, exportedDependencies) {
 
     companion object {
         private val C_NAMES_NAME = Name.identifier("cnames")

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/KotlinNativeTest.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/KotlinNativeTest.kt
@@ -14,6 +14,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.gradle.process.ExecSpec
 import org.jetbrains.kotlin.konan.exec.Command
 
 import java.io.File

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2395,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-2395
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2395,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-2395
-kotlinStdlibTestsVersion=1.4.30-dev-2395
-testKotlinCompilerVersion=1.4.30-dev-2395
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2687,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-2687
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2687,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-2687
+kotlinStdlibTestsVersion=1.4.30-dev-2687
+testKotlinCompilerVersion=1.4.30-dev-2687
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/exec/ExecuteCommand.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.konan.KonanExternalToolFailure
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.lang.ProcessBuilder.Redirect
+import java.nio.file.Files
 
 
 open class Command(initialCommand: List<String>) {
@@ -83,7 +84,7 @@ open class Command(initialCommand: List<String>) {
     fun getResult(withErrors: Boolean, handleError: Boolean = false): Result {
         log()
 
-        val outputFile = createTempFile()
+        val outputFile = Files.createTempFile(null, null).toFile()
         outputFile.deleteOnExit()
 
         try {

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/KonanToolRunner.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/KonanToolRunner.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.konan.target.Family
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.util.DependencyProcessor
+import java.nio.file.Files
 
 internal interface KonanToolRunner: Named {
     val mainClass: String
@@ -135,16 +136,12 @@ internal class KonanCompilerRunner(
             return args
         }
 
-        val argFile = createTempFile(prefix = "konancArgs", suffix = ".lst").apply {
-            deleteOnExit()
+        val argFile = Files.createTempFile("konancArgs", ".lst").toAbsolutePath().apply {
+            toFile().deleteOnExit()
         }
-        argFile.printWriter().use { writer ->
-            args.forEach {
-                writer.println(it)
-            }
-        }
+        Files.write(argFile, args)
 
-        return listOf("@${argFile.absolutePath}")
+        return listOf("@${argFile}")
     }
 }
 

--- a/utilities/cli-runner/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/GeneratePlatformLibraries.kt
+++ b/utilities/cli-runner/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/GeneratePlatformLibraries.kt
@@ -25,6 +25,8 @@ import org.jetbrains.kotlin.native.interop.tool.CommonInteropArguments.Companion
 import org.jetbrains.kotlin.native.interop.tool.SHORT_MODULE_NAME
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.system.exitProcess
 import java.io.File as JFile
@@ -175,11 +177,11 @@ private class DefFile(val name: String, val depends: MutableList<DefFile>) {
 }
 
 private fun createTempDir(prefix: String, parent: File): File =
-        File(createTempDir(prefix, directory = JFile(parent.absolutePath)).absolutePath)
+        File(Files.createTempDirectory(Paths.get(parent.absolutePath), prefix).toString())
 
 private fun File.deleteAtomicallyIfPossible(tmpDirectory: File) {
     // Try to atomically delete the old directory.
-    val tmpToDelete = createTempFile(directory = JFile(tmpDirectory.absolutePath))
+    val tmpToDelete = Files.createTempFile(Paths.get(tmpDirectory.absolutePath), null, null).toFile()
     if (renameAtomic(this.absolutePath, tmpToDelete.absolutePath, replaceExisting = true)) {
         tmpToDelete.deleteRecursively()
     } else {


### PR DESCRIPTION
* 6e7b5a55b39 - (HEAD -> master, tag: build-1.4.30-dev-2687, tag: build-1.4.30-dev-2671, origin/master, origin/HEAD) kotlinx-metadata: Don't write flags for absent property accessors (vor 2 Tagen) <Dmitriy Dolovov>
* a6cbae97192 - (tag: build-1.4.30-dev-2660) [FIR] Rename FirErrors.SYNTAX_ERROR to SYNTAX (vor 3 Tagen) <Dmitriy Novozhilov>
* 2f5b231d505 - [FIR] Add default renderers to FirDiagnosticFactories (vor 3 Tagen) <Dmitriy Novozhilov>
* dc662efcf4d - [FIR] Introduce FirDiagnosticRenderers (vor 3 Tagen) <Dmitriy Novozhilov>
* ed0e5adce7b - [FIR] Make FirAnalyzerFacade returns diagnostics grouped by fir file (vor 3 Tagen) <Dmitriy Novozhilov>
* dabc259ae82 - [FIR] Make diagnostics collectors returns List instead of Iterable (vor 3 Tagen) <Dmitriy Novozhilov>
* 20453bf0d8d - [FIR] Get rid of FirSessionProvider.project property (vor 3 Tagen) <Dmitriy Novozhilov>
* 82a2ecfe146 - [FIR] Cleanup creating sessions in CLI FIR compiler (vor 3 Tagen) <Dmitriy Novozhilov>
* 3aa8b09e310 - [FIR] Add configurable language version settings to FirSessionFactories (vor 3 Tagen) <Dmitriy Novozhilov>
* 5d76df6e1a5 - (tag: build-1.4.30-dev-2659) KT-43045 mangle function name for fake override with default impl (vor 3 Tagen) <Dmitry Petrov>
* 1ecf5943abb - (tag: build-1.4.30-dev-2657) [JVM_IR] Determine correct type of empty varargs array. (vor 3 Tagen) <Mads Ager>
* ffc003c0513 - (tag: build-1.4.30-dev-2650) IR: copy IrProperty's attributes in deepCopyWithSymbols (vor 3 Tagen) <Georgy Bronnikov>
* 7b988764757 - (tag: build-1.4.30-dev-2649) Parcelize: Fix typo in diagnostic message (KT-43290) (vor 3 Tagen) <Yan Zhulanow>
* e3bfb9245c7 - (tag: build-1.4.30-dev-2638) [FIR] Rename `nested` directory with testdata to `innerClasses` (vor 3 Tagen) <Dmitriy Novozhilov>
* 419f54259cd - [TEST] Change semantics of `CHECK_TYPE` directive and update testdata (vor 3 Tagen) <Dmitriy Novozhilov>
* 653b26174b6 - (tag: build-1.4.30-dev-2636) KT-43006 don't generate no-arg constructor with inline class parameters (vor 3 Tagen) <Dmitry Petrov>
* 364773bf0fb - (tag: build-1.4.30-dev-2628) IR: fix IrClassSymbol.starProjectedType (vor 3 Tagen) <Georgy Bronnikov>
* f5329b6f1d7 - (tag: build-1.4.30-dev-2619) [Commonizer] Don't publish sources and javadocs (vor 4 Tagen) <Dmitriy Dolovov>
* 15cc9793787 - (tag: build-1.4.30-dev-2616) [FIR] Add enter contract node as exit for exceptional path to avoid compiler crashing (vor 4 Tagen) <Dmitriy Novozhilov>
* 87380d1913e - [FIR] Don't assume that exit lambda node is target for exceptional exit for inplace lambdas (vor 4 Tagen) <Dmitriy Novozhilov>
* 440cf788846 - FIR CFG: add more uncaught exception paths (vor 4 Tagen) <Jinseong Jeon>
* 7b06885348e - FIR checker: reproduce KT-43156 (vor 4 Tagen) <Jinseong Jeon>
* f4347a60c2d - [FIR] Fix typo (vor 4 Tagen) <Dmitriy Novozhilov>
* 3c48f2eb685 - (tag: build-1.4.30-dev-2615) [FIR] Handle isProp/setProp synthetic pair properly in Java use-site scope (vor 4 Tagen) <Mikhail Glukhikh>
* 2725930460a - [FIR] Code cleanup in JavaClassUseSiteMemberScope (vor 4 Tagen) <Mikhail Glukhikh>
* fb961f7070c - [FIR] Copy also synthetic setter during fake override generation (vor 4 Tagen) <Mikhail Glukhikh>
* 22fb6203446 - [FIR Java] Copy also synthetic setter during enhancement (vor 4 Tagen) <Mikhail Glukhikh>
* e0abf3a62cc - [FIR Java] More precise synthetic setter search in use-site scope (vor 4 Tagen) <Mikhail Glukhikh>
* c515af43736 - Fir2IrDeclarationStorage: extract common getIrCallableSymbol (vor 4 Tagen) <Mikhail Glukhikh>
* b90391ced43 - [FIR2IR] Implement getIrConstructorSymbol like getIrFunctionSymbol (vor 4 Tagen) <Mikhail Glukhikh>
* 0cc57fc90cd - Fir2IrDeclarationStorage: reorder functions slightly (vor 4 Tagen) <Mikhail Glukhikh>
* 90f135dc3e8 - [FIR2IR] Use computeDeclarationOrigin in getIrPropertySymbol (vor 4 Tagen) <Mikhail Glukhikh>
* 6c1f5a45135 - [FIR2IR] Cache functions/properties both by symbol & signature (vor 4 Tagen) <Mikhail Glukhikh>
* 92840b8ec5d - FirTypeIntersectionScope: fix typo in name (vor 4 Tagen) <Mikhail Glukhikh>
* 5b947144d4a - FirTypeIntersectionScope: don't create in no-supertypes situation (vor 4 Tagen) <Mikhail Glukhikh>
* 8ace0d9ad14 - [FIR] Replace local types with Any in deserializer (vor 4 Tagen) <Mikhail Glukhikh>
* 744918fb479 - [FIR] Cleanup ConeIntegerLiteralTypeImpl (vor 4 Tagen) <Mikhail Glukhikh>
* 0d03e5f235e - [FIR] Simplify constructStarProjectedType (vor 4 Tagen) <Mikhail Glukhikh>
* af522320582 - [FIR2IR] Use proper lookup tags in data class member generator (vor 4 Tagen) <Mikhail Glukhikh>
* 7905bc86325 - Forbid creation of local ConeClassLikeLookupTagImpl (vor 4 Tagen) <Mikhail Glukhikh>
* 5dc79641372 - (tag: build-1.4.30-dev-2606) Optimize the way of enabling "--warning-mode=fail" (vor 4 Tagen) <Bingran>
* e5539b9a9e4 - (tag: build-1.4.30-dev-2605) Gradle, Native: Log raw and transformed args in KotlinToolRunner, p.2 (vor 4 Tagen) <Dmitriy Dolovov>
* 47676968409 - (tag: build-1.4.30-dev-2603) Qualify replacement expression with receiver to workaround KT-42874 (vor 4 Tagen) <Ilya Gorbunov>
* e0655b2f961 - (tag: build-1.4.30-dev-2599) Unmute fixed android importing tests in platform 202 (vor 4 Tagen) <Andrey Uskov>
* a0d5af8dd17 - Execute gutters calculation in read action in tests (vor 4 Tagen) <Andrey Uskov>
* e5be9601e63 - Disable indexation ExternalSystem tests (vor 4 Tagen) <Andrey Uskov>
* 9318d401f7c - Fix test runtime dependencies in NativeImportingTests (vor 4 Tagen) <Andrey Uskov>
* dea383460eb - Add dependency on platform-images in tests (vor 4 Tagen) <Andrey Uskov>
* 5f7d7ff9c7e - (tag: build-1.4.30-dev-2598) Parcelize: Activate checkers only when the plugin is enabled for module (KT-43291) (vor 4 Tagen) <Yan Zhulanow>
* 9d207c2cf53 - (tag: build-1.4.30-dev-2593) FIR IDE: temporary mute some not passing tests (vor 5 Tagen) <Ilya Kirillov>
* 3e43efb93ea - FIR IDE: fix working with copied file in completion (vor 5 Tagen) <Ilya Kirillov>
* 0d596565324 - FIR IDE: Add resolving KtParameter in FirLazyDeclarationResolver (vor 5 Tagen) <Igor Yakovlev>
* 345a0d3f895 - [FIR] Implement `writeGenericType` in FirJvmTypeMapper (vor 5 Tagen) <Dmitriy Novozhilov>
* 9350f7aff98 - FIR IDE: remove unused method in light classes with compilation error (vor 5 Tagen) <Ilya Kirillov>
* b42bed7b3c3 - FIR IDE: make some access to FIR elements under read locks, resolve under write locks (vor 5 Tagen) <Ilya Kirillov>
* 12ed92cd49c - FIR IDE: allow getting parent declaration for Java one (vor 5 Tagen) <Ilya Kirillov>
* cbd1ec35cef - FIR IDE: lazy resolve property accessors (vor 5 Tagen) <Ilya Kirillov>
* fbc6f1b10f6 - FIR IDE: introduce SOURCE_MEMBER_GENERATED declaration kind (vor 5 Tagen) <Ilya Kirillov>
* 7dcda00e1d0 - FIR IDE: do not fail on invalid code (vor 5 Tagen) <Ilya Kirillov>
* c646cb3d7e5 - FIR IDE: fix deadlock in getter symbol resolve (vor 5 Tagen) <Ilya Kirillov>
* 171157ff784 - FIR IDE: allow reference resolving from EDT (vor 5 Tagen) <Ilya Kirillov>
* b742a475ff4 - [FIR IDE] Initial FIR LightClass implementation (vor 5 Tagen) <Igor Yakovlev>
* c881cf7af66 - [FIR IDE] Add when branch for new symbols in FunctionCallHighlightingVisitor (vor 5 Tagen) <Igor Yakovlev>
* b423da106f0 - [FIR IDE] Add fir data into symbols to support FIR LC (vor 5 Tagen) <Igor Yakovlev>
* 3d935038940 - FIR IDE: introduce analyze function for with by existing module resolve state (vor 5 Tagen) <Ilya Kirillov>
* dbb54c87bcf - [FIR IDE] Add Fir lightclasses tests and fix FindUsages tests (vor 5 Tagen) <Igor Yakovlev>
* 3cefef03fff - Move refactoring for ifTrue and ifFalse extensions (vor 5 Tagen) <Igor Yakovlev>
* a42674ef0e8 - FIR IDE: add hack to allow access symbols on edt (vor 5 Tagen) <Ilya Kirillov>
* 97f062cb2a7 - [FIR IDE] Add FirJvmTypeMapper to Ide components factory (vor 5 Tagen) <Igor Yakovlev>
* 36ffde5ca85 - [FIR] Implement isArrayOrNullableArray for ConeTypeContext (vor 5 Tagen) <Igor Yakovlev>
* 06cb64bb515 - (tag: build-1.4.30-dev-2592) Allow open callable members in expect interfaces (vor 5 Tagen) <sebastian.sellmair>
* bf0156f7c6e - (tag: build-1.4.30-dev-2591) Native, Gradle IT: Fix GeneralNativeIT.testNativeArgsWithSpaces() (vor 5 Tagen) <Dmitriy Dolovov>
* 0fe842c38f4 - Gradle, Native: Log raw and transformed arguments in KotlinToolRunner (vor 5 Tagen) <Dmitriy Dolovov>
* ee7f3b1bfea - Native: Use NIO Files.createTemp*() in favor of File.createTemp*() extension functions (vor 5 Tagen) <Dmitriy Dolovov>
* 47e2656ca94 - (tag: build-1.4.30-dev-2589, tag: build-1.4.30-dev-2584) JVM_IR keep track of original overrides at collection stubs generation (vor 5 Tagen) <Dmitry Petrov>
* 65d8e5a6153 - (tag: build-1.4.30-dev-2580) Don't publish kotlin-dist-for-ide in publishIdeArtifacts as it's now published alone (vor 5 Tagen) <Yan Zhulanow>
* 01f3c06ec94 - (tag: build-1.4.30-dev-2576) Add test for KT-40412 (vor 5 Tagen) <Roman Artemev>
* 116606ecd21 - (tag: build-1.4.30-dev-2564) JVM IR: fix class kind of created java.lang.Deprecated symbol (vor 5 Tagen) <Alexander Udalov>
* c1b73f5feec - (tag: build-1.4.30-dev-2557) [Wasm] Diable Wasm IR tests on Windows TeamCity (vor 5 Tagen) <Svyatoslav Kuzmich>
* 3feff16a774 - Cleanup 193 compatibility fixes (vor 5 Tagen) <Vyacheslav Gerasimov>
* 8620d26a8ab - Delete 193 bunch files (vor 5 Tagen) <Vyacheslav Gerasimov>
* ade46ef8084 - Update Kotlin/Native: 1.4.30-dev-17200 (vor 5 Tagen) <Alexander Gorshenev>
* 3666327c818 - (tag: build-1.4.30-dev-2552) Fix JVM `maven-publish` caching by not capturing state in POM rewriting (vor 5 Tagen) <Sergey Igushkin>
* d1ba2f3d46d - (tag: build-1.4.30-dev-2551) Restore KotlinExplicitMovementProvider in as41 and as42 (vor 5 Tagen) <Sam Wang>
* 4f76c747ec6 - (tag: build-1.4.30-dev-2550) Mark org.jetbrains.kotlin.mavenProjectImportHandler as dynamic (vor 5 Tagen) <Vladimir Dolzhenko>
* b0f6b739d07 - Declare missed org.jetbrains.kotlin.defaultErrorMessages EP (vor 5 Tagen) <Vladimir Dolzhenko>
* 51a1990e504 - Drop missing gradle extensions from jvm-common.xml (vor 5 Tagen) <Vladimir Dolzhenko>
* 0eea3a5e957 - (tag: build-1.4.30-dev-2540) Bump AS version (vor 5 Tagen) <Kirill Shmakov>
* f2f00a46540 - (tag: build-1.4.30-dev-2539) Fix BB test to work on JDK 6 (vor 5 Tagen) <Mikhail Glukhikh>
* 078963eead7 - (tag: build-1.4.30-dev-2538) Native, Gradle IT: Fix assertion message (vor 5 Tagen) <Dmitriy Dolovov>
* fbd8de04b8d - (tag: build-1.4.30-dev-2536) [Gradle, K/N] Configuration cache support for run with warns (vor 5 Tagen) <Alexander Likhachev>
* 2d2042ad12e - [Gradle, K/N] Configuration cache support for compile & link with warns (vor 5 Tagen) <Alexander Likhachev>
* a3b951e505e - (tag: build-1.4.30-dev-2535) [Gradle, Cocoapods] Refactor, log process outputs with `info` level (vor 5 Tagen) <Yaroslav Chernyshev>
* 67b262aa343 - (tag: build-1.4.30-dev-2534) [FIR] Move tracking candidate applicability from CheckerSink to Candidate (vor 5 Tagen) <Dmitriy Novozhilov>
* f1ac1f177b0 - [FIR] Extract overload by lambda return type into separate component (vor 5 Tagen) <Dmitriy Novozhilov>
* a97c107a2b1 - [FIR] Replace callee reference before checking completion from inference session (vor 5 Tagen) <Dmitriy Novozhilov>
* 9f5aadd2f4c - [FIR] Implement overload resolution by lambda return type (vor 5 Tagen) <Dmitriy Novozhilov>
* 025ec8e8b14 - Add `FQ_NAME` postfix to OVERLOAD_RESOLUTION_BY_LAMBDA_ANNOTATION (vor 5 Tagen) <Dmitriy Novozhilov>
* dfad21270f8 - [FIR] Remove workaround for #KT-43129 (vor 5 Tagen) <Dmitriy Novozhilov>
* 1148d527ee4 - (tag: build-1.4.30-dev-2531) Build: Upgradle gradle to 6.7 (vor 5 Tagen) <Vyacheslav Gerasimov>
* 173954b3b3b - (tag: build-1.4.30-dev-2530, tag: build-1.4.30-dev-2527) Add samples for Random.nextX() functions (vor 5 Tagen) <Kris>
* ebdd0236339 - Add samples for last() and lastOrNull() functions (vor 5 Tagen) <Kris>
* e83a3c3f27a - (tag: build-1.4.30-dev-2521) Parcelize: Use @Parcelize annotations from Android Extensions instead of the copied&deprecated ones (KT-42342, KT-43150) (vor 5 Tagen) <Yan Zhulanow>
* fa42a6ba582 - (tag: build-1.4.30-dev-2520) Use non-local return target instead of inline site in suspend function (vor 5 Tagen) <Ilmir Usmanov>
* d4f08018ce5 - (tag: build-1.4.30-dev-2518) [FIR2IR] Extract special symbol provider to make JVM extension (vor 6 Tagen) <Mikhail Glukhikh>
* bc47a30dd38 - [FIR] Handle 'EnhancedNullability' more properly (vor 6 Tagen) <Mikhail Glukhikh>
* e7a84fd1eee - [FIR2IR] Preserve 'EnhancedNullability' type annotation in IR (vor 6 Tagen) <Mikhail Glukhikh>
* f8dc56e2bb5 - FIR render: fix typos on RenderMode (vor 6 Tagen) <Jinseong Jeon>
* f8e03786c0d - Mute not relevant JS/WASM back ends for new BB tests (vor 6 Tagen) <Mikhail Glukhikh>
* 9486f58fb1f - [FIR] fix subtyping for definitely notnull types. (vor 6 Tagen) <Juan Chen>
* eb804709da4 - [FIR] fix subtyping for nullable captured types. (vor 6 Tagen) <Juan Chen>
* d96223a2ffc - (tag: build-1.4.30-dev-2515) Fix compiler warnings in new wasm modules (vor 6 Tagen) <Alexander Udalov>
* 84d13937111 - Minor, workaround compiler exception (KT-43286) (vor 6 Tagen) <Alexander Udalov>
* 202459531d2 - (tag: build-1.4.30-dev-2512) Add support of nullable serializers to UseSerializers annotation (#3898) (vor 6 Tagen) <Sergey Shanshin>
* 66f5c985057 - (tag: build-1.4.30-dev-2508) Deprecate createTempFile/createTempDir functions (vor 6 Tagen) <Ilya Gorbunov>
* 31bfc7d4e36 - (tag: build-1.4.30-dev-2503) Fix test data (vor 6 Tagen) <Georgy Bronnikov>
* 2c404a654bb - JVM_IR: avoid scope violation in BridgeLowering (vor 6 Tagen) <Georgy Bronnikov>
* d246005891d - JVM_IR: fix unbound type parameters in AddContinuationLowering (vor 6 Tagen) <Georgy Bronnikov>
* 9929047f5d4 - JVM_IR: avoid scope violation in BridgeLowering (vor 6 Tagen) <Georgy Bronnikov>
* e10d8e51b6a - (tag: build-1.4.30-dev-2498) JVM_IR more precise superclass stub filtering (vor 6 Tagen) <Dmitry Petrov>
* 7f26deb5e60 - (tag: build-1.4.30-dev-2497) [Wasm] Enable for loops optimization (vor 6 Tagen) <Svyatoslav Kuzmich>
* 233bb47b997 - (tag: build-1.4.30-dev-2488) FIR: Fix SAM conversion for raw types with non-trivial TP upper bounds (vor 6 Tagen) <Denis Zharkov>
* ce4a11144d7 - FIR: Correctly handle nullable/flexible captured types (vor 6 Tagen) <Denis Zharkov>
* ed07bbc7344 - FIR: Fix inner type resolution during body transformation (vor 6 Tagen) <Denis Zharkov>
* a5545b96cb4 - FIR: Fix ambiguity between current Companion and one from supertypes (vor 6 Tagen) <Denis Zharkov>
* 96352b9c8c1 - (tag: build-1.4.30-dev-2487) Add (and disable) metadata compilation for single backend source sets (vor 6 Tagen) <sebastian.sellmair>
* 03e63f1103a - (tag: build-1.4.30-dev-2486) [Wasm] Enable maven-publish plugin in wasm stdlib (vor 6 Tagen) <Svyatoslav Kuzmich>
* ffe3487aa56 - [Wasm] Don't generate unnecessary unreachable instructions (vor 6 Tagen) <Svyatoslav Kuzmich>
* b371b61cf5b - [Wasm] Indent blocks of produced WAT (vor 6 Tagen) <Svyatoslav Kuzmich>
* 4d59a582914 - [Wasm] Add interop annotation @JsFun (vor 6 Tagen) <Svyatoslav Kuzmich>
* e51a76bc4e4 - [Wasm] Basic CLI (vor 6 Tagen) <Svyatoslav Kuzmich>
* 80f316168e3 - (tag: build-1.4.30-dev-2484) Updated IDE perf tests vega visualization to handle wide time ranges with aggregation (vor 6 Tagen) <Vladimir Dolzhenko>
* 297c33b4526 - [IR] Correct line number on suspend function with implicit unit return (vor 6 Tagen) <Kristoffer Andersen>
* c2fec383846 - (tag: build-1.4.30-dev-2472) [JS IR BE] Unmute fixed tests (vor 6 Tagen) <Roman Artemev>
* 94acfa50bd2 - [IR BE] Remap dispatch receiver for inner ctor too (vor 6 Tagen) <Roman Artemev>
* 1ced0138ff2 - [JS IR BE] Drop redundant marker since function doesn't use descriptors anymore. (vor 6 Tagen) <Roman Artemev>
* e66daf90fd1 - (tag: build-1.4.30-dev-2471) Advance bootstrap to 1.4.30-dev-2196 (vor 6 Tagen) <Dmitriy Novozhilov>
* 785466aceeb - (tag: build-1.4.30-dev-2461) Minor: add '// JVM_TARGET: 1.8' (vor 6 Tagen) <Dmitry Petrov>
* 106ee1d1ffd - (tag: build-1.4.30-dev-2453) JVM IR: restore ability to suppress codegen-reported diagnostics (vor 6 Tagen) <Alexander Udalov>
* 61548a0a363 - Fix inspections and slightly "kotlinify" KotlinSuppressCache (vor 6 Tagen) <Alexander Udalov>
* 9d3c9a823d5 - Improve rendering of failures in AbstractWriteFlagsTest (vor 6 Tagen) <Alexander Udalov>
* 0e91d3fcb0a - JVM IR: generate ACC_SYNTHETIC for deprecated-hidden declarations correctly (vor 6 Tagen) <Alexander Udalov>
* d9efc2d9222 - (tag: build-1.4.30-dev-2451) Fix warnings in compiler code and tests (vor 6 Tagen) <Alexander Udalov>
* ebfbc2f6013 - (tag: build-1.4.30-dev-2435) KT-43205 Ignore annotations in `CallableClsStubBuilder` when needed (vor 7 Tagen) <Roman Golyshev>
* fdd7fa5aeaa - (tag: build-1.4.30-dev-2428) [Wasm] Mute codegen box tests (vor 7 Tagen) <Svyatoslav Kuzmich>
* 02a84fa6e18 - [Wasm] Remove wasmBox tests (vor 7 Tagen) <Svyatoslav Kuzmich>
* bfd0f21e9d2 - [Wasm] Major compiler and stdlib update (vor 7 Tagen) <Svyatoslav Kuzmich>
* 3be38d17965 - [Wasm] Add Wasm IR (vor 7 Tagen) <Svyatoslav Kuzmich>
* 65cf991e849 - [JS IR] Move JS-specific isInlineClass utils from common to JS compiler module (vor 7 Tagen) <Svyatoslav Kuzmich>
* e101e6762cb - Add uploading IDE performance benchmarks to ES (vor 7 Tagen) <Vladimir Dolzhenko>
* ff7c38b2dff - Unmuted a test (vor 7 Tagen) <Alexander Gorshenev>
* eea5a9102c4 - Bump klib abi version to 1.4.2 to reflect absence of serialized fake overrides (vor 7 Tagen) <Alexander Gorshenev>
* cb288d47ea5 - Don't serialize fake overrides anymore (vor 7 Tagen) <Alexander Gorshenev>
* 5de7a10df0e - Eliminated -Xdeserialize-fake-overrides (vor 7 Tagen) <Alexander Gorshenev>
* b9c6267a63c - (tag: build-1.4.30-dev-2422) KT-43217 Encode @EnhancedNullability types in IdSignature (vor 7 Tagen) <Dmitry Petrov>
* f6df624c6b1 - (tag: build-1.4.30-dev-2410) KT-43202 Fix isEap function: support RC version (vor 7 Tagen) <Stanislav Erokhin>
* 5e0f54a30b3 - (tag: build-1.4.30-dev-2406) [IR] Fixed https://youtrack.jetbrains.com/issue/KT-43159 (vor 7 Tagen) <Igor Chevdar>