### PR TITLE
Use common pattern for function-like macro

### DIFF
--- a/runtime/src/legacymm/cpp/CyclicCollector.cpp
+++ b/runtime/src/legacymm/cpp/CyclicCollector.cpp
@@ -129,10 +129,10 @@ class CyclicCollector {
 
  public:
   CyclicCollector() {
-    CHECK_CALL(pthread_mutex_init(&lock_, nullptr), "Cannot init collector mutex")
-    CHECK_CALL(pthread_mutex_init(&timestampLock_, nullptr), "Cannot init collector timestamp mutex")
-    CHECK_CALL(pthread_cond_init(&cond_, nullptr), "Cannot init collector condition")
-    CHECK_CALL(pthread_create(&gcThread_, nullptr, gcWorkerRoutine, this), "Cannot start collector thread")
+    CHECK_CALL(pthread_mutex_init(&lock_, nullptr), "Cannot init collector mutex");
+    CHECK_CALL(pthread_mutex_init(&timestampLock_, nullptr), "Cannot init collector timestamp mutex");
+    CHECK_CALL(pthread_cond_init(&cond_, nullptr), "Cannot init collector condition");
+    CHECK_CALL(pthread_create(&gcThread_, nullptr, gcWorkerRoutine, this), "Cannot start collector thread");
   }
 
   void clear() {
@@ -146,7 +146,7 @@ class CyclicCollector {
       Locker locker(&lock_);
       terminateCollector_ = true;
       if (enabled) shallRunCollector_ = true;
-      CHECK_CALL(pthread_cond_signal(&cond_), "Cannot signal collector")
+      CHECK_CALL(pthread_cond_signal(&cond_), "Cannot signal collector");
     }
     // TODO: improve waiting for collector termination.
     while (atomicGet(&terminateCollector_)) {}
@@ -173,7 +173,7 @@ class CyclicCollector {
        KStdUnorderedMap<ObjHeader*, int> sideRefCounts;
        int restartCount = 0;
        while (!terminateCollector_) {
-         CHECK_CALL(pthread_cond_wait(&cond_, &lock_), "Cannot wait collector condition")
+         CHECK_CALL(pthread_cond_wait(&cond_, &lock_), "Cannot wait collector condition");
          if (!shallRunCollector_) continue;
          atomicSet(&gcRunning_, 1);
          restartCount = 0;
@@ -325,7 +325,7 @@ class CyclicCollector {
     // When exiting the worker - we shall collect the cyclic garbage here.
     if (enabled) {
       shallRunCollector_ = true;
-      CHECK_CALL(pthread_cond_signal(&cond_), "Cannot signal collector")
+      CHECK_CALL(pthread_cond_signal(&cond_), "Cannot signal collector");
     }
     currentAliveWorkers_--;
   }
@@ -416,7 +416,7 @@ class CyclicCollector {
     if (checkIfShallCollect()) {
       Locker locker(&lock_);
       shallRunCollector_ = true;
-      CHECK_CALL(pthread_cond_signal(&cond_), "Cannot signal collector")
+      CHECK_CALL(pthread_cond_signal(&cond_), "Cannot signal collector");
     }
   }
 
@@ -424,7 +424,7 @@ class CyclicCollector {
     if (atomicGet(&gcRunning_) != 0) return;
     Locker lock(&lock_);
     shallRunCollector_ = true;
-    CHECK_CALL(pthread_cond_signal(&cond_), "Cannot signal collector")
+    CHECK_CALL(pthread_cond_signal(&cond_), "Cannot signal collector");
   }
 
   void localGC() {

--- a/runtime/src/legacymm/cpp/Memory.cpp
+++ b/runtime/src/legacymm/cpp/Memory.cpp
@@ -1169,7 +1169,7 @@ void freeAggregatingFrozenContainer(ContainerHeader* container) {
   auto* state = memoryState;
   RuntimeAssert(isAggregatingFrozenContainer(container), "expected fictitious frozen container");
   MEMORY_LOG("%p is fictitious frozen container\n", container);
-  RuntimeAssert(!container->buffered(), "frozen objects must not participate in GC")
+  RuntimeAssert(!container->buffered(), "frozen objects must not participate in GC");
 #if USE_GC
   // Forbid finalizerQueue handling.
   ++state->finalizerQueueSuspendCount;
@@ -2052,7 +2052,7 @@ MemoryState* initMemory(bool firstRuntime) {
                 ==
                 offsetof(MetaObjHeader, typeInfo_),
                 "Layout mismatch");
-  RuntimeAssert(sizeof(FrameOverlay) % sizeof(ObjHeader**) == 0, "Frame overlay should contain only pointers")
+  RuntimeAssert(sizeof(FrameOverlay) % sizeof(ObjHeader**) == 0, "Frame overlay should contain only pointers");
   RuntimeAssert(memoryState == nullptr, "memory state must be clear");
   memoryState = konanConstructInstance<MemoryState>();
   INIT_EVENT(memoryState)

--- a/runtime/src/main/cpp/KAssert.h
+++ b/runtime/src/main/cpp/KAssert.h
@@ -67,10 +67,11 @@ extern "C" const int KonanNeedDebugInfo;
 
 // Use RuntimeCheck() in runtime checks that could fail due to external condition and shall lead
 // to program termination. Never compiled out.
+// TODO: Consider using `CURRENT_SOURCE_LOCATION` when `KonanNeedDebugInfo` is `true`.
 #define RuntimeCheck(condition, format, ...) \
     do { \
         if (!(condition)) { \
-            RuntimeAssertFailed(CURRENT_SOURCE_LOCATION, format, ##__VA_ARGS__); \
+            RuntimeAssertFailed(nullptr, format, ##__VA_ARGS__); \
         } \
     } while (false)
 

--- a/runtime/src/main/cpp/KAssert.h
+++ b/runtime/src/main/cpp/KAssert.h
@@ -25,6 +25,13 @@
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 
+#if KONAN_ENABLE_ASSERT
+#define CURRENT_SOURCE_LOCATION __FILE__ ":" TOSTRING(__LINE__)
+#else
+// Do not generate location strings, when asserts are disabled to reduce code size.
+#define CURRENT_SOURCE_LOCATION nullptr
+#endif
+
 RUNTIME_NORETURN void RuntimeAssertFailed(const char* location, const char* message, ...);
 
 namespace internal {
@@ -46,24 +53,30 @@ extern "C" const int KonanNeedDebugInfo;
 
 #if KONAN_ENABLE_ASSERT
 // Use RuntimeAssert() in internal state checks, which could be ignored in production.
-#define RuntimeAssert(condition, format, ...)                                     \
-if (KonanNeedDebugInfo && (!(condition))) {                                       \
-    RuntimeAssertFailed( __FILE__ ":" TOSTRING(__LINE__), format, ##__VA_ARGS__); \
-}
+#define RuntimeAssert(condition, format, ...) \
+    do { \
+        if (KonanNeedDebugInfo && (!(condition))) { \
+            RuntimeAssertFailed(CURRENT_SOURCE_LOCATION, format, ##__VA_ARGS__); \
+        } \
+    } while (false)
 #else
-#define RuntimeAssert(condition, message)
+#define RuntimeAssert(condition, format, ...) \
+    do { \
+    } while (false)
 #endif
 
 // Use RuntimeCheck() in runtime checks that could fail due to external condition and shall lead
 // to program termination. Never compiled out.
-#define RuntimeCheck(condition, format, ...)             \
-  if (!(condition)) {                                    \
-    RuntimeAssertFailed(nullptr, format, ##__VA_ARGS__); \
-  }
+#define RuntimeCheck(condition, format, ...) \
+    do { \
+        if (!(condition)) { \
+            RuntimeAssertFailed(CURRENT_SOURCE_LOCATION, format, ##__VA_ARGS__); \
+        } \
+    } while (false)
 
 #define TODO(...) \
     do { \
-        ::internal::TODOImpl(__FILE__ ":" TOSTRING(__LINE__), ##__VA_ARGS__); \
+        ::internal::TODOImpl(CURRENT_SOURCE_LOCATION, ##__VA_ARGS__); \
     } while (false)
 
 #endif // RUNTIME_ASSERT_H

--- a/runtime/src/main/cpp/MemorySharedRefs.cpp
+++ b/runtime/src/main/cpp/MemorySharedRefs.cpp
@@ -177,7 +177,7 @@ void BackRefFromAssociatedObject::releaseRef() {
 }
 
 void BackRefFromAssociatedObject::detach() {
-  RuntimeAssert(atomicGet(&refCount) == 0, "unexpected refCount")
+  RuntimeAssert(atomicGet(&refCount) == 0, "unexpected refCount");
   obj_ = nullptr; // Handled in addRef/tryAddRef/releaseRef/ref.
 }
 


### PR DESCRIPTION
```cpp
do {
   <stmts>
} while (false)
```
is a common pattern for function-like macro. It makes macro invocation look like a normal function call by requiring a trailing semicolon.