### PR TITLE
Deprecate kotlinc K/N scripts because they clash with real kotlinc

### DIFF
--- a/cmd/kotlinc
+++ b/cmd/kotlinc
@@ -17,4 +17,4 @@
 DIR="${BASH_SOURCE[0]%/*}"
 : ${DIR:="."}
 
-"${DIR}"/run_konan konanc "$@"
+"${DIR}"/run_konan kotlinc "$@"

--- a/cmd/kotlinc.bat
+++ b/cmd/kotlinc.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-call %~dps0run_konan.bat konanc %*
+call %~dps0run_konan.bat kotlinc %*

--- a/utilities/cli-runner/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/main.kt
+++ b/utilities/cli-runner/src/main/kotlin/org/jetbrains/kotlin/cli/utilities/main.kt
@@ -15,6 +15,25 @@ private fun mainImpl(args: Array<String>, konancMain: (Array<String>) -> Unit) {
     when (utilityName) {
         "konanc" ->
             konancMain(utilityArgs)
+        "kotlinc" -> {
+            println("""
+                NOTE: you are running "kotlinc" CLI tool from Kotlin/Native distribution,
+                it runs Kotlin/Native compiler that produces native binaries from Kotlin code.
+                If your intention was to compile Kotlin code to JVM bytecode instead, then you
+                need to use "kotlinc" from the main Kotlin distribution (e.g. it can be
+                downloaded as kotlin-compiler-X.Y.ZZ.zip archive from
+                https://github.com/JetBrains/kotlin/releases/latest, or installed using various
+                package managers).
+
+                WARNING: if your intention was to run Kotlin/Native compiler, then please use
+                "kotlinc-native" CLI tool instead of "kotlinc". "kotlinc" tool will be removed
+                from Kotlin/Native distribution, so it will stop clashing with "kotlinc" from
+                the main Kotlin distribution.
+
+            """.trimIndent())
+
+            konancMain(utilityArgs)
+        }
         "cinterop" -> {
             val konancArgs = invokeInterop("native", utilityArgs)
             konancArgs?.let { konancMain(it) }


### PR DESCRIPTION
Also make them print the message clarifying that it's Kotlin/Native,
not Kotlin/JVM.

 #KT-43874 Fixed.