### PR TITLE
Make isHidden and isAssignable explicit on IrValueParameters.

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
@@ -87,7 +87,9 @@ internal val Context.getBoxFunction: (IrClass) -> IrSimpleFunction by Context.la
                     varargElementType = null,
                     isCrossinline = false,
                     type = parameterType,
-                    isNoinline = false
+                    isNoinline = false,
+                    isHidden = false,
+                    isAssignable = false
             ).apply {
                 it.bind(this)
                 parent = function
@@ -142,7 +144,9 @@ internal val Context.getUnboxFunction: (IrClass) -> IrSimpleFunction by Context.
                     varargElementType = null,
                     isCrossinline = false,
                     type = parameterType,
-                    isNoinline = false
+                    isNoinline = false,
+                    isHidden = false,
+                    isAssignable = false
             ).apply {
                 it.bind(this)
                 parent = function

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -213,7 +213,8 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                                         SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, invokeFunctionOrigin,
                                         IrValueParameterSymbolImpl(it), it.name, it.index,
                                         functionClass.typeParameters[it.index].defaultType, null,
-                                        it.isCrossinline, it.isNoinline
+                                        it.isCrossinline, it.isNoinline,
+                                        isHidden = false, isAssignable = false
                                 ).also { it.parent = this }
                             }
                             if (!isFakeOverride)
@@ -271,7 +272,9 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                 toIrType(descriptor.type),
                 varargType?.let { toIrType(it) },
                 descriptor.isCrossinline,
-                descriptor.isNoinline
+                descriptor.isNoinline,
+                isHidden = false,
+                isAssignable = false
         ).also {
             it.parent = this
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
@@ -55,7 +55,9 @@ internal fun makeEntryPoint(context: Context): IrFunction {
                     varargElementType = null,
                     isCrossinline = false,
                     type = context.irBuiltIns.arrayClass.typeWith(context.irBuiltIns.stringType),
-                    isNoinline = false
+                    isNoinline = false,
+                    isHidden = false,
+                    isAssignable = false
             ).apply {
                 it.bind(this)
                 parent = function

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -1142,7 +1142,11 @@ private class ObjCBlockPointerValuePassing(
                 Name.identifier("blockPointer"),
                 0,
                 symbols.nativePtrType,
-                varargElementType = null, isCrossinline = false, isNoinline = false
+                varargElementType = null,
+                isCrossinline = false,
+                isNoinline = false,
+                isHidden = false,
+                isAssignable = false
         )
         constructorParameterDescriptor.bind(constructorParameter)
         constructor.valueParameters += constructorParameter
@@ -1187,7 +1191,11 @@ private class ObjCBlockPointerValuePassing(
                     Name.identifier("p$index"),
                     index,
                     functionType.arguments[index].typeOrNull!!,
-                    varargElementType = null, isCrossinline = false, isNoinline = false
+                    varargElementType = null,
+                    isCrossinline = false,
+                    isNoinline = false,
+                    isHidden = false,
+                    isAssignable = false
             )
             parameterDescriptor.bind(parameter)
             parameter.parent = invokeMethod

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -87,7 +87,11 @@ internal class KotlinBridgeBuilder(
                 bridge.startOffset, bridge.endOffset, bridge.origin,
                 IrValueParameterSymbolImpl(descriptor),
                 Name.identifier("p$index"), index, type,
-                null, false, false
+                null,
+                isCrossinline = false,
+                isNoinline = false,
+                isHidden = false,
+                isAssignable = false
         ).apply {
             descriptor.bind(this)
             parent = bridge

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -104,6 +104,7 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                                 varargElementType = null,
                                 isCrossinline = arg.isCrossinline,
                                 isNoinline = arg.isNoinline,
+                                isHidden = arg.isHidden,
                                 isAssignable = arg.isAssignable
                         ).apply { it.bind(this) }
                     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -141,7 +141,9 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
                                 type,
                                 varargElementType = null,
                                 isCrossinline = false,
-                                isNoinline = false
+                                isNoinline = false,
+                                isHidden = false,
+                                isAssignable = false
                         ).apply {
                             it.bind(this)
                             parent = loweredConstructor

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -356,7 +356,9 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
                         type,
                         varargElementType = null,
                         isCrossinline = false,
-                        isNoinline = false
+                        isNoinline = false,
+                        isHidden = false,
+                        isAssignable = false
                 ).apply {
                     it.bind(this)
                     parent = newFunction

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -374,7 +374,8 @@ fun IrValueParameter.copy(newDescriptor: ParameterDescriptor): IrValueParameter 
     return IrValueParameterImpl(
         startOffset, endOffset, IrDeclarationOrigin.DEFINED, IrValueParameterSymbolImpl(newDescriptor),
         newDescriptor.name, newDescriptor.indexOrMinusOne, type, varargElementType,
-        newDescriptor.isCrossinline, newDescriptor.isNoinline
+        newDescriptor.isCrossinline, newDescriptor.isNoinline,
+        isHidden = false, isAssignable = false
     )
 }
 


### PR DESCRIPTION
This make native compatible with change to remove default arguments
for these in the kotlin repo where they were confused.