### PR TITLE
[kotlin compiler][update] 1.5.0-dev-1023

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Boxing.kt
@@ -14,8 +14,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
@@ -59,11 +57,10 @@ internal val Context.getBoxFunction: (IrClass) -> IrSimpleFunction by Context.la
     val startOffset = inlinedClass.startOffset
     val endOffset = inlinedClass.endOffset
 
-    val descriptor = WrappedSimpleFunctionDescriptor()
     IrFunctionImpl(
             startOffset, endOffset,
             DECLARATION_ORIGIN_INLINE_CLASS_SPECIAL_FUNCTION,
-            IrSimpleFunctionSymbolImpl(descriptor),
+            IrSimpleFunctionSymbolImpl(),
             Name.special("<${inlinedClass.name}-box>"),
             DescriptorVisibilities.PUBLIC,
             Modality.FINAL,
@@ -77,11 +74,11 @@ internal val Context.getBoxFunction: (IrClass) -> IrSimpleFunction by Context.la
             isOperator = false,
             isInfix = false
     ).also { function ->
-        function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
+        function.valueParameters = listOf(
             IrValueParameterImpl(
                     startOffset, endOffset,
                     IrDeclarationOrigin.DEFINED,
-                    IrValueParameterSymbolImpl(it),
+                    IrValueParameterSymbolImpl(),
                     Name.identifier("value"),
                     index = 0,
                     varargElementType = null,
@@ -91,11 +88,8 @@ internal val Context.getBoxFunction: (IrClass) -> IrSimpleFunction by Context.la
                     isHidden = false,
                     isAssignable = false
             ).apply {
-                it.bind(this)
                 parent = function
-            }
-        })
-        descriptor.bind(function)
+            })
         function.parent = inlinedClass.getContainingFile()!!
     }
 }
@@ -116,11 +110,10 @@ internal val Context.getUnboxFunction: (IrClass) -> IrSimpleFunction by Context.
     val startOffset = inlinedClass.startOffset
     val endOffset = inlinedClass.endOffset
 
-    val descriptor = WrappedSimpleFunctionDescriptor()
     IrFunctionImpl(
             startOffset, endOffset,
             DECLARATION_ORIGIN_INLINE_CLASS_SPECIAL_FUNCTION,
-            IrSimpleFunctionSymbolImpl(descriptor),
+            IrSimpleFunctionSymbolImpl(),
             Name.special("<${inlinedClass.name}-unbox>"),
             DescriptorVisibilities.PUBLIC,
             Modality.FINAL,
@@ -134,11 +127,11 @@ internal val Context.getUnboxFunction: (IrClass) -> IrSimpleFunction by Context.
             isOperator = false,
             isInfix = false
     ).also { function ->
-        function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
+        function.valueParameters = listOf(
             IrValueParameterImpl(
                     startOffset, endOffset,
                     IrDeclarationOrigin.DEFINED,
-                    IrValueParameterSymbolImpl(it),
+                    IrValueParameterSymbolImpl(),
                     Name.identifier("value"),
                     index = 0,
                     varargElementType = null,
@@ -148,11 +141,8 @@ internal val Context.getUnboxFunction: (IrClass) -> IrSimpleFunction by Context.
                     isHidden = false,
                     isAssignable = false
             ).apply {
-                it.bind(this)
                 parent = function
-            }
-        })
-        descriptor.bind(function)
+            })
         function.parent = inlinedClass.getContainingFile()!!
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/Context.kt
@@ -41,7 +41,6 @@ import org.jetbrains.kotlin.backend.common.ir.copyToWithoutSuperTypes
 import org.jetbrains.kotlin.backend.konan.objcexport.ObjCExport
 import org.jetbrains.kotlin.backend.konan.llvm.coverage.CoverageManager
 import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyClass
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrFieldSymbolImpl
 import org.jetbrains.kotlin.name.FqName
@@ -138,7 +137,7 @@ internal class SpecialDeclarationsFactory(val context: Context) {
         return bridges.getOrPut(key) { createBridge(key) }
     }
 
-    private fun createBridge(key: BridgeKey): IrSimpleFunction = WrappedSimpleFunctionDescriptor().let { descriptor ->
+    private fun createBridge(key: BridgeKey): IrSimpleFunction {
         val (function, bridgeDirections) = key
         val startOffset = function.startOffset
         val endOffset = function.endOffset
@@ -148,10 +147,10 @@ internal class SpecialDeclarationsFactory(val context: Context) {
                     null
                 else this.irClass?.defaultType ?: context.irBuiltIns.anyNType
 
-        IrFunctionImpl(
+        return IrFunctionImpl(
                 startOffset, endOffset,
                 DECLARATION_ORIGIN_BRIDGE_METHOD(function),
-                IrSimpleFunctionSymbolImpl(descriptor),
+                IrSimpleFunctionSymbolImpl(),
                 "<bridge-$bridgeDirections>${function.computeFunctionName()}".synthesizedName,
                 function.visibility,
                 function.modality,
@@ -166,7 +165,6 @@ internal class SpecialDeclarationsFactory(val context: Context) {
                 isInfix = false
         ).apply {
             val bridge = this
-            descriptor.bind(bridge)
             parent = function.parent
 
             dispatchReceiverParameter = function.dispatchReceiverParameter?.let {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EntryPoint.kt
@@ -15,8 +15,6 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.impl.IrTryImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
@@ -25,13 +23,12 @@ import org.jetbrains.kotlin.ir.util.irCatch
 import org.jetbrains.kotlin.name.Name
 
 internal fun makeEntryPoint(context: Context): IrFunction {
-    val entryPointDescriptor = WrappedSimpleFunctionDescriptor()
     val actualMain = context.ir.symbols.entryPoint!!.owner
     val entryPoint = IrFunctionImpl(
             actualMain.startOffset,
             actualMain.startOffset,
             IrDeclarationOrigin.DEFINED,
-            IrSimpleFunctionSymbolImpl(entryPointDescriptor),
+            IrSimpleFunctionSymbolImpl(),
             Name.identifier("Konan_start"),
             DescriptorVisibilities.PRIVATE,
             Modality.FINAL,
@@ -45,11 +42,11 @@ internal fun makeEntryPoint(context: Context): IrFunction {
             isOperator = false,
             isInfix = false
     ).also { function ->
-        function.valueParameters = listOf(WrappedValueParameterDescriptor().let {
+        function.valueParameters = listOf(
             IrValueParameterImpl(
                     actualMain.startOffset, actualMain.startOffset,
                     IrDeclarationOrigin.DEFINED,
-                    IrValueParameterSymbolImpl(it),
+                    IrValueParameterSymbolImpl(),
                     Name.identifier("args"),
                     index = 0,
                     varargElementType = null,
@@ -59,12 +56,9 @@ internal fun makeEntryPoint(context: Context): IrFunction {
                     isHidden = false,
                     isAssignable = false
             ).apply {
-                it.bind(this)
                 parent = function
-            }
-        })
+            })
     }
-    entryPointDescriptor.bind(entryPoint)
     entryPoint.annotations += buildSimpleAnnotation(context.irBuiltIns,
             actualMain.startOffset, actualMain.startOffset,
             context.ir.symbols.exportForCppRuntime.owner, "Konan_start")

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/EnumSpecialDescriptorsFactory.kt
@@ -22,9 +22,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFieldImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedClassDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedFieldDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetFieldImpl
@@ -135,11 +132,11 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
         val startOffset = enumClass.startOffset
         val endOffset = enumClass.endOffset
 
-        val implObject = WrappedClassDescriptor().let {
+        val implObject =
             IrClassImpl(
                     startOffset, endOffset,
                     DECLARATION_ORIGIN_ENUM,
-                    IrClassSymbolImpl(it),
+                    IrClassSymbolImpl(),
                     "OBJECT".synthesizedName,
                     ClassKind.OBJECT,
                     DescriptorVisibilities.PUBLIC,
@@ -152,18 +149,16 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
                     isExpect = false,
                     isFun = false
             ).apply {
-                it.bind(this)
                 parent = enumClass
                 createParameterDeclarations()
             }
-        }
 
         val valuesType = valuesArrayType(enumClass)
-        val valuesField = WrappedFieldDescriptor().let {
+        val valuesField =
             IrFieldImpl(
                     startOffset, endOffset,
                     DECLARATION_ORIGIN_ENUM,
-                    IrFieldSymbolImpl(it),
+                    IrFieldSymbolImpl(),
                     "VALUES".synthesizedName,
                     valuesType,
                     DescriptorVisibilities.PRIVATE,
@@ -171,16 +166,14 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
                     isExternal = false,
                     isStatic = false,
             ).apply {
-                it.bind(this)
                 parent = implObject
             }
-        }
 
-        val valuesGetter = WrappedSimpleFunctionDescriptor().let {
+        val valuesGetter =
             IrFunctionImpl(
                     startOffset, endOffset,
                     DECLARATION_ORIGIN_ENUM,
-                    IrSimpleFunctionSymbolImpl(it),
+                    IrSimpleFunctionSymbolImpl(),
                     "get-VALUES".synthesizedName,
                     DescriptorVisibilities.PUBLIC,
                     Modality.FINAL,
@@ -194,10 +187,8 @@ internal class EnumSpecialDeclarationsFactory(val context: Context) {
                     isOperator = false,
                     isInfix = false
             ).apply {
-                it.bind(this)
                 parent = implObject
             }
-        }
 
         val constructorOfAny = context.irBuiltIns.anyClass.owner.constructors.first()
         implObject.addSimpleDelegatingConstructor(

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGen.kt
@@ -549,12 +549,11 @@ private fun KotlinStubs.createFakeKotlinExternalFunction(
         cFunctionName: String,
         isObjCMethod: Boolean
 ): IrSimpleFunction {
-    val bridgeDescriptor = WrappedSimpleFunctionDescriptor()
     val bridge = IrFunctionImpl(
             UNDEFINED_OFFSET,
             UNDEFINED_OFFSET,
             IrDeclarationOrigin.DEFINED,
-            IrSimpleFunctionSymbolImpl(bridgeDescriptor),
+            IrSimpleFunctionSymbolImpl(),
             Name.identifier(cFunctionName),
             DescriptorVisibilities.PRIVATE,
             Modality.FINAL,
@@ -568,7 +567,6 @@ private fun KotlinStubs.createFakeKotlinExternalFunction(
             isOperator = false,
             isInfix = false
     )
-    bridgeDescriptor.bind(bridge)
 
     bridge.annotations += buildSimpleAnnotation(irBuiltIns, UNDEFINED_OFFSET, UNDEFINED_OFFSET,
             symbols.symbolName.owner, cFunctionName)
@@ -1098,16 +1096,14 @@ private class ObjCBlockPointerValuePassing(
     private fun IrBuilderWithScope.generateKotlinFunctionClass(): IrConstructor {
         val symbols = stubs.symbols
 
-        val classDescriptor = WrappedClassDescriptor()
         val irClass = IrClassImpl(
                 startOffset, endOffset,
-                OBJC_BLOCK_FUNCTION_IMPL, IrClassSymbolImpl(classDescriptor),
+                OBJC_BLOCK_FUNCTION_IMPL, IrClassSymbolImpl(),
                 Name.identifier(stubs.getUniqueKotlinFunctionReferenceClassName("BlockFunctionImpl")),
                 ClassKind.CLASS, DescriptorVisibilities.PRIVATE, Modality.FINAL,
                 isCompanion = false, isInner = false, isData = false, isExternal = false,
                 isInline = false, isExpect = false, isFun = false
         )
-        classDescriptor.bind(irClass)
         irClass.createParameterDeclarations()
 
         irClass.superTypes += stubs.irBuiltIns.anyType
@@ -1121,24 +1117,21 @@ private class ObjCBlockPointerValuePassing(
                 isMutable = false, owner = irClass
         )
 
-        val constructorDescriptor = WrappedClassConstructorDescriptor()
         val constructor = IrConstructorImpl(
                 startOffset, endOffset,
                 OBJC_BLOCK_FUNCTION_IMPL,
-                IrConstructorSymbolImpl(constructorDescriptor),
+                IrConstructorSymbolImpl(),
                 Name.special("<init>"),
                 DescriptorVisibilities.PUBLIC,
                 irClass.defaultType,
                 isInline = false, isExternal = false, isPrimary = true, isExpect = false
         )
-        constructorDescriptor.bind(constructor)
         irClass.addChild(constructor)
 
-        val constructorParameterDescriptor = WrappedValueParameterDescriptor()
         val constructorParameter = IrValueParameterImpl(
                 startOffset, endOffset,
                 OBJC_BLOCK_FUNCTION_IMPL,
-                IrValueParameterSymbolImpl(constructorParameterDescriptor),
+                IrValueParameterSymbolImpl(),
                 Name.identifier("blockPointer"),
                 0,
                 symbols.nativePtrType,
@@ -1148,7 +1141,6 @@ private class ObjCBlockPointerValuePassing(
                 isHidden = false,
                 isAssignable = false
         )
-        constructorParameterDescriptor.bind(constructorParameter)
         constructor.valueParameters += constructorParameter
         constructorParameter.parent = constructor
 
@@ -1166,28 +1158,25 @@ private class ObjCBlockPointerValuePassing(
         val overriddenInvokeMethod = (functionType.classifier.owner as IrClass).simpleFunctions()
                 .single { it.name == OperatorNameConventions.INVOKE }
 
-        val invokeMethodDescriptor = WrappedSimpleFunctionDescriptor()
         val invokeMethod = IrFunctionImpl(
                 startOffset, endOffset,
                 OBJC_BLOCK_FUNCTION_IMPL,
-                IrSimpleFunctionSymbolImpl(invokeMethodDescriptor),
+                IrSimpleFunctionSymbolImpl(),
                 overriddenInvokeMethod.name,
                 DescriptorVisibilities.PUBLIC, Modality.FINAL,
                 returnType = functionType.arguments.last().typeOrNull!!,
                 isInline = false, isExternal = false, isTailrec = false, isSuspend = false, isExpect = false,
                 isFakeOverride = false, isOperator = false, isInfix = false
         )
-        invokeMethodDescriptor.bind(invokeMethod)
         invokeMethod.overriddenSymbols += overriddenInvokeMethod.symbol
         irClass.addChild(invokeMethod)
         invokeMethod.createDispatchReceiverParameter()
 
         invokeMethod.valueParameters += (0 until parameterCount).map { index ->
-            val parameterDescriptor = WrappedValueParameterDescriptor()
             val parameter = IrValueParameterImpl(
                     startOffset, endOffset,
                     OBJC_BLOCK_FUNCTION_IMPL,
-                    IrValueParameterSymbolImpl(parameterDescriptor),
+                    IrValueParameterSymbolImpl(),
                     Name.identifier("p$index"),
                     index,
                     functionType.arguments[index].typeOrNull!!,
@@ -1197,7 +1186,6 @@ private class ObjCBlockPointerValuePassing(
                     isHidden = false,
                     isAssignable = false
             )
-            parameterDescriptor.bind(parameter)
             parameter.parent = invokeMethod
             parameter
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/cgen/CBridgeGenUtils.kt
@@ -15,8 +15,6 @@ import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrTryImpl
@@ -81,11 +79,10 @@ internal class KotlinBridgeBuilder(
 
     fun addParameter(type: IrType): IrValueParameter {
         val index = counter++
-        val descriptor = WrappedValueParameterDescriptor()
 
         return IrValueParameterImpl(
                 bridge.startOffset, bridge.endOffset, bridge.origin,
-                IrValueParameterSymbolImpl(descriptor),
+                IrValueParameterSymbolImpl(),
                 Name.identifier("p$index"), index, type,
                 null,
                 isCrossinline = false,
@@ -93,7 +90,6 @@ internal class KotlinBridgeBuilder(
                 isHidden = false,
                 isAssignable = false
         ).apply {
-            descriptor.bind(this)
             parent = bridge
             bridge.valueParameters += this
         }
@@ -114,12 +110,11 @@ private fun createKotlinBridge(
         isExternal: Boolean,
         foreignExceptionMode: ForeignExceptionMode.Mode
 ): IrFunction {
-    val bridgeDescriptor = WrappedSimpleFunctionDescriptor()
     val bridge = IrFunctionImpl(
             startOffset,
             endOffset,
             IrDeclarationOrigin.DEFINED,
-            IrSimpleFunctionSymbolImpl(bridgeDescriptor),
+            IrSimpleFunctionSymbolImpl(),
             Name.identifier(cBridgeName),
             DescriptorVisibilities.PRIVATE,
             Modality.FINAL,
@@ -133,7 +128,6 @@ private fun createKotlinBridge(
             isOperator = false,
             isInfix = false
     )
-    bridgeDescriptor.bind(bridge)
     if (isExternal) {
         bridge.annotations += buildSimpleAnnotation(stubs.irBuiltIns, startOffset, endOffset,
                 stubs.symbols.symbolName.owner, cBridgeName)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/KonanSharedVariablesManager.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/descriptors/KonanSharedVariablesManager.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.IrSetValue
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
@@ -44,17 +43,14 @@ internal class KonanSharedVariablesManager(val context: KonanBackendContext) : S
         }
 
         return with(originalDeclaration) {
-            WrappedVariableDescriptor().let {
-                IrVariableImpl(
-                        startOffset, endOffset, origin,
-                        IrVariableSymbolImpl(it), name, refConstructorCall.type,
-                        isVar = false,
-                        isConst = false,
-                        isLateinit = false
-                ).apply {
-                    it.bind(this)
-                    initializer = refConstructorCall
-                }
+            IrVariableImpl(
+                    startOffset, endOffset, origin,
+                    IrVariableSymbolImpl(), name, refConstructorCall.type,
+                    isVar = false,
+                    isConst = false,
+                    isLateinit = false
+            ).apply {
+                initializer = refConstructorCall
             }
         }
     }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/DescriptorToIrTranslationUtils.kt
@@ -60,7 +60,7 @@ internal interface DescriptorToIrTranslationMixin {
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB, it, descriptor
                 )
             }.also { irClass ->
-                symbolTable.withScope(descriptor) {
+                symbolTable.withScope(irClass) {
                     irClass.superTypes += descriptor.typeConstructor.supertypes.map {
                         it.toIrType()
                     }
@@ -133,7 +133,7 @@ internal interface DescriptorToIrTranslationMixin {
             origin: IrDeclarationOrigin = IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB
     ): IrSimpleFunction {
         val irFunction = symbolTable.declareSimpleFunctionWithOverrides(SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, origin, functionDescriptor)
-        symbolTable.withScope(functionDescriptor) {
+        symbolTable.withScope(irFunction) {
             irFunction.returnType = functionDescriptor.returnType!!.toIrType()
             irFunction.valueParameters +=  functionDescriptor.valueParameters.map {
                 symbolTable.declareValueParameter(SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrDeclarationOrigin.DEFINED, it, it.type.toIrType())

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumClassGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/interop/cenum/CEnumClassGenerator.kt
@@ -93,7 +93,7 @@ internal class CEnumClassGenerator(
                 .findDeclarationByName<PropertyDescriptor>("value")
                 ?: error("No `value` property in ${irClass.name}")
         val irProperty = createProperty(propertyDescriptor)
-        symbolTable.withScope(propertyDescriptor) {
+        symbolTable.withScope(irProperty) {
             irProperty.backingField = symbolTable.declareField(
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET, IrDeclarationOrigin.PROPERTY_BACKING_FIELD,
                     propertyDescriptor, propertyDescriptor.type.toIrType(), DescriptorVisibilities.PRIVATE

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/Autoboxing.kt
@@ -20,8 +20,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFieldImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrPropertyImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedPropertyDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
 import org.jetbrains.kotlin.ir.symbols.*
@@ -414,13 +412,12 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
     private fun buildBoxField(declaration: IrClass) {
         val startOffset = declaration.startOffset
         val endOffset = declaration.endOffset
-        val descriptor = WrappedPropertyDescriptor()
 
         val irField = IrFieldImpl(
                 startOffset,
                 endOffset,
                 IrDeclarationOrigin.DEFINED,
-                IrFieldSymbolImpl(descriptor),
+                IrFieldSymbolImpl(),
                 Name.identifier("value"),
                 declaration.defaultType,
                 DescriptorVisibilities.PRIVATE,
@@ -434,7 +431,7 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
                 startOffset,
                 endOffset,
                 IrDeclarationOrigin.DEFINED,
-                IrPropertySymbolImpl(descriptor),
+                IrPropertySymbolImpl(),
                 irField.name,
                 irField.visibility,
                 Modality.FINAL,
@@ -444,7 +441,6 @@ private class InlineClassTransformer(private val context: Context) : IrBuildingT
                 isDelegated = false,
                 isExternal = false
         )
-        descriptor.bind(irProperty)
         irProperty.backingField = irField
 
         declaration.addChild(irProperty)
@@ -553,11 +549,10 @@ private val Context.getLoweredInlineClassConstructor: (IrConstructor) -> IrSimpl
         irConstructor.returnType
     }
 
-    val descriptor = WrappedSimpleFunctionDescriptor()
     IrFunctionImpl(
             irConstructor.startOffset, irConstructor.endOffset,
             IrDeclarationOrigin.DEFINED,
-            IrSimpleFunctionSymbolImpl(descriptor),
+            IrSimpleFunctionSymbolImpl(),
             Name.special("<constructor>"),
             irConstructor.visibility,
             Modality.FINAL,
@@ -571,7 +566,6 @@ private val Context.getLoweredInlineClassConstructor: (IrConstructor) -> IrSimpl
             isOperator = false,
             isInfix = false
     ).apply {
-        descriptor.bind(this)
         parent = irConstructor.parent
 
         // Note: technically speaking, this function doesn't have access to class type parameters (since it is "static").

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/BridgesBuilding.kt
@@ -19,8 +19,6 @@ import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -71,11 +69,11 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                     val arg = jobFunction.valueParameters[0]
                     val startOffset = jobFunction.startOffset
                     val endOffset = jobFunction.endOffset
-                    runtimeJobFunction = WrappedSimpleFunctionDescriptor().let {
+                    runtimeJobFunction =
                         IrFunctionImpl(
                                 startOffset, endOffset,
                                 IrDeclarationOrigin.DEFINED,
-                                IrSimpleFunctionSymbolImpl(it),
+                                IrSimpleFunctionSymbolImpl(),
                                 jobFunction.name,
                                 jobFunction.visibility,
                                 jobFunction.modality,
@@ -88,16 +86,13 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                                 isFakeOverride = false,
                                 isOperator = false,
                                 isInfix = false
-                    ).apply {
-                            it.bind(this)
-                        }
-                    }
+                    )
 
-                    runtimeJobFunction.valueParameters += WrappedValueParameterDescriptor().let {
+                    runtimeJobFunction.valueParameters +=
                         IrValueParameterImpl(
                                 startOffset, endOffset,
                                 IrDeclarationOrigin.DEFINED,
-                                IrValueParameterSymbolImpl(it),
+                                IrValueParameterSymbolImpl(),
                                 arg.name,
                                 arg.index,
                                 type = context.irBuiltIns.anyNType,
@@ -106,8 +101,7 @@ internal class WorkersBridgesBuilding(val context: Context) : DeclarationContain
                                 isNoinline = arg.isNoinline,
                                 isHidden = arg.isHidden,
                                 isAssignable = arg.isAssignable
-                        ).apply { it.bind(this) }
-                    }
+                        )
                 }
                 val overriddenJobDescriptor = OverriddenFunctionInfo(jobFunction, runtimeJobFunction)
                 if (!overriddenJobDescriptor.needBridge) return expression

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/DelegationLowering.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFieldImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedFieldDescriptor
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrLocalDelegatedPropertyReference
 import org.jetbrains.kotlin.ir.expressions.IrPropertyReference
@@ -84,11 +83,11 @@ internal class PropertyDelegationLowering(val context: Context) : FileLoweringPa
 
         val kPropertiesFieldType: IrType = context.ir.symbols.array.typeWith(kPropertyImplType)
 
-        val kPropertiesField = WrappedFieldDescriptor().let {
+        val kPropertiesField =
             IrFieldImpl(
                     SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                     DECLARATION_ORIGIN_KPROPERTIES_FOR_DELEGATION,
-                    IrFieldSymbolImpl(it),
+                    IrFieldSymbolImpl(),
                     "KPROPERTIES".synthesizedName,
                     kPropertiesFieldType,
                     DescriptorVisibilities.PRIVATE,
@@ -96,11 +95,9 @@ internal class PropertyDelegationLowering(val context: Context) : FileLoweringPa
                     isExternal = false,
                     isStatic = true,
             ).apply {
-                it.bind(this)
                 parent = irFile
                 annotations += buildSimpleAnnotation(context.irBuiltIns, startOffset, endOffset, context.ir.symbols.sharedImmutable.owner)
             }
-        }
 
         irFile.transformChildrenVoid(object : IrElementTransformerVoidWithContext() {
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/EnumConstructorsLowering.kt
@@ -16,8 +16,6 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedClassConstructorDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedValueParameterDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
@@ -109,11 +107,11 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
         private fun lowerEnumConstructor(constructor: IrConstructor): IrConstructor {
             val startOffset = constructor.startOffset
             val endOffset = constructor.endOffset
-            val loweredConstructor = WrappedClassConstructorDescriptor().let {
+            val loweredConstructor =
                 IrConstructorImpl(
                         startOffset, endOffset,
                         constructor.origin,
-                        IrConstructorSymbolImpl(it),
+                        IrConstructorSymbolImpl(),
                         constructor.name,
                         DescriptorVisibilities.PROTECTED,
                         constructor.returnType,
@@ -122,32 +120,27 @@ internal class EnumConstructorsLowering(val context: Context) : ClassLoweringPas
                         isPrimary = constructor.isPrimary,
                         isExpect = false
                 ).apply {
-                    it.bind(this)
                     parent = constructor.parent
                     val body = constructor.body!!
                     this.body = body // Will be transformed later.
                     body.setDeclarationsParent(this)
                 }
-            }
 
             fun createSynthesizedValueParameter(index: Int, name: String, type: IrType): IrValueParameter =
-                    WrappedValueParameterDescriptor().let {
-                        IrValueParameterImpl(
-                                startOffset, endOffset,
-                                DECLARATION_ORIGIN_ENUM,
-                                IrValueParameterSymbolImpl(it),
-                                Name.identifier(name),
-                                index,
-                                type,
-                                varargElementType = null,
-                                isCrossinline = false,
-                                isNoinline = false,
-                                isHidden = false,
-                                isAssignable = false
-                        ).apply {
-                            it.bind(this)
-                            parent = loweredConstructor
-                        }
+                    IrValueParameterImpl(
+                            startOffset, endOffset,
+                            DECLARATION_ORIGIN_ENUM,
+                            IrValueParameterSymbolImpl(),
+                            Name.identifier(name),
+                            index,
+                            type,
+                            varargElementType = null,
+                            isCrossinline = false,
+                            isNoinline = false,
+                            isHidden = false,
+                            isAssignable = false
+                    ).apply {
+                        parent = loweredConstructor
                     }
 
             loweredConstructor.valueParameters += createSynthesizedValueParameter(0, "name", context.irBuiltIns.stringType)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FunctionReferenceLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/FunctionReferenceLowering.kt
@@ -25,9 +25,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedClassConstructorDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedClassDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -224,11 +221,11 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
         private val adaptedReferenceOriginalTarget: IrFunction? = adapteeCall?.symbol?.owner
         private val functionReferenceTarget = adaptedReferenceOriginalTarget ?: referencedFunction
 
-        private val functionReferenceClass: IrClass = WrappedClassDescriptor().let {
+        private val functionReferenceClass: IrClass =
             IrClassImpl(
                     startOffset,endOffset,
                     DECLARATION_ORIGIN_FUNCTION_REFERENCE_IMPL,
-                    IrClassSymbolImpl(it),
+                    IrClassSymbolImpl(),
                     "${functionReferenceTarget.name}\$FUNCTION_REFERENCE\$${context.functionReferenceCount++}".synthesizedName,
                     ClassKind.CLASS,
                     DescriptorVisibilities.PRIVATE,
@@ -241,11 +238,9 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
                     isExpect = false,
                     isFun = false
             ).apply {
-                it.bind(this)
                 parent = this@FunctionReferenceBuilder.parent
                 createParameterDeclarations()
             }
-        }
 
         private val functionReferenceThis = functionReferenceClass.thisReceiver!!
 
@@ -337,11 +332,11 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
             return BuiltFunctionReference(functionReferenceClass, constructor)
         }
 
-        private fun buildConstructor(): IrConstructor = WrappedClassConstructorDescriptor().let {
+        private fun buildConstructor(): IrConstructor =
             IrConstructorImpl(
                     startOffset, endOffset,
                     DECLARATION_ORIGIN_FUNCTION_REFERENCE_IMPL,
-                    IrConstructorSymbolImpl(it),
+                    IrConstructorSymbolImpl(),
                     Name.special("<init>"),
                     DescriptorVisibilities.PUBLIC,
                     functionReferenceClass.defaultType,
@@ -350,7 +345,6 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
                     isPrimary = true,
                     isExpect = false
             ).apply {
-                it.bind(this)
                 parent = functionReferenceClass
                 functionReferenceClass.declarations += this
 
@@ -387,7 +381,6 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
                     }
                 }
             }
-        }
 
         private fun getFlags() =
                 (if (referencedFunction.isSuspend) 1 else 0) + getAdaptedCallableReferenceFlags() shl 1
@@ -418,11 +411,11 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
             return false
         }
 
-        private fun buildInvokeMethod(superFunction: IrSimpleFunction): IrSimpleFunction = WrappedSimpleFunctionDescriptor().let {
+        private fun buildInvokeMethod(superFunction: IrSimpleFunction): IrSimpleFunction =
             IrFunctionImpl(
                     startOffset, endOffset,
                     DECLARATION_ORIGIN_FUNCTION_REFERENCE_IMPL,
-                    IrSimpleFunctionSymbolImpl(it),
+                    IrSimpleFunctionSymbolImpl(),
                     superFunction.name,
                     DescriptorVisibilities.PRIVATE,
                     Modality.FINAL,
@@ -436,7 +429,6 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
                     isOperator = false,
                     isInfix = false
             ).apply {
-                it.bind(this)
                 val function = this
                 parent = functionReferenceClass
                 functionReferenceClass.declarations += function
@@ -486,6 +478,5 @@ internal class FunctionReferenceLowering(val context: Context): FileLoweringPass
                     )
                 }
             }
-        }
     }
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/InitializersLowering.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
@@ -108,11 +107,11 @@ internal class InitializersLowering(val context: CommonBackendContext) : ClassLo
 
             val startOffset = irClass.startOffset
             val endOffset = irClass.endOffset
-            val initializeFun = WrappedSimpleFunctionDescriptor().let {
+            val initializeFun =
                 IrFunctionImpl(
                         startOffset, endOffset,
                         DECLARATION_ORIGIN_ANONYMOUS_INITIALIZER,
-                        IrSimpleFunctionSymbolImpl(it),
+                        IrSimpleFunctionSymbolImpl(),
                         "INITIALIZER".synthesizedName,
                         DescriptorVisibilities.PRIVATE,
                         Modality.FINAL,
@@ -126,7 +125,6 @@ internal class InitializersLowering(val context: CommonBackendContext) : ClassLo
                         isOperator = false,
                         isInfix = false
                 ).apply {
-                    it.bind(this)
                     parent = irClass
                     irClass.declarations.add(this)
 
@@ -134,7 +132,6 @@ internal class InitializersLowering(val context: CommonBackendContext) : ClassLo
 
                     body = IrBlockBodyImpl(startOffset, endOffset, initializers)
                 }
-            }
 
             for (initializer in initializers) {
                 initializer.transformChildrenVoid(object : IrElementTransformerVoid() {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeSuspendFunctionLowering.kt
@@ -14,8 +14,6 @@ import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrSetValueImpl
@@ -478,11 +476,11 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
     }
 
     // These are marker functions to split up the lowering on two parts.
-    private val saveState = WrappedSimpleFunctionDescriptor().let {
+    private val saveState =
         IrFunctionImpl(
                 SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                 IrDeclarationOrigin.DEFINED,
-                IrSimpleFunctionSymbolImpl(it),
+                IrSimpleFunctionSymbolImpl(),
                 "saveState".synthesizedName,
                 DescriptorVisibilities.PRIVATE,
                 Modality.ABSTRACT,
@@ -495,16 +493,13 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
                 isFakeOverride = false,
                 isOperator = false,
                 isInfix = false
-        ).apply {
-            it.bind(this)
-        }
-    }
+        )
 
-    private val restoreState = WrappedSimpleFunctionDescriptor().let {
+    private val restoreState =
         IrFunctionImpl(
                 SYNTHETIC_OFFSET, SYNTHETIC_OFFSET,
                 IrDeclarationOrigin.DEFINED,
-                IrSimpleFunctionSymbolImpl(it),
+                IrSimpleFunctionSymbolImpl(),
                 "restoreState".synthesizedName,
                 DescriptorVisibilities.PRIVATE,
                 Modality.ABSTRACT,
@@ -517,29 +512,24 @@ internal class NativeSuspendFunctionsLowering(ctx: Context): AbstractSuspendFunc
                 isFakeOverride = false,
                 isOperator = false,
                 isInfix = false
-        ).apply {
-            it.bind(this)
-        }
-    }
+        )
 
     private fun IrBuilderWithScope.irVar(name: Name, type: IrType,
                                          isMutable: Boolean = false,
-                                         initializer: IrExpression? = null) = WrappedVariableDescriptor().let {
+                                         initializer: IrExpression? = null) =
         IrVariableImpl(
                 startOffset, endOffset,
                 DECLARATION_ORIGIN_COROUTINE_IMPL,
-                IrVariableSymbolImpl(it),
+                IrVariableSymbolImpl(),
                 name,
                 type,
                 isMutable,
                 isConst = false,
                 isLateinit = false
         ).apply {
-            it.bind(this)
             this.initializer = initializer
             this.parent = this@irVar.parent
         }
-    }
 
     private fun IrBuilderWithScope.irGetOrThrow(result: IrExpression): IrExpression =
             irCall(symbols.kotlinResultGetOrThrow.owner).apply {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/RedundantCoercionsCleaner.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/RedundantCoercionsCleaner.kt
@@ -150,7 +150,7 @@ internal class RedundantCoercionsCleaner(val context: Context) : FileLoweringPas
                             expression
                         else {
                             val oldSymbol = expression.symbol
-                            val newSymbol = IrReturnableBlockSymbolImpl(expression.descriptor)
+                            val newSymbol = IrReturnableBlockSymbolImpl()
                             val transformedReturnableBlock = with(expression) {
                                 IrReturnableBlockImpl(
                                         startOffset = startOffset,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/TestProcessor.kt
@@ -22,9 +22,6 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrClassImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrConstructorImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrFunctionImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedClassConstructorDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedClassDescriptor
-import org.jetbrains.kotlin.ir.descriptors.WrappedSimpleFunctionDescriptor
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.*
 import org.jetbrains.kotlin.ir.symbols.impl.IrClassSymbolImpl
@@ -335,11 +332,11 @@ internal class TestProcessor (val context: Context) {
      */
     private fun buildObjectGetter(objectSymbol: IrClassSymbol,
                                   owner: IrClass,
-                                  getterName: Name): IrSimpleFunction = WrappedSimpleFunctionDescriptor().let { descriptor ->
+                                  getterName: Name): IrSimpleFunction =
         IrFunctionImpl(
                 owner.startOffset, owner.endOffset,
                 TEST_SUITE_GENERATED_MEMBER,
-                IrSimpleFunctionSymbolImpl(descriptor),
+                IrSimpleFunctionSymbolImpl(),
                 getterName,
                 DescriptorVisibilities.PROTECTED,
                 Modality.FINAL,
@@ -353,7 +350,6 @@ internal class TestProcessor (val context: Context) {
                 isOperator = false,
                 isInfix = false
         ).apply {
-            descriptor.bind(this)
             parent = owner
 
             val superFunction = baseClassSuite.simpleFunctions()
@@ -367,7 +363,6 @@ internal class TestProcessor (val context: Context) {
                 )
             }
         }
-    }
 
     /**
      * Builds a method in `[testSuite]` class with name `[getterName]`
@@ -375,11 +370,11 @@ internal class TestProcessor (val context: Context) {
      */
     private fun buildInstanceGetter(classSymbol: IrClassSymbol,
                                     owner: IrClass,
-                                    getterName: Name): IrSimpleFunction = WrappedSimpleFunctionDescriptor().let { descriptor ->
+                                    getterName: Name): IrSimpleFunction =
         IrFunctionImpl(
                 owner.startOffset, owner.endOffset,
                 TEST_SUITE_GENERATED_MEMBER,
-                IrSimpleFunctionSymbolImpl(descriptor),
+                IrSimpleFunctionSymbolImpl(),
                 getterName,
                 DescriptorVisibilities.PROTECTED,
                 Modality.FINAL,
@@ -393,7 +388,6 @@ internal class TestProcessor (val context: Context) {
                 isOperator = false,
                 isInfix = false
         ).apply {
-            descriptor.bind(this)
             parent = owner
 
             val superFunction = baseClassSuite.simpleFunctions()
@@ -407,7 +401,6 @@ internal class TestProcessor (val context: Context) {
                 +irReturn(irCall(constructor))
             }
         }
-    }
 
     private val baseClassSuiteConstructor = baseClassSuite.constructors.single {
         it.valueParameters.size == 2
@@ -426,11 +419,11 @@ internal class TestProcessor (val context: Context) {
                                            testSuite: IrClassSymbol,
                                            owner: IrClass,
                                            functions: Collection<TestFunction>,
-                                           ignored: Boolean): IrConstructor = WrappedClassConstructorDescriptor().let { descriptor ->
+                                           ignored: Boolean): IrConstructor =
         IrConstructorImpl(
                 testSuite.owner.startOffset, testSuite.owner.endOffset,
                 TEST_SUITE_GENERATED_MEMBER,
-                IrConstructorSymbolImpl(descriptor),
+                IrConstructorSymbolImpl(),
                 Name.special("<init>"),
                 DescriptorVisibilities.PUBLIC,
                 testSuite.typeWithStarProjections,
@@ -439,7 +432,6 @@ internal class TestProcessor (val context: Context) {
                 isPrimary = true,
                 isExpect = false
         ).apply {
-            descriptor.bind(this)
             parent = owner
 
             fun IrClass.getFunction(name: String, predicate: (IrSimpleFunction) -> Boolean) =
@@ -469,7 +461,6 @@ internal class TestProcessor (val context: Context) {
                         registerTestCase, registerFunction, functions)
             }
         }
-    }
 
     private val IrClass.ignored: Boolean get() = annotations.hasAnnotation(IGNORE_FQ_NAME)
 
@@ -479,11 +470,11 @@ internal class TestProcessor (val context: Context) {
      */
     private fun buildClassSuite(testClass: IrClass,
                                 testCompanion: IrClass?,
-                                functions: Collection<TestFunction>): IrClass = WrappedClassDescriptor().let { descriptor ->
+                                functions: Collection<TestFunction>): IrClass =
         IrClassImpl(
                 testClass.startOffset, testClass.endOffset,
                 TEST_SUITE_CLASS,
-                IrClassSymbolImpl(descriptor),
+                IrClassSymbolImpl(),
                 testClass.name.synthesizeSuiteClassName(),
                 ClassKind.CLASS,
                 DescriptorVisibilities.PRIVATE,
@@ -496,7 +487,6 @@ internal class TestProcessor (val context: Context) {
                 isExpect = false,
                 isFun = false
         ).apply {
-            descriptor.bind(this)
             createParameterDeclarations()
 
             val testClassType = testClass.defaultType
@@ -531,7 +521,6 @@ internal class TestProcessor (val context: Context) {
             superTypes += symbols.baseClassSuite.typeWith(listOf(testClassType, testCompanionType))
             addFakeOverrides(context.irBuiltIns)
         }
-    }
     //endregion
 
     // region IR generation methods

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/optimizations/Devirtualization.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
-import org.jetbrains.kotlin.ir.descriptors.WrappedVariableDescriptor
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
@@ -1318,13 +1317,10 @@ internal object Devirtualization {
         }
 
         fun <T : IrElement> IrStatementsBuilder<T>.irTemporary(value: IrExpression, tempName: String, type: IrType): IrVariable {
-            val descriptor = WrappedVariableDescriptor()
-
             val temporary = IrVariableImpl(
-                value.startOffset, value.endOffset, IrDeclarationOrigin.IR_TEMPORARY_VARIABLE, IrVariableSymbolImpl(descriptor),
+                value.startOffset, value.endOffset, IrDeclarationOrigin.IR_TEMPORARY_VARIABLE, IrVariableSymbolImpl(),
                 Name.identifier(tempName), type, isVar = false, isConst = false, isLateinit = false
             ).apply {
-                descriptor.bind(this)
                 this.initializer = value
             }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -210,7 +210,7 @@ internal class KonanIrLinker(
             if (actualModule !== moduleDescriptor) {
                 val moduleDeserializer = deserializersForModules[actualModule] ?: error("No module deserializer for $actualModule")
                 moduleDeserializer.addModuleReachableTopLevel(idSig)
-                return symbolTable.referenceClassFromLinker(descriptor, idSig)
+                return symbolTable.referenceClassFromLinker(idSig)
             }
 
             return declaredDeclaration.getOrPut(idSig) { buildForwardDeclarationStub(descriptor) }.symbol

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-805,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.0-dev-805
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-805,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.0-dev-805
-kotlinStdlibTestsVersion=1.5.0-dev-805
-testKotlinCompilerVersion=1.5.0-dev-805
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1023,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.0-dev-1023
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1023,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.0-dev-1023
+kotlinStdlibTestsVersion=1.5.0-dev-1023
+testKotlinCompilerVersion=1.5.0-dev-1023
 konanVersion=1.5.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 33892f3ddf2 - (HEAD -> master, tag: build-1.5.0-dev-1023, origin/master, origin/HEAD) Make checker tests independent of plugin version (KTI-433) (vor 2 Tagen) <Nikolay Krasko>
* f72cec79044 - Minor: remove unused methods (vor 2 Tagen) <Nikolay Krasko>
* 37473ad640f - (tag: build-1.5.0-dev-1019) Substitute lambda's receiver type during completion including the builder inference stub variables substitution (vor 2 Tagen) <Victor Petukhov>
* 672859d447d - (tag: build-1.5.0-dev-1015) [Wasm] Support init blocks in inline classes (vor 3 Tagen) <Svyatoslav Kuzmich>
* 0945c110bfc - [JS IR] Support init blocks in inline classes (vor 3 Tagen) <Svyatoslav Kuzmich>
* 07b6f0d8710 - (tag: build-1.5.0-dev-1007) Fix failing tests (vor 3 Tagen) <Victor Petukhov>
* 0d40fde713d - (tag: build-1.5.0-dev-1003) FIR synthetics: make setter subtype check more precise #KT-43347 Fixed (vor 3 Tagen) <Mikhail Glukhikh>
* 8c8f81330a1 - FIR Java: make value parameter annotations lazy (vor 3 Tagen) <Mikhail Glukhikh>
* 1239a8629ec - FIR Java: make type annotations lazy (vor 3 Tagen) <Mikhail Glukhikh>
* 776c4ba6ca7 - Add test for KT-25489 (to reproduce, turn UL classes OFF) (vor 3 Tagen) <Mikhail Glukhikh>
* 532124d9a17 - (tag: build-1.5.0-dev-1001) Increase timeout for flaky muted tests synchronization requests (vor 3 Tagen) <Yunir Salimzyanov>
* f2ecf7f666e - Mute MultiModuleHighlightingTest via csv-file (vor 3 Tagen) <Yunir Salimzyanov>
* 7ed6aae46e8 - (tag: build-1.5.0-dev-998) Fix tests after rebasing (vor 3 Tagen) <Victor Petukhov>
* 50a388aec16 - Mute wasm tests around builder inference and callable references (vor 3 Tagen) <Victor Petukhov>
* 0dde5ddd7e2 - Fail calls constraints of which contain uninferred type parameter (vor 3 Tagen) <Victor Petukhov>
* 9afc13f0022 - Unwrap block expressions to report errors on them about not enough type information (vor 3 Tagen) <Victor Petukhov>
* 4c56962678b - Report errors on callable references which contains postponed type variables in the receiver type (vor 3 Tagen) <Victor Petukhov>
* 86edc5ca3a3 - Reuse information from already recorder descriptor for some callable references and don't rewrite at slice (vor 3 Tagen) <Victor Petukhov>
* 1926434b182 - Report error about uninferred type parameter for some special call' subcalls (vor 3 Tagen) <Victor Petukhov>
* 0b472f858ba - Don't create DONT_CARE type for CR and lambdas within builder inference calls (vor 3 Tagen) <Victor Petukhov>
* b4d8adeeb43 - Don't clean type info for containment operator if the resolution was unsuccessful, but all diagnostics were about only input types and non-strict only input types check was enabled (vor 3 Tagen) <Victor Petukhov>
* 954c9cecca6 - Compute type for callable references and lambdas inside not null assertion if couldn't get already recorded type (vor 3 Tagen) <Victor Petukhov>
* 39e579db91c - Move tests for builder inference into the corresponding directory (vor 3 Tagen) <Victor Petukhov>
* 9b148325feb - (tag: build-1.5.0-dev-985) Minor: regenerate tests (vor 3 Tagen) <Dmitry Petrov>
* 9715ae88fef - (tag: build-1.5.0-dev-983) Minor: regenerate tests (vor 3 Tagen) <Dmitry Petrov>
* 03594baa07e - (tag: build-1.5.0-dev-973) [IR] Improve dumpKotlinLike (vor 4 Tagen) <Zalim Bashorov>
* f7b0f55532c - [JS IR test] Add an ability to setup phases to dump after and  phases to validate after in box tests using system properties (vor 4 Tagen) <Zalim Bashorov>
* ee60a1a4317 - [IR] Add an ability to change dump strategy using a system property (vor 4 Tagen) <Zalim Bashorov>
* 274b09cf36e - [JS IR] Support generating JS expression from IrComposite (vor 4 Tagen) <Zalim Bashorov>
* 72593e3d307 - [JS IR] Revert jsClass_js-ir.kt to not break compatibility with older compiler versions (vor 4 Tagen) <Zalim Bashorov>
* d7e3f826bb0 - [JS IR] Generate jsClass function inside the compiler instead of relying on declaration inside stdlib (vor 4 Tagen) <Zalim Bashorov>
* df6635085bd - [JS IR] Replace calls with invalid type arguments for type parameters with call to `errorCode` function from runtime. (vor 4 Tagen) <Zalim Bashorov>
* ff77155b5a0 - [JS IR] A type argument of the jsClass intrinsic must be a class (IrClass) (vor 4 Tagen) <Zalim Bashorov>
* c1f6a72ae17 - [JS IR] Remove inline properties with reified parameters (vor 4 Tagen) <Zalim Bashorov>
* da8dacb4959 - [JS IR] run RemoveInlineFunctionsWithReifiedTypeParametersLowering earlier (vor 4 Tagen) <Zalim Bashorov>
* bc9828f3f32 - [JS IR] Generate a key using hashedMangle for all IR declarations in mapToKey (vor 4 Tagen) <Zalim Bashorov>
* 7c5ea414b71 - [JS IR] Use mappedNames in NameTable only for REPL (vor 4 Tagen) <Zalim Bashorov>
* faa24e3230a - (tag: build-1.5.0-dev-972) KT-44043 Sealed interfaces: 201/203 compatibility fix (vor 4 Tagen) <Andrei Klunnyi>
* a1574bf50ab - (tag: build-1.5.0-dev-971) JVM box tests for KT-30548 (vor 4 Tagen) <Dmitry Petrov>
* daa6255ab79 - (tag: build-1.5.0-dev-966) Update testdata of PsiCheckerSealedTest after 07b980fe (vor 4 Tagen) <Dmitriy Novozhilov>
* f00e5b19929 - (tag: build-1.5.0-dev-964) FIR: Check `relativeClassName` of found class in `JavaSymbolProvider` (vor 4 Tagen) <Roman Golyshev>
* 2ce51a4c116 - (tag: build-1.5.0-dev-962) [Gradle, JS] Fix tests with decamelizing names (vor 4 Tagen) <Ilya Goncharov>
* 0bd4de65e13 - [Gradle, JS] Fix upper case names in js files, decamelize instead (vor 4 Tagen) <Ilya Goncharov>
* 9c67d8f89e1 - (tag: build-1.5.0-dev-961) IC Mangling: Correctly mangle functions with generic return type (vor 4 Tagen) <Ilmir Usmanov>
* f8cca288aba - (tag: build-1.5.0-dev-959) KT-44075 Sealed interfaces: New Kotlin Class/File menu update (vor 4 Tagen) <Andrei Klunnyi>
* 740b8a9aec6 - (tag: build-1.5.0-dev-958) [Commonizer] Fix computing outer class type arguments (vor 4 Tagen) <Dmitriy Dolovov>
* 8bd4e673411 - (tag: build-1.5.0-dev-954) [Test] Drop obsolete FIR tests (vor 4 Tagen) <Dmitriy Novozhilov>
* 660c438ebe7 - [Test] Migrate tests of foreign annotations to new infrastructure (vor 4 Tagen) <Dmitriy Novozhilov>
* ef3d966d530 - [Test] Fix dependencies in task `[JPS] Generate All Tests` (vor 4 Tagen) <Dmitriy Novozhilov>
* 8689fc43cdd - [Test] Move java generation utils to :compiler:tests-compiler-utils module (vor 4 Tagen) <Dmitriy Novozhilov>
* cb7b1652e72 - [Test] Extract MockLibraryUtil to :compiler:tests-compiler-utils (vor 4 Tagen) <Dmitriy Novozhilov>
* eadec089375 - [Test] Reformat MockLibraryUtil according to code style (vor 4 Tagen) <Dmitriy Novozhilov>
* e287742842f - [Test] Add ability to provide additional analysis flags in EnvironmentConfigurator (vor 4 Tagen) <Dmitriy Novozhilov>
* c4691de72d2 - [Test] Deprecate AbstractDiagnosticsTest in old test infrastructure (vor 4 Tagen) <Dmitriy Novozhilov>
* a9f913a97f7 - [Test] Migrate AbstractDiagnosticsWithJdk15Test to new infrastructure (vor 4 Tagen) <Dmitriy Novozhilov>
* 02fb11a2cd5 - [Test] Fix double reading of module directives (vor 4 Tagen) <Dmitriy Novozhilov>
* 0e3ed3fee62 - [Test] Remove duplicating code from ClassicFrontend2IrConverter (vor 4 Tagen) <Dmitriy Novozhilov>
* 1a03d5c93ea - (tag: build-1.5.0-dev-949) Fix ISE when inferring type of a property that delegates to itself (vor 4 Tagen) <Denis.Zharkov>
* cbb8459e4e5 - Fix AE: No receiver found on incomplete code with $-signs (vor 4 Tagen) <Denis.Zharkov>
* 77d4a46a6b4 - Fix light classes exception occurring on obfuscated Kotlin libraries (vor 4 Tagen) <Denis.Zharkov>
* 7b9f6c15600 - Fix exceptions caused by cyclic dependency between ModuleDescriptor and JvmBuiltIns (vor 4 Tagen) <Denis.Zharkov>
* 5a8dc00a0d8 - Rename JvmBuiltInsSettings -> JvmBuiltInsCustomizer (vor 4 Tagen) <Denis.Zharkov>
* 70ae7560839 - (tag: build-1.5.0-dev-947) Revert "[Test] Save TargetBackend instead of BackendKind in TestModule" (vor 4 Tagen) <Dmitriy Novozhilov>
* 07b980fea0b - (tag: build-1.5.0-dev-943) [FE] Fix error message of SEALED_INHERITOR_IN_DIFFERENT_PACKAGE diagnostic (vor 4 Tagen) <Dmitriy Novozhilov>
* 29d923d50dd - [Test] Save TargetBackend instead of BackendKind in TestModule (vor 4 Tagen) <Dmitriy Novozhilov>
* 70c4bdf32e6 - [FE] Detect recursion when typealias referenced as annotation in its RHS (vor 4 Tagen) <Dmitriy Novozhilov>
* d3349197baa - (tag: build-1.5.0-dev-925) Minor: regenerate tests (vor 4 Tagen) <Dmitry Petrov>
* 4e261cc3584 - JVM_IR KT-24258 fix NPE message for delegated properties (vor 4 Tagen) <Dmitry Petrov>
* ad8bed078f9 - JVM box tests for KT-24193 (vor 4 Tagen) <Dmitry Petrov>
* a8d848ccbdb - JVM box tests for KT-23974 (vor 4 Tagen) <Dmitry Petrov>
* 3f7a776fb80 - JVM box tests for KT-21092 (vor 4 Tagen) <Dmitry Petrov>
* 0841a6b0ead - irText tests for KT-19306 (vor 4 Tagen) <Dmitry Petrov>
* 9f908cdf7c8 - JVM box tests for KT-16752 (vor 4 Tagen) <Dmitry Petrov>
* 8bfcef415e7 - Do not generate variables for non-generated fields (vor 4 Tagen) <Ilmir Usmanov>
* 8a7bc2ef6fc - Rename continuation fields according the convention and count them in IR (vor 4 Tagen) <Iaroslav Postovalov>
* cd2b05eb00f - Discard misc.xml changes (vor 4 Tagen) <Iaroslav Postovalov>
* 165ba853375 - Remove useless OptIn annotation (vor 4 Tagen) <Iaroslav Postovalov>
* b13822bb2d1 - Remove unrelated change (vor 4 Tagen) <Iaroslav Postovalov>
* 6f34f00c612 - Do not generate the field for unused parameters in suspend lambdas (vor 4 Tagen) <Iaroslav Postovalov>
* f49cf2d5cab - (tag: build-1.5.0-dev-920) IC Mangling: correctly mangle inline default functions (vor 5 Tagen) <Ilmir Usmanov>
* 7c9cf45a3fc - (tag: build-1.5.0-dev-915) FIR IDE: fix testdata (vor 5 Tagen) <Ilya Kirillov>
* b2b364eca68 - FIR IDE: resolve fir file to BODY_RESOLVE when it requested by getOrBuildFir (vor 5 Tagen) <Ilya Kirillov>
* fa42f9302e4 - FIR IDE: unmute passing test (vor 5 Tagen) <Ilya Kirillov>
* ce779038980 - FIR IDE: add deadlock checking for read/write resolve locks (vor 5 Tagen) <Ilya Kirillov>
* 0ec152e457c - FIR IDE: fix deadlock in override check (vor 5 Tagen) <Ilya Kirillov>
* 8a17a16ee27 - FIR IDE: consider modification in invalid PSI as OOBM (vor 5 Tagen) <Ilya Kirillov>
* d06a5fb4130 - FIR IDE: disable some script stuff in FIR plugin as causes exceptions (vor 5 Tagen) <Ilya Kirillov>
* 70b1edb81d6 - FIR IDE: allow using some light classes stuff from EDT :( (vor 5 Tagen) <Ilya Kirillov>
* 306b46b8f2f - FIR IDE: consider FirErrorReferenceWithCandidate as reference with error (vor 5 Tagen) <Ilya Kirillov>
* 9a86d2e10c4 - FIR IDE: do not mark declaration with some lazy resolve phase if only some children are resolved to that phase (vor 5 Tagen) <Ilya Kirillov>
* 1e2536402d9 - FIR: render constructor resolve phase in FirRenderer when renderDeclarationResolvePhase is requested (vor 5 Tagen) <Ilya Kirillov>
* 85c65e20b35 - FIR: add meaningful error message when type ref is unresolved (vor 5 Tagen) <Ilya Kirillov>
* 6ad396f417b - FIR: use transformer creator from existing return type calculator when creating a new one (vor 5 Tagen) <Ilya Kirillov>
* 68f6e734bee - FIR IDE: add test case for resolving call as value argument (vor 5 Tagen) <Ilya Kirillov>
* af5aa5fa663 - FIR IDE: add more info to the call resolve error message (vor 5 Tagen) <Ilya Kirillov>
* c5788290f3d - FIR IDE: refactor: move designation & transformer creation in lazy resolve to separate functions (vor 5 Tagen) <Ilya Kirillov>
* c61b0d1f314 - FIR IDE: fix designation collection for lazy resolve (vor 5 Tagen) <Ilya Kirillov>
* 3aef1154c8d - FIR IDE: Get rid of `FirTransformerProvider` class (vor 5 Tagen) <Roman Golyshev>
* d3cab96ca07 - FIR IDE: consider declaration to be lazy resolvable if it has fqName (vor 5 Tagen) <Ilya Kirillov>
* 8e592bdff0c - FIR IDE: invalidate analysis session cache on out of block (vor 5 Tagen) <Ilya Kirillov>
* 9c26edbaaaa - FIR IDE: split ValidityToken.isValid into isValid & isAccessible (vor 5 Tagen) <Ilya Kirillov>
* a2befd46353 - FIR IDE: add missing ClsJavaStubByVirtualFileCache service (vor 5 Tagen) <Ilya Kirillov>
* eead868cd2c - FIR IDE: use correct out of block modification tracker (vor 5 Tagen) <Ilya Kirillov>
* 0862928bf70 - FIR IDE: move KotlinOutOfBlockModificationTrackerFactory to frontend independent module (vor 5 Tagen) <Ilya Kirillov>
* a30d9e0ed3f - FIR: add fake source fir element to `it` parameter symbol (vor 5 Tagen) <Ilya Kirillov>
* af0e8b28d56 - FIR IDE: add missing statistic extension points (vor 5 Tagen) <Ilya Kirillov>
* b35d4134a7d - (tag: build-1.5.0-dev-913) Psi2IR: workaround for IR-based descriptors (vor 5 Tagen) <Georgy Bronnikov>
* 99c874ba8ac - IR: use NullDescriptorRemapper in DeepCopySymbolRemapper (vor 5 Tagen) <Georgy Bronnikov>
* c5961da780d - IR: remove WrappedDescriptors altogether (vor 5 Tagen) <Georgy Bronnikov>
* e9f45e23f21 - IR: NullDescriptorsRemapper (vor 5 Tagen) <Georgy Bronnikov>
* 3683cd0f7ba - IR: fix IrBasedTypeAliasDescriptor (vor 5 Tagen) <Georgy Bronnikov>
* 076272f7ca5 - FIR2IR: avoid descriptors computing hashCode (vor 5 Tagen) <Georgy Bronnikov>
* b07dccb8d78 - Fir2IR: remove wrapped descriptors (vor 5 Tagen) <Georgy Bronnikov>
* b05400154d9 - IR: remove IrSymbolDeclaration (vor 5 Tagen) <Georgy Bronnikov>
* d714adacae8 - IR: removing WrappedDescriptors from symbols (vor 5 Tagen) <Georgy Bronnikov>
* 989d4350b14 - IR: make descriptor optional in IrSymbol (vor 5 Tagen) <Georgy Bronnikov>
* aaa3f2e2c16 - (tag: build-1.5.0-dev-906) FIR2IR: correct IR origin for substitution overrides (vor 5 Tagen) <Jinseong Jeon>
* 34dbbdce070 - FIR2IR: use lookupTag or class to getLocalClass, not classId (vor 5 Tagen) <Jinseong Jeon>
* 94315bc4dce - (tag: build-1.5.0-dev-903) Remove mapping to kotlin-ultimate from vsc.xml (vor 5 Tagen) <Alexander Dudinsky>
* 632f5af442e - (tag: build-1.5.0-dev-900) Minor: kt21014.kt - add JVM_TARGET 1.8 (vor 5 Tagen) <Dmitry Petrov>
* 10a57272601 - (tag: build-1.5.0-dev-893) Merge together MultiplatformHighlighting and MultiplatformAnalysis tests (vor 5 Tagen) <Alexander Dudinsky>
* 73576c80e44 - (tag: build-1.5.0-dev-890) FIR2IR: calculate IR parent for Java field ahead (vor 5 Tagen) <Jinseong Jeon>
* 89577543a28 - (tag: build-1.5.0-dev-888) Build: Disable plugin marker publication for sonatype (vor 5 Tagen) <Vyacheslav Gerasimov>
* 107a825c5f2 - (tag: build-1.5.0-dev-882) Make FileDescriptorForVisibilityCheck subtype of PackageFragmentDescriptor (vor 5 Tagen) <Mikhail Glukhikh>
* 3ae8521f12c - (tag: build-1.5.0-dev-877) Minor: drop kt21014.kt (SIGSEGV on HotSpot 6.0_45-b06) (vor 6 Tagen) <Dmitry Petrov>
* f6472331896 - (tag: build-1.5.0-dev-872) Minor: drop empty bunch file (vor 6 Tagen) <Dmitry Petrov>
* 796d821776c - JVM_IR box tests for JDK9 (vor 6 Tagen) <Dmitry Petrov>
* c9d330207b2 - JVM_IR no nullability annotations on SAM wrapper constructor parameters (vor 6 Tagen) <Dmitry Petrov>
* 4780c73e406 - Ignore anonymous inner classes in LightAnalysisMode tests (vor 6 Tagen) <Dmitry Petrov>
* 0dff583070e - JVM KT-36984 SAM wrappers are anonymous inner classes (vor 6 Tagen) <Dmitry Petrov>
* 57dd9fc87a9 - JVM_IR KT-36984 SAM wrappers are anonymous inner classes (vor 6 Tagen) <Dmitry Petrov>
* 443cd0fc2c6 - (tag: build-1.5.0-dev-866) Tests for issues fixed in JVM_IR (vor 6 Tagen) <Dmitry Petrov>
* 5e5b236ef84 - (tag: build-1.5.0-dev-863) Extract record related parts into smaller bunch files for 201 (vor 6 Tagen) <Denis.Zharkov>
* e05d26b9b0a - (origin/push/mg-google-prs) FIR2IR: cache type parameters in delegated property (vor 6 Tagen) <Jinseong Jeon>
* 78fa8814c47 - FIR: unwrap f/overrides when determining mutability of property reference (vor 6 Tagen) <Jinseong Jeon>
* 0918e73dfff - (tag: build-1.5.0-dev-854, tag: build-1.5.0-dev-834, origin/push/nk/all) Move wasm tests to JS tests configuration (KTI-419) (vor 7 Tagen) <Nikolay Krasko>
* 554fa358e8f - (tag: build-1.5.0-dev-829) [FIR] Fix calculating offsets of light tree source elements for local declarations (vor 7 Tagen) <Dmitriy Novozhilov>
* 298e27bdac1 - [Test] Migrate AbstractExtendedFirDiagnosticsTest to new infrastructure (vor 7 Tagen) <Dmitriy Novozhilov>
* a276d059174 - [Test] Generate FIR tests with new infrastructure in :analysis-tests module (vor 7 Tagen) <Dmitriy Novozhilov>
* 537e4f0bb45 - [Test] Move existing fir tests on old infrastructure to :legacy-fir-tests module (vor 7 Tagen) <Dmitriy Novozhilov>
* 1f258c28fc6 - [Test] Extract main compiler test generator to separate project (vor 7 Tagen) <Dmitriy Novozhilov>
* d753d21dee4 - (tag: build-1.5.0-dev-828) FIR2IR: don't add SAM conversion for explicit subtype cases (vor 7 Tagen) <Jinseong Jeon>
* 7df289746c7 - FIR: fix invoke lookup for SAM resolution (vor 7 Tagen) <Jinseong Jeon>
* 3bca6ae8937 - FIR: allow lower bound of flexible type when finding contributed invoke (vor 7 Tagen) <Jinseong Jeon>
* 4a24f0fab3f - FIR2IR: use FirSamResolverImpl to get function type for possible SAM type (vor 7 Tagen) <Jinseong Jeon>
* d5a6991b2dc - FIR: extend SAM conversion to subtype of functional type (vor 7 Tagen) <Jinseong Jeon>
* c6a40b23220 - (tag: build-1.5.0-dev-827) Optimize/simplify FirJvmTypeMapper.defaultType (vor 7 Tagen) <Mikhail Glukhikh>
* 3ab5b575941 - Optimize/simplify FirJvmTypeMapper.representativeUpperBound (vor 7 Tagen) <Mikhail Glukhikh>
* 42b590d07ca - Optimize/simplify FirSealedClassConstructorCallChecker (vor 7 Tagen) <Mikhail Glukhikh>
* c94c71cc503 - Optimize/simplify ConeClassLikeLookupTag.getNestedClassifierScope (vor 7 Tagen) <Mikhail Glukhikh>
* 7add1866168 - Optimize/simplify FirClass<*>.findNonInterfaceSupertype (vor 7 Tagen) <Mikhail Glukhikh>
* 3e8016ed25c - (tag: build-1.5.0-dev-819) KTIJ-717 [Java side inspection]: "implementation of Kotlin sealed" (vor 7 Tagen) <Andrei Klunnyi>
* 65cf941b9be - (tag: build-1.5.0-dev-818, origin/rr/ic/fixes-em) Remove assertion about dispatch receiver in scripts (vor 7 Tagen) <Ilya Chernikov>
* 0671fd9aaa2 - Support destructuring declarations in scratch files (vor 7 Tagen) <Ilya Chernikov>
* 9ee17cd610b - Do not throw assertion on recursion in typealias declaration, (vor 7 Tagen) <Ilya Chernikov>
* 02c617468fa - Add support for a callback on recursion for memoized functions (vor 7 Tagen) <Ilya Chernikov>
* eef06cded39 - (tag: build-1.5.0-dev-815) JVM IR: output stable ABI binaries by default (vor 7 Tagen) <Alexander Udalov>
* e0593ff70f5 - Minor, extract CompilerConfiguration.messageCollector to extension property (vor 7 Tagen) <Alexander Udalov>
* 691b20a6852 - JVM IR, FIR: set IR configuration key to true if FIR is enabled (vor 7 Tagen) <Alexander Udalov>
* 06805ffbaa6 - Change CLI flags for controlling diagnostics for ABI of FIR and JVM IR (vor 7 Tagen) <Alexander Udalov>
* 3f517d7e8d7 - Add new metadata flag for class files compiled with FIR (vor 7 Tagen) <Alexander Udalov>
* cbd90c3af5b - Refactor boolean IR ABI stability flag to enum (vor 7 Tagen) <Alexander Udalov>
* b7d32a87548 - Minor, invert analysis flag that allows unstable dependencies (vor 7 Tagen) <Alexander Udalov>
* 7d370300951 - JVM IR, FIR: add JvmBackendExtension instead of MetadataSerializerFactory (vor 7 Tagen) <Alexander Udalov>