### PR TITLE
Fix reporting of filtered out test suites

### DIFF
--- a/runtime/src/main/kotlin/kotlin/native/internal/test/TestRunner.kt
+++ b/runtime/src/main/kotlin/kotlin/native/internal/test/TestRunner.kt
@@ -257,10 +257,11 @@ internal class TestRunner(val suites: List<TestSuite>, args: Array<String>) {
         val iterationTime = measureTimeMillis {
             suitesFiltered.forEach {
                 if (it.ignored) {
-                    if (reportExcludedTestSuites) {
-                        sendToListeners { ignoreSuite(it) }
-                    }
+                    sendToListeners { ignoreSuite(it) }
                 } else {
+                    if (!reportExcludedTestSuites && it.size == 0) {
+                        return@forEach
+                    }
                     sendToListeners { startSuite(it) }
                     val time = measureTimeMillis { it.run() }
                     sendToListeners { finishSuite(it, time) }


### PR DESCRIPTION
This fixes the `--ktest_no_excluded_test_suites` command line option behavior to match its description in the help page.

It is a follow-up for https://github.com/JetBrains/kotlin-native/pull/4522, where I apparently misunderstood how test filtering works. Sorry for that, now the CLI flag is tested more carefully.