### PR TITLE
Fix mingw-linux_arm32_hfp cross-compilation

### DIFF
--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -461,7 +461,7 @@ staticLibraryRelocationMode.linux_arm32_hfp = pic
 
 linker.linux_x64-linux_arm32_hfp = $targetToolchain.linux_x64-linux_arm32_hfp/bin/ld
 linkerHostSpecificFlags.linux_x64-linux_arm32_hfp =
-linker.mingw_x64-linux_arm32_hfp = $targetToolchain.mingw_x64-linux_arm32_hfp/bin/ld
+linker.mingw_x64-linux_arm32_hfp = $targetToolchain.mingw_x64-linux_arm32_hfp/bin/ld.gold
 linkerHostSpecificFlags.mingw_x64-linux_arm32_hfp =
 linker.macos_x64-linux_arm32_hfp = $targetToolchain.macos_x64-linux_arm32_hfp/bin/ld.lld
 linkerHostSpecificFlags.macos_x64-linux_arm32_hfp = --no-threads


### PR DESCRIPTION
Use gold linker instead of default one since the latter doesn't support elf.