### PR TITLE
kotlin compiler][update] 1.4.30-dev-3308 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-3009,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-3009
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-3009,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-3009
-kotlinStdlibTestsVersion=1.4.30-dev-3009
-testKotlinCompilerVersion=1.4.30-dev-3009
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-3308,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.4.30-dev-3308
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-3308,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.4.30-dev-3308
+kotlinStdlibTestsVersion=1.4.30-dev-3308
+testKotlinCompilerVersion=1.4.30-dev-3308
 konanVersion=1.4.30
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/KotlinNativePlatformPlugin.kt
+++ b/tools/kotlin-native-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/konan/KotlinNativePlatformPlugin.kt
@@ -13,8 +13,6 @@ open class KotlinNativePlatformPlugin: KotlinPlatformImplementationPluginBase("n
     private val Project.konanMultiplatformTasks: Collection<KonanCompileTask>
         get() = tasks.withType(KonanCompileTask::class.java).filter { it.enableMultiplatform }
 
-    override fun configurationsForCommonModuleDependency(project: Project) = emptyList<Configuration>()
-
     open class RequestedCommonSourceSet @Inject constructor(private val name: String): Named {
         override fun getName() = name
     }


### PR DESCRIPTION
* 0634351fbcb - (HEAD -> master, tag: build-1.4.30-dev-3308, origin/master, origin/HEAD) Introduce pathString/absolute/absolutePathString (vor 18 Stunden) <Ilya Gorbunov>
* 84f5a294f77 - Allow passing null parent directory to createTempFile/Directory (vor 18 Stunden) <Ilya Gorbunov>
* 64d85f259c0 - Relax writeText/appendText parameter type to CharSequence (vor 18 Stunden) <Ilya Gorbunov>
* 2ee8bf7dde1 - (tag: build-1.4.30-dev-3302, origin/rr/demiurg906/platform-switch) Add fastutil dependency for 202 and higher platforms (vor 2 Tagen) <Pavel Punegov>
* f668e906cc2 - Build: unmute passed tests (vor 2 Tagen) <Dmitriy Novozhilov>
* e7d305b97ab - Build: mute failing stepping tests (vor 2 Tagen) <Dmitriy Novozhilov>
* 78c786de46e - Build: Mute failing goto declaration tests (vor 2 Tagen) <Dmitriy Novozhilov>
* 33b545aea78 - Build: Mute failing gradle import with android tests (vor 2 Tagen) <Dmitriy Novozhilov>
* 85c59328c7e - [DEBUGGER] Temporary mute AbstractKotlinEvaluateExpressionTest (vor 2 Tagen) <Dmitriy Novozhilov>
* 3d33ea7da8e - Use absolute paths to locate existed projects to open in AbstractConfigureKotlinTest (vor 2 Tagen) <Vladimir Dolzhenko>
* 124888eb438 - Revert back AddFunctionParametersFix test data output for 201- (vor 2 Tagen) <Vladimir Dolzhenko>
* e251a9be14a - Build: fix finding layout-api jar in parcelize box test due to platform change (vor 2 Tagen) <Dmitriy Novozhilov>
* cc1a0bf6d75 - [FE] Update testdata (vor 2 Tagen) <Dmitriy Novozhilov>
* 17e6e88176c - Fixed AddFunctionParametersFix test data output (vor 2 Tagen) <Vladimir Dolzhenko>
* 406e863a73e - [FE] Fix creating location of compiler errors in CLI (vor 2 Tagen) <Dmitriy Novozhilov>
* dc364b8be48 - Remove useless @author comment (vor 2 Tagen) <Dmitriy Novozhilov>
* 95e5ea48406 - temporary ignore/disable tests (vor 2 Tagen) <Vladimir Dolzhenko>
* 02f71a63b8f - [FE] Disable `SKIP_DEBUG` flag when building java model from binaries (vor 2 Tagen) <Dmitriy Novozhilov>
* bf1abed2467 - Build: add shadowing processor for core.xml in embeddable compiler (vor 2 Tagen) <Dmitriy Novozhilov>
* ad953b6285a - Build: remove redundant bunch TODO's (vor 2 Tagen) <Dmitriy Novozhilov>
* 986ab9cb548 - Build: remove useless .as40 files (vor 2 Tagen) <Dmitriy Novozhilov>
* 1b559fe6761 - Don't set KOTLIN_BUNDLED in unit tests (vor 2 Tagen) <Dmitriy Novozhilov>
* 7396abf5a4b - Build: add fastutil dependency to scripting tests (vor 2 Tagen) <Dmitriy Novozhilov>
* 5ab9710cc5a - Remove `./local` directory from CodeConformanceTest (vor 2 Tagen) <Dmitriy Novozhilov>
* d3ef0eb5193 - Build: register missing TreeAspect service in KtParsingTestCase (vor 2 Tagen) <Dmitriy Novozhilov>
* 68719831ee1 - Build: update asm version in kotlinp (vor 2 Tagen) <Dmitriy Novozhilov>
* dc35a130086 - Build: remove useless bunch files (vor 2 Tagen) <Dmitriy Novozhilov>
* 46fcc7d59df - Build: fix registration of `ClassFileDecompilers` extension (vor 2 Tagen) <Dmitriy Novozhilov>
* 48cbb74a017 - Build: drop deprecated extension point used in test of old j2k (vor 2 Tagen) <Dmitriy Novozhilov>
* d887814cc52 - Build: fix compilation of :libraries:tools:kotlin-maven-plugin-test (vor 2 Tagen) <Dmitriy Novozhilov>
* 4779092ba5d - Build: fix API differences between 201 and 202 in idea performance tests (vor 2 Tagen) <Dmitriy Novozhilov>
* 2a053c214d7 - Build: fix API differences between 201 and 202 in scratch tests (vor 2 Tagen) <Dmitriy Novozhilov>
* d50d56f68c3 - Build: fix API differences between 201 and 202 in NewKotlinFileAction (vor 2 Tagen) <Dmitriy Novozhilov>
* e4e28a54953 - Build: update grovy dependencies in :compiler:tests-spec (vor 2 Tagen) <Dmitriy Novozhilov>
* 07dd9179e8c - Build: change 202 platform version (vor 2 Tagen) <Dmitriy Novozhilov>
* eeb9b3214c2 - Switch to 202 platform (vor 2 Tagen) <Dmitriy Novozhilov>
* 89bba936156 - (tag: build-1.4.30-dev-3300) Introduce GetScriptingClassByClassLoader interface (vor 2 Tagen) <Ilya Muradyan>
* 65ce7cd0c20 - Fix path for Windows in Fibonacci test (vor 2 Tagen) <Ilya Muradyan>
* 78e607c6b0d - (tag: build-1.4.30-dev-3294) Value classes: Support @JvmName annotation on functions with inline (vor 2 Tagen) <Ilmir Usmanov>
* 871912f257d - (tag: build-1.4.30-dev-3289) Value Classes: Increase BINARY_STUB_VERSION after decompiler changes (vor 2 Tagen) <Ilmir Usmanov>
* 05c4dfef3d0 - Value classes: Use 'value' keyword instead of 'inline' in stub dumps (vor 2 Tagen) <Ilmir Usmanov>
* 9b9c43b7028 - Value classes: Change relevant diagnostic to say 'value class' (vor 2 Tagen) <Ilmir Usmanov>
* ca3e7cf1a72 - Value classes: Report lacking @JvmInline only on JVM backend (vor 2 Tagen) <Ilmir Usmanov>
* 92f1681de0e - Value classes: treat @JvmInline value classes as inline classes (vor 2 Tagen) <Ilmir Usmanov>
* 6c68660ffd1 - Value classes: Render 'value' before class (vor 2 Tagen) <Ilmir Usmanov>
* f158411f9a2 - Value classes: Increase JVM metadata version to distinguish (vor 2 Tagen) <Ilmir Usmanov>
* 361ed117bb4 - Value classes: Add isValue property to class descriptors (vor 2 Tagen) <Ilmir Usmanov>
* 8eff3a6bb33 - Value classes: Increase stub version due to changes in the parser (vor 2 Tagen) <Ilmir Usmanov>
* 11b2a07a597 - Value classes: Support 'value' modifier in parser (vor 2 Tagen) <Ilmir Usmanov>
* d5979ffdedb - (tag: build-1.4.30-dev-3286) FIR IDE: add tests for checking module invalidation (vor 2 Tagen) <Ilya Kirillov>
* 2fb4a917f69 - FIR IDE: fix module invalidation algorithm (vor 2 Tagen) <Ilya Kirillov>
* 519f1549f0a - FIR IDE: separate logic of TestProjectStructure from AbstractFirMultiModuleLazyResolveTest (vor 2 Tagen) <Ilya Kirillov>
* 3515cd546d4 - FIR IDE: use PersistentMap to store FromModuleViewSessionCache mappings (vor 2 Tagen) <Ilya Kirillov>
* 76c0dc7dba6 - (tag: build-1.4.30-dev-3278) FIR IDE: add property support for incremental analysis (vor 3 Tagen) <Ilya Kirillov>
* 953dba808b7 - FIR IDE: move withFirDeclaration to LowLevelFirApiFacade (vor 3 Tagen) <Ilya Kirillov>
* b4d63b9b139 - FIR IDE: add docs for LowLevelFirApiFacade functions (vor 3 Tagen) <Ilya Kirillov>
* 93648e6cd3d - FIR IDE: use mor specific exception in EntityWasGarbageCollectedException (vor 3 Tagen) <Ilya Kirillov>
* 65a7ee50124 - FIR IDE: remove duplicating withFirResolvedToBodyResolve (vor 3 Tagen) <Ilya Kirillov>
* 3141fead0d7 - FIR IDE: get rid of LowLevelFirApiFacade object (vor 3 Tagen) <Ilya Kirillov>
* a206eca1642 - (tag: build-1.4.30-dev-3272) JVM_IR KT-43611 report signature clash on private interface members (vor 3 Tagen) <Dmitry Petrov>
* fd935b7c54d - (tag: build-1.4.30-dev-3270) [TEST] Move generated js compiler tests to `test-gen` directories (vor 3 Tagen) <Dmitriy Novozhilov>
* 77ed51b3ab7 - (tag: build-1.4.30-dev-3266) [JS IR] Add message for for enabling option for overwriting reachable nodes (vor 3 Tagen) <Ilya Goncharov>
* 908732b3c1e - (tag: build-1.4.30-dev-3257, tag: build-1.4.30-dev-3254) [TEST] Move generated visualizer tests to `test-gen` directories (vor 3 Tagen) <Dmitriy Novozhilov>
* eca769f8e44 - [TEST] Move generated fir tests to `test-gen` directories (vor 3 Tagen) <Dmitriy Novozhilov>
* 1ee38286a85 - [TEST] Move generated compiler tests to `test-gen` directory (vor 3 Tagen) <Dmitriy Novozhilov>
* 524419a2fe4 - (tag: build-1.4.30-dev-3240) IC Mangling: Use new mangling scheme for range tests (vor 3 Tagen) <Ilmir Usmanov>
* 6381d97aabd - JVM_IR: compute classId on IR structures (vor 3 Tagen) <Georgy Bronnikov>
* ee1e05fedd9 - (tag: build-1.4.30-dev-3225) KT-42151 fix type arguments in local class constructor reference types (vor 4 Tagen) <Dmitry Petrov>
* b2b8562f923 - (tag: build-1.4.30-dev-3221) Properly extract JVM version in kapt (vor 4 Tagen) <Mikhael Bogdanov>
* 9ed5b8f870e - (tag: build-1.4.30-dev-3220) IC & Coroutines: Do not box suspend operator fun invoke receiver (vor 4 Tagen) <Ilmir Usmanov>
* 4e334217a8e - IC & Coroutines: Unbox inline class parameter of suspend lambda (vor 4 Tagen) <Ilmir Usmanov>
* eba260f6813 - IC & Coroutines: Unbox inline classes of suspend lambdas (vor 4 Tagen) <Ilmir Usmanov>
* 0a0b5b5d2be - (tag: build-1.4.30-dev-3218) [FIR DFA] Don't consider anonymous object as stable initializer to bind (vor 4 Tagen) <Mikhail Glukhikh>
* 1dc897346ca - [FIR] Fix WRONG_IMPLIES_CONDITION problem in DFA model (vor 4 Tagen) <Mikhail Glukhikh>
* 7fd96f5773e - (tag: build-1.4.30-dev-3211) Fix annotation spelling in docs (vor 4 Tagen) <Ilya Gorbunov>
* db9f301eed9 - [FE] Make DiagnosticFactory.name not null (vor 4 Tagen) <Dmitriy Novozhilov>
* 94ce56bfdc4 - (tag: build-1.4.30-dev-3199, tag: build-1.4.30-dev-3189, origin/master-for-ide) Minor. Add words to project dictionary (vor 4 Tagen) <Dmitriy Dolovov>
* c7412844583 - [Commonizer] Stricter processing of forward declarations (vor 4 Tagen) <Dmitriy Dolovov>
* eca231a01d5 - [Commonizer] Extract CIR classifiers cache from the root node (vor 4 Tagen) <Dmitriy Dolovov>
* 8d9abed3dcc - [Commonizer] Minor. More specific upper bounds for CirNodeWithClassId (vor 4 Tagen) <Dmitriy Dolovov>
* d4b0bf4ad89 - (tag: build-1.4.30-dev-3184) [FIR] Make DEFAULT positioning strategy public, drop duplicated one (vor 4 Tagen) <Mikhail Glukhikh>
* 97c1a3f270d - Simplify FirSupertypeInitializedWithoutPrimaryConstructor checker (vor 4 Tagen) <Mikhail Glukhikh>
* bf2b318beec - Simplify FirSupertypeInitializedInInterfaceChecker (vor 4 Tagen) <Mikhail Glukhikh>
* 12726cd366d - FIR light builder: use type reference node as FirTypeRef source (vor 4 Tagen) <Mikhail Glukhikh>
* d5f17ea41c2 - Simplify FirDelegationInInterfaceChecker (vor 4 Tagen) <Mikhail Glukhikh>
* b673996586a - Simplify source operations in FirAnnotationArgumentChecker (vor 4 Tagen) <Mikhail Glukhikh>
* 1c71e64f58a - [FIR] Create string interpolating call even for single argument (vor 4 Tagen) <Mikhail Glukhikh>
* 915a66f4fa4 - [FIR] Introduce & use "multiplexing" SourceElementPositioningStrategy (vor 4 Tagen) <Mikhail Glukhikh>
* f3334b03c4f - FIR checkers: simplify FirSupertypeInitializedWithoutPrimaryConstructor (vor 4 Tagen) <Mikhail Glukhikh>
* 58301d8820f - FIR exposed visibility checkers: use positioning strategy (vor 4 Tagen) <Mikhail Glukhikh>
* f095a33970a - FIR checkers: extract getChildren(), simplify findSuperTypeDelegation() (vor 4 Tagen) <Mikhail Glukhikh>
* 1e3621a896b - FIR checkers: simplify hasPrimaryConstructor by source element check (vor 4 Tagen) <Mikhail Glukhikh>
* 0838ab7fe72 - FIR checkers: simplify hasVal / hasVar source element checks (vor 4 Tagen) <Mikhail Glukhikh>
* c6b703b5985 - Simplify LighterASTNode.toFirLightSourceElement (vor 4 Tagen) <Mikhail Glukhikh>
* 037c5050695 - Unbind general FirDiagnostic from PsiFile & PsiElement (vor 4 Tagen) <Mikhail Glukhikh>
* 68b748e1645 - Rename DebugInfoUtil.java to DebugInfoUtil.kt, same with AnalyzingUtils (vor 4 Tagen) <Mikhail Glukhikh>
* 6f8947dd048 - Extract UnboundDiagnostic, DiagnosticFactory/Renderer to frontend-common (vor 4 Tagen) <Mikhail Glukhikh>
* 52a07e31c7e - [FIR] Remove D_I_EXPRESSION_TYPE from qualified calls in spec test data (vor 4 Tagen) <Mikhail Glukhikh>
* 558ac1678ec - Create FIR fake source element for checked safe call subject (vor 4 Tagen) <Mikhail Glukhikh>
* 2592eed0e7f - [FIR TEST] More precise control of source kind in createDebugInfo (vor 4 Tagen) <Mikhail Glukhikh>
* 82c5cefba90 - Update test data in FIR diagnostic spec tests (vor 4 Tagen) <Mikhail Glukhikh>
* e7e162c7eb6 - [FIR TEST] Filter some particular tokens during createDebugInfo (vor 4 Tagen) <Mikhail Glukhikh>
* c602ccb33ef - Create FIR fake source element for vararg argument expression (vor 4 Tagen) <Mikhail Glukhikh>
* fa3f8055738 - Support FirDiagnostic.isValid properly (vor 4 Tagen) <Mikhail Glukhikh>
* c7ae176ae43 - [FIR] Inherit FIR with parameter renderer from the old parameter renderer (vor 4 Tagen) <Mikhail Glukhikh>
* 3dec848c037 - [FIR] Implement light tree DECLARATION_NAME & SIGNATURE strategies (vor 4 Tagen) <Mikhail Glukhikh>
* 42c59f7383c - [FIR] Enhance light tree DEFAULT strategy for objects to cover header only (vor 4 Tagen) <Mikhail Glukhikh>
* d844b33b1c5 - [FIR] Implement light tree CONSTRUCTOR_DELEGATION_CALL strategy (vor 4 Tagen) <Mikhail Glukhikh>
* 8320a2966ac - [FIR] Implement light tree VAL_VAR strategy as an example (vor 4 Tagen) <Mikhail Glukhikh>
* 1795c4f3e57 - Implement common Diagnostic(Factory/Renderer) in related FIR classes (vor 4 Tagen) <Mikhail Glukhikh>
* d47e16331c1 - Convert DiagnosticFactory.java to Kotlin (vor 4 Tagen) <Mikhail Glukhikh>
* 84f3a4ba9d7 - Rename DiagnosticFactory.java to DiagnosticFactory.kt (vor 4 Tagen) <Mikhail Glukhikh>
* 9040999b55a - Convert Diagnostic.java to Kotlin (vor 4 Tagen) <Mikhail Glukhikh>
* b6cfcc6cada - Rename Diagnostic.java to Diagnostic.kt (vor 4 Tagen) <Mikhail Glukhikh>
* d942780c14f - [FIR] Introduce LightTreePositioningStrategy (vor 4 Tagen) <Mikhail Glukhikh>
* 1cb2aeaeff1 - FirSourceElement: introduce common 'treeStructure' property (vor 4 Tagen) <Mikhail Glukhikh>
* 3a2b15521b9 - FirSourceElement: introduce common 'lighterASTNode' property (vor 4 Tagen) <Mikhail Glukhikh>
* 6abd6561168 - (tag: build-1.4.30-dev-3169) [IR] dumpKotlinLike: update testdata after rebase (vor 5 Tagen) <Zalim Bashorov>
* 0d5a0b207e1 - [IR] KotlinLikeDumper: add a note about some conventions used for TODO comments (vor 5 Tagen) <Zalim Bashorov>
* c0042695473 - [IR] KotlinLikeDumper: unify and add more comments for the cases when used a syntax which is invalid in Kotlin (vor 5 Tagen) <Zalim Bashorov>
* 5a755054f8d - [IR] dumpKotlinLike: add a comment about some conventions which could be unclear (vor 5 Tagen) <Zalim Bashorov>
* 69f0f4ef190 - [IR] update testdata: unify printing custom/non-standard modifiers (vor 5 Tagen) <Zalim Bashorov>
* 90fdfbde68d - [IR] KotlinLikeDumper: unify printing custom/non-standard modifiers (vor 5 Tagen) <Zalim Bashorov>
* 57cb8f97e99 - [IR] update testdata: don't use "D" suffix on double constants (vor 5 Tagen) <Zalim Bashorov>
* 73771a35134 - [IR] KotlinLikeDumper: don't use "D" suffix on double constants (vor 5 Tagen) <Zalim Bashorov>
* 7df6575a183 - [IR] update testdata: unify representation for error nodes (vor 5 Tagen) <Zalim Bashorov>
* ef9a9016355 - [IR] KotlinLikeDumper: unify representation for error nodes (vor 5 Tagen) <Zalim Bashorov>
* f8690d0395c - [IR] KotlinLikeDumper: minor, collapse an `if` to helper function and add few more todos (vor 5 Tagen) <Zalim Bashorov>
* c68040753d9 - [IR] dumpKotlinLike: add testdata for FIR tests (vor 5 Tagen) <Zalim Bashorov>
* d7bd4240e1a - [IR] dumpKotlinLike: don't crash when type argument is null (vor 5 Tagen) <Zalim Bashorov>
* dec067af8cb - [IR] stop overwriting testdata for dumpKotlinLike and use assertEqualsToFile (vor 5 Tagen) <Zalim Bashorov>
* 43ee50b91d4 - [IR] update testdata after rebase (vor 5 Tagen) <Zalim Bashorov>
* 2773e4baca0 - [IR] KotlinLikeDumper.kt -> dumpKotlinLike.kt (vor 5 Tagen) <Zalim Bashorov>
* 36591ba5f73 - [IR] KotlinLikeDumper: replace all usages of commentBlockH with commentBlock (vor 5 Tagen) <Zalim Bashorov>
* ad0f154ed1f - [IR] add new testdata after rebase (vor 5 Tagen) <Zalim Bashorov>
* f9fe82e735d - [IR] KotlinLikeDumper: process specially when IrElseBranch's condition is not `true` constant (vor 5 Tagen) <Zalim Bashorov>
* 503370c9c2f - [IR] update testdata: escape special symbols in Char and String constant values (vor 5 Tagen) <Zalim Bashorov>
* 0f10b5eb9e4 - [IR] KotlinLikeDumper: escape special symbols in Char and String constant values (vor 5 Tagen) <Zalim Bashorov>
* 92dda5cd92e - [IR] KotlinLikeDumper.kt: cleanup (vor 5 Tagen) <Zalim Bashorov>
* 5b0efe2b64c - [IR] KotlinLikeDumper: rearrange methods (vor 5 Tagen) <Zalim Bashorov>
* d9dbc01c3ec - [IR] KotlinLikeDumper: `p.print("")` -> `p.printIndent()` (vor 5 Tagen) <Zalim Bashorov>
* c7d9b7adbe9 - [IR] KotlinLikeDumper: rearrange methods (vor 5 Tagen) <Zalim Bashorov>
* 76e959ef8c6 - [IR] KotlinLikeDumper: minor, update some comments (vor 5 Tagen) <Zalim Bashorov>
* e94528fe0d6 - [IR] update testdata: print class name for callable references without receivers (vor 5 Tagen) <Zalim Bashorov>
* b6e37c1f89d - [IR] KotlinLikeDumper: print class name for callable references without receivers (vor 5 Tagen) <Zalim Bashorov>
* 2dbd784a6a8 - [IR] update testdata: print `else -> ...` (vor 5 Tagen) <Zalim Bashorov>
* 14dabed85a5 - [IR] KotlinLikeDumper.kt: move branch support to corresponding visit* methods (vor 5 Tagen) <Zalim Bashorov>
* 8f155c23a0c - [IR] update testdata: better support for callable references (vor 5 Tagen) <Zalim Bashorov>
* 0d3d61862ba - [IR] KotlinLikeDumper: better support for callable references (vor 5 Tagen) <Zalim Bashorov>
* 87eb06a21f1 - [IR] update testdata: improve annotations rendering in case when argument was not provided and there is default value (vor 5 Tagen) <Zalim Bashorov>
* a34a311e86b - [IR] update testdata: support annotations on parameters (vor 5 Tagen) <Zalim Bashorov>
* 182cb52bdba - [IR] KotlinLikeDumper: various changes for value and type params (vor 5 Tagen) <Zalim Bashorov>
* 5cb2572c60d - [IR] update testdata: better support for enum and object accesses (vor 5 Tagen) <Zalim Bashorov>
* 1fd12b7b8a2 - [IR] KotlinLikeDumper: better support for enum and object accesses (vor 5 Tagen) <Zalim Bashorov>
* 635cb44bf37 - [IR] update testdata: support IrDynamic* nodes (vor 5 Tagen) <Zalim Bashorov>
* 82839e6a671 - [IR] KotlinLikeDumper: support IrDynamic* nodes (vor 5 Tagen) <Zalim Bashorov>
* cdc74304c7e - [IR] add testdata for irJsText (vor 5 Tagen) <Zalim Bashorov>
* 68b17fe55b0 - [IR] KotlinLikeDumper: add more visit* to implement (vor 5 Tagen) <Zalim Bashorov>
* 4fb762e019c - [IR] update testdata: minor updates for error nodes (vor 5 Tagen) <Zalim Bashorov>
* b129788823b - [IR] KotlinLikeDumper: minor updates for error nodes (vor 5 Tagen) <Zalim Bashorov>
* a128cdc99c0 - [IR] KotlinLikeDumper: add more TODOs and remove some obsolete ones (vor 5 Tagen) <Zalim Bashorov>
* bf207205902 - [IR] KotlinLikeDumper: reformat (vor 5 Tagen) <Zalim Bashorov>
* ad5df79e396 - [IR] KotlinLikeDumper: merge Break & Continue (vor 5 Tagen) <Zalim Bashorov>
* 64b42401a1d - [IR] update testdata: print a parameter in catch (vor 5 Tagen) <Zalim Bashorov>
* 2775c89ebb8 - [IR] KotlinLikeDumper: print a parameter in catch (vor 5 Tagen) <Zalim Bashorov>
* 5c8a93c7ff5 - [IR] update testdata: support labels on loops, break & continue (vor 5 Tagen) <Zalim Bashorov>
* 9daa86c1a2c - [IR] KotlinLikeDumper: support labels on loops, break & continue (vor 5 Tagen) <Zalim Bashorov>
* 21da2b0350a - [IR] update testdata: print whole string concatenation at one line (vor 5 Tagen) <Zalim Bashorov>
* 91c9d9d25c6 - [IR] KotlinLikeDumper: print whole string concatenation at one line (vor 5 Tagen) <Zalim Bashorov>
* a6b408978f5 - [IR] update testdata: super and receiver for field accesses (vor 5 Tagen) <Zalim Bashorov>
* 029ee6f2e79 - [IR] KotlinLikeDumper: super and receiver on field accesses (vor 5 Tagen) <Zalim Bashorov>
* 0bf587ad4b5 - [IR] KotlinLikeDumper: deduplicate code between IrDelegatingConstructorCall and  IrEnumConstructorCall (vor 5 Tagen) <Zalim Bashorov>
* e56787c0b00 - [IR] update testdata: IrInstanceInitializerCall (vor 5 Tagen) <Zalim Bashorov>
* 26dd0097136 - [IR] KotlinLikeDumper: change rendering for IrInstanceInitializerCall (vor 5 Tagen) <Zalim Bashorov>
* ab8188b032a - [IR] update testdata: removed extra indentation for function expressions (vor 5 Tagen) <Zalim Bashorov>
* cf5ba824539 - [IR] KotlinLikeDumper: don't indent function expressions (vor 5 Tagen) <Zalim Bashorov>
* 5500b014f53 - [IR] update testdata: better support for IrEnumConstructorCall and IrEnumEntry (vor 5 Tagen) <Zalim Bashorov>
* 602f0ddbc86 - [IR] update testdata after using maxBlankLines=1 for Printer (vor 5 Tagen) <Zalim Bashorov>
* 6e318893f65 - [IR] KotlinLikeDumper: support for IrEnumConstructorCall and better rendering for IrEnumEntry (vor 5 Tagen) <Zalim Bashorov>
* b518c19b385 - [IR] update testdata: support for IrDelegatingConstructorCall (vor 5 Tagen) <Zalim Bashorov>
* 84d6e435907 - [IR] update testdata: print arguments for annotations (vor 5 Tagen) <Zalim Bashorov>
* 2a19dc32f29 - [IR] update testdata: better support for IrConstructorCall (vor 5 Tagen) <Zalim Bashorov>
* 197f5ca885a - [IR] update testdata: better support for IrCall (vor 5 Tagen) <Zalim Bashorov>
* ef2adfa835d - [IR] KotlinLikeDumper: better support for calls and annotations (vor 5 Tagen) <Zalim Bashorov>
* fc5c674c609 - [IR] update testdata (vor 5 Tagen) <Zalim Bashorov>
* 6a1ab1b325e - [IR] KotlinLikeDumper: WIP (vor 5 Tagen) <Zalim Bashorov>
* 0294ff4f106 - [IR] add TODO to RenderIrElement (vor 5 Tagen) <Zalim Bashorov>
* a5b224fda18 - [IR] add new testdata after rebase (vor 5 Tagen) <Zalim Bashorov>
* 3b1a6389ab2 - [IR] update testdata after rebase (vor 5 Tagen) <Zalim Bashorov>
* 1c6c996084a - [IR] KotlinLikeDumper: fixes after rebase (vor 5 Tagen) <Zalim Bashorov>
* 7abd09ce96c - [IR] initial version of dumpKotlinLike (vor 5 Tagen) <Zalim Bashorov>
* 8d5facb15f5 - [IR] add testdata for dumpKotlinLike (vor 5 Tagen) <Zalim Bashorov>
* d2022ab115f - [IR] hack AbstractIrTextTestCase to test dumpKotlinLike (vor 5 Tagen) <Zalim Bashorov>
* 6241f9be2db - (tag: build-1.4.30-dev-3165) Build: Fix ide plugin maven artifacts publication (vor 5 Tagen) <Vyacheslav Gerasimov>
* 8f187f328ad - (tag: build-1.4.30-dev-3162) Switch ASM artifact (vor 5 Tagen) <Mikhael Bogdanov>
* b5143ba2ab3 - (tag: build-1.4.30-dev-3161) Optimize check for missing fields in deserialization (#3862) (vor 5 Tagen) <Sergey Shanshin>
* f9503efb74a - (tag: build-1.4.30-dev-3159) [JS IR] Make WITH_RUNTIME imply KJS_WITH_FULL_RUNTIME (vor 5 Tagen) <Svyatoslav Kuzmich>
* b0ebb02b6fe - (tag: build-1.4.30-dev-3158) Fix more deprecated configurations and disable fail mode for some tests (vor 5 Tagen) <Bingran>
* 858f73124dd - Update settings script properly, more tests with warning-mode=fail (vor 5 Tagen) <Bingran>
* 52c22d891f9 - MPP plugin: add expectedBy deps to "api" configuration (vor 5 Tagen) <Bingran>
* 4bf63a95395 - Sort class members to ensure deterministic builds (vor 5 Tagen) <Hung Nguyen>
* 07a797cc3a7 - (tag: build-1.4.30-dev-3155) [IR] Fixed bug with type parameters of referenced constructor (vor 5 Tagen) <Igor Chevdar>
* c90546104e5 - (tag: build-1.4.30-dev-3149) Uast: partial fix for reified functions resolve (#3923, KT-41279) (vor 5 Tagen) <Kevin Bierhoff>
* 7cc6204d6bf - (tag: build-1.4.30-dev-3144) Minor: update testData (vor 5 Tagen) <Dmitry Petrov>
* e5dce9f994c - KT-42933 inline class backing field can't be static (vor 5 Tagen) <Dmitry Petrov>
* f6abc5c3cf2 - KT-43286 use JVM 1.8 intrinsics for coercible unsigned values only (vor 5 Tagen) <Dmitry Petrov>
* 498047e64e8 - KT-43562 don't remap static inline class funs as special builtins (vor 5 Tagen) <Dmitry Petrov>
* f6c73720895 - (tag: build-1.4.30-dev-3141) Fix serializing properties with custom accessors (#3907) (vor 5 Tagen) <Sergey Shanshin>
* 7327c202006 - (tag: build-1.4.30-dev-3140) FIR: add a resolution mode for property delegates (vor 5 Tagen) <pyos>
* 0a5b899aab5 - FIR: more comprehensive substitution of stub types after builder inference (vor 5 Tagen) <Jinseong Jeon>
* 30c97e6cb46 - FIR: update unsubstituted return types in builder (vor 5 Tagen) <Jinseong Jeon>
* d58e5b1d95a - Remove unnecessary semi-colons (vor 5 Tagen) <Jinseong Jeon>
* a0dd62f8c58 - Remove unnecessary expression (vor 5 Tagen) <Jinseong Jeon>
* dfc5059d6b0 - FIR: reproduce KT-43340 (vor 5 Tagen) <Jinseong Jeon>
* c13650fd791 - (tag: build-1.4.30-dev-3131) KT-43511 [Gradle Runner]: run task is not created for top level modules (vor 5 Tagen) <Andrei Klunnyi>
* 25a631a1ca8 - (tag: build-1.4.30-dev-3125) Improved IDE performance tests vega specs (vor 5 Tagen) <Vladimir Dolzhenko>
* dcdd69d039b - (tag: build-1.4.30-dev-3123) Invalidate caches before resolve in AbstractPerformanceHighlightingTest (vor 5 Tagen) <Ilya Kirillov>
* 04846ca47a3 - (tag: build-1.4.30-dev-3122) Rework checking constraints by presented `OnlyInputTypes` annotation in accordance with changed incorporation mechanism (vor 5 Tagen) <Victor Petukhov>
* 0857b9c9e75 - Rethink constraints incorporation (vor 5 Tagen) <Victor Petukhov>
* 616e40f8799 - Reuse equality constraints during simplification in adding constraints (vor 5 Tagen) <Victor Petukhov>
* aabe7090790 - (tag: build-1.4.30-dev-3116) Value classes: Add @JvmInline annotation to stdlib (vor 5 Tagen) <Ilmir Usmanov>
* a7100134a0b - (tag: build-1.4.30-dev-3111) Don't mark testJsTestOutputFileInProjectWithAndroid as flaky in 202 (vor 6 Tagen) <Andrey Uskov>
* ee40b3a4a4b - (tag: build-1.4.30-dev-3109) Drop redundant fields around AbstractFir2IrLazyFunction (vor 6 Tagen) <Mikhail Glukhikh>
* fda5ee7d06e - Fir2IrLazyPropertyAccessor: make inline iff FIR accessor is inline (vor 6 Tagen) <Mikhail Glukhikh>
* d27a0c91f67 - Extract AbstractFir2IrLazyFunction (base for accessor & simple function) (vor 6 Tagen) <Mikhail Glukhikh>
* c03fa59a63f - Introduce Fir2IrLazyPropertyAccessor (vor 6 Tagen) <Mikhail Glukhikh>
* 71179326237 - JVM IR: handle JvmStatic in object as module phase (vor 6 Tagen) <Alexander Udalov>
* 0a00cbefaf7 - JVM IR: minor, refactor replaceThisByStaticReference (vor 6 Tagen) <Alexander Udalov>
* ebb545a9fbf - (tag: build-1.4.30-dev-3106) Split ChangeLog file to files by major releases (vor 6 Tagen) <Margarita Bobova>
* 71d3d8bffc1 - Add ChangeLog for 1.4.20 (vor 6 Tagen) <Margarita Bobova>
* b1c355e7eb9 - Directly search in IrClass for declarations to fill bodies with plugin (vor 6 Tagen) <Leonid Startsev>
* 5efefabb93b - (tag: build-1.4.30-dev-3102) [JS IR] webpackConfigAppliers as internal to not break Gradle lambda serialization in some cases (vor 6 Tagen) <Ilya Goncharov>
* 42a9d64578a - (tag: build-1.4.30-dev-3098) Track binary output class names (vor 6 Tagen) <Mikhael Bogdanov>
* 6748560184f - Proper support of aggregated processors (vor 6 Tagen) <Mikhael Bogdanov>
* f382a55b17b - (tag: build-1.4.30-dev-3095) [JS IR] Add EXPECTED_REACHABLE_NODES for JS tests of external tail args (vor 6 Tagen) <Ilya Goncharov>
* 176071b7db8 - Add support of nullable serializers to UseSerializers annotation (#3906) (vor 6 Tagen) <Sergey Shanshin>
* 6c7247cbd35 - (tag: build-1.4.30-dev-3092) syncKotlinAndAndroidSourceSets: Don't register Kotlin source dirs in Android java source dirs (vor 6 Tagen) <sebastian.sellmair>
* 2286498d8d9 - Share defaultSourceFolder logic between syncKotlinAndAndroidSourceSets.kt and KotlinSourceSetFactory.kt (vor 6 Tagen) <sebastian.sellmair>
* 7c7eada452d - Add comment about unsupported associate compilations to functionalTest source files (vor 6 Tagen) <sebastian.sellmair>
* 3f98e2974ce - Expand AndroidSourceSet#kotlinSourceSet to AndroidSourceSet#kotlinSourceSetOrNull (vor 6 Tagen) <sebastian.sellmair>
* 3e5cbf324de - syncKotlinAndAndroidSourceSets.kt: Cover flavors with tests (vor 6 Tagen) <sebastian.sellmair>
* cdfbbca5807 - Also register `shaders` for kotlin source sets (vor 6 Tagen) <sebastian.sellmair>
* 2c325c45e29 - Register Kotlin MPP source sets in AGP (vor 6 Tagen) <sellmair>
* 3a166f35926 - (tag: build-1.4.30-dev-3088) KT-43525 forbid @JvmOverloads on mangled funs and hidden constructors (vor 6 Tagen) <Dmitry Petrov>
* ca78261d7f4 - (tag: build-1.4.30-dev-3080) Minor, fix "unknown -Xstring-concat mode" error message (vor 6 Tagen) <Alexander Udalov>
* ed481add084 - Fix performance regression in KotlinSuppressCache.isSuppressedByAnnotated (vor 6 Tagen) <Alexander Udalov>
* efee3ea6485 - (tag: build-1.4.30-dev-3076) [JS IR] - Remove file lowering declarations from lowering phases (vor 6 Tagen) <Ilya Goncharov>
* 1b5ebd83de9 - [JS IR] Lazy initialisation is optional for tests (vor 6 Tagen) <Ilya Goncharov>
* a2d41b86bf5 - [JS IR] Add compiler argument about lazy initialisation (vor 6 Tagen) <Ilya Goncharov>
* fcb3ee5e45b - [JS IR]Add check on pureness to not calculate fields to expression twice (vor 6 Tagen) <Ilya Goncharov>
* aa0f9dc1e20 - [JS IR] Don't target exact wasm backend (vor 6 Tagen) <Ilya Goncharov>
* c224394dfce - [JS IR] Return with createdOn hack (vor 6 Tagen) <Ilya Goncharov>
* 8b4d42e70a1 - [JS IR] Add initialisation call for functions in method (vor 6 Tagen) <Ilya Goncharov>
* 06b276f9c30 - [JS IR] Migrate on body lowering pass and declaration transformer (vor 6 Tagen) <Ilya Goncharov>
* 99d07402344 - [JS IR] Ignore JS_IR backend in top level side effect properties (vor 6 Tagen) <Ilya Goncharov>
* d6bc309c940 - [JS IR] Eager initialisation for all pure properties (vor 6 Tagen) <Ilya Goncharov>
* 3da9761f379 - [JS IR] Add test on lazy initialisation (vor 6 Tagen) <Ilya Goncharov>
* f4c1e523388 - [JS IR] Continuation parameter in main through accessor (vor 6 Tagen) <Ilya Goncharov>
* 34ee146148b - [JS IR] Internal visibility for init fun (vor 6 Tagen) <Ilya Goncharov>
* 07b6ef65a3f - [JS IR] Init delegated properties as usual (vor 6 Tagen) <Ilya Goncharov>
* 841118a64d4 - [JS IR] Add init properties call to top level functions (vor 6 Tagen) <Ilya Goncharov>
* 5746a7c4fc8 - [JS IR] Only consider top level properties (vor 6 Tagen) <Ilya Goncharov>
* 0dc4f51d744 - [JS IR] Add init function call into first step of property accessor (vor 6 Tagen) <Ilya Goncharov>
* 71bfed32532 - [JS IR] From searcher get only properties, mutate in lowering (vor 6 Tagen) <Ilya Goncharov>
* 42e1a3280bd - [JS IR] Add guard into init properties function (vor 6 Tagen) <Ilya Goncharov>
* d752b7439e4 - [JS IR] Add init function for properties (vor 6 Tagen) <Ilya Goncharov>
* 003ea4bcdf6 - (tag: build-1.4.30-dev-3070) [Gradle, MPP] Make metadata jar task cc-compatible with warnings (vor 6 Tagen) <Alexander Likhachev>
* 3282e092d8c - (tag: build-1.4.30-dev-3058) [JS] Don't fail on recursive upper bounds while resolving JsExports (vor 7 Tagen) <Shagen Ogandzhanian>
* f9a032dbfac - (tag: build-1.4.30-dev-3053) FIR2IR: add AnnotationGenerator to Fir2IrComponents (vor 7 Tagen) <Jinseong Jeon>
* eff4cec3e08 - FIR2IR: convert annotations on delegated members (vor 7 Tagen) <Jinseong Jeon>
* d9800746242 - FIR: deserialize the `fun interface` flag (vor 7 Tagen) <pyos>
* 20c7c4881d3 - FIR: fix @JvmPackageName (vor 7 Tagen) <pyos>
* 2d4e9af2893 - (tag: build-1.4.30-dev-3046) [JS IR] Throw exception if test class or test method has explicit parameter (vor 7 Tagen) <Shagen Ogandzhanian>
* c4a8d1c3a19 - (tag: build-1.4.30-dev-3044) FIR: use java functional interface as a source of sam function call (vor 7 Tagen) <Ilya Kirillov>
* 7b1eef136ee - FIR IDE: introduce KtFirCollectionLiteralReference (vor 7 Tagen) <Ilya Kirillov>
* bac5ebcb120 - FIR IDE: use custom thread local value for storing KtFirScopeProvider (vor 7 Tagen) <Ilya Kirillov>
* b31def0bae3 - FIR IDE: invalidate analysis session on project roots change (vor 7 Tagen) <Ilya Kirillov>
* be95d067f36 - FIR IDE: add KotlinOutOfBlockPsiTreeChangePreprocessor (vor 7 Tagen) <Ilya Kirillov>
* 7a86ca632d8 - FIR IDE: fix collecting diagnostics for anonymous object declaration (vor 7 Tagen) <Ilya Kirillov>
* 7061608567e - FIR IDE: introduce common function to mute tests (vor 7 Tagen) <Ilya Kirillov>
* e4d2e38ea20 - FIR IDE: fix reference resolving of qualified expression with nested classes (vor 7 Tagen) <Ilya Kirillov>
* 164f4d14d71 - FIR IDE: do not collect diagnostics for generated declarations (vor 7 Tagen) <Ilya Kirillov>
* 60cc30286ca - FIR IDE: update file structure testdata after structure elements classes rename (vor 7 Tagen) <Ilya Kirillov>
* 75990f7619c - FIR IDE: fix tesdata (vor 7 Tagen) <Ilya Kirillov>
* 73206202857 - FIR IDE: add local visibility to symbols (vor 7 Tagen) <Ilya Kirillov>
* 5fdcc4bb83d - FIR IDE: refactor KotlinFirModificationTrackerService (vor 7 Tagen) <Ilya Kirillov>
* 112f6771eb2 - FIR IDE: fix compilation (vor 7 Tagen) <Ilya Kirillov>
* 65b5e4b62be - FIR IDE: make some session components to be non-thread local (vor 7 Tagen) <Ilya Kirillov>
* c3caa3a137f - FIR IDE: clean AbstractFirReferenceResolveTest (vor 7 Tagen) <Ilya Kirillov>
* 3174eb4b097 - FIR IDE: do not get ktDeclaration for FirFile (vor 7 Tagen) <Ilya Kirillov>
* ff7857a8123 - FIR IDE: refactor, simplify structure element class names (vor 7 Tagen) <Ilya Kirillov>
* 15277c09749 - FIR IDE: introduce memory leak checking in symbols test (vor 7 Tagen) <Ilya Kirillov>
* 11e94c1de1c - FIR IDE: fix building of local declaration symbols (vor 7 Tagen) <Ilya Kirillov>
* e78e26234bd - FIR IDE: do not store cone session in every KtFirType (vor 7 Tagen) <Ilya Kirillov>
* e54d16e7e44 - FIR IDE: fix fir declaration leak in symbols (vor 7 Tagen) <Ilya Kirillov>
* b01ee163d11 - FIR IDE: wrap KotlinDeserializedJvmSymbolsProvider into thread safe cache (vor 7 Tagen) <Ilya Kirillov>
* 911662bc2f6 - FIR IDE: introduce out of block modification tracker tests (vor 7 Tagen) <Ilya Kirillov>
* da7b12f7e10 - FIR IDE: introduce ProjectWideOutOfBlockKotlinModificationTrackerTest (vor 7 Tagen) <Ilya Kirillov>
* 880e76b203e - FIR IDE: introduce FIR IDE specific out of block modification tracker (vor 7 Tagen) <Ilya Kirillov>
* 6c1faec1716 - FIR IDE: introduce file structure tests (vor 7 Tagen) <Ilya Kirillov>
* 7c912cd3e46 - FIR IDE: introduce FileElementFactory (vor 7 Tagen) <Ilya Kirillov>
* 315629c99be - FIR IDE: refactor lock provider (vor 7 Tagen) <Ilya Kirillov>
* 559b07d78aa - FIR IDE: fix memory leak in scope provider (vor 7 Tagen) <Ilya Kirillov>
* 64895fe7da1 - (tag: build-1.4.30-dev-3035) [JS IR] Test with js specific moved to `js.translator` (vor 7 Tagen) <Ilya Goncharov>
* fe3030c4329 - [JS IR] Drop last null arguments in calls of external functions (vor 7 Tagen) <Ilya Goncharov>
* 5c731c6c04c - [JS IR] Add test in external js fun with default args (vor 7 Tagen) <Ilya Goncharov>
* 8eb2ae18dcb - (tag: build-1.4.30-dev-3030) FIR checker: refactor EventOccurrencesRange accumulation (vor 7 Tagen) <Jinseong Jeon>
* b9d3578a866 - FIR checker: refactor ControlFlowInfos whose key is EdgeLabel (vor 7 Tagen) <Jinseong Jeon>
* b6a4c279a4a - FIR checker: refactor ControlFlowInfos whose value is EventOccurrencesRange (vor 7 Tagen) <Jinseong Jeon>
* cf8f5b0912e - FIR checker: make calls effect analyzer path-sensitive (vor 7 Tagen) <Jinseong Jeon>
* 26626795796 - (tag: build-1.4.30-dev-3022) KT-43399 properly erase extension receiver type in property$annotations (vor 7 Tagen) <Dmitry Petrov>
* 551d0c1b64e - JVM_IR KT-43440 private-to-this default interface funs are private (vor 7 Tagen) <Dmitry Petrov>
* bf7fdcda6e6 - KT-42909 fix missing loop variable in 'withIndex' ranges (vor 7 Tagen) <Dmitry Petrov>
* a9c9406a554 - [Gradle, K/N] Set LIBCLANG_DISABLE_CRASH_RECOVERY=1 for cinterop (vor 7 Tagen) <Ilya Matveev>
* 37197a95cdf - Update ReadMe.md (vor 7 Tagen) <Alexander Anisimov>
* 18612c1ef08 - (tag: build-1.4.30-dev-3019) [JVM+IR] Rebase LVT test of destructuing in lambda params (vor 7 Tagen) <Kristoffer Andersen>
* ccc272c49f4 - (tag: build-1.4.30-dev-3015) KT-43489: KGP - Avoid storing build history mapping in a property (vor 7 Tagen) <Ivan Gavrilovic>
* 2c28e6556b8 - (tag: build-1.4.30-dev-3012) Add JetBrains to the first part of text (vor 7 Tagen) <Alexander Anisimov>