### PR TITLE
Fix path in gitchurn project

### DIFF
--- a/INTEROP.md
+++ b/INTEROP.md
@@ -36,7 +36,7 @@ Install libgit2 and prepare stubs for the git library:
 ```bash
 
 cd samples/gitchurn
-../../dist/bin/cinterop -def src/main/c_interop/libgit2.def \
+../../dist/bin/cinterop -def src/nativeInterop/cinterop/libgit2.def \
  -compiler-option -I/usr/local/include -o libgit2
 ```
 
@@ -47,7 +47,7 @@ Compile the client:
 <div class="sample" markdown="1" theme="idea" mode="shell">
 
 ```bash
-../../dist/bin/kotlinc src/main/kotlin \
+../../dist/bin/kotlinc src/gitChurnMain/kotlin \
  -library libgit2 -o GitChurn
 ```
 


### PR DESCRIPTION
Fixed path according to actual project directory:
https://github.com/JetBrains/kotlin-native/tree/master/samples/gitchurn/src/