### PR TITLE
Fix WorkerBoundReference kdoc

### DIFF
--- a/runtime/src/main/kotlin/kotlin/native/concurrent/WorkerBoundReference.kt
+++ b/runtime/src/main/kotlin/kotlin/native/concurrent/WorkerBoundReference.kt
@@ -23,7 +23,7 @@ external private fun describeWorkerBoundReference(ref: NativePtr): String
  * the worker [WorkerBoundReference] was created on, unless the referred object is frozen too.
  *
  * Note: Garbage collector currently cannot free any reference cycles with frozen [WorkerBoundReference] in them.
- * To resolve such cycles consider using [AtomicReference<WorkerBoundReference?>] which can be explicitly
+ * To resolve such cycles consider using [AtomicReference]`<WorkerBoundReference?>` which can be explicitly
  * nulled out.
  */
 @NoReorderFields


### PR DESCRIPTION
The `[AtomicReference<WorkerBoundReference?>]` is rendered in an unexpected manner, see https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.native.concurrent/-worker-bound-reference/

Change this to a somewhat more safe pattern.