### PR TITLE
[kotlin compiler][update] 1.5.0-dev-805

### DIFF
--- a/build-tools/settings.gradle.kts
+++ b/build-tools/settings.gradle.kts
@@ -3,11 +3,13 @@ pluginManagement {
         rootDir.resolve("../gradle.properties").reader().use(::load)
     }
 
+    val buildKotlinCompilerRepo: String by rootProperties
     val kotlinCompilerRepo: String by rootProperties
-    val kotlinVersion by rootProperties
+    val buildKotlinVersion by rootProperties
 
     repositories {
         maven(kotlinCompilerRepo)
+        maven(buildKotlinCompilerRepo)
         maven("https://cache-redirector.jetbrains.com/maven-central")
         mavenCentral()
     }
@@ -15,7 +17,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "kotlin") {
-                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$buildKotlinVersion")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-500,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.0-dev-500
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-500,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.0-dev-500
-kotlinStdlibTestsVersion=1.5.0-dev-500
-testKotlinCompilerVersion=1.5.0-dev-500
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-805,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.0-dev-805
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-805,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.0-dev-805
+kotlinStdlibTestsVersion=1.5.0-dev-805
+testKotlinCompilerVersion=1.5.0-dev-805
 konanVersion=1.5.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* a5ddb1fdf13 - (HEAD -> master, tag: build-1.5.0-dev-805, origin/master, origin/HEAD) Update error about unsupported inline classes (vor 2 Tagen) <Leonid Startsev>
* 272273baed7 - Support serializable inline classes in IR plugin (vor 2 Tagen) <Leonid Startsev>
* 631a72d14a8 - Support old serialization runtime versions (vor 2 Tagen) <Leonid Startsev>
* f671c27f274 - (tag: build-1.5.0-dev-804) Adapt serialization exceptions constructor calls in legacy JS (vor 2 Tagen) <Leonid Startsev>
* 18e7a1485c0 - Additional fix for Compose: (vor 2 Tagen) <Leonid Startsev>
* f922ebbfc38 - (tag: build-1.5.0-dev-797) Value classes: Add JvmInlineValueClasses language feature (vor 3 Tagen) <Ilmir Usmanov>
* 48d9812d9e3 - (tag: build-1.5.0-dev-795) Review fixes around type enhancement and loading type use annotations (vor 3 Tagen) <Victor Petukhov>
* 9a52863fbda - Report warnings about type mismatches based on freshly supported nullability annotations deeply (vor 3 Tagen) <Victor Petukhov>
* d6017420dec - Mark freshly supported annotations to use that mark for reporting corresponding warnings (vor 3 Tagen) <Victor Petukhov>
* 9693ea19fb0 - Add tests for type enhancement uncluding with compiled java (vor 3 Tagen) <Victor Petukhov>
* 71ca18e937b - Support diagnostic tests with Kotlin against compiled Java (vor 3 Tagen) <Victor Petukhov>
* 6f8f531d87c - Put type enhancement improvements under the compiler flag (vor 3 Tagen) <Victor Petukhov>
* 857cc92326c - Support preference of TYPE_USE annotations to enhance over others like METHOD, FIELD and VALUE_PARAMETER to avoid double applying them in case of arrays: @NotNull Integer [] (both to the array element and to the entire array) (vor 3 Tagen) <Victor Petukhov>
* 69f31afecce - Exclude tests for loading type use annotations and type enhancement based on them to pass using javac and psi class files reading (vor 3 Tagen) <Victor Petukhov>
* f389654fea3 - Support type enhancement for super classes' types (vor 3 Tagen) <Victor Petukhov>
* 276498793f7 - Support enhancement of type parameter's bound for all nullability annotations (vor 3 Tagen) <Victor Petukhov>
* c91301d04cb - Support type use annotations on fields (vor 3 Tagen) <Victor Petukhov>
* b0debbe4c97 - Add forced mark "isDeprecated" as false for missing types among javac types (vor 3 Tagen) <Victor Petukhov>
* 8777d28228d - Use new jetbrains annotations with type use target for "load java 8" tests (vor 3 Tagen) <Victor Petukhov>
* 6f64e2c0360 - Avoid a cycle of analysing of type parameters via checking that it's a type parameter first (vor 3 Tagen) <Victor Petukhov>
* a89329e0775 - Support reading from class files of the type use annotations on type parameters and type arguments (vor 3 Tagen) <Victor Petukhov>
* 0833719a799 - Support annotations on array types (vor 3 Tagen) <Victor Petukhov>
* f0ab8bc332a - Clean up some code in `compiler.resolution.common.jvm` (vor 3 Tagen) <Victor Petukhov>
* 63aa8092800 - (tag: build-1.5.0-dev-790) [FIR IDE] Add fir type annotations test (vor 3 Tagen) <Igor Yakovlev>
* c4b708b5dcc - [FIR IDE] Fixed test data for types (vor 3 Tagen) <Igor Yakovlev>
* 9e89cfae08c - [FIR IDE] Fixed invalid leaks test (vor 3 Tagen) <Igor Yakovlev>
* fb944707415 - [FIR IDE] Fix resolve value parameter symbol (vor 3 Tagen) <Igor Yakovlev>
* 8891a337e29 - [FIR IDE] Implement type annotations for fir symbols (vor 3 Tagen) <Igor Yakovlev>
* 9670f67912e - [FIR IDE] Make annotations and extension receiver lazy (vor 3 Tagen) <Igor Yakovlev>
* 9c2d06cf703 - (tag: build-1.5.0-dev-782) FIR: strengthen resolution success check for augmented array set call (vor 3 Tagen) <Jinseong Jeon>
* 9bf2dfaa023 - (tag: build-1.5.0-dev-781) KT-40200: Fix main function detector in lazy resolve overload resolver (vor 3 Tagen) <Simon Ogorodnik>
* 92adccde478 - (tag: build-1.5.0-dev-779) Probably fix issue with creating module descriptor for SDK twice (vor 3 Tagen) <Dmitriy Novozhilov>
* 6296f6dc333 - [FE] Don't throw assertion in OverrideResolver if directOverridden is empty (vor 3 Tagen) <Dmitriy Novozhilov>
* dea01125d69 - (tag: build-1.5.0-dev-775) FIR deserializer: keep SourceElement for more precise Fir2IrLazyClass's source (vor 3 Tagen) <Jinseong Jeon>
* fe0c25693d2 - FIR2IR: do not convert @ExtensionFunctionType twice (vor 3 Tagen) <Jinseong Jeon>
* 46084316829 - (tag: build-1.5.0-dev-771) FIR2IR: correct base symbols of fake overrides for delegated member (vor 3 Tagen) <Jinseong Jeon>
* 44c6ec2c449 - (tag: build-1.5.0-dev-767) FIR checker: make unused checker handle invoke properly (vor 3 Tagen) <Jinseong Jeon>
* d907c48d9ce - (tag: build-1.5.0-dev-764) Allow KtEnumEntry...RefExpression.referencedElement be nullable (vor 3 Tagen) <Mikhail Glukhikh>
* 4f96f9d6a17 - (tag: build-1.5.0-dev-762) [JS IR] Initialize enum fields before accessing them in companion object (vor 3 Tagen) <Shagen Ogandzhanian>
* 3eb0745b58f - (tag: build-1.5.0-dev-750) KTIJ-650 [Code completion]: "sealed interface" is for 1.5+ only (vor 4 Tagen) <Andrei Klunnyi>
* 27ebb6c946b - KTIJ-650 [Code completion]: test framework fix (vor 4 Tagen) <Andrei Klunnyi>
* efc7ab50237 - (tag: build-1.5.0-dev-748) KTIJ-664 [SealedClassInheritorsProvider]: test fixes (vor 4 Tagen) <Andrei Klunnyi>
* 88a0fe7ec19 - (tag: build-1.5.0-dev-727) Make a longer description for Kotlin Android plugin (vor 4 Tagen) <Nikolay Krasko>
* 43c04dfd086 - (tag: build-1.5.0-dev-726) [Wasm] Publish stdlib: remove separate project (vor 4 Tagen) <Ilya Gorbunov>
* be688356c96 - (tag: build-1.5.0-dev-722) [IR] Fixed bug with thread unsafety (vor 4 Tagen) <Igor Chevdar>
* 03693e3d5a7 - (tag: build-1.5.0-dev-721) [klib] Optimized away some Files.exists() (vor 4 Tagen) <Igor Chevdar>
* f597343d822 - (tag: build-1.5.0-dev-710) [TEST] Fix testdata (vor 5 Tagen) <Dmitriy Novozhilov>
* 8974d31bb8b - [TEST] Fix problem with line separator on windows (vor 5 Tagen) <Dmitriy Novozhilov>
* f2fa36f9cb2 - (tag: build-1.5.0-dev-709) Split modules scan based if facedSettings can affect api/lang level of module (vor 5 Tagen) <Vladimir Dolzhenko>
* e7c4121e678 - (tag: build-1.5.0-dev-677, tag: build-1.5.0-dev-676, tag: build-1.5.0-dev-675) [TEST] Add muting tests with .fail file for js box tests (vor 5 Tagen) <Dmitriy Novozhilov>
* 416f17e5ece - [TEST] Drop remaining tests of experimental coroutines (vor 5 Tagen) <Dmitriy Novozhilov>
* 019cb1485e1 - [TEST] Extract language feature regex pattern to :test-infrastructure-utils (vor 5 Tagen) <Dmitriy Novozhilov>
* 4ed2651c1f0 - [CMI] Rename platforms to attributes in some forgotten places (vor 5 Tagen) <Dmitriy Novozhilov>
* e1802fde296 - [TD] Update test data after previous commit (vor 5 Tagen) <Dmitriy Novozhilov>
* 49d9b859502 - [TEST] Migrate AbstractFirDiagnosticsWithLightTreeTest to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* 7e9deb76022 - [FIR] Fix NPE in light tree source utils (vor 5 Tagen) <Dmitriy Novozhilov>
* b048296dcaa - [FIR] Fix calculating offsets for light tree source elements (vor 5 Tagen) <Dmitriy Novozhilov>
* acbc468fdde - [FIR] Add light tree mode to FirAnalyzerFacade (vor 5 Tagen) <Dmitriy Novozhilov>
* 2aa1cb74519 - [TEST] Migrate AbstractDiagnosticsNativeTest to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* e7f84860784 - [TEST] Migrate AbstractDiagnosticsTestWithJvmBackend to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* 71ffaa2d97b - [TEST] Migrate AbstractDiagnosticsTestWithJsStdLib to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* 1fe5148f0d3 - [TEST] Extract compiler-specific test utils from :tests-common to new module (vor 5 Tagen) <Dmitriy Novozhilov>
* d15c7861b27 - [TEST] Invert dependency between :test-generator and :tests-common modules (vor 5 Tagen) <Dmitriy Novozhilov>
* bc7e18fb8a7 - [TEST] Regenerate tests after previous commit (vor 5 Tagen) <Dmitriy Novozhilov>
* 9e2d6914254 - [TEST] Move utils for checking all files presented to KtTestUtil (vor 5 Tagen) <Dmitriy Novozhilov>
* 64ce307f7fa - [TEST] Drop mechanism for muting tests with .mute files (vor 5 Tagen) <Dmitriy Novozhilov>
* f8ad096abb4 - [TEST] Mute tests in IC JS Klib tests using exclude pattern instead of .mute file (vor 5 Tagen) <Dmitriy Novozhilov>
* d9848544dc1 - [TEST] Move auto mute wrapping utils to :compiler:tests-mutes (vor 5 Tagen) <Dmitriy Novozhilov>
* 8a5fc2ad294 - [Build] Split `:tests-mutes` package to common and TC integration parts (vor 5 Tagen) <Dmitriy Novozhilov>
* 26d7ea6ce68 - [TEST] Migrate AbstractDiagnosticsWithModifiedMockJdkTest to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* b43fa94cb64 - [TEST] Migrate AbstractDiagnosticsWithUnsignedTypes to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* 23e704f3619 - [TEST] Migrate AbstractDiagnosticsWithExplicitApi to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* c0e4452cf84 - [TEST] Migrate AbstractDiagnosticsWithJdk9Test to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* 61302a2e081 - [TEST] Migrate duplicating javac tests to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* b44dc55109a - [TD] Mute some javac tests or update their testdata (vor 5 Tagen) <Dmitriy Novozhilov>
* 8ddf419be59 - [Build] Fix gradle tests filter for JUnit 5 (vor 5 Tagen) <Dmitriy Novozhilov>
* e6b5cb52160 - [TD] Update diagnostics test data due to new test runners (vor 5 Tagen) <Dmitriy Novozhilov>
* 1d04fecd29d - [TD] Remove some outdated tests with unsupported EXPLICIT_FLEXIBLE directive (vor 5 Tagen) <Dmitriy Novozhilov>
* 0b0e2c3ad23 - [TD] Create real helpers files for coroutines checkers (vor 5 Tagen) <Dmitriy Novozhilov>
* 710c5ec8cce - [TEST] Drop old generated tests which are duplicated by new ones (vor 5 Tagen) <Dmitriy Novozhilov>
* 6128d5e7f2d - [TEST] Generate new tests using new runners and old testdata (vor 5 Tagen) <Dmitriy Novozhilov>
* d7224ad63e5 - [Build] Add generating and running new compiler tests to gradle (vor 5 Tagen) <Dmitriy Novozhilov>
* 3bd3545a05e - [TEST] Add abstract test runners for some of compiler test in new infrastructure (vor 5 Tagen) <Dmitriy Novozhilov>
* 32fda13ef9f - [TEST] Implement test generators for junit 5 based tests (vor 5 Tagen) <Dmitriy Novozhilov>
* cb5183ab4d1 - [TEST] Add implementation of new infrastructure services for compiler tests (vor 5 Tagen) <Dmitriy Novozhilov>
* dd402b16d92 - [TEST] Add core of new tests infrastructure (vor 5 Tagen) <Dmitriy Novozhilov>
* 35437e6da9a - [FE] Allow explicitly specify dependent modules fin TopDownAnalyzerFacade (vor 5 Tagen) <Dmitriy Novozhilov>
* c8f3a4802e4 - [TEST] Introduce test-infrastructure-utils module and extract common test utilities here (vor 5 Tagen) <Dmitriy Novozhilov>
* 1c91b74ff0e - [CMI] Fix clearing code meta infos from original text (vor 5 Tagen) <Dmitriy Novozhilov>
* 79601826740 - [CMI] Fix CodeMetaInfoParser to properly handle nested meta infos (vor 5 Tagen) <Dmitriy Novozhilov>
* c558df5b4a1 - [CMI] Fix rendering metainfos at the end of file (vor 5 Tagen) <Dmitriy Novozhilov>
* ceb44ddccd3 - [CMI] Improve CodeMetaInfoRenderer (vor 5 Tagen) <Dmitriy Novozhilov>
* 98a2f29f958 - [CMI] Allow using right angle bracket symbol in MetaInfo message (vor 5 Tagen) <Dmitriy Novozhilov>
* 09df07349c2 - [CMI] Add ability to replace render configuration of DiagnosticCodeMetaInfo (vor 5 Tagen) <Dmitriy Novozhilov>
* d6ff83c7d8d - [CMI] Add ability to copy ParsedCodeMetaInfo (vor 5 Tagen) <Dmitriy Novozhilov>
* 3bf60b3accf - [CMI] Rename `CodeMetaInfo.platforms` to `attributes` (vor 5 Tagen) <Dmitriy Novozhilov>
* ced9a6fe355 - [CMI] Replace `getTag` with `tag` property in `CodeMetaInfo` (vor 5 Tagen) <Dmitriy Novozhilov>
* 9e31b049fce - [CMI] Add additional constructor for DiagnosticCodeMetaInfo (vor 5 Tagen) <Dmitriy Novozhilov>
* 87a6a669537 - [CMI] Parse description of meta info and save it to ParsedCodeMetaInfo (vor 5 Tagen) <Dmitriy Novozhilov>
* 2bbab3170fe - [CMI] Replace StringBuffer with StringBuilder in CodeMetaInfoRenderer (vor 5 Tagen) <Dmitriy Novozhilov>
* 25c011ca40b - [CMI] Extract core of CodeMetaInfo to :compiler:tests-common (vor 5 Tagen) <Dmitriy Novozhilov>
* 4ad9f486420 - [CMI] Cleanup code of CodeMetaInfo (vor 5 Tagen) <Dmitriy Novozhilov>
* 23c088afd64 - [TEST-GEN] Reorganize package structure in `:generators:test-generator` module (vor 5 Tagen) <Dmitriy Novozhilov>
* 380e8a38145 - [TEST-GEN] Extract run of TestGenerator to top of test generation DSL (vor 5 Tagen) <Dmitriy Novozhilov>
* 2a73aaba4d2 - [TEST-GEN] Move all generation data to `TestGroup.TestClass` (vor 5 Tagen) <Dmitriy Novozhilov>
* c51ea6b1421 - [TEST-GEN] Create abstract TestGenerator and move current generator logic to TestGeneratorImpl (vor 5 Tagen) <Dmitriy Novozhilov>
* d45fb4dfd81 - [TEST-GEN] Extract logic of generating test methods into separate abstraction MethodGenerator (vor 5 Tagen) <Dmitriy Novozhilov>
* 2acbe96f15d - [TEST-GEN] Convert Test Generation DSL classes from java to kotlin (vor 5 Tagen) <Dmitriy Novozhilov>
* 31bccb4fb03 - [TEST-GEN] Rename .java to .kt (vor 5 Tagen) <Dmitriy Novozhilov>
* 580d2ed693d - [TEST-GEN] Add some comments to TestGenerationDSL (vor 5 Tagen) <Dmitriy Novozhilov>
* 0e43eaa6629 - (tag: build-1.5.0-dev-674) Don't call possibleGetterNamesByPropertyName without a reason (vor 5 Tagen) <Mikhail Glukhikh>
* 44948aa9a2b - (tag: build-1.5.0-dev-669) [FE] Properly report diagnostics about type arguments of implicit invoke (vor 5 Tagen) <Dmitriy Novozhilov>
* 329066a4f38 - [Parser] Fix parsing of unfinished dot access in string template (vor 5 Tagen) <Dmitriy Novozhilov>
* 8999fd88b1a - (tag: build-1.5.0-dev-658, origin/rr/pdn_jvm_be_fix) JVM_IR KT-43401 KT-43518 fix ACC_STRICT and ACC_SYNCHRONIZED flags (vor 5 Tagen) <Dmitry Petrov>
* 7ed3860c705 - (tag: build-1.5.0-dev-654) JVM_IR KT-43043 fix nullability annotations for inline class members (vor 5 Tagen) <Dmitry Petrov>
* 2b3fc330ad5 - (tag: build-1.5.0-dev-653) KTIJ-664 [SealedClassInheritorsProvider]: test fixes (vor 5 Tagen) <Andrei Klunnyi>
* c2bf124d862 - (tag: build-1.5.0-dev-652) [FIR IDE] File symbol scope and symbol test (vor 5 Tagen) <Igor Yakovlev>
* 2f4842b2719 - [FIR IDE] Add KtFileScope to support KtFileSymbol (vor 5 Tagen) <Igor Yakovlev>
* 2fa5ab6e313 - [FIR IDE] LC Remove difficult caching from FirLightClassBase (vor 5 Tagen) <Igor Yakovlev>
* f282b721bc5 - [FIR IDE] LC Fix test data (vor 5 Tagen) <Igor Yakovlev>
* f5d8ae0550a - [FIR IDE] LC add caching to light facades (vor 5 Tagen) <Igor Yakovlev>
* da54dbba8ef - [FIR IDE] LC Add callable declarations to KtFileSymbol (vor 5 Tagen) <Igor Yakovlev>
* fb63b74b37a - [FIR IDE] LC Add KtFileSymbol and fix facade annotations (vor 5 Tagen) <Igor Yakovlev>
* 46071c19257 - [FIR IDE] LC fix annotations with special sites and nullability (vor 5 Tagen) <Igor Yakovlev>
* 2e7866ca866 - [FIR IDE] LC Fix annotations and modifiers for class members (vor 5 Tagen) <Igor Yakovlev>
* 3019f439fbe - [FIR IDE] LC More accurate processing for JvmSynthetic and JvmHidden annotations (vor 5 Tagen) <Igor Yakovlev>
* 3895ad375c9 - [FIR IDE] LC add jvmstatic method into companion object (vor 5 Tagen) <Igor Yakovlev>
* d32d0a65f0f - (tag: build-1.5.0-dev-643) Revert "Report warning on @JvmStatic in private companion objects" (vor 5 Tagen) <Victor Petukhov>
* 94deddef7f5 - Revert "Minor: cover negative cases with test +m" (vor 5 Tagen) <Victor Petukhov>
* 5a9ff3471a4 - (tag: build-1.5.0-dev-633) FIR IDE: fix function targets on context element copy (vor 6 Tagen) <Ilya Kirillov>
* 67fc1bcb3dd - FIR IDE: add debug error message when not possible to find fir declarartion by psi (vor 6 Tagen) <Ilya Kirillov>
* 940ec06f5bc - FIR IDE: precalculate completion context on dependent analysis session creation (vor 6 Tagen) <Ilya Kirillov>
* 40b1a4df5a3 - FIR IDE: temp mute failing find usages test (vor 6 Tagen) <Ilya Kirillov>
* 2d5b23b650c - FIR IDE: separate KtExpressionTypeProvider into components (vor 6 Tagen) <Ilya Kirillov>
* 2101816f032 - FIR IDE: add expected type calculation for function calls (vor 6 Tagen) <Ilya Kirillov>
* 7be8d69870f - FIR IDE: add completion weighers tests for return/if/while (vor 6 Tagen) <Ilya Kirillov>
* b16ebe2dc4d - FIR IDE: consider if & while conditions expected type as boolean (vor 6 Tagen) <Ilya Kirillov>
* c2d83353e81 - FIR IDE: introduce builtin types container (vor 6 Tagen) <Ilya Kirillov>
* 835577383b5 - FIR IDE: introduce expected type provider for return expressions (vor 6 Tagen) <Ilya Kirillov>
* 299f36183cc - FIR IDE: add tests for completion weighers from old testdata (vor 6 Tagen) <Ilya Kirillov>
* 19fff2b1e73 - FIR IDE: implement expected type weigher for completion (vor 6 Tagen) <Ilya Kirillov>
* c61d4b5f9c1 - FIR IDE: introduce return statement target provider (vor 6 Tagen) <Ilya Kirillov>
* a0ed14eafe5 - FIR: use real source element for return statement (vor 6 Tagen) <Ilya Kirillov>
* 3af0257b380 - (tag: build-1.5.0-dev-627) KTIJ-664 [SealedClassInheritorsProvider]: IDE-specific implementation (vor 6 Tagen) <Andrei Klunnyi>
* f02b73103b7 - KTIJ-650 [Code completion]: no "sealed" for classes with modifiers (vor 6 Tagen) <Andrei Klunnyi>
* fe64b13140e - KTIJ-650 [Code completion]: support for "sealed interface" (vor 6 Tagen) <Andrei Klunnyi>
* 602ed42b99b - (tag: build-1.5.0-dev-626) [Wasm] Move intrinsic generators to generators/wasm (vor 6 Tagen) <Svyatoslav Kuzmich>
* efeabac2c54 - (tag: build-1.5.0-dev-620) FIR: do not force coercion-to-Unit for nullable lambda return type (vor 6 Tagen) <Jinseong Jeon>
* 6239301f4ea - FIR: no constraint for coerced-to-Unit last expression of lambda (vor 6 Tagen) <Jinseong Jeon>
* 4ab0897d7d7 - FIR: pass the explicit expected type to block type (vor 6 Tagen) <Jinseong Jeon>
* 0ea6b32c018 - NI: allow lower bound of flexible type for coercion-to-Unit (vor 6 Tagen) <Jinseong Jeon>
* b0f6461fa9f - (tag: build-1.5.0-dev-598) JVM_IR KT-42020 special IdSignature for some fake override members (vor 6 Tagen) <Dmitry Petrov>
* 12cfba9ca96 - (tag: build-1.5.0-dev-590) FIR BB: remove stale test ignoring tags in old language versions (vor 6 Tagen) <Jinseong Jeon>
* f7ade2b0b84 - FIR2IR: introduce implicit casts for extension receivers (vor 6 Tagen) <Jinseong Jeon>
* 6e9ac6b3338 - (tag: build-1.5.0-dev-584) [Commonizer] Internal tool for tracking memory usage (vor 6 Tagen) <Dmitriy Dolovov>
* 010a2901322 - (tag: build-1.5.0-dev-580) [LC] Fix for light classes equivalence (vor 6 Tagen) <Igor Yakovlev>
* 45112a3c11e - (tag: build-1.5.0-dev-575) [ULC] Fix invalid positive inheritor for self checking (vor 7 Tagen) <Igor Yakovlev>
* 0f4173cdfa6 - (tag: build-1.5.0-dev-572) Fix running stdlib tests in worker on Native (vor 7 Tagen) <Svyatoslav Scherbina>
* 8f4e4a4d404 - Specify common sources for stdlib test compilation tasks (vor 7 Tagen) <Ilya Gorbunov>
* c094d77794a - Fix DeepRecursiveFunction in worker on Native (vor 7 Tagen) <Svyatoslav Scherbina>
* b3d8c4a0fc0 - (tag: build-1.5.0-dev-571) [JS IR] Apply missing property for all tests tasks like jsIrTest and quickTest (vor 7 Tagen) <Svyatoslav Kuzmich>
* 32cc95a3b0c - (tag: build-1.5.0-dev-569) [JS IR] Skip export annotations while generating default stubs (vor 7 Tagen) <Shagen Ogandzhanian>
* 7efc95705ab - (tag: build-1.5.0-dev-568) [Wasm] Publish stdlib klib to maven (vor 7 Tagen) <Svyatoslav Kuzmich>
* d37271bf358 - (tag: build-1.5.0-dev-559, tag: build-1.5.0-dev-550) [Wasm] Support packed integer array elements (vor 7 Tagen) <Svyatoslav Kuzmich>
* 51e8d782b0c - [Wasm] Support packed integer class fields (vor 7 Tagen) <Svyatoslav Kuzmich>
* 28168bf230a - (tag: build-1.5.0-dev-549, origin/rr/stdlib/js-map-entries-contains-fix-merge) Correctly implement specialized MutableEntrySet.contains KT-41278 (vor 7 Tagen) <Ilya Gorbunov>
* 0a3f3bef51e - (tag: build-1.5.0-dev-529) [Gradle, JS]Process error output and rethrow errors and warns to console (vor 7 Tagen) <Ilya Goncharov>
* 55b0775565f - (tag: build-1.5.0-dev-528) [FE] Call SealedClassInheritorsProvider only for sealed classes (vor 7 Tagen) <Dmitriy Novozhilov>
* 0a2269cccbe - (tag: build-1.5.0-dev-518) Fixed out-of-process compiler execution if project directy is absent (vor 8 Tagen) <Andrey Uskov>
* 9be7221efda - Clear IC caches if they were not properly closed (vor 8 Tagen) <Andrey Uskov>
* 7bdd7ce6b80 - Reformat DirtyClassesMap (vor 8 Tagen) <Andrey Uskov>
* 275a02ce88e - Fix synchronization when working with IC caches (vor 8 Tagen) <Andrey Uskov>
* af95b8d1fe8 - Add explicit path sensitivity for InspectClassesForMultiModuleIC (vor 8 Tagen) <Andrey Uskov>
* 2e607335dbd - Add tests for incremental compilation of sealed interfaces (vor 8 Tagen) <Andrey Uskov>
* 36f99156fd1 - IC of sealed classes (vor 8 Tagen) <Andrey Uskov>