### PR TITLE
[kotlin compiler][update] 1.5.0-dev-156

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
@@ -87,7 +87,9 @@ internal val Context.getBoxFunction: (IrClass) -> IrSimpleFunction by Context.la
                     varargElementType = null,
                     isCrossinline = false,
                     type = parameterType,
-                    isNoinline = false
+                    isNoinline = false,
+                    isHidden = false,
+                    isAssignable = false
             ).apply {
                 it.bind(this)
                 parent = function
@@ -142,7 +144,9 @@ internal val Context.getUnboxFunction: (IrClass) -> IrSimpleFunction by Context.
                     varargElementType = null,
                     isCrossinline = false,
                     type = parameterType,
-                    isNoinline = false
+                    isNoinline = false,
+                    isHidden = false,
+                    isAssignable = false
             ).apply {
                 it.bind(this)
                 parent = function

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -213,7 +213,7 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                                         SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, invokeFunctionOrigin,
                                         IrValueParameterSymbolImpl(it), it.name, it.index,
                                         functionClass.typeParameters[it.index].defaultType, null,
-                                        it.isCrossinline, it.isNoinline
+                                        it.isCrossinline, it.isNoinline, false, false
                                 ).also { it.parent = this }
                             }
                             if (!isFakeOverride)
@@ -271,7 +271,9 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                 toIrType(descriptor.type),
                 varargType?.let { toIrType(it) },
                 descriptor.isCrossinline,
-                descriptor.isNoinline
+                descriptor.isNoinline,
+            false,
+            false
         ).also {
             it.parent = this
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
@@ -55,7 +55,9 @@ internal fun makeEntryPoint(context: Context): IrFunction {
                     varargElementType = null,
                     isCrossinline = false,
                     type = context.irBuiltIns.arrayClass.typeWith(context.irBuiltIns.stringType),
-                    isNoinline = false
+                    isNoinline = false,
+                    isAssignable = false,
+                    isHidden = false
             ).apply {
                 it.bind(this)
                 parent = function

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -1142,7 +1142,7 @@ private class ObjCBlockPointerValuePassing(
                 Name.identifier("blockPointer"),
                 0,
                 symbols.nativePtrType,
-                varargElementType = null, isCrossinline = false, isNoinline = false
+                varargElementType = null, isCrossinline = false, isNoinline = false, isHidden = false, isAssignable = false
         )
         constructorParameterDescriptor.bind(constructorParameter)
         constructor.valueParameters += constructorParameter
@@ -1187,7 +1187,8 @@ private class ObjCBlockPointerValuePassing(
                     Name.identifier("p$index"),
                     index,
                     functionType.arguments[index].typeOrNull!!,
-                    varargElementType = null, isCrossinline = false, isNoinline = false
+                    varargElementType = null, isCrossinline = false, isNoinline = false,
+                    isHidden = false, isAssignable = false
             )
             parameterDescriptor.bind(parameter)
             parameter.parent = invokeMethod

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -87,7 +87,7 @@ internal class KotlinBridgeBuilder(
                 bridge.startOffset, bridge.endOffset, bridge.origin,
                 IrValueParameterSymbolImpl(descriptor),
                 Name.identifier("p$index"), index, type,
-                null, false, false
+                null, false, false, false, false
         ).apply {
             descriptor.bind(this)
             parent = bridge

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -104,7 +104,8 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                                 varargElementType = null,
                                 isCrossinline = arg.isCrossinline,
                                 isNoinline = arg.isNoinline,
-                                isAssignable = arg.isAssignable
+                                isAssignable = arg.isAssignable,
+                                isHidden = arg.isHidden
                         ).apply { it.bind(this) }
                     }
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -141,7 +141,9 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
                                 type,
                                 varargElementType = null,
                                 isCrossinline = false,
-                                isNoinline = false
+                                isNoinline = false,
+                                isHidden = false,
+                                isAssignable = false
                         ).apply {
                             it.bind(this)
                             parent = loweredConstructor

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InteropLowering.kt
@@ -356,7 +356,9 @@ private class InteropLoweringPart1(val context: Context) : BaseInteropIrTransfor
                         type,
                         varargElementType = null,
                         isCrossinline = false,
-                        isNoinline = false
+                        isNoinline = false,
+                        isHidden = false,
+                        isAssignable = false
                 ).apply {
                     it.bind(this)
                     parent = newFunction

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -374,7 +374,7 @@ fun IrValueParameter.copy(newDescriptor: ParameterDescriptor): IrValueParameter 
     return IrValueParameterImpl(
         startOffset, endOffset, IrDeclarationOrigin.DEFINED, IrValueParameterSymbolImpl(newDescriptor),
         newDescriptor.name, newDescriptor.indexOrMinusOne, type, varargElementType,
-        newDescriptor.isCrossinline, newDescriptor.isNoinline
+        newDescriptor.isCrossinline, newDescriptor.isNoinline, false, false
     )
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-3308,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.4.30-dev-3308
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.30-dev-3308,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.4.30-dev-3308
-kotlinStdlibTestsVersion=1.4.30-dev-3308
-testKotlinCompilerVersion=1.4.30-dev-3308
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-156,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.0-dev-156
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-156,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.0-dev-156
+kotlinStdlibTestsVersion=1.5.0-dev-156
+testKotlinCompilerVersion=1.5.0-dev-156
 konanVersion=1.5.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 5f91f79382e - (HEAD -> master, tag: build-1.5.0-dev-156, origin/master, origin/HEAD) Remove usage of idea file systems for checking js libraries (vor 35 Stunden) <Nikolay Krasko>
* c959ad7911f - (tag: build-1.5.0-dev-155) FIR checker: revisit per-label iterations to avoid !! (vor 2 Tagen) <Jinseong Jeon>
* 762e315ce39 - FIR checker: deprecate path-insensitive data collection (vor 2 Tagen) <Jinseong Jeon>
* 168503573ab - FIR checker: make unused checker path-sensitive (vor 2 Tagen) <Jinseong Jeon>
* 3d7d87ace5e - FIR: keep nullability of lambda return type (vor 2 Tagen) <Jinseong Jeon>
* 28a1d1ceac7 - (tag: build-1.5.0-dev-152) Disable test on Windows (vor 2 Tagen) <Mikhael Bogdanov>
* c87edc44f38 - (tag: build-1.5.0-dev-148) Fix compilation error in :noarg-ide-plugin (vor 2 Tagen) <Alexander Udalov>
* 69be56d0424 - (tag: build-1.5.0-dev-143) Value classes: Forbid cloneable value classes (vor 2 Tagen) <Ilmir Usmanov>
* 25c228297a6 - (tag: build-1.5.0-dev-142) JVM IR: support noarg compiler plugin (vor 2 Tagen) <Alexander Udalov>
* a06bffc4b97 - Noarg: prohibit noarg for inner and local classes (vor 2 Tagen) <Alexander Udalov>
* a343fffe9ea - Noarg: somewhat refactor tests (vor 2 Tagen) <Alexander Udalov>
* b10e2061449 - IR: minor, deduplicate unbound symbol in error message (vor 2 Tagen) <Alexander Udalov>
* bf4f2605d4b - (tag: build-1.5.0-dev-137) Mark FirPsiCheckerTestGenerated.Regression.testJet53 as FLAKY (vor 3 Tagen) <Nikolay Krasko>
* 7354bcbc991 - (tag: build-1.5.0-dev-136) Build: Publish kotlin-compiler-internal-test-framework maven artifact (vor 3 Tagen) <Vyacheslav Gerasimov>
* 5d9e86863a3 - (tag: build-1.5.0-dev-135) [IR] Make isHidden and isAssignable explicit on IrValueParameter. (vor 3 Tagen) <Mads Ager>
* 3dbe02b7fe6 - (tag: build-1.5.0-dev-134) JVM_IR KT-43109 generate internal bridge for custom internal 'toArray' (vor 3 Tagen) <Dmitry Petrov>
* 149bcc2d22e - (tag: build-1.5.0-dev-129) Revert using regex Pattern in String.replace (vor 3 Tagen) <Ilya Gorbunov>
* 5167d69b7ce - (tag: build-1.5.0-dev-125) FIR checker: introduce member property checker (vor 3 Tagen) <Jinseong Jeon>
* 2bf22caeb7c - (tag: build-1.5.0-dev-123) Revert "Keep application environment alive between JPS tests" (vor 3 Tagen) <Nikolay Krasko>
* 2d8bdcbc9b9 - Minor: use unique temp directories in jps-build tests (vor 3 Tagen) <Nikolay Krasko>
* 1ee0892f733 - (tag: build-1.5.0-dev-106) [ULC] Fix NPE on generating data class ctor parameters (vor 3 Tagen) <Igor Yakovlev>
* f43899086a9 - (tag: build-1.5.0-dev-96) Value Classes: Forbid var properties with value class receivers (vor 3 Tagen) <Ilmir Usmanov>
* 19b16da183c - (tag: build-1.5.0-dev-94) Minor. Add test to check value classes (vor 3 Tagen) <Ilmir Usmanov>
* 0d55c9108d4 - (tag: build-1.5.0-dev-91) IC: Forbid inner classes inside inline classes (vor 3 Tagen) <Ilmir Usmanov>
* 15c325cf104 - Value classes: Allow nested inline classes (vor 3 Tagen) <Ilmir Usmanov>
* 235813736ec - (tag: build-1.5.0-dev-89, tag: build-1.5.0-dev-84) Build: Set file access rights explicitly in kotlin-stdlib-js jar (vor 3 Tagen) <Vyacheslav Gerasimov>
* 4626f21c585 - (tag: build-1.5.0-dev-76) Record type arguments for FirResolvedQualifier (vor 4 Tagen) <Mikhail Glukhikh>
* 68d271fc91f - Move FirModifierList inside FirModifierChecker to reduce its scope (vor 4 Tagen) <Mikhail Glukhikh>
* 94ddb712130 - [FIR] Simplify UnusedChecker & delete FirSourceChildren.kt (vor 4 Tagen) <Mikhail Glukhikh>
* 8abf27898d4 - Simplify FirMemberDeclaration.implicitModality (vor 4 Tagen) <Mikhail Glukhikh>
* 5fbdc0af5e6 - [FIR] Introduce & use MODALITY_MODIFIER positioning strategy (vor 4 Tagen) <Mikhail Glukhikh>
* 54f9edb597c - Simplify RedundantVisibilityModifierChecker (vor 4 Tagen) <Mikhail Glukhikh>
* b1c9d4b0463 - [FIR] Introduce & use VISIBILITY_MODIFIER positioning strategy (vor 4 Tagen) <Mikhail Glukhikh>
* 7f1b539011a - [FIR] Simplify CanBeValChecker.getDestructuringChildrenCount (vor 4 Tagen) <Mikhail Glukhikh>
* 38779339131 - [FIR] Adapt VAL_OR_VAR strategy & use it in CanBeValChecker (vor 4 Tagen) <Mikhail Glukhikh>
* ea7d738ee19 - [FIR] Introduce & use SourceElementPositioningStrategies.OPERATOR (vor 4 Tagen) <Mikhail Glukhikh>
* c9806c5af9e - [FIR] Simplify RedundantExplicitTypeChecker (vor 4 Tagen) <Mikhail Glukhikh>
* 516fce37dbe - (tag: build-1.5.0-dev-73) Value classes: Allow unsigned arrays in annotations (vor 4 Tagen) <Ilmir Usmanov>
* a9c072f8261 - (tag: build-1.5.0-dev-70) Regenerate compiler tests (vor 4 Tagen) <Alexander Udalov>
* caea0a9df09 - (tag: build-1.5.0-dev-62) JVM_IR KT-43721 coerce intrinsic result to corresponding unsigned type (vor 4 Tagen) <Dmitry Petrov>
* c776fcbd00e - (tag: build-1.5.0-dev-60) [JVM_IR] Fix incorrect name in inner class attributes. (vor 4 Tagen) <Mads Ager>
* fae5b8da4bc - [JVM] Do not put the name of default lambda parameter in LVT. (vor 4 Tagen) <Mads Ager>
* e5c46a86aa5 - (tag: build-1.5.0-dev-59) [Commonizer] Minor. Rename file (vor 4 Tagen) <Dmitriy Dolovov>
* daf42c1ee65 - [Commonizer] Remove unnecessary nullability at CirKnownClassifiers.commonDependeeLibraries (vor 4 Tagen) <Dmitriy Dolovov>
* 984b3c2f30c - (tag: build-1.5.0-dev-56) Fix to address platform expectation for project path (vor 4 Tagen) <Vladimir Dolzhenko>
* 68f8e88d8b5 - (tag: build-1.5.0-dev-51) [Commonizer] Introduce various types of classifier caches (vor 4 Tagen) <Dmitriy Dolovov>
* dce3d4d1b71 - [Commonizer] Rename InputTarget and OutputTarget (vor 4 Tagen) <Dmitriy Dolovov>
* b0ff3e7e5ea - [Commonizer] More fine-grained control of commonized module dependencies (vor 4 Tagen) <Dmitriy Dolovov>
* 9d749feb644 - (tag: build-1.5.0-dev-49) Fix gradle test for endorsed libraries in K/N (#3953) (vor 4 Tagen) <LepilkinaElena>
* d25ad269e06 - (tag: build-1.5.0-dev-44) Reuse captured arguments for flexible type's bounds properly, by equality of type constructors modulo mutability and type argument (vor 4 Tagen) <Victor Petukhov>
* 9f58e4bcfed - Add `FlexibleTypeBoundsChecker` which can answer the question: "can two types be different bounds of the same flexible type?"; and provide the base bound for the given bound. (vor 4 Tagen) <Victor Petukhov>
* 1ccbb09029e - Fix formatting in flexibleTypes.kt (vor 4 Tagen) <Victor Petukhov>
* 8e5bcd349e4 - (tag: build-1.5.0-dev-32) [JS IR] Respect JsExport while assigning stable names (vor 4 Tagen) <Shagen Ogandzhanian>
* 6b649d02d3a - (tag: build-1.5.0-dev-31) JVM IR: fix visibility/modality of $suspendImpl methods (vor 4 Tagen) <Alexander Udalov>
* 8ce2e4654b4 - JVM IR: allow custom toArray to have any array type (vor 4 Tagen) <Alexander Udalov>
* e6a3e38c4db - (tag: build-1.5.0-dev-27) JVM_IR no static inline class members for Kotlin JvmDefault methods (vor 5 Tagen) <Dmitry Petrov>
* 11673bd09c1 - (tag: build-1.5.0-dev-25) KAPT: add tests for processed types, remove dead code, simplify logic (vor 5 Tagen) <Ivan Gavrilovic>
* 08a2b47c77c - Incremental KAPT: fix typo and do check processed sources on clean build (vor 5 Tagen) <Ivan Gavrilovic>
* 0522583602b - Incremental KAPT: add test for isolating AP with classpath origin (vor 5 Tagen) <Ivan Gavrilovic>
* 05e47da4583 - Incremental KAPT: simplify impacted types computation (vor 5 Tagen) <Ivan Gavrilovic>
* c7e5beece52 - Use types are origins for incremental KAPT and track generated source (vor 5 Tagen) <Ivan Gavrilovic>
* d512158c258 - (tag: build-1.5.0-dev-22) [JS IR] Remove redundant guard assertion for extension funs with default params (vor 5 Tagen) <Shagen Ogandzhanian>
* a917ebd11e6 - (tag: build-1.5.0-dev-19) JVM IR: use origin to detect property/typealias $annotations methods (vor 5 Tagen) <Alexander Udalov>
* c7c793c7245 - JVM IR: do not use origin DEFAULT_IMPLS_BRIDGE(_TO_SYNTHETIC) (vor 5 Tagen) <Alexander Udalov>
* d41d1bf64d0 - JVM IR: remove obsolete isDefaultImplsBridge in findInterfaceImplementation (vor 5 Tagen) <Alexander Udalov>
* be03bc477dd - JVM IR: do not use origin DEFAULT_IMPLS_WITH_MOVED_RECEIVERS(_SYNTHETIC) (vor 5 Tagen) <Alexander Udalov>
* 988cc521741 - JVM IR: do not use origin DEFAULT_IMPLS_BRIDGE_FOR_COMPATIBILITY(_SYNTHETIC) (vor 5 Tagen) <Alexander Udalov>
* 697b2b02f15 - (tag: build-1.5.0-dev-18) [JS IR] Add properties lazy initialization with multiple modules (vor 5 Tagen) <Ilya Goncharov>
* 6cb573cb45a - (tag: build-1.5.0-dev-6) [FIR] Import parents of companion objects first (vor 5 Tagen) <pyos>
* 4d7b6c022b2 - (tag: build-1.5.0-dev-5) [FIR IDE] LC Anonymous to SuperClass type substitution (vor 5 Tagen) <Igor Yakovlev>
* 842d31d04ea - [FIR IDE] Fix HL API test data (vor 5 Tagen) <Igor Yakovlev>
* 7cbcde77dd3 - [FIR IDE] LC More accurate fields visibility and modality (vor 5 Tagen) <Igor Yakovlev>
* a7d7aa123ef - [FIR IDE] LC minor refactorings (vor 5 Tagen) <Igor Yakovlev>
* a1603716ed7 - [FIR IDE] LC Add anonymous objects support (vor 5 Tagen) <Igor Yakovlev>
* 56306673202 - [FIR IDE] LC better support for JvmMultiFileClass annotation (vor 5 Tagen) <Igor Yakovlev>
* 56c3faee00b - [FIR IDE] LC Fix generating unique field names (vor 5 Tagen) <Igor Yakovlev>
* 18e5af37ffe - [FIR IDE] LC Fixed incorrect JvmOverloads (vor 5 Tagen) <Igor Yakovlev>
* 535aa1e9e0d - [FIR IDE] LC expand typealiases for applied annotations (vor 5 Tagen) <Igor Yakovlev>
* 229c6f97acc - [FIR IDE] LC Fixed nullability for getters (vor 5 Tagen) <Igor Yakovlev>
* aff90b335ca - [FIR IDE] LC Implement special keywords like transient, volatile, synchronized, strictfp (vor 5 Tagen) <Igor Yakovlev>
* 6aff96a4018 - [FIR IDE] Remove extra analyzing for local declarations (vor 5 Tagen) <Igor Yakovlev>
* 3fc424246bd - [FIR IDE] LC basic support for type arguments (vor 5 Tagen) <Igor Yakovlev>
* 2a8f7833933 - [FIR IDE] HL API Better support of nullability and modality (vor 5 Tagen) <Igor Yakovlev>
* 4c69043a152 - [FIR IDE] Move refactoring and minor bugfixing for modality, jvmname, etc. (vor 5 Tagen) <Igor Yakovlev>
* 3e3ec5fc69f - [FIR IDE] Supporting member scopes in EnumEntries (vor 5 Tagen) <Igor Yakovlev>
* fdaf31dbf3f - [FIR IDE] Fix typemapping for FirTypeAliasSymbol (vor 5 Tagen) <Igor Yakovlev>
* aae0081f3fd - [FIR IDE] Fixed invalid HL API getters request (vor 5 Tagen) <Igor Yakovlev>
* 2429f429c5e - (tag: build-1.5.0-dev-4) [FIR] Set isStubTypeEqualsToAnything = true for inference as in FE 1.0 (vor 5 Tagen) <Mikhail Glukhikh>
* eae8821dec1 - FIR Java: unbind possible named annotation cycle (vor 5 Tagen) <Mikhail Glukhikh>
* 2ffedd27311 - (tag: build-1.5.0-dev-2) Fix Daemon compiler tests on Windows (vor 5 Tagen) <Nikolay Krasko>
* 8a969dab7d0 - (tag: build-1.5.0-dev-1, tag: build-1.4.30-dev-3428) Bugfix for FIR (vor 5 Tagen) <Georgy Bronnikov>
* b23d7a79b0e - IR: get rid of WrappedDescriptorWithContainerSource (vor 5 Tagen) <Georgy Bronnikov>
* c0cd9064d72 - IR: IrMemberWithContainerSource (vor 5 Tagen) <Georgy Bronnikov>
* 14b773c1fd1 - JVM_IR: do not rely on DescriptorWithContainerSource in InlineCodegen (vor 5 Tagen) <Georgy Bronnikov>
* f0a787551a2 - (tag: build-1.4.30-dev-3420) Value classes: Raise retention of @JvmInline to RUNTIME (vor 5 Tagen) <Ilmir Usmanov>
* 129de76288f - Value classes: Generate @JvmInline annotation for inline classes (vor 5 Tagen) <Ilmir Usmanov>
* ae8abd18327 - (tag: build-1.4.30-dev-3406, origin/master-for-ide) Minor: ignore nestedBigArityFunCalls.kt in WASM (vor 6 Tagen) <Dmitry Petrov>
* 1412ee96f89 - JVM_IR KT-43524 static wrappers for deprecated accessors are deprecated (vor 6 Tagen) <Dmitry Petrov>
* e96fc74ffa4 - JVM_IR KT-43519 no delegates for external funs in multifile facades (vor 6 Tagen) <Dmitry Petrov>
* 2b4564059e0 - JVM_IR KT-43459 fix $annotations method receiver type (vor 6 Tagen) <Dmitry Petrov>
* 85b59489319 - JVM_IR KT-43051 no static inline class members for default Java methods (vor 6 Tagen) <Dmitry Petrov>
* 4c3ffc34515 - JVM_IR KT-41911 process big arity 'invoke' arguments recursively (vor 6 Tagen) <Dmitry Petrov>
* b0e2d5637d4 - (tag: build-1.4.30-dev-3405) Mute a test for WASM (vor 6 Tagen) <Georgy Bronnikov>
* bb4950a0215 - (tag: build-1.4.30-dev-3397) Regenerate LightAnalysis tests (vor 6 Tagen) <Georgy Bronnikov>
* 91bccad72bd - (tag: build-1.4.30-dev-3396) [JS] Fix path of generated js tests (vor 6 Tagen) <Dmitriy Novozhilov>
* 7550a1870b9 - (tag: build-1.4.30-dev-3391) [FIR2IR] Make checks about f/o accessors necessity more precise (vor 6 Tagen) <Mikhail Glukhikh>
* b179b567a98 - (tag: build-1.4.30-dev-3389) [Gradle, JS] Add test on resolution of js project with directory dependency (vor 6 Tagen) <Ilya Goncharov>
* 2fdc2dfaaf0 - (tag: build-1.4.30-dev-3388) JVM IR: fix regression in JvmStatic-in-object lowering for properties (vor 6 Tagen) <Alexander Udalov>
* 4607eca987c - (tag: build-1.4.30-dev-3383) JVM_IR: bug fix in classFileContainsMethod (vor 6 Tagen) <Georgy Bronnikov>
* f50480d2588 - (tag: build-1.4.30-dev-3378) FIR IDE: Fix resolving of nested types in type references (vor 6 Tagen) <Roman Golyshev>
* 94a5379631b - FIR IDE: Add tests for resolving from nested types references (vor 6 Tagen) <Roman Golyshev>
* 19ca9c0fdeb - (tag: build-1.4.30-dev-3364) Enable JVM IR for bootstrap in the project (vor 6 Tagen) <Alexander Udalov>
* 606de266461 - (tag: build-1.4.30-dev-3362) JVM IR: fix generation of equals/hashCode for fun interfaces over references (vor 7 Tagen) <Alexander Udalov>
* 50ae360ff93 - (tag: build-1.4.30-dev-3360) FIR2IR: fix the way annotations are moved to fields (vor 7 Tagen) <pyos>
* 4817d5e01d5 - (tag: build-1.4.30-dev-3354) KTIJ-585 [Gradle Runner]: main() cannot be launched from AS 4.1 (vor 7 Tagen) <Andrei Klunnyi>
* 995d96e5a37 - (tag: build-1.4.30-dev-3350) [JS IR] Use one concat elements for non vararg and vararg arguments (vor 7 Tagen) <Ilya Goncharov>
* 67e4b0948e7 - [JS IR] Constructor call with vararg invoking with apply (vor 7 Tagen) <Ilya Goncharov>
* ac42dcd8dae - [JS IR] Add test for external fun vararg (vor 7 Tagen) <Ilya Goncharov>
* e7789d2e308 - (tag: build-1.4.30-dev-3348) [Gradle, JS] Add filter on file on fileCollectionDependencies because Gradle can't hash directory (vor 7 Tagen) <Ilya Goncharov>
* 96ed99d62e1 - (tag: build-1.4.30-dev-3343, tag: build-1.4.30-M1-7, tag: build-1.4.30-M1-4) JVM_IR KT-40305 no nullability assertions on built-in stubs (vor 7 Tagen) <Dmitry Petrov>
* b2aed536c99 - JVM_IR KT-39612 process subexpressions recursively in 'name' lowering (vor 7 Tagen) <Dmitry Petrov>
* 3b604cfa7f5 - JVM_IR KT-32701 generate multiple big arity invokes, report error later (vor 7 Tagen) <Dmitry Petrov>
* a157b58c61f - JVM_IR KT-43610 keep track of "special bridges" for interface funs (vor 7 Tagen) <Dmitry Petrov>
* c43db2ee8de - (tag: build-1.4.30-dev-3341) [TEST] Inherit `UpdateConfigurationQuickFixTest` from `KotlinLightPlatformCodeInsightFixtureTestCase` (vor 7 Tagen) <Dmitriy Novozhilov>
* 7d9eeb68475 - (tag: build-1.4.30-dev-3338) Minor, add workaround for KT-42137 (vor 7 Tagen) <Alexander Udalov>
* e1d54bf99f8 - Minor, add workaround for KT-43666 (vor 7 Tagen) <Alexander Udalov>
* ad579de3284 - (tag: build-1.4.30-dev-3337) Don't run KaptPathsTest.testSymbolicLinks test on Windows (vor 7 Tagen) <Mikhael Bogdanov>
* d706a7ff740 - (tag: build-1.4.30-dev-3331, tag: build-1.4.30-3) Build: mute failing tests (vor 7 Tagen) <Dmitriy Novozhilov>
* 1cccf2645fa - (tag: build-1.4.30-dev-3330) FIR: serialize HAS_CONSTANT at least for const properties (vor 7 Tagen) <pyos>
* 04d9afe83e3 - FIR Java: add workaround for classId = null in JavaAnnotation (vor 7 Tagen) <Mikhail Glukhikh>
* feb13f98c02 - [FIR2IR] Handle Java annotation parameter mapping properly (vor 7 Tagen) <Mikhail Glukhikh>
* 9b30655d664 - [FIR] Load Java annotations named arguments properly (see KT-43584) (vor 7 Tagen) <Mikhail Glukhikh>
* e6f380182a6 - (tag: build-1.4.30-dev-3329) Revert "FIR IDE: Add tests for resolving from nested types references" (vor 7 Tagen) <Roman Golyshev>
* f8b6559b6a4 - Revert "FIR IDE: Fix resolving of nested types in type references" (vor 7 Tagen) <Roman Golyshev>
* dba14ba9955 - (tag: build-1.4.30-dev-3327) FIR IDE: Fix resolving of nested types in type references (vor 7 Tagen) <Roman Golyshev>
* e127ea3dadd - FIR IDE: Add tests for resolving from nested types references (vor 7 Tagen) <Roman Golyshev>
* 8a00470b40b - (tag: build-1.4.30-dev-3324) Enable kotlin-annotation-processing-base tests on TC (vor 7 Tagen) <Mikhael Bogdanov>
* 29bed39a54c - (tag: build-1.4.30-dev-3319, tag: build-1.4.30-2) Bump to native version version with watchos_x64 enabled (vor 7 Tagen) <Sergey Bogolepov>
* 37ee2cbe537 - [KT-43276] Update tests to support watchos_x64 (vor 7 Tagen) <Sergey Bogolepov>
* d6f54a77307 - [KT-43276] Fix `watchos` target shortcut. (vor 7 Tagen) <Sergey Bogolepov>
* f3424a98b7b - generateMppTargetContainerWithPresets: remove unneeded hack (vor 7 Tagen) <Sergey Bogolepov>
* e39560b1345 - [KT-43276] Add watchos_x64 target (vor 7 Tagen) <Sergey Bogolepov>