### PR TITLE
[kotlin compiler][update] 1.5.0-dev-500

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BuiltInFictitiousFunctionIrClassFactory.kt
@@ -213,7 +213,8 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                                         SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, invokeFunctionOrigin,
                                         IrValueParameterSymbolImpl(it), it.name, it.index,
                                         functionClass.typeParameters[it.index].defaultType, null,
-                                        it.isCrossinline, it.isNoinline, false, false
+                                        it.isCrossinline, it.isNoinline,
+                                        isHidden = false, isAssignable = false
                                 ).also { it.parent = this }
                             }
                             if (!isFakeOverride)
@@ -272,8 +273,8 @@ internal class BuiltInFictitiousFunctionIrClassFactory(
                 varargType?.let { toIrType(it) },
                 descriptor.isCrossinline,
                 descriptor.isNoinline,
-            false,
-            false
+                isHidden = false,
+                isAssignable = false
         ).also {
             it.parent = this
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
@@ -56,8 +56,8 @@ internal fun makeEntryPoint(context: Context): IrFunction {
                     isCrossinline = false,
                     type = context.irBuiltIns.arrayClass.typeWith(context.irBuiltIns.stringType),
                     isNoinline = false,
-                    isAssignable = false,
-                    isHidden = false
+                    isHidden = false,
+                    isAssignable = false
             ).apply {
                 it.bind(this)
                 parent = function

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -1142,7 +1142,11 @@ private class ObjCBlockPointerValuePassing(
                 Name.identifier("blockPointer"),
                 0,
                 symbols.nativePtrType,
-                varargElementType = null, isCrossinline = false, isNoinline = false, isHidden = false, isAssignable = false
+                varargElementType = null,
+                isCrossinline = false,
+                isNoinline = false,
+                isHidden = false,
+                isAssignable = false
         )
         constructorParameterDescriptor.bind(constructorParameter)
         constructor.valueParameters += constructorParameter
@@ -1187,8 +1191,11 @@ private class ObjCBlockPointerValuePassing(
                     Name.identifier("p$index"),
                     index,
                     functionType.arguments[index].typeOrNull!!,
-                    varargElementType = null, isCrossinline = false, isNoinline = false,
-                    isHidden = false, isAssignable = false
+                    varargElementType = null,
+                    isCrossinline = false,
+                    isNoinline = false,
+                    isHidden = false,
+                    isAssignable = false
             )
             parameterDescriptor.bind(parameter)
             parameter.parent = invokeMethod

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -87,7 +87,11 @@ internal class KotlinBridgeBuilder(
                 bridge.startOffset, bridge.endOffset, bridge.origin,
                 IrValueParameterSymbolImpl(descriptor),
                 Name.identifier("p$index"), index, type,
-                null, false, false, false, false
+                null,
+                isCrossinline = false,
+                isNoinline = false,
+                isHidden = false,
+                isAssignable = false
         ).apply {
             descriptor.bind(this)
             parent = bridge

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -104,8 +104,8 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                                 varargElementType = null,
                                 isCrossinline = arg.isCrossinline,
                                 isNoinline = arg.isNoinline,
-                                isAssignable = arg.isAssignable,
-                                isHidden = arg.isHidden
+                                isHidden = arg.isHidden,
+                                isAssignable = arg.isAssignable
                         ).apply { it.bind(this) }
                     }
                 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/ir/util/IrUtils2.kt
@@ -374,7 +374,8 @@ fun IrValueParameter.copy(newDescriptor: ParameterDescriptor): IrValueParameter 
     return IrValueParameterImpl(
         startOffset, endOffset, IrDeclarationOrigin.DEFINED, IrValueParameterSymbolImpl(newDescriptor),
         newDescriptor.name, newDescriptor.indexOrMinusOne, type, varargElementType,
-        newDescriptor.isCrossinline, newDescriptor.isNoinline, false, false
+        newDescriptor.isCrossinline, newDescriptor.isNoinline,
+        isHidden = false, isAssignable = false
     )
 }
 

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3229,6 +3229,11 @@ task inline_defaultArgs(type: KonanLocalTest) {
     source = "codegen/inline/defaultArgs.kt"
 }
 
+task inline_propertyAccessorInline(type: KonanLocalTest) {
+    goldValue = "123\n42\n"
+    source = "codegen/inline/propertyAccessorInline.kt"
+}
+
 task inline_twiceInlinedObject(type: KonanLocalTest) {
     goldValue = "Ok\n"
     source = "codegen/inline/twiceInlinedObject.kt"

--- a/backend.native/tests/codegen/inline/propertyAccessorInline.kt
+++ b/backend.native/tests/codegen/inline/propertyAccessorInline.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the LICENSE file.
+ */
+
+package codegen.inline.propertyAccessorInline
+
+import kotlin.test.*
+
+object C {
+    const val x = 42
+}
+
+fun getC(): C {
+    println(123)
+    return C
+}
+
+@Test fun runTest() {
+    println(getC().x)
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-156,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.0-dev-156
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-156,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.0-dev-156
-kotlinStdlibTestsVersion=1.5.0-dev-156
-testKotlinCompilerVersion=1.5.0-dev-156
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-500,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.0-dev-500
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-500,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.0-dev-500
+kotlinStdlibTestsVersion=1.5.0-dev-500
+testKotlinCompilerVersion=1.5.0-dev-500
 konanVersion=1.5.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* a0651cdba7f - (tag: build-1.5.0-dev-500) FIR IDE: add Java synthetic properties support for completion (vor 31 Stunden) <Ilya Kirillov>
* 48b71505663 - FIR IDE: split KtPropertySymbol into KtKotlinPropertySymbol and KtJavaSyntheticPropertySymbol (vor 31 Stunden) <Ilya Kirillov>
* 2201dd51984 - FIR: make FirSyntheticPropertiesScope to be name aware (vor 31 Stunden) <Ilya Kirillov>
* 8a5f260d044 - (tag: build-1.5.0-dev-496) [IR] Align debugging of suspend lambdas with old BE (vor 32 Stunden) <Kristoffer Andersen>
* 2be62c13b0d - (tag: build-1.5.0-dev-485) [Commonizer] Minor. Renamings (vor 2 Tagen) <Dmitriy Dolovov>
* b7330a9e141 - (tag: build-1.5.0-dev-481) JVM_IR KT-43877 fix generic signatures for SAM-converted lambdas (vor 2 Tagen) <Dmitry Petrov>
* dc11c2de770 - (tag: build-1.5.0-dev-477) IC Mangling: Use correct java field type if the type is inline class (vor 2 Tagen) <Ilmir Usmanov>
* 2b0a99b7b01 - IC Mangling: Use correct java field type if the type is inline class (vor 2 Tagen) <Ilmir Usmanov>
* 69bb65496f5 - IC Mangling: Change test since we pass boxed inline class to java method (vor 2 Tagen) <Ilmir Usmanov>
* cbb8eb494a7 - IC Mangling: Do not mangle functions with inline classes from Java (vor 2 Tagen) <Ilmir Usmanov>
* 0cab69a7a05 - IC Mangling: Do not mangle functions with inline classes from Java (vor 2 Tagen) <Ilmir Usmanov>
* 5aaaa3881df - (tag: build-1.5.0-dev-470, tag: build-1.5.0-dev-457) Refine diagnostic text for NULLABLE_TYPE_PARAMETER_AGAINST_NOT_NULL_TYPE_PARAMETER (vor 2 Tagen) <Denis.Zharkov>
* b143cb9ae59 - (tag: build-1.5.0-dev-450, tag: build-1.5.0-dev-444) Disable new test on WASM (vor 3 Tagen) <Mikhael Bogdanov>
* c922484758a - (tag: build-1.5.0-dev-443) [JVM_IR] Use direct field access to backing fields on current class. (vor 3 Tagen) <Mads Ager>
* 1d14926444e - (tag: build-1.5.0-dev-432) Re-enable evaluation tests in 201 platform (vor 3 Tagen) <Nikolay Krasko>
* 1bc369c63c0 - (tag: build-1.5.0-dev-428) Build: Enable caching for test task with enabled test distribution (vor 3 Tagen) <Vyacheslav Gerasimov>
* 8f2ad57f7a5 - (tag: build-1.5.0-dev-425) FIR: pass elvis expected type to lhs/rhs (vor 3 Tagen) <Jinseong Jeon>
* 41f56729f9f - FIR: serialize correct fqnames for local classes (vor 3 Tagen) <pyos>
* 12f936f6b7b - FIR2IR: do not approximate reified type arguments to super class (vor 3 Tagen) <pyos>
* 148d540580d - FIR checker: make unused checker visit qualified accesses in annotations (vor 3 Tagen) <Jinseong Jeon>
* 5efe774dbad - FIR: remap Java meta-annotations to Kotlin equivalents (vor 3 Tagen) <pyos>
* a9ad85f306e - (tag: build-1.5.0-dev-423) FIR IDE: temporary mute find usages test as it fails because of incorrect resolve of init blocks (vor 3 Tagen) <Ilya Kirillov>
* 170928f4986 - FIR IDE: allow type rendering only in analysis session (vor 3 Tagen) <Ilya Kirillov>
* f30c6bf86a7 - FIR IDE: rework KtCall to work with error cals (vor 3 Tagen) <Ilya Kirillov>
* e6327ef4905 - (tag: build-1.5.0-dev-420) Build: Enable test distribution for :js:js.tests:test task (vor 3 Tagen) <Vyacheslav Gerasimov>
* 06fd7f8526b - Build: Add helper to configure gradle test distribution (vor 3 Tagen) <Vyacheslav Gerasimov>
* 7bbb738a713 - Build: Cleanup :js:js.tests buildscript (vor 3 Tagen) <Vyacheslav Gerasimov>
* d43af46bf46 - Build: Add V8 engine & repl.js to js tests inputs (vor 3 Tagen) <Vyacheslav Gerasimov>
* fadedc84dbd - (tag: build-1.5.0-dev-417) [JVM_IR] Refactor and add bytecode text tests for compose-like code. (vor 3 Tagen) <Mads Ager>
* 83588e9f221 - [JVM_IR] Add tests of Compose-like default argument handling. (vor 3 Tagen) <Mads Ager>
* a7efa5c98bb - [IR] Fix remapping of arguments in LocalDeclarationsLowering. (vor 3 Tagen) <Mads Ager>
* 167e60b9fb4 - (tag: build-1.5.0-dev-415) [JS IR] Assert createdOn equals 0 for properties initialization fun for file (vor 3 Tagen) <Ilya Goncharov>
* 5be28520fcf - (tag: build-1.5.0-dev-412) JVM_IR KT-43851 preserve static initialization order in const val read (vor 3 Tagen) <Dmitry Petrov>
* b0ef6ee1fc5 - JVM_IR Minor: refactor rawType (vor 3 Tagen) <Dmitry Petrov>
* f4a25066a8d - (tag: build-1.5.0-dev-403) Fix freshly added CLI tests for windows agents (vor 3 Tagen) <Denis.Zharkov>
* dd66da7c654 - (tag: build-1.5.0-dev-393) Optimize FirJavaSyntheticNamesProvider.possibleGetterNamesByPropertyName (vor 3 Tagen) <Mikhail Glukhikh>
* 6d545fc281d - Make FirTowerLevel an abstract class (vor 3 Tagen) <Mikhail Glukhikh>
* 34d7a7c1848 - FIR tower levels: inline processElementsByName[AndStoreResult] (vor 3 Tagen) <Mikhail Glukhikh>
* af4941b222d - [FIR] Drop delayedNode from ControlFlowGraph.orderNodes (vor 3 Tagen) <Mikhail Glukhikh>
* 7b277600a94 - Optimize/simplify loadFunctions(Properties)ByName in FIR deserializer (vor 3 Tagen) <Mikhail Glukhikh>
* e51503ab420 - Code cleanup: KotlinDeserializedJvmSymbolsProvider (vor 3 Tagen) <Mikhail Glukhikh>
* 1383e923ea9 - Drop KotlinDeserializedJvmSymbolsProvider.findRegularClass (vor 3 Tagen) <Mikhail Glukhikh>
* 7e99f0ee238 - Optimize ConeInferenceContext.typeDepth a bit (vor 3 Tagen) <Mikhail Glukhikh>
* 67c7b5ca0a8 - Optimize/simplify FirAbstractImportingScope.getStaticsScope (vor 3 Tagen) <Mikhail Glukhikh>
* d90cc452fe1 - Simplify: FirSymbolProvider.getClassDeclaredPropertySymbols (vor 3 Tagen) <Mikhail Glukhikh>
* e344d9e4388 - Drop unused functions from FirBuiltinSymbolProvider (vor 3 Tagen) <Mikhail Glukhikh>
* bb0410b143b - [FIR] Drop unused utility functions from StandardTypes.kt (vor 3 Tagen) <Mikhail Glukhikh>
* f88d51613fd - (tag: build-1.5.0-dev-391) Remove old 193 and as40 bunches (vor 3 Tagen) <Yunir Salimzyanov>
* bf8de487a05 - (tag: build-1.5.0-dev-388, tag: build-1.5.0-dev-384) CliTrace: rewrite smart cast-vulnerable piece of code (vor 3 Tagen) <Mikhail Glukhikh>
* c8c83c04c08 - (tag: build-1.5.0-dev-381, tag: build-1.5.0-dev-380) [IR] Fix saving function calls during inlining const properties in PropertyAccessorInlineLowering (#3971) (vor 3 Tagen) <LepilkinaElena>
* dccfb33bcc9 - (tag: build-1.5.0-dev-373) JVM_IR: Unbox argument of type kotlin.Result (vor 3 Tagen) <Ilmir Usmanov>
* 775d610045d - Value classes: Forbid any identity equality check on value class (vor 3 Tagen) <Ilmir Usmanov>
* 7e088457a25 - Temporary clear sinceVersion for ProhibitUsingNullableTypeParameterAgainstNotNullAnnotated (vor 3 Tagen) <Denis.Zharkov>
* dbc85a5f189 - (tag: build-1.5.0-dev-361) [TEST] Fix compilation of CodegenTestsOnAndroidGenerator.kt (vor 4 Tagen) <Dmitriy Novozhilov>
* b416c669b08 - [TEST] Update testdata due to dropped COMMON_COROUTINE_TEST directive (vor 4 Tagen) <Dmitriy Novozhilov>
* aacf934b49c - [TEST] Drop machinery about experimental coroutines from compiler tests (vor 4 Tagen) <Dmitriy Novozhilov>
* 8c4b7ad1e16 - [TEST] Drop generating tests for coroutines of Kotlin 1.2 (vor 4 Tagen) <Dmitriy Novozhilov>
* 0389589d839 - (tag: build-1.5.0-dev-360) Build: Setup inputs and outputs for :js:js-tests:test task properly (vor 4 Tagen) <Vyacheslav Gerasimov>
* d5c1e5681cd - (tag: build-1.5.0-dev-355) [IR] Don't assume subclasses as part of member scope of sealed class (vor 4 Tagen) <Dmitriy Novozhilov>
* b6bd7c48f4e - [FE] Rename FreedomForSealedClasses feature with more meaningful name (vor 4 Tagen) <Dmitriy Novozhilov>
* 77aad06008d - [FE] Add bunch files to fix compilation on 201 platform (vor 4 Tagen) <Dmitriy Novozhilov>
* 3246e6b9ac2 - [IC] Add ability to pass additional compiler args to IC tests (vor 4 Tagen) <Dmitriy Novozhilov>
* 57a081c3990 - [FE] Prohibit inheritance of sealed classes in different module (vor 4 Tagen) <Dmitriy Novozhilov>
* f8d6f79c177 - [FE] Temporary disable exhaustiveness checker for java sealed classes (vor 4 Tagen) <Dmitriy Novozhilov>
* 1c9f9130e6e - [FE] Prohibit implementing java sealed classes (vor 4 Tagen) <Dmitriy Novozhilov>
* 6809adee9c2 - [FE] Extract computation of sealed class inheritors into separate component (vor 4 Tagen) <Dmitriy Novozhilov>
* c0a1aecf9b1 - [FE] Add test for compiling against library with kotlin sealed classes and interfaces (vor 4 Tagen) <Dmitriy Novozhilov>
* 7897bb6adbb - [FE] Support sealed classes and interfaces from java (vor 4 Tagen) <Dmitriy Novozhilov>
* bdfb71b149d - [FE] Add sealed classes related properties to java model (vor 4 Tagen) <Dmitriy Novozhilov>
* 8e9e34350fc - [FE] Properly support sealed interfaces in exhaustiveness checker (vor 4 Tagen) <Dmitriy Novozhilov>
* 96099545607 - [FE] Allow using sealed modifier on interface and compute `sealed` modality for them (vor 4 Tagen) <Dmitriy Novozhilov>
* d605c7e4916 - [FE] Prohibit inheritors of sealed classes which are declared in different package (vor 4 Tagen) <Dmitriy Novozhilov>
* e76acc8ee09 - [FE] Collect inheritors of sealed classes from new places in `computeSealedSubclasses` (vor 4 Tagen) <Dmitriy Novozhilov>
* 70c61be1ef1 - [FE] Allow declare sealed class inheritors as inner or nested classes (vor 4 Tagen) <Dmitriy Novozhilov>
* f5f1984a605 - [FE] Allow declare sealed class inheritors in different files in one module (vor 4 Tagen) <Dmitriy Novozhilov>
* 1a377069dd8 - (tag: build-1.5.0-dev-351) Allow AnalysisHandlerExtension to provide additional classpath on retry (vor 4 Tagen) <Jiaxiang Chen>
* a6cb156ce92 - Allow multiple retry for AnalysisHandlerExtension (vor 4 Tagen) <Jiaxiang Chen>
* 313dfaf48cf - (tag: build-1.5.0-dev-341) JVM_IR KT-43812 erase generic arguments of SAM wrapper supertype (vor 4 Tagen) <Dmitry Petrov>
* 5daa406cdff - (tag: build-1.5.0-dev-340) Use FirNamedFunctionSymbol in FirScope.processFunctionsByName (vor 4 Tagen) <Mikhail Glukhikh>
* 2dfba10d840 - FIR: extend suspend conversion to intersection type (vor 4 Tagen) <Jinseong Jeon>
* 42ea4463eee - Fix type argument inconsistency in FirResolvedQualifier (vor 4 Tagen) <Mikhail Glukhikh>
* d6e144c80ec - [FIR] Extend callableNames known for JvmMappedScope (vor 4 Tagen) <Mikhail Glukhikh>
* 94014ba3eb8 - Fir2IrLazyClass: don't generate non-f/o properties from superclass (vor 4 Tagen) <Mikhail Glukhikh>
* 9b0ada2b0f8 - [FIR2IR] Generate f/o overridden symbol with FakeOverrideGenerator (vor 4 Tagen) <Mikhail Glukhikh>
* 91834ccf467 - Use FirNamedFunctionSymbol in FirSimpleFunction & its inheritors (vor 4 Tagen) <Mikhail Glukhikh>
* 15021f30ff2 - Use FirNamedFunctionSymbol around processOverriddenFunctions (vor 4 Tagen) <Mikhail Glukhikh>
* 8fedfd2d2ac - (tag: build-1.5.0-dev-338) Minor, add workaround for KT-43812 (vor 4 Tagen) <Alexander Udalov>
* 2b22cbcdd27 - Advance bootstrap to 1.5.0-dev-309 (vor 4 Tagen) <Dmitriy Novozhilov>
* 38b59ddabf2 - (tag: build-1.5.0-dev-335) Wizard: Fix tests (vor 4 Tagen) <anastasiia.spaseeva>
* 71459db9dd9 - Wizard: Do not add bintray repoitory for eap versions (vor 4 Tagen) <anastasiia.spaseeva>
* 2d8a8d252b0 - (tag: build-1.5.0-dev-327) Add 201 bunch files for JavaClass implementations (vor 4 Tagen) <Denis.Zharkov>
* 5a006a36907 - Minor. Specify targetBackend for new IR tests (vor 4 Tagen) <Denis.Zharkov>
* 92b402759b2 - Report incorrect JVM target only when @JvmRecord is actually used (vor 4 Tagen) <Denis.Zharkov>
* 920ed558eed - Add some tests on corner cases for @JvmRecord (vor 4 Tagen) <Denis.Zharkov>
* 3aa55620d08 - Prohibit explicit j.l.Record supertype even for @JvmRecord (vor 4 Tagen) <Denis.Zharkov>
* 2b29e70b640 - Temporary avoid using constant from the new ASM (vor 4 Tagen) <Denis.Zharkov>
* f399f013dd7 - Temporary add another env variable JDK_15_0 that is set on TC agents (vor 4 Tagen) <Denis.Zharkov>
* 46c3979acd0 - Separate JVM target option from javac's --enable-preview analogue (vor 4 Tagen) <Denis.Zharkov>
* 3abd8b1ab28 - Adapt CliTests for api requirement of @JvmRecord (vor 4 Tagen) <Denis.Zharkov>
* dc1a1c5821e - Support cross-module usages of @JvmRecord classes (vor 4 Tagen) <Denis.Zharkov>
* ac0604377d1 - Minor. Extract runJvmInstance for running BB tests with custom JVM (vor 4 Tagen) <Denis.Zharkov>
* 6e4f84dddfc - Add @SinceKotlin("1.5") on JvmRecord annotation (vor 4 Tagen) <Denis.Zharkov>
* ddbd62054f4 - Prohibit extending java.lang.Record from non-@JvmRecord classes (vor 4 Tagen) <Denis.Zharkov>
* 695d0dbfbbf - Check JvmRecordSupport language feature before generating synthetic properties (vor 4 Tagen) <Denis.Zharkov>
* a4bf36aee7b - Support @JvmRecord for JVM_IR (vor 4 Tagen) <Denis.Zharkov>
* f64980a5976 - Add check for bytecode target when @JvmRecord is used (vor 4 Tagen) <Denis.Zharkov>
* b860a0c6644 - Separate JvmTarget::bytecodeVersion version into major/minor parts (vor 4 Tagen) <Denis.Zharkov>
* c8851c4f751 - Prohibit @JvmRecord for non-data classes (vor 4 Tagen) <Denis.Zharkov>
* cc0b584445d - Adapt test infrastructure to the latest changes (vor 4 Tagen) <Denis.Zharkov>
* 1d873a1a73c - Move earlier generated tests (vor 4 Tagen) <Denis.Zharkov>
* 033f43794d1 - Prohibit irrelevant fields in @JvmRecord classes (vor 4 Tagen) <Denis.Zharkov>
* 1b575d79030 - Add initial support for @JvmRecord in backend (vor 4 Tagen) <Denis.Zharkov>
* 26d525fa3c2 - Prepare ClassBuilder for record components (vor 4 Tagen) <Denis.Zharkov>
* f6a3580c934 - Add @JvmRecord diagnostics for open and enums (vor 4 Tagen) <Denis.Zharkov>
* bef50c0342d - Correct descriptor shape for @JvmRecord annotated classes (vor 4 Tagen) <Denis.Zharkov>
* ca2e199b53e - Minor. Move @JvmRecord tests to relevant directory (vor 4 Tagen) <Denis.Zharkov>
* d4de2c4dced - Add check that we have JDK 15 in classpath when using @JvmRecord (vor 4 Tagen) <Denis.Zharkov>
* 85962d8312f - Add check that @JvmRecord classes cannot inherit other classes (vor 4 Tagen) <Denis.Zharkov>
* 4f5db241eaa - Add @JvmRecord annotation and relevant diagnostics (vor 4 Tagen) <Denis.Zharkov>
* 059e2aab7a4 - Make BlackBox tests for Java 9 generated (vor 4 Tagen) <Denis.Zharkov>
* 5d054190166 - Add simple JDK15 BlackBox test (vor 4 Tagen) <Denis.Zharkov>
* 513f7177ca4 - Support loading Java records (vor 4 Tagen) <Denis.Zharkov>
* f25b7672a79 - Introduce FULL_JDK_15 TestJdkKind (vor 4 Tagen) <Denis.Zharkov>
* 430da22b4b2 - Setup 15_PREVIEW LanguageLevel for Java sources in CLI (vor 4 Tagen) <Denis.Zharkov>
* ff52a3f867f - (tag: build-1.5.0-dev-322) [Gradle, JS] Null library and libraryTarget when they are null (vor 4 Tagen) <Ilya Goncharov>
* d4233f3f0ea - (tag: build-1.5.0-dev-321) [Wasm] Use Wasm GC arrays instead of JS arrays (vor 4 Tagen) <Svyatoslav Kuzmich>
* d15af70a3ea - [Wasm] Refactoring: replace "struct types" with "GC types" (vor 4 Tagen) <Svyatoslav Kuzmich>
* 4bb163fd1fc - [Wasm IR] Add missing GC and function reference instructions (vor 4 Tagen) <Svyatoslav Kuzmich>
* 6063353b647 - [Wasm] Generate stdlib WasmOp based on WasmOp from Wasm IR (vor 4 Tagen) <Svyatoslav Kuzmich>
* 1cfb81455ca - (tag: build-1.5.0-dev-317) Generate correct names for companion @JvmStatic accessors in annotation class (vor 4 Tagen) <Mikhael Bogdanov>
* 3e0efeef31b - (tag: build-1.5.0-dev-309) JVM IR: add test for complex generic diamond hierarchy (vor 4 Tagen) <Alexander Udalov>
* 3370fa03d73 - Revert "JVM IR: remove obsolete isDefaultImplsBridge in findInterfaceImplementation" (vor 4 Tagen) <Alexander Udalov>
* 69c88a8a0a4 - (tag: build-1.5.0-dev-299) PSI2IR KT-41284 use getters for open data class property values (vor 4 Tagen) <Dmitry Petrov>
* d8d30263d33 - (tag: build-1.5.0-dev-298) IC Mangling: search parents for method if descriptor is fake override (vor 5 Tagen) <Ilmir Usmanov>
* e089e3606fd - (tag: build-1.5.0-dev-297) Disable `testSingleAndroidTarget` while OOM investigation in progress KT-43755 (vor 5 Tagen) <Alexander Dudinsky>
* df9ecb0f4ae - (tag: build-1.5.0-dev-289) Dependency of js tests generation on compiler test data generation (KTI-404) (vor 5 Tagen) <Nikolay Krasko>
* 0ca7c504520 - (tag: build-1.5.0-dev-288) FIR IDE: refactor, separate resolveSimpleNameReference into functions (vor 5 Tagen) <Ilya Kirillov>
* 717e087fd92 - (tag: build-1.5.0-dev-275) [JVM] Do not collaps unrelated locals in state machine transform. (vor 5 Tagen) <Mads Ager>
* 1bb864bbb06 - [JVM] Add tests that expose problem with locals collapsing. (vor 5 Tagen) <Mads Ager>
* 8e38f9d176e - (tag: build-1.5.0-dev-268) Stop mangle common project descriptor in GenerateTestSupport tests (vor 5 Tagen) <Nikolay Krasko>
* b0347c38222 - Stable order of generation and errors in ConvertSealedClassToEnumIntention (vor 5 Tagen) <Nikolay Krasko>
* 2ad4824eb05 - (tag: build-1.5.0-dev-241) Fix exception on resolving collection literal inside lambda (vor 5 Tagen) <Mikhail Zarechenskiy>
* c5015c9294e - (tag: build-1.5.0-dev-235) Don't recognize IrVariable as declaration scope in inlining (vor 6 Tagen) <Mikhael Bogdanov>
* 7f51f579986 - (tag: build-1.5.0-dev-234) Generate correct $default method for actual suspend function (vor 6 Tagen) <Ilmir Usmanov>
* 0dc5f3ac002 - (tag: build-1.5.0-dev-233) IC: call JvmDefault method of inline class using boxed receiver (vor 6 Tagen) <Ilmir Usmanov>
* d6330337a98 - (tag: build-1.5.0-dev-218) FIR IDE: introduce param for enabling disabled tests (vor 6 Tagen) <Ilya Kirillov>
* a671054fa32 - FIR IDE: change until-build to 203.* in plugin.xml (vor 6 Tagen) <Ilya Kirillov>
* b6d80a11498 - (tag: build-1.5.0-dev-214) Build: Fix kotlin-compiler-internal-test-framework empty sources jar (vor 6 Tagen) <Vyacheslav Gerasimov>
* 1d51dffd768 - (tag: build-1.5.0-dev-211) Reminder about -Pidea.fir.plugin=true for running fir-idea tests (vor 6 Tagen) <Nikolay Krasko>
* e5c62c38389 - (tag: build-1.5.0-dev-205) [JS] Disable special checks in labeled-block-to-do-while (vor 6 Tagen) <Zalim Bashorov>
* 7ca54ec4058 - [JS IR] unmute test arraySort.kt (vor 6 Tagen) <Zalim Bashorov>
* 4c69f78de8a - [JS] Replace J2V8 based ScriptEngine with a process-based version (vor 6 Tagen) <Zalim Bashorov>
* 39cc149da0c - [JS] Revert disabling running ES6 tests on all platforms except linux (vor 6 Tagen) <Zalim Bashorov>
* 2cb4a4906f9 - [JS] Remove j2v8 from dependencies (vor 6 Tagen) <Zalim Bashorov>
* f4431a21fc6 - [JS] Make all JS test tasks depending on setupV8 (vor 6 Tagen) <Zalim Bashorov>
* 9cc3725db16 - [JS] Move JS engines download and setup code higher to use it from other tasks (vor 6 Tagen) <Zalim Bashorov>
* bc4c2349c08 - [JS] Extract engine setup related code from wasmTest (vor 6 Tagen) <Zalim Bashorov>
* 70eb3d24860 - [JS] BasicBoxTest.kt: cleanup (vor 6 Tagen) <Zalim Bashorov>
* f573b81456d - [JS] Minor: fix typo in AntTaskJsTest (vor 6 Tagen) <Zalim Bashorov>
* b8903f8cf88 - (tag: build-1.5.0-dev-191) Enable kotlin-annotation-processing-cli tests on TC (vor 6 Tagen) <Mikhael Bogdanov>
* 078aa18479e - (tag: build-1.5.0-dev-190) Fix KAPT cli tests on windows (vor 6 Tagen) <Ivan Gavrilovic>
* 82ad230e0d9 - (tag: build-1.5.0-dev-182) [Gradle, JS] Add nodeArgs to NodeJsExec (vor 6 Tagen) <Ilya Goncharov>
* cdfe1771d99 - (tag: build-1.5.0-dev-181) FIR DFA: reimplement type OR operation to its original semantics (vor 6 Tagen) <Jinseong Jeon>
* 16b93126950 - FIR DFA: refactor type statements manipulation (vor 6 Tagen) <Jinseong Jeon>
* 7ea58adc502 - FIR: reproduce KT-43569 (vor 6 Tagen) <Jinseong Jeon>
* 0d8cdb7bdb5 - (tag: build-1.5.0-dev-171) Fix double registered "com.intellij.psi.classFileDecompiler" for 203 platform (vor 6 Tagen) <Nikita Bobko>