### PR TITLE
Workaround inconsistent descriptor for Any.hashCode in ObjCExport

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExportMapper.kt
@@ -265,7 +265,8 @@ private fun ObjCExportMapper.bridgeReturnType(
             }
         }
 
-        descriptor.containingDeclaration == descriptor.builtIns.any && descriptor.name.asString() == "hashCode" -> {
+        descriptor.containingDeclaration.let { it is ClassDescriptor && KotlinBuiltIns.isAny(it) } &&
+                descriptor.name.asString() == "hashCode" -> {
             assert(!convertExceptionsToErrors)
             MethodBridge.ReturnValue.HashCode
         }


### PR DESCRIPTION
(broken by https://github.com/JetBrains/kotlin-native/pull/4621)