### PR TITLE
Use clang format attribute

### DIFF
--- a/runtime/src/main/cpp/KAssert.h
+++ b/runtime/src/main/cpp/KAssert.h
@@ -32,7 +32,7 @@
 #define CURRENT_SOURCE_LOCATION nullptr
 #endif
 
-RUNTIME_NORETURN void RuntimeAssertFailed(const char* location, const char* message, ...);
+RUNTIME_NORETURN void RuntimeAssertFailed(const char* location, const char* format, ...) __attribute__((format(printf, 2, 3)));
 
 namespace internal {
 
@@ -42,7 +42,7 @@ inline RUNTIME_NORETURN void TODOImpl(const char* location) {
 
 // TODO: Support format string when `RuntimeAssertFailed` supports it.
 inline RUNTIME_NORETURN void TODOImpl(const char* location, const char* message) {
-    RuntimeAssertFailed(location, message);
+    RuntimeAssertFailed(location, "%s", message);
 }
 
 } // namespace internal

--- a/runtime/src/main/cpp/Porting.h
+++ b/runtime/src/main/cpp/Porting.h
@@ -27,8 +27,8 @@ namespace konan {
 
 // Console operations.
 void consoleInit();
-void consolePrintf(const char* format, ...);
-void consoleErrorf(const char* format, ...);
+void consolePrintf(const char* format, ...) __attribute__((format(printf, 1, 2)));
+void consoleErrorf(const char* format, ...) __attribute__((format(printf, 1, 2)));
 void consoleWriteUtf8(const void* utf8, uint32_t sizeBytes);
 void consoleErrorUtf8(const void* utf8, uint32_t sizeBytes);
 // Negative return value denotes that read wasn't successful.
@@ -46,8 +46,8 @@ void onThreadExit(void (*destructor)(void*), void* destructorParameter);
 // memcpy/memmove/memcmp are not here intentionally, as frequently implemented/optimized
 // by C compiler.
 void* memmem(const void *big, size_t bigLen, const void *little, size_t littleLen);
-int snprintf(char* buffer, size_t size, const char* format, ...);
-int vsnprintf(char* buffer, size_t size, const char* format, va_list args);
+int snprintf(char* buffer, size_t size, const char* format, ...) __attribute__((format(printf, 3, 4)));
+int vsnprintf(char* buffer, size_t size, const char* format, va_list args) __attribute__((format(printf, 3, 0)));
 size_t strnlen(const char* buffer, size_t maxSize);
 
 

--- a/runtime/src/main/cpp/StdCppStubs.cpp
+++ b/runtime/src/main/cpp/StdCppStubs.cpp
@@ -32,7 +32,8 @@ RUNTIME_USED RUNTIME_WEAK extern "C" char* Konan_cxa_demangle(
 
 namespace std {
 RUNTIME_WEAK void __throw_length_error(const char* __s __attribute__((unused))) {
-  RuntimeAssert(false, __s);
+  // TODO: Don't we always need to abort here?
+  RuntimeAssert(false, "%s", __s);
 }
 
 }  // namespace std

--- a/runtime/src/main/cpp/StdCppStubs.cpp
+++ b/runtime/src/main/cpp/StdCppStubs.cpp
@@ -32,8 +32,7 @@ RUNTIME_USED RUNTIME_WEAK extern "C" char* Konan_cxa_demangle(
 
 namespace std {
 RUNTIME_WEAK void __throw_length_error(const char* __s __attribute__((unused))) {
-  // TODO: Don't we always need to abort here?
-  RuntimeAssert(false, "%s", __s);
+  RuntimeCheck(false, "%s", __s);
 }
 
 }  // namespace std

--- a/runtime/src/main/cpp/Worker.cpp
+++ b/runtime/src/main/cpp/Worker.cpp
@@ -511,7 +511,7 @@ class State {
 
     if (remainingNativeWorkers != 0) {
       konan::consoleErrorf(
-        "Unfinished workers detected, %lu workers leaked!\n"
+        "Unfinished workers detected, %zu workers leaked!\n"
         "Use `Platform.isMemoryLeakCheckerActive = false` to avoid this check.\n",
         remainingNativeWorkers);
       konan::consoleFlush();


### PR DESCRIPTION
`__attribute__(format(...))` forces the compiler to check call sites for valid usage of format strings.
