### PR TITLE
Don't generate ObjCExport bridges for private setters of public properties

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportCodeSpec.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportCodeSpec.kt
@@ -22,7 +22,10 @@ internal fun ObjCExportedInterface.createCodeSpec(symbolTable: SymbolTable): Obj
 
     fun List<CallableMemberDescriptor>.toObjCMethods() = createObjCMethods(this.flatMap {
         when (it) {
-            is PropertyDescriptor -> listOfNotNull(it.getter, it.setter)
+            is PropertyDescriptor -> listOfNotNull(
+                    it.getter,
+                    it.setter?.takeIf(mapper::shouldBeExposed) // Similar to [ObjCExportTranslatorImpl.buildProperty].
+            )
             is FunctionDescriptor -> listOf(it)
             else -> error(it)
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportHeaderGenerator.kt
@@ -552,6 +552,7 @@ internal class ObjCExportTranslatorImpl(
 
         val setterName: String?
         val propertySetter = property.setter
+        // Note: the condition below is similar to "toObjCMethods" logic in [ObjCExportedInterface.createCodeSpec].
         if (propertySetter != null && mapper.shouldBeExposed(propertySetter)) {
             val setterSelector = mapper.getBaseMethods(propertySetter).map { namer.getSelector(it) }.distinct().single()
             setterName = if (setterSelector != "set" + name.capitalize() + ":") setterSelector else null

--- a/backend.native/tests/objcexport/expectedLazy.h
+++ b/backend.native/tests/objcexport/expectedLazy.h
@@ -612,6 +612,26 @@ __attribute__((swift_name("Kt41907Kt")))
 @end;
 
 __attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("KT43599")))
+@interface KtKT43599 : KtBase
+- (instancetype)init __attribute__((swift_name("init()"))) __attribute__((objc_designated_initializer));
++ (instancetype)new __attribute__((availability(swift, unavailable, message="use object initializers instead")));
+@property (readonly) NSString *memberProperty __attribute__((swift_name("memberProperty")));
+@end;
+
+@interface KtKT43599 (Kt43599Kt)
+@property (readonly) NSString *extensionProperty __attribute__((swift_name("extensionProperty")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
+__attribute__((swift_name("Kt43599Kt")))
+@interface KtKt43599Kt : KtBase
++ (void)setTopLevelLateinitPropertyValue:(NSString *)value __attribute__((swift_name("setTopLevelLateinitProperty(value:)")));
+@property (class, readonly) NSString *topLevelProperty __attribute__((swift_name("topLevelProperty")));
+@property (class, readonly) NSString *topLevelLateinitProperty __attribute__((swift_name("topLevelLateinitProperty")));
+@end;
+
+__attribute__((objc_subclassing_restricted))
 __attribute__((swift_name("LibraryKt")))
 @interface KtLibraryKt : KtBase
 + (NSString *)readDataFromLibraryClassInput:(KtA *)input __attribute__((swift_name("readDataFromLibraryClass(input:)")));

--- a/backend.native/tests/objcexport/kt43599.kt
+++ b/backend.native/tests/objcexport/kt43599.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package kt43599
+
+// Note: this test relies on two-stage compilation.
+
+class KT43599 {
+    var memberProperty = "memberProperty"
+        private set
+}
+
+var KT43599.extensionProperty
+    get() = "extensionProperty"
+    private set(value) { TODO() }
+
+var topLevelProperty
+    get() = "topLevelProperty"
+    private set(value) { TODO() }
+
+lateinit var topLevelLateinitProperty: String
+    private set
+
+fun setTopLevelLateinitProperty(value: String) {
+    topLevelLateinitProperty = value
+}

--- a/backend.native/tests/objcexport/kt43599.swift
+++ b/backend.native/tests/objcexport/kt43599.swift
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+import Kt
+
+private func testPropertyWithPrivateSetter() throws {
+    try assertEquals(actual: KT43599().memberProperty, expected: "memberProperty")
+    try assertEquals(actual: KT43599().extensionProperty, expected: "extensionProperty")
+    try assertEquals(actual: Kt43599Kt.topLevelProperty, expected: "topLevelProperty")
+
+    // Checking the reported case too:
+    Kt43599Kt.setTopLevelLateinitProperty(value: "topLevelLateinitProperty")
+    try assertEquals(actual: Kt43599Kt.topLevelLateinitProperty, expected: "topLevelLateinitProperty")
+}
+
+class Kt43599Tests : SimpleTestProvider {
+    override init() {
+        super.init()
+
+        test("TestPropertyWithPrivateSetter", testPropertyWithPrivateSetter)
+    }
+}


### PR DESCRIPTION

#KT-43599 Fixed