### PR TITLE
[kotlin compiler][update] 1.5.0-dev-1282

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1023,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.0-dev-1023
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1023,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.0-dev-1023
-kotlinStdlibTestsVersion=1.5.0-dev-1023
-testKotlinCompilerVersion=1.5.0-dev-1023
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1282,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.0-dev-1282
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1282,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.0-dev-1282
+kotlinStdlibTestsVersion=1.5.0-dev-1282
+testKotlinCompilerVersion=1.5.0-dev-1282
 konanVersion=1.5.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/runtime/src/main/kotlin/kotlin/CharCode.kt
+++ b/runtime/src/main/kotlin/kotlin/CharCode.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlin
+
+/**
+ * Creates a Char with the specified [code].
+ *
+ * @sample samples.text.Chars.charFromCode
+ */
+@OptIn(ExperimentalUnsignedTypes::class)
+@ExperimentalStdlibApi
+@SinceKotlin("1.4")
+@kotlin.internal.InlineOnly
+public actual inline fun Char(code: UShort): Char {
+    return code.toInt().toChar()
+}

--- a/runtime/src/main/kotlin/kotlin/text/Char.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Char.kt
@@ -64,16 +64,74 @@ external public fun Char.isUpperCase(): Boolean
 external public fun Char.isLowerCase(): Boolean
 
 /**
- * Converts this character to uppercase.
+ * Converts this character to upper case using Unicode mapping rules of the invariant locale.
  */
 @SymbolName("Kotlin_Char_toUpperCase")
 external public actual fun Char.toUpperCase(): Char
 
 /**
- * Converts this character to lowercase.
+ * Converts this character to upper case using Unicode mapping rules of the invariant locale.
+ *
+ * This function performs one-to-one character mapping.
+ * To support one-to-many character mapping use the [uppercase] function.
+ * If this character has no mapping equivalent, the character itself is returned.
+ *
+ * @sample samples.text.Chars.uppercase
+ */
+@SinceKotlin("1.4")
+@ExperimentalStdlibApi
+public actual fun Char.uppercaseChar(): Char = toUpperCase()
+
+/**
+ * Converts this character to upper case using Unicode mapping rules of the invariant locale.
+ *
+ * This function supports one-to-many character mapping, thus the length of the returned string can be greater than one.
+ * For example, `'\uFB00'.uppercase()` returns `"\u0046\u0046"`,
+ * where `'\uFB00'` is the LATIN SMALL LIGATURE FF character (`ﬀ`).
+ * If this character has no upper case mapping, the result of `toString()` of this char is returned.
+ *
+ * @sample samples.text.Chars.uppercase
+ */
+@SinceKotlin("1.4")
+@ExperimentalStdlibApi
+public actual fun Char.uppercase(): String {
+    return uppercaseChar().toString()
+}
+
+/**
+ * Converts this character to lower case using Unicode mapping rules of the invariant locale.
  */
 @SymbolName("Kotlin_Char_toLowerCase")
 external public actual fun Char.toLowerCase(): Char
+
+/**
+ * Converts this character to lower case using Unicode mapping rules of the invariant locale.
+ *
+ * This function performs one-to-one character mapping.
+ * To support one-to-many character mapping use the [lowercase] function.
+ * If this character has no mapping equivalent, the character itself is returned.
+ *
+ * @sample samples.text.Chars.lowercase
+ */
+@SinceKotlin("1.4")
+@ExperimentalStdlibApi
+public actual fun Char.lowercaseChar(): Char = toLowerCase()
+
+/**
+ * Converts this character to lower case using Unicode mapping rules of the invariant locale.
+ *
+ * This function supports one-to-many character mapping, thus the length of the returned string can be greater than one.
+ * For example, `'\u0130'.lowercase()` returns `"\u0069\u0307"`,
+ * where `'\u0130'` is the LATIN CAPITAL LETTER I WITH DOT ABOVE character (`İ`).
+ * If this character has no lower case mapping, the result of `toString()` of this char is returned.
+ *
+ * @sample samples.text.Chars.lowercase
+ */
+@SinceKotlin("1.4")
+@ExperimentalStdlibApi
+public actual fun Char.lowercase(): String {
+    return lowercaseChar().toString()
+}
 
 /**
  * Returns `true` if this character is a Unicode high-surrogate code unit (also known as leading-surrogate code unit).

--- a/runtime/src/main/kotlin/kotlin/text/Strings.kt
+++ b/runtime/src/main/kotlin/kotlin/text/Strings.kt
@@ -159,11 +159,34 @@ public external fun String.regionMatches(
 public actual external fun String.toUpperCase(): String
 
 /**
+ * Returns a copy of this string converted to upper case using Unicode mapping rules of the invariant locale.
+ *
+ * This function supports one-to-many and many-to-one character mapping,
+ * thus the length of the returned string can be different from the length of the original string.
+ *
+ * @sample samples.text.Strings.uppercase
+ */
+@SinceKotlin("1.4")
+@ExperimentalStdlibApi
+public actual fun String.uppercase(): String = toUpperCase()
+
+/**
  * Returns a copy of this string converted to lower case using the rules of the default locale.
  */
 @SymbolName("Kotlin_String_toLowerCase")
-@Suppress("NOTHING_TO_INLINE")
 public actual external fun String.toLowerCase(): String
+
+/**
+ * Returns a copy of this string converted to lower case using Unicode mapping rules of the invariant locale.
+ *
+ * This function supports one-to-many and many-to-one character mapping,
+ * thus the length of the returned string can be different from the length of the original string.
+ *
+ * @sample samples.text.Strings.lowercase
+ */
+@SinceKotlin("1.4")
+@ExperimentalStdlibApi
+public actual fun String.lowercase(): String = toLowerCase()
 
 /**
  * Returns a [CharArray] containing characters of this string.


### PR DESCRIPTION
* 98a9e142e8b - (HEAD -> master, tag: build-1.5.0-dev-1282, origin/master, origin/HEAD) JVM IR: Fix visibility of protected/private functions with reified types (vor 3 Tagen) <Steven Schäfer>
* dad10e94aa1 - (tag: build-1.5.0-dev-1281) JVM IR: Mangle names of $$forInline functions (vor 3 Tagen) <Steven Schäfer>
* 7cc06489dd7 - (tag: build-1.5.0-dev-1267) IR: move enum value array initialization out of <clinit> (vor 3 Tagen) <Jinseong Jeon>
* f8f08e81342 - IR: add a test about maximum number of constants in an enum class (vor 3 Tagen) <Jinseong Jeon>
* 0a8858fbfe9 - (tag: build-1.5.0-dev-1263) [minor] document -compiler-path option for kotlin runner (vor 4 Tagen) <Ilya Chernikov>
* 979144157fb - Implement -howtorun option for kotlin runner (vor 4 Tagen) <Ilya Chernikov>
* edc730f70b9 - Implement -no-stdlib argument support in kotlin runner (vor 4 Tagen) <Ilya Chernikov>
* d2ecc1e3619 - Implement -X arguments passing from kotlin runner to compiler (vor 4 Tagen) <Ilya Chernikov>
* 9a7d1948a7a - Implement support for -Xdefault-script-extension cli option (vor 4 Tagen) <Ilya Chernikov>
* 534342a5662 - [minor] use new kotlin.io.path API in tests (vor 4 Tagen) <Ilya Chernikov>
* 1bd6cc823c6 - Fix provided properties access generation (vor 4 Tagen) <Ilya Chernikov>
* ffdcda89143 - [build] Fix JDK detection on Mac OS X 11 (Big Sur) (vor 4 Tagen) <Ilya Chernikov>
* 77836f1aa9d - (tag: build-1.5.0-dev-1258) [Test] Port checkVariableTable suspend lambda tests (vor 4 Tagen) <Kristoffer Andersen>
* 82abc80215f - (tag: build-1.5.0-dev-1256) Move old changelogs to docs/changelogs/ (vor 4 Tagen) <Alexander Udalov>
* db3bebb531c - (tag: build-1.5.0-dev-1255) Add Revved up by Gradle Enterprise badge to Readme (vor 5 Tagen) <Nelson Osacky>
* 41c4693ebf4 - (tag: build-1.5.0-dev-1233) Build: remove obsolete -Xir-binary-with-stable-abi (vor 7 Tagen) <Alexander Udalov>
* ee2ae0c4712 - (tag: build-1.5.0-dev-1225) JVM IR: remove obsolete -Xir-check-local-names (vor 7 Tagen) <Alexander Udalov>
* acd29481bd9 - (tag: build-1.5.0-dev-1220) Regenerate sources of builtins and stdlib (vor 7 Tagen) <Alexander Udalov>
* ed9a0e514d8 - (tag: build-1.5.0-dev-1219) Regenerate tests and fir-tree (vor 8 Tagen) <Alexander Udalov>
* 96de9144dec - (tag: build-1.5.0-dev-1211) [JS IR] Generate stub for exported functions with default params (vor 11 Tagen) <Shagen Ogandzhanian>
* bf3f6594d59 - (tag: build-1.5.0-dev-1210) IR: do not lose $default function annotations when generating calls (vor 11 Tagen) <Alexander Udalov>
* ac325f61117 - IR: add toString for IrBased descriptors (vor 11 Tagen) <Alexander Udalov>
* 3c37bbaf645 - (tag: build-1.5.0-dev-1209) Duration: normalize to avoid negative zeroes (KT-44168) (vor 11 Tagen) <Ilya Gorbunov>
* ae6f10df3be - Duration: reject NaN duration values (KT-44168) (vor 11 Tagen) <Ilya Gorbunov>
* 1d40ed39d03 - (tag: build-1.5.0-dev-1206) KotlinVersion: Advance snapshot version 1.4.255 -> 1.5.255 (vor 11 Tagen) <Ilya Gorbunov>
* 133e39b7837 - (tag: build-1.5.0-dev-1204, origin/push/nk/all) Advance snapshot version 1.4.255 -> 1.5.255 (KTI-421) (vor 11 Tagen) <Nikolay Krasko>
* 662787b12bb - (tag: build-1.5.0-dev-1192) Straighten Char-to-code and Char-to-digit conversions out #KT-23451 (vor 11 Tagen) <Abduqodiri Qurbonzoda>
* 79e426270cb - (tag: build-1.5.0-dev-1188) Rename Random.Default serialization surrogate object (KT-25571) (vor 11 Tagen) <Ilya Gorbunov>
* 00506a75d35 - (tag: build-1.5.0-dev-1183) Make Random implementations serializable (KT-25571) (vor 11 Tagen) <Iaroslav Postovalov>
* 38967f208ea - (tag: build-1.5.0-dev-1170, origin/rr/skuzmich/wasm-interface-calls-improvements2) [Wasm] Remove unused WasmI1 type (vor 12 Tagen) <Svyatoslav Kuzmich>
* 22239e27330 - [Wasm] Remove unused super class field in type info (vor 12 Tagen) <Svyatoslav Kuzmich>
* 785c9477826 - [Wasm] Improve class type checks (vor 12 Tagen) <Svyatoslav Kuzmich>
* b6ad1584c97 - [Wasm] Improve interface method dispatch (vor 12 Tagen) <Svyatoslav Kuzmich>
* e7dc199ad72 - (tag: build-1.5.0-dev-1162) Init enum entries whenever we access companion object or accessing valueOf (vor 12 Tagen) <Shagen Ogandzhanian>
* 7fa04afda2a - (tag: build-1.5.0-dev-1155) JVM_IR KT-32115 fix $$delegatedProperties initialization in enum (vor 12 Tagen) <Dmitry Petrov>
* 3e3ffee2a04 - (tag: build-1.5.0-dev-1152, origin/push/demiurg906/bootstrap-update) Advance bootstrap to 1.5.0-dev-1141 (vor 12 Tagen) <Dmitriy Novozhilov>
* 81e00ca371f - (tag: build-1.5.0-dev-1145) JVM box tests for KT-30402 (vor 12 Tagen) <Dmitry Petrov>
* 1314adb6f7b - (tag: build-1.5.0-dev-1143) Locale-agnostic case conversions by default #KT-43023 (vor 12 Tagen) <Abduqodiri Qurbonzoda>
* 80289e4a3ff - (tag: build-1.5.0-dev-1141, origin/master-for-ide) IC Mangling: Generate inline class literal instead of underlying type (vor 12 Tagen) <Ilmir Usmanov>
* 55a5695fc0d - (tag: build-1.5.0-dev-1132) [JS] Forbid export of interfaces (vor 13 Tagen) <Shagen Ogandzhanian>
* a6534c46535 - (tag: build-1.5.0-dev-1117) [FIR] Fix completion of synthetic call arguments (vor 13 Tagen) <Mikhail Glukhikh>
* b7a382f097f - (tag: build-1.5.0-dev-1115) Revert "Fix ISE when inferring type of a property that delegates to itself" (vor 13 Tagen) <Denis.Zharkov>
* 826985450e9 - (tag: build-1.5.0-dev-1110) Add test for KT-42036 (vor 13 Tagen) <Roman Artemev>
* 30a5eee4813 - (tag: build-1.5.0-dev-1108) Don't approximate abbreviation during substitution it as it can't be projected at top-level (vor 13 Tagen) <Victor Petukhov>
* 009add2b41e - (tag: build-1.5.0-dev-1107) [Test] Report difference in test data file in a first place (vor 13 Tagen) <Dmitriy Novozhilov>
* 0af1c81d623 - (tag: build-1.5.0-dev-1104) Revert "Probably fix issue with creating module descriptor for SDK twice" (vor 13 Tagen) <Dmitriy Novozhilov>
* 6230a7861aa - (tag: build-1.5.0-dev-1098) Wizard: do not print plugin repositories in build files if all of them are default ones (vor 13 Tagen) <Ilya Kirillov>
* 74077bf6d27 - (tag: build-1.5.0-dev-1090) [FIR] Don't attempt to process interface constructors (vor 13 Tagen) <Mikhail Glukhikh>
* 6a6e2a1c77b - (tag: build-1.5.0-dev-1089) Set custom timeout for flaky muted tests synchronization requests (vor 13 Tagen) <Yunir Salimzyanov>
* 27dd9484ba1 - (tag: build-1.5.0-dev-1086) Add missed type arguments for a star projection into the enhanced type arguments list (vor 13 Tagen) <Victor Petukhov>
* 531ba4bb482 - (tag: build-1.5.0-dev-1070) [IR] Narrow usage scope of ObsoleteDescriptorBasedAPI in CheckIrElementVisitor (vor 2 Wochen) <Zalim Bashorov>
* 02849edc22e - [IR] Make descriptor parameter optional for IrFileSymbolImpl and IrExternalPackageFragmentSymbolImpl (vor 2 Wochen) <Zalim Bashorov>
* 14254ceb0bb - [IR] Remove no longer needed usages of ObsoleteDescriptorBasedAPI (vor 2 Wochen) <Zalim Bashorov>
* 0372dae3cea - [JS scripting] Remove usages of descriptor based APIs and proper support for callable references (vor 2 Wochen) <Zalim Bashorov>
* 9ac7c3d8bc2 - [Wasm] Remove usage of descriptor based API usage from WasmSharedVariablesManager (vor 2 Wochen) <Zalim Bashorov>
* c569ec1badf - [IR] Add dumpKotlinLike for IrType and IrTypeArgument (vor 2 Wochen) <Zalim Bashorov>
* 77a9d14f93a - (tag: build-1.5.0-dev-1067) Capitalize/decapitalize only ASCII characters across project (vor 2 Wochen) <Alexander Udalov>
* 5d4b0b19d41 - (tag: build-1.5.0-dev-1066) JVM_IR KT-13213 split string constants into parts of acceptable length (vor 2 Wochen) <Dmitry Petrov>
* 3f287d344ef - (tag: build-1.5.0-dev-1065) KT-43941 [Sealed interfaces]: subclass intention (vor 2 Wochen) <Andrei Klunnyi>
* 1cac8b0d614 - KT-43941 [Sealed interfaces]: preliminary, J2K (vor 2 Wochen) <Andrei Klunnyi>
* 86792131cd6 - KT-43941 [Sealed interfaces]: preliminary, code cleanup (vor 2 Wochen) <Andrei Klunnyi>
* acbf382d043 - (tag: build-1.5.0-dev-1054) FIR: Add test on ambiguous vararg (vor 2 Wochen) <Denis.Zharkov>
* 8c7b23a8dd3 - FIR Java/JVM: avoid plain "Array" comparison (vor 2 Wochen) <Jinseong Jeon>
* 383de7a9c5d - FIR Java: Fix Java override ambiguity with vararg value type (vor 2 Wochen) <Jinseong Jeon>
* d663f204e5e - (tag: build-1.5.0-dev-1050) FIR Java: make method annotations lazy (vor 2 Wochen) <Mikhail Glukhikh>
* c8c34ebf172 - FIR Java: make constructor annotations lazy (vor 2 Wochen) <Mikhail Glukhikh>
* 56df95b8e7e - FIR Java: make field annotations lazy (vor 2 Wochen) <Mikhail Glukhikh>