### PR TITLE
Fix mingw-linux cross-compilation in 1.4.30

### DIFF
--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Linker.kt
@@ -356,7 +356,6 @@ class GccBasedLinker(targetProperties: GccConfigurables)
             if (!dynamic) +"$absoluteTargetSysRoot/$crtPrefix/crt1.o"
             +"$absoluteTargetSysRoot/$crtPrefix/crti.o"
             +if (dynamic) "$libGcc/crtbeginS.o" else "$libGcc/crtbegin.o"
-            +"-L$llvmLib"
             +"-L$libGcc"
             if (!isMips) +"--hash-style=gnu" // MIPS doesn't support hash-style=gnu
             +specificLibs


### PR DESCRIPTION
It breaks mingw-linux cross-compilation because host libraries appear earlier than target ones.