### PR TITLE
[kotlin compiler][update] 1.4.30-dev-3009

### DIFF
--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2Native.kt
@@ -248,7 +248,7 @@ class K2Native : CLICompiler<K2NativeCompilerArguments>() {
                 parseShortModuleName(arguments, configuration, outputKind)?.let {
                     put(SHORT_MODULE_NAME, it)
                 }
-                put(DISABLE_FAKE_OVERRIDE_VALIDATOR, arguments.disableFakeOverrideValidator)
+                put(FAKE_OVERRIDE_VALIDATOR, arguments.fakeOverrideValidator)
                 putIfNotNull(PRE_LINK_CACHES, parsePreLinkCachesValue(configuration, arguments.preLinkCaches))
                 putIfNotNull(OVERRIDE_KONAN_PROPERTIES, parseOverrideKonanProperties(arguments, configuration))
                 put(DESTROY_RUNTIME_MODE, when (arguments.destroyRuntimeMode) {

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -142,9 +142,6 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     )
     var exportedLibraries: Array<String>? = null
 
-    @Argument(value="-Xdisable-fake-override-validator", description = "This option is deprecated")
-    var disableFakeOverrideValidator: Boolean = false
-
     @Argument(value="-Xfake-override-validator", description = "Enable IR fake override validator")
     var fakeOverrideValidator: Boolean = false
 

--- a/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
+++ b/backend.native/cli.bc/src/org/jetbrains/kotlin/cli/bc/K2NativeCompilerArguments.kt
@@ -142,8 +142,11 @@ class K2NativeCompilerArguments : CommonCompilerArguments() {
     )
     var exportedLibraries: Array<String>? = null
 
-    @Argument(value="-Xdisable-fake-override-validator", description = "Disable IR fake override validator")
+    @Argument(value="-Xdisable-fake-override-validator", description = "This option is deprecated")
     var disableFakeOverrideValidator: Boolean = false
+
+    @Argument(value="-Xfake-override-validator", description = "Enable IR fake override validator")
+    var fakeOverrideValidator: Boolean = false
 
     @Argument(
             value = "-Xframework-import-header",

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -187,7 +187,6 @@ internal class SpecialDeclarationsFactory(val context: Context) {
 }
 
 internal class Context(config: KonanConfig) : KonanBackendContext(config) {
-    override val lateinitNullableFields = mutableMapOf<IrField, IrField>()
     lateinit var frontendServices: FrontendServices
     lateinit var environment: KotlinCoreEnvironment
     lateinit var bindingContext: BindingContext

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
@@ -36,8 +36,6 @@ internal abstract class KonanBackendContext(val config: KonanConfig) : CommonBac
 
     abstract override val ir: KonanIr
 
-    override val transformedFunction: MutableMap<IrFunctionSymbol, IrSimpleFunctionSymbol>
-        get() = TODO("not implemented")
     override val scriptMode: Boolean = false
 
     override val sharedVariablesManager by lazy {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanConfigurationKeys.kt
@@ -16,8 +16,8 @@ class KonanConfigKeys {
                 = CompilerConfigurationKey.create("check dependencies and download the missing ones")
         val DEBUG: CompilerConfigurationKey<Boolean>
                 = CompilerConfigurationKey.create("add debug information")
-        val DISABLE_FAKE_OVERRIDE_VALIDATOR: CompilerConfigurationKey<Boolean>
-                = CompilerConfigurationKey.create("disable fake override validator")
+        val FAKE_OVERRIDE_VALIDATOR: CompilerConfigurationKey<Boolean>
+                = CompilerConfigurationKey.create("fake override validator")
         val DISABLED_PHASES: CompilerConfigurationKey<List<String>> 
                 = CompilerConfigurationKey.create("disable backend phases")
         val BITCODE_EMBEDDING_MODE: CompilerConfigurationKey<BitcodeEmbedding.Mode>

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
@@ -175,7 +175,7 @@ internal fun Context.psiToIr(
 
     val modules = if (isProducingLibrary) emptyMap() else (irDeserializer as KonanIrLinker).modules
 
-    if (!config.configuration.getBoolean(KonanConfigKeys.DISABLE_FAKE_OVERRIDE_VALIDATOR)) {
+    if (config.configuration.getBoolean(KonanConfigKeys.FAKE_OVERRIDE_VALIDATOR)) {
         val fakeOverrideChecker = FakeOverrideChecker(KonanManglerIr, KonanManglerDesc)
         modules.values.forEach { fakeOverrideChecker.check(it) }
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
@@ -820,7 +820,7 @@ internal object Devirtualization {
                 val value = fromId.toLong() or (toId.toLong() shl 32)
                 // This is 64-bit extension of a hashing method from Knuth's "The Art of Computer Programming".
                 // The magic constant is the closest prime to 2^64 * phi, where phi is the golden ratio.
-                val bucketIdx = ((value.toULong() * 11400714819323198393UL) % bagOfEdges.size.toUInt()).toInt()
+                val bucketIdx = ((value.toULong() * 11400714819323198393UL) % bagOfEdges.size.toULong()).toInt()
                 val bucket = bagOfEdges[bucketIdx] ?: LongArrayList().also { bagOfEdges[bucketIdx] = it }
                 for (x in bucket)
                     if (x == value) return

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,15 @@ allprojects {
         }
     }
 
+    if (findProperty("kotlin.build.useIR") == "true") {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                useIR = true
+                freeCompilerArgs += ["-Xir-binary-with-stable-abi"]
+            }
+        }
+    }
+
     setupHostAndTarget()
     loadCommandLineProperties()
     loadLocalProperties()

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2687,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-2687
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-2687,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-2687
-kotlinStdlibTestsVersion=1.4.30-dev-2687
-testKotlinCompilerVersion=1.4.30-dev-2687
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-3009,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-3009
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-3009,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-3009
+kotlinStdlibTestsVersion=1.4.30-dev-3009
+testKotlinCompilerVersion=1.4.30-dev-3009
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,5 +42,8 @@ ktorVersion=1.2.1
 shadowVersion=5.1.0
 metadataVersion=0.0.1-dev-10
 
+# Uncomment to compile Kotlin/Native backend modules with JVM IR backend.
+# kotlin.build.useIR=true
+
 # Uncomment to enable composite build
 #kotlinProjectPath=<insert the path to Kotlin project root here>


### PR DESCRIPTION
* 926dc085da4 - (HEAD -> master, tag: build-1.4.30-dev-3009, tag: build-1.4.30-dev-3000, origin/master, origin/HEAD) Fix typo (vor 2 Tagen) <Hollow Man>
* 3351887ae5a - (tag: build-1.4.30-dev-2979) Build: Upgrade GE plugin to 3.5 (vor 3 Tagen) <Vyacheslav Gerasimov>
* dd9c0c5c6e7 - (tag: build-1.4.30-dev-2969) Use separate logic for filtering and skipping in collectAndFilterRealOverrides [KT-43487] (#3921) (vor 3 Tagen) <LepilkinaElena>
* 362775b6b64 - (tag: build-1.4.30-dev-2951) JVM IR: minor, improve exception message (vor 3 Tagen) <Alexander Udalov>
* b495fd542f0 - (tag: build-1.4.30-dev-2949) JVM, JVM_IR: KT-42281 proper array->primitive coercion (vor 3 Tagen) <Dmitry Petrov>
* e59c8e0a5c4 - JVM_IR KT-42137 bridges are not generated for fake overrides (vor 3 Tagen) <Dmitry Petrov>
* 5d5473ef08e - (tag: build-1.4.30-dev-2943) [IR BE] Drop unused context member (vor 3 Tagen) <Roman Artemev>
* 51cff97b782 - [JS IR BE] Drop implicit declaration file (vor 3 Tagen) <Roman Artemev>
* 67604551c5f - (tag: build-1.4.30-dev-2934) FIR: reuse visibility checker when determining immutable property reference (vor 3 Tagen) <Jinseong Jeon>
* 463d53ee5c7 - FIR: handle reference to property with invisible setter (vor 3 Tagen) <Jinseong Jeon>
* b2b2629e794 - (tag: build-1.4.30-dev-2933) Use new kotlin.io.path API in tests (vor 3 Tagen) <Ilya Gorbunov>
* d38e1455298 - Use new kotlin.io.path API in generators (vor 3 Tagen) <Ilya Gorbunov>
* dce3e57685e - Use NIO Files for creating temp files: idea plugin (vor 3 Tagen) <Ilya Gorbunov>
* 090b562db7b - Use NIO Files for creating temp files: scripting, daemon, main-kts (vor 3 Tagen) <Ilya Gorbunov>
* c9bbdf6575a - Use NIO Files for creating temp files: build tools (vor 3 Tagen) <Ilya Gorbunov>
* 30bb7d19c0b - (tag: build-1.4.30-dev-2921) Revert "Build: Temporary disable capturing inputs for tasks" (vor 3 Tagen) <Nikolay Krasko>
* e8af601cea5 - Mute very flaky FirPsiCheckerTestGenerated.Regression.testJet53 (vor 3 Tagen) <Nikolay Krasko>
* 7bfe2c0bbc5 - (tag: build-1.4.30-dev-2917) JVM IR: Update test expectation for testSamAdapterAndInlineOnce (vor 3 Tagen) <Steven Schäfer>
* 8574cb44662 - JVM IR: Don't generate line numbers and null checks in SAM wrapper constructors (vor 3 Tagen) <Steven Schäfer>
* 68e2d0d245c - JVM IR: Generate synthetic final implementation methods in SAM wrappers (vor 3 Tagen) <Steven Schäfer>
* a475fa2a213 - JVM IR: Use raw types in SAM wrappers (vor 3 Tagen) <Steven Schäfer>
* 999151abac2 - JVM IR: Generate SAM wrapper fields as synthetic final (vor 3 Tagen) <Steven Schäfer>
* ec1d42e92bb - JVM IR: Generate SAM wrapper classes as non-synthetic (vor 3 Tagen) <Steven Schäfer>
* 36711a768ba - JVM IR: Use inline SAM wrappers inside of inline lambdas (vor 3 Tagen) <Steven Schäfer>
* f2b8c67962d - (tag: build-1.4.30-dev-2913) Fix JvmTarget6OnJvm11 tests after 7b5544ebd3 (vor 4 Tagen) <Alexander Udalov>
* c22071566e7 - (tag: build-1.4.30-dev-2909) IC mangling: Use old mangling scheme when LV is 1.3 (vor 4 Tagen) <Ilmir Usmanov>
* 7ee35af7213 - IC mangling: Use correct mangling scheme when (vor 4 Tagen) <Ilmir Usmanov>
* 7761d303657 - Minor. Add test to check fallback (vor 4 Tagen) <Ilmir Usmanov>
* 7a18ab90947 - IC mangling: Generate version requirements to properties as well (vor 4 Tagen) <Ilmir Usmanov>
* 0d79ed10776 - Minor. Update test data (vor 4 Tagen) <Ilmir Usmanov>
* 9070d6d581a - IC mangling: Use old mangling scheme in stdlib (vor 4 Tagen) <Ilmir Usmanov>
* 89d45bf909f - IC mangling: Use old mangling scheme in FIR tests (vor 4 Tagen) <Ilmir Usmanov>
* 2cd9016016e - IC mangling: Replace compiler hack with configuration flag (vor 4 Tagen) <Ilmir Usmanov>
* bc1b6fef1fa - IC mangling: Generalize mangling algorithm between two backends (vor 4 Tagen) <Ilmir Usmanov>
* b33774e5f22 - IC mangling: Use empty list as a separator in the new mangling scheme (vor 4 Tagen) <Ilmir Usmanov>
* 20e7a77b789 - IC mangling: Write version 1.4.30 requirement to functions with new mangling (vor 4 Tagen) <Ilmir Usmanov>
* 2829d37cf51 - IC mangling: Use old mangling scheme for stdlib (vor 4 Tagen) <Ilmir Usmanov>
* 488d4ab018c - IC mangling: Use '_' instead of 'x' as a placeholder before hashing (vor 4 Tagen) <Ilmir Usmanov>
* f7164404c9a - IC mangling: Ignore FIR tests (vor 4 Tagen) <Ilmir Usmanov>
* 23184bae054 - IC mangling: JVM_IR: Fallback to old mangling rules (vor 4 Tagen) <Ilmir Usmanov>
* 546eea19826 - IC mangling: Old JVM BE: Fallback to old mangling rules (vor 4 Tagen) <Ilmir Usmanov>
* c62093f54cf - IC mangling: Change mangling rules (vor 4 Tagen) <Ilmir Usmanov>
* d21a01ef599 - (tag: build-1.4.30-dev-2905) IR: improve "no such .. argument slot" exception message (vor 4 Tagen) <Alexander Udalov>
* 8ede19811dc - (tag: build-1.4.30-dev-2897) Make mpp tests gutters aware of different platforms run (vor 4 Tagen) <Kirill Shmakov>
* 0d50ccc42dc - (tag: build-1.4.30-dev-2895) [Commonizer] Fix: Lost nullability in commonized type aliases (vor 4 Tagen) <Dmitriy Dolovov>
* e17158d9612 - (tag: build-1.4.30-dev-2891) JVM_IR KT-42758 don't use 'this' for object self-reference by name (vor 4 Tagen) <Dmitry Petrov>
* 118a7d4e346 - JVM_IR KT-43242 generate switch subject as primitive 'int' (vor 4 Tagen) <Dmitry Petrov>
* 05ddbeab0a8 - (tag: build-1.4.30-dev-2886) KT-42561 [Gradle Runner]: run task is created for extra modules (vor 4 Tagen) <Andrei Klunnyi>
* b0c74c841e7 - (tag: build-1.4.30-dev-2874) Remove extra copyOf calls during filtering in collectRealOverrides (#3916) (vor 4 Tagen) <LepilkinaElena>
* 7b5544ebd3d - (tag: build-1.4.30-dev-2861) Use -source/target 1.6 for Java sources in codegen tests (vor 5 Tagen) <Alexander Udalov>
* 7b4e0b2f5d3 - (tag: build-1.4.30-dev-2857) [JVM_IR] Deal with lowering ordering issues for JvmStatic function references. (vor 5 Tagen) <Mads Ager>
* 3d2f5f4bc14 - (tag: build-1.4.30-dev-2855) KT-42018 explicitly cast inline class values in safe-as (vor 5 Tagen) <Dmitry Petrov>
* edd3b457d4f - (tag: build-1.4.30-dev-2847) [JVM+IR] Migrate/improve receiver mangling test suite (vor 5 Tagen) <Kristoffer Andersen>
* 5967e8295e4 - [IR] Align captured receiver variable naming with old BE (vor 5 Tagen) <Kristoffer Andersen>
* 7732fc38e0b - (tag: build-1.4.30-dev-2842) Add more IDE performance tests vega chart specs (vor 5 Tagen) <Vladimir Dolzhenko>
* bcf6980f673 - (tag: build-1.4.30-dev-2841) [FIR2IR] Fix CCE in FirTypeRef.canBeNull (vor 5 Tagen) <Mikhail Glukhikh>
* 91738b7f88c - (tag: build-1.4.30-dev-2839) [FIR] Fix broken IDE test data (vor 5 Tagen) <Mikhail Glukhikh>
* ca41f733b63 - (tag: build-1.4.30-dev-2835) KT-41841 no delegate to private $default fun in multifile facade (vor 5 Tagen) <Dmitry Petrov>
* 9a99af53ba8 - (tag: build-1.4.30-dev-2827) FIR JVM: correct signature conversion for array (vor 5 Tagen) <Jinseong Jeon>
* 77ce5ea15d1 - FIR Java: handle primitive void return type for synthetic setter (vor 5 Tagen) <Jinseong Jeon>
* 5c61079d75e - FIR: reproduce KT-43339 (Throwable.stackTrace) (vor 5 Tagen) <Jinseong Jeon>
* 4cb32cd38ab - FIR2IR: add implicit NOT_NULL cast for @FlexibleNullability type (vor 5 Tagen) <Jinseong Jeon>
* b658e99f91f - FIR Java: simplify flexible nullability manipulations (vor 5 Tagen) <Mikhail Glukhikh>
* fc7f589caa1 - FIR Java: record Java types with flexible nullability (vor 5 Tagen) <Jinseong Jeon>
* 1f48092ec11 - FIR Java: convert more annotations to @EnhancedNullability (vor 5 Tagen) <Jinseong Jeon>
* 01ef41ab17b - (tag: build-1.4.30-dev-2826) No need to explicitly deprecate -Xdisable-fake-override-validator A warning is produced automagically (vor 5 Tagen) <Alexander Gorshenev>
* f42b902bc8b - Made -Xfake-override-validator off by default Deprected -Xdisable-fake-override-validator (vor 5 Tagen) <Alexander Gorshenev>
* 4e03b1e05f3 - (tag: build-1.4.30-dev-2812) JVM: Allow the JvmSynthetic annotation on file classes (KT-41884) (vor 5 Tagen) <Steven Schäfer>
* 66bc142f920 - (tag: build-1.4.30-dev-2798) [Commonizer] Empty sources/javadocs Jars (vor 6 Tagen) <Dmitriy Dolovov>
* a27c6b77cfd - (tag: build-1.4.30-dev-2795, tag: build-1.4.30-dev-2794) KT-43370 ACC_DEPRECATED on property accessors implemented by delegation (vor 6 Tagen) <Dmitry Petrov>
* 986bdd1099b - Build: replace usages of `kotlin.build.useIR` with `kotlinBuildProperties.useIR` (vor 6 Tagen) <Dmitriy Novozhilov>
* c625a83ab5d - Build: replace usages of `idea.fir.plugin` with `kotlinBuildProperties.useFirIdeaPlugin` (vor 6 Tagen) <Dmitriy Novozhilov>
* 1a3727a17c2 - Build: advance kotlin-build-gradle-plugin version in build files (vor 6 Tagen) <Dmitriy Novozhilov>
* f531612aa49 - Build: update kotlin-build-gradle-plugin version (vor 6 Tagen) <Dmitriy Novozhilov>
* bab08c29bed - Build: add several FIR flags to kotlin-build-gradle-plugin (vor 6 Tagen) <Dmitriy Novozhilov>
* 8160f579d34 - Build: add useIR/useIRForLibraries to kotlin-build-gradle-plugin (vor 6 Tagen) <Alexander Udalov>
* e331e80b5db - (tag: build-1.4.30-dev-2785) Build: Temporary disable capturing inputs for tasks (vor 6 Tagen) <Nikolay Krasko>
* 33a0ec9b4f4 - (tag: build-1.4.30-dev-2765) KGP: Clean up configurations setup (vor 6 Tagen) <Ivan Gavrilovic>
* 519aeeb644b - KT-40140: Task configuration avoidance for Android projects (vor 6 Tagen) <Ivan Gavrilovic>
* d376585821b - IDE dependencies: Publish kotlin-coroutines-experimental-compat library (vor 6 Tagen) <Yan Zhulanow>
* d7474bb2f79 - (tag: build-1.4.30-dev-2753) Build: Use only @Exported & whitelisted classes for tools.jar api (vor 6 Tagen) <Vyacheslav Gerasimov>
* ac851523d84 - (tag: build-1.4.30-dev-2750) [Gradle, MPP] Make KotlinCompileCommon task cc-compatible with warnings (vor 6 Tagen) <Alexander Likhachev>
* c6f46598cab - (tag: build-1.4.30-dev-2740) Set TARGET_BACKEND to JVM for failing irrelevant tests (vor 6 Tagen) <Denis Zharkov>
* 68fdeaf865f - (tag: build-1.4.30-dev-2738) Produce deterministic jar files. (vor 7 Tagen) <Martin Petrov>
* a3830b26115 - (tag: build-1.4.30-dev-2736) JVM IR: copy corresponding property+annotations for DefaultImpls methods (vor 7 Tagen) <Alexander Udalov>
* 5212ae6bbde - JVM IR: keep property annotations for inline class replacements (vor 7 Tagen) <Alexander Udalov>
* 4ca60a2d7da - Fix warnings and some inspections in buildSrc (vor 7 Tagen) <Alexander Udalov>
* 22109e97d65 - (tag: build-1.4.30-dev-2717) FIR: Unmute passing FirPsiCheckerTestGenerated.testJet53 (vor 7 Tagen) <Denis Zharkov>
* 14305d1eba6 - FIR: Simplify callable references resolution (vor 7 Tagen) <Denis Zharkov>
* 387fd895a66 - FIR: Drop unused FirComposedSuperTypeRef (vor 7 Tagen) <Denis Zharkov>
* ad35723f56d - FIR: Simplify super-qualified calls resolution (vor 7 Tagen) <Denis Zharkov>
* d4c7d4fc7ce - FIR: Fix callable references resolution with stub receivers (vor 7 Tagen) <Denis Zharkov>
* f97cc0b62d8 - FIR: Rework receivers processing in resolution (vor 7 Tagen) <Denis Zharkov>
* e2099a03077 - FIR: Fix false-positive successful resolution of call with lambda receiver (vor 7 Tagen) <Denis Zharkov>
* 396e799e5d1 - FIR: Fix resolution for type-alias based SAM (vor 7 Tagen) <Denis Zharkov>
* 4c9a4548f2b - FIR: Fix overrides binding for Java inheritor (vor 7 Tagen) <Denis Zharkov>
* 855af08f7c1 - Regenerate tests (vor 7 Tagen) <Denis Zharkov>
* 4f7b45dfccd - (tag: build-1.4.30-dev-2715) Fir2IrTypeConverter: simplify captured type cache (vor 7 Tagen) <Mikhail Glukhikh>
* cb77b76c0dd - FIR2IR: convert recursive captured type properly (vor 7 Tagen) <Jinseong Jeon>
* 8ecf0569277 - (tag: build-1.4.30-dev-2713) [FIR2IR] Enter scope a bit earlier in createIrPropertyAccessor (vor 7 Tagen) <Mikhail Glukhikh>
* 59c86bcdc4d - [FIR2IR] Provide more information for errors inside convertToIrSetCall (vor 7 Tagen) <Mikhail Glukhikh>
* 9de244515e4 - (tag: build-1.4.30-dev-2711) Upgrade coroutines: 1.3.7 -> 1.3.8 (vor 7 Tagen) <Mikhail Glukhikh>
* 93f868fb96d - (tag: build-1.4.30-dev-2710) KT-43196 member extension property can't be "primary" in inline class (vor 7 Tagen) <Dmitry Petrov>
* b6f958f8560 - (tag: build-1.4.30-dev-2700) Do not queue bg task under read action (vor 7 Tagen) <Vladimir Dolzhenko>