### PR TITLE
[kotlin compiler][update] 1.5.0-dev-1616

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1282,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.0-dev-1282
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1282,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.0-dev-1282
-kotlinStdlibTestsVersion=1.5.0-dev-1282
-testKotlinCompilerVersion=1.5.0-dev-1282
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1616,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.0-dev-1616
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1616,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.0-dev-1616
+kotlinStdlibTestsVersion=1.5.0-dev-1616
+testKotlinCompilerVersion=1.5.0-dev-1616
 konanVersion=1.5.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 0c463d3260b - (HEAD -> master, tag: build-1.5.0-dev-1616, origin/master, origin/HEAD) KT-44378 don't generate no-arg constructor for sealed classes (vor 2 Tagen) <Dmitry Petrov>
* ee93efc19d1 - (tag: build-1.5.0-dev-1615) [Commonizer] Avoid leaking non-commonized types as arguments in short-circuited TAs (vor 2 Tagen) <Dmitriy Dolovov>
* 8fa848bed38 - (tag: build-1.5.0-dev-1602) FIR IDE: fix testdata after rebase (vor 3 Tagen) <Ilya Kirillov>
* 459c919072e - FIR IDE: introduce JAVA_SYNTHETIC_PROPERTY symbol origin (vor 3 Tagen) <Ilya Kirillov>
* a5e6c1d82b1 - FIR IDE: implement new getTopLevelFunction(/property)Symbols in FirModuleWithDependenciesSymbolProvider (vor 3 Tagen) <Ilya Kirillov>
* 450ab33f161 - FIR IDE: do not highlight by-name argument as parameter (vor 3 Tagen) <Ilya Kirillov>
* 16cd2f08fe0 - FIR: preserve delegatedTypeRef when transforming FirFunctionTypeRef (vor 3 Tagen) <Ilya Kirillov>
* b405cbb1ff4 - FIR IDE: consider synthetic functional interfaces to have LIBRARY origin (vor 3 Tagen) <Ilya Kirillov>
* 981f9320334 - FIR IDE: ignore synthetic references in reference resolve (vor 3 Tagen) <Ilya Kirillov>
* 087840122af - FIR: mark FirBuiltinSymbolProvider with ThreadSafeMutableState (vor 3 Tagen) <Ilya Kirillov>
* 56bd6a30b3e - FIR IDE: introduce delegated symbol origin (vor 3 Tagen) <Ilya Kirillov>
* 2a9779cd899 - FIR IDE: resolve reference to intersection override member to overridden members (vor 3 Tagen) <Ilya Kirillov>
* 95eb701f750 - FIR: introduce symbols for intersection override (vor 3 Tagen) <Ilya Kirillov>
* 2ef8f58d905 - FIR IDE: add KDoc for KtSymbolOrogin (vor 3 Tagen) <Ilya Kirillov>
* e0607785289 - FIR IDE: implement assignment statement references (vor 3 Tagen) <Ilya Kirillov>
* 14d2b1be498 - FIR IDE: resolve by-name-parameter call (vor 3 Tagen) <Ilya Kirillov>
* 47894c6cc9d - FIR IDE: invalidate LibraryModificationTracker in memory leak test (vor 3 Tagen) <Ilya Kirillov>
* 87e6dbf4351 - FIR IDE: generate heap dump on memory leak in memory leak test (vor 3 Tagen) <Ilya Kirillov>
* f454ec8e4ab - FIR IDE: introduce methods for working with annotations (vor 3 Tagen) <Ilya Kirillov>
* 191a1ee2429 - FIR: add fake source fir element to `it` parameter (vor 3 Tagen) <Ilya Kirillov>
* 132fc9e68b7 - FIR IDE: invalidate caches between tests (vor 3 Tagen) <Ilya Kirillov>
* 861c9b8e450 - FIR IDE: unmute passing tests (vor 3 Tagen) <Ilya Kirillov>
* c97c4fa99cc - FIR IDE: fix finding fir in container which have conflicting duplicate by name (vor 3 Tagen) <Ilya Kirillov>
* 601d5cbff8b - FIR IDE: fix duplicating diagnostics collection (vor 3 Tagen) <Ilya Kirillov>
* 008260451c4 - FIR: make FirNestedClassifierScopeWithSubstitution to be name aware (vor 3 Tagen) <Ilya Kirillov>
* c2866152bf7 - FIR IDE: fix not initialized containingClassAttr for copied declaration (vor 3 Tagen) <Ilya Kirillov>
* a7903c64f1a - FIR IDE: do not consider function literal as fqName-having declaration (vor 3 Tagen) <Ilya Kirillov>
* 1fb33207b8c - FIR IDE: add meaningful error message when opening non-source file (vor 3 Tagen) <Ilya Kirillov>
* 1901436c96d - FIR IDE: add more info to error messages (vor 3 Tagen) <Ilya Kirillov>
* c1319831884 - FIR IDE: implement FirIdeProvider.getClassNamesInPackage (vor 3 Tagen) <Ilya Kirillov>
* a52674f1813 - FIR: use more meaningful error messages (vor 3 Tagen) <Ilya Kirillov>
* 4d07eb27bb3 - FIR IDE: add incremental analysis test for function in companion object (vor 3 Tagen) <Ilya Kirillov>
* e63d084cdc6 - FIR IDE: allow getting light class name from EDT (vor 3 Tagen) <Ilya Kirillov>
* d53af8170b4 - FIR IDE: cache module libraries (vor 3 Tagen) <Ilya Kirillov>
* 8c113f02d56 - FIR IDE: consider top level file change as out of block modification (vor 3 Tagen) <Ilya Kirillov>
* d3dd6e3b962 - FIR IDE: delegate light classes is valid to corresponding symbol validity check (vor 3 Tagen) <Ilya Kirillov>
* a95f38569fc - FIR IDE: fix FirModuleWithDependenciesSymbolProvider recursive calls (vor 3 Tagen) <Ilya Kirillov>
* 5838357e613 - (tag: build-1.5.0-dev-1590) Extract long project wizard tests to separate TC configuration (KTI-422) (vor 3 Tagen) <Nikolay Krasko>
* 2f30b0994a5 - (tag: build-1.5.0-dev-1588) Minor: mute test in WASM (vor 3 Tagen) <Dmitry Petrov>
* 6b5ee6c9f97 - (tag: build-1.5.0-dev-1586) FIR checker: warn redundant open in interface members properly (vor 3 Tagen) <Jinseong Jeon>
* 2e8b5f23801 - FIR checker: make member property checker robust to conflict modifiers (vor 3 Tagen) <Jinseong Jeon>
* 39df3e2b0ad - FIR checker: introduce member function checker (vor 3 Tagen) <Jinseong Jeon>
* 5594af0d703 - FIR checker: utilize modifier retrievals (vor 3 Tagen) <Jinseong Jeon>
* 3af820eaf40 - FIR: utilize lookups of certain properties of classes/functions (vor 3 Tagen) <Jinseong Jeon>
* ec68ac36dbf - FIR checker: use the aliased checker when possible (vor 3 Tagen) <Jinseong Jeon>
* 03cb0c3cd18 - FIR checker: introduce PropertyChecker alias (vor 3 Tagen) <Jinseong Jeon>
* db65c787e59 - FIR checker component generator: handle type parameters in alias arguments (vor 3 Tagen) <Jinseong Jeon>
* f3dfb381632 - (tag: build-1.5.0-dev-1571) [Gradle, JS] Exclude transitive dependencies of semver4j (vor 3 Tagen) <Ilya Goncharov>
* e742af54448 - (tag: build-1.5.0-dev-1565) [Test] Run fir diagnostics tests with light tree in sequential mode (vor 3 Tagen) <Dmitriy Novozhilov>
* 2f1e4862e54 - [Test] Enable builtin parallel tests execution form JUnit5 in :compiler:tests-common-new (vor 3 Tagen) <Dmitriy Novozhilov>
* 78b2eb994b9 - Deduplicate logic of computing orphan source sets in MPP Gradle Import (vor 3 Tagen) <Dmitry Savvinov>
* 1d0a696a628 - Simplify building of source-sets during MPP Import (vor 3 Tagen) <Dmitry Savvinov>
* 9e58e3c3fd1 - Remove unused KotlinSourceSetImpl.defaultIsTestModule; simplify logic of test modules detection (vor 3 Tagen) <Dmitry Savvinov>
* 58b20642958 - Introduce MultiplatformModelImportingContext (vor 3 Tagen) <Dmitry Savvinov>
* f87aa4612b4 - Minor: return map straight away (vor 3 Tagen) <Dmitry Savvinov>
* cf2bd75a731 - Minor: reformat (vor 3 Tagen) <Dmitry Savvinov>
* 0aef3680c1f - Remove useless function (vor 3 Tagen) <Dmitry Savvinov>
* 824efe84986 - Remove useless condition (vor 3 Tagen) <Dmitry Savvinov>
* ecd96e14c92 - Use all participated compilations for source-sets platform detection even in non-HMPP (vor 3 Tagen) <Dmitry Savvinov>
* 09286504b73 - Add a bunch of tests on corner-cases in Gradle MPP Import (vor 3 Tagen) <Dmitry Savvinov>
* 69261ca1e6e - Add tests on precise platforms importing (vor 3 Tagen) <Dmitry Savvinov>
* 250cc1dc921 - (tag: build-1.5.0-dev-1563) [JVM] Never treat arguments to methods as locals that can be removed. (vor 3 Tagen) <Mads Ager>
* ada51509c4f - (tag: build-1.5.0-dev-1560) Test caches for linux_x64 on Linux host. (vor 3 Tagen) <Sergey Bogolepov>
* ed18fcdf28d - Use target-specific cache control in tests (vor 3 Tagen) <Sergey Bogolepov>
* 2dabfbc6138 - Bump Native version. (vor 3 Tagen) <Sergey Bogolepov>
* 092020577c6 - More precise native cache control. (vor 3 Tagen) <Sergey Bogolepov>
* d017e1c2ce1 - (tag: build-1.5.0-dev-1544) Add protection for master branch in VCS settings (vor 3 Tagen) <Nikolay Krasko>
* a0d42b5da65 - Build: Download ktor from maven central (KTI-445) (vor 3 Tagen) <Nikolay Krasko>
* 0a1e4fd7d72 - Download ktor from maven central in wizard project (vor 3 Tagen) <Nikolay Krasko>
* ae67bb4565e - (tag: build-1.5.0-dev-1543) Add changelog for 1.4.30-M1 (vor 3 Tagen) <Margarita Bobova>
* c1360c5a7a9 - (tag: build-1.5.0-dev-1540) Uast: resolve reified callees from classpath (#4013, KT-41279) (vor 3 Tagen) <Kevin Bierhoff>
* c0dd731818c - (tag: build-1.5.0-dev-1528) Load JVM built-ins in IDE from module dependencies (vor 4 Tagen) <Pavel Kirpichenkov>
* 1479c7a2707 - Minor: load FALLBACK built-ins in JvmPlatformAnalyzerServices (vor 4 Tagen) <Dmitry Savvinov>
* ba4cc4e075e - Minor: cleanup (vor 4 Tagen) <Pavel Kirpichenkov>
* b9d5c1bc39d - Move KotlinSdk to idea-analysis module (vor 4 Tagen) <Pavel Kirpichenkov>
* 2df4d26b37a - Built-ins in IDE: update tests (vor 4 Tagen) <Pavel Kirpichenkov>
* d6c27608ace - Minor: remove effectively unused test runner (vor 4 Tagen) <Dmitry Savvinov>
* 71c71d86191 - (tag: build-1.5.0-dev-1521) AndroidDependencyResolver: compatibility with AGP 7 (vor 4 Tagen) <Vyacheslav Karpukhin>
* c1722350b64 - (tag: build-1.5.0-dev-1516, origin/jupiter/rr/yunir/check-promote-to-autopush, origin/jupiter/master) Add constructors to KtScope (vor 4 Tagen) <Stanislav Erokhin>
* c5229291be6 - Add dispatchReceiver and extensionReceiver to relevant KtSymbols (vor 4 Tagen) <Stanislav Erokhin>
* 96b6efd4018 - Add type parameters to the KtConstructorSymbol (vor 4 Tagen) <Stanislav Erokhin>
* 732a9974792 - Use Variance instead of custom class in KtTypeArgumentWithVariance (vor 4 Tagen) <Stanislav Erokhin>
* f6bf2f6b7b7 - Add variance and isReified into KtTypeParameterSymbol (vor 4 Tagen) <Stanislav Erokhin>
* c17eee0085b - Add data/inline/fun/isExternal flags to KtClassLikeSymbol (vor 4 Tagen) <Stanislav Erokhin>
* 7e4ba1a062c - Remove unused Unknown modality from KtSymbolWithModality. (vor 4 Tagen) <Stanislav Erokhin>
* e1e096b4eaa - Add PRIVATE_TO_THIS visibility to KtSymbolWithVisibility (vor 4 Tagen) <Stanislav Erokhin>
* d50a5e75175 - Add ConstantValueKind to KtSimpleConstantValue (vor 4 Tagen) <Stanislav Erokhin>
* d24331955e9 - Rename FirConstKind to ConstantValueKind and move it to compiler.common (vor 4 Tagen) <Stanislav Erokhin>
* eed27906e30 - (tag: build-1.5.0-dev-1508) KT-44043 [Sealed interfaces]: tests (vor 4 Tagen) <Andrei Klunnyi>
* 43cc0226134 - KT-44043 [Sealed interfaces]: quickfix for nested -> to another file (vor 4 Tagen) <Andrei Klunnyi>
* da98fc4b074 - KT-44043 [Sealed interfaces]: quickfix for nested -> to upper level (vor 4 Tagen) <Andrei Klunnyi>
* 521bebee0ff - KT-44043 [Sealed interfaces]: quickfix for top level abstractions (vor 4 Tagen) <Andrei Klunnyi>
* a6b51da3081 - (tag: build-1.5.0-dev-1490, origin/master-for-ide) Fix compilation in the case of JDK_16 pointing to JDK 1.8 (vor 4 Tagen) <Alexander Udalov>
* 3be62dfc890 - (tag: build-1.5.0-dev-1489) Build: enable -Werror in stdlib/core/compiler/plugins modules (vor 4 Tagen) <Alexander Udalov>
* cc90ff78fd2 - Build: output build time for tasks with --info (vor 4 Tagen) <Alexander Udalov>
* 07ce991b3f8 - Build: minor, remove extra newlines in log (vor 4 Tagen) <Alexander Udalov>
* 2a7a297399b - Suppress "runtime JAR files version mismatch" warnings in some plugins (vor 4 Tagen) <Alexander Udalov>
* 0d8f909bda6 - Use ObsoleteTestInfrastructure instead of Deprecated in black box tests (vor 4 Tagen) <Alexander Udalov>
* 221f44da5fc - Fix warnings in stdlib/compiler/plugins/test code (vor 4 Tagen) <Alexander Udalov>
* b3d85e656e9 - Fix warnings after update to 202 platform (vor 4 Tagen) <Alexander Udalov>
* ee7691f1ad8 - Fix IntArrayList deprecation warning in JvmDependenciesIndexImpl (vor 4 Tagen) <Alexander Udalov>
* 8ae19f5cd7a - Fix deprecated Interner/StringInterner usages after update to 202 (vor 4 Tagen) <Alexander Udalov>
* f8c2f4a8d0d - Fix incorrect code in AbstractJspecifyAnnotationsTest (vor 4 Tagen) <Alexander Udalov>
* d101f1b3a67 - Minor, fix compiler warnings in kotlin-serialization-compiler (vor 4 Tagen) <Alexander Udalov>
* e0363788f40 - (tag: build-1.5.0-dev-1487) Remove some remaining tests on old coroutines (vor 4 Tagen) <Alexander Udalov>
* 7953974f3df - (tag: build-1.5.0-dev-1474) [FIR] Make WRONG_IMPLIES_CONDITION warning instead of error (vor 5 Tagen) <Mikhail Glukhikh>
* 7c8a67b20b6 - Make useFir build property set -Xuse-fir flag (vor 5 Tagen) <Simon Ogorodnik>
* bfbb6afee5c - (tag: build-1.5.0-dev-1472) Add sourcesJar from metadata target to root multiplatform publication (vor 5 Tagen) <sebastian.sellmair>
* dfdd107fc01 - (tag: build-1.5.0-dev-1466) Update KAPT stubs for tests (vor 5 Tagen) <Ivan Gavrilovic>
* 3b2986f0699 - Apply consistent sorting for elements from the same position (vor 5 Tagen) <Ivan Gavrilovic>
* ad8517c19ae - Add tests from the reverted commit (vor 5 Tagen) <Ivan Gavrilovic>
* ecc0eee3cf7 - KT-44130: Sort fields and methods in generated stubs (vor 5 Tagen) <Ivan Gavrilovic>
* a320152a036 - Revert "Sort class members to ensure deterministic builds" (vor 5 Tagen) <Ivan Gavrilovic>
* 77f8c1e58fa - (tag: build-1.5.0-dev-1447) Improve cacheability test coverage on kotlin compile, kapt tasks (vor 5 Tagen) <Bingran>
* 1c8a25c1066 - (tag: build-1.5.0-dev-1443) KT-44020: Rename KAPT configuration used as task property (vor 5 Tagen) <Ivan Gavrilovic>
* 47c4197098c - (tag: build-1.5.0-dev-1429) [JS old] Revert fix made for KT-44221 in ab753625 (vor 5 Tagen) <Zalim Bashorov>
* 0d6c5dd2bc1 - (tag: build-1.5.0-dev-1425) Fix incorrect generation of Ant task tests, restore tests (vor 5 Tagen) <Alexander Udalov>
* 0e62cd99984 - (tag: build-1.5.0-dev-1412) Regenerate tests (vor 6 Tagen) <Dmitriy Novozhilov>
* e3066a166eb - [Test] Migrate AbstractFirBlackBoxCodegenTest to new infrastructure (vor 6 Tagen) <Dmitriy Novozhilov>
* af5a635f85d - [Test] Ignore error diagnostics from FIR in some BB tests (vor 6 Tagen) <Dmitriy Novozhilov>
* 2eeed1281cc - [Test] Mute failing FIR BB tests related to MPP (vor 6 Tagen) <Dmitriy Novozhilov>
* 5329a6ce8e5 - [Test] Properly dispose class loader for running BB tests (vor 6 Tagen) <Dmitriy Novozhilov>
* e6fd74f3688 - [Test] Add ability to remove default directives in test configuration (vor 6 Tagen) <Dmitriy Novozhilov>
* e3c7bd5f851 - [Test] Migrate AbstractIrBlackBoxCodegenTest to new infrastructure (vor 6 Tagen) <Dmitriy Novozhilov>
* f1a2e66ba4e - [Test] Setup proper jvm target for kotlinClassImplementsJavaInterface test (vor 6 Tagen) <Dmitriy Novozhilov>
* 93ce37319ac - [Test] Drop BlackBoxCodegenTestGenerated from :compiler:tests-different:jdk (vor 6 Tagen) <Dmitriy Novozhilov>
* 85c87f7df92 - [Test] Migrate AbstractBlackBoxCodegenTest to new infrastructure (vor 6 Tagen) <Dmitriy Novozhilov>
* f01122d8dcc - [Test] Fix module names according to MPP module conventions in test data (vor 6 Tagen) <Dmitriy Novozhilov>
* 0608c50e27a - [Test] Properly configure dependencies for common modules in ModuleStructureExtractor (vor 6 Tagen) <Dmitriy Novozhilov>
* 285ccf75838 - [Test] Don't generate JVM BB tests for expect-actual linker (vor 6 Tagen) <Dmitriy Novozhilov>
* 3a41f1e4355 - [Test] Filter out `support` module with coroutine helpers from module deps (vor 6 Tagen) <Dmitriy Novozhilov>
* 065255adbe8 - [Test] Support friend modules in new test infrastructure (vor 6 Tagen) <Dmitriy Novozhilov>
* 7e92fb8eb93 - [Test] Remove redundant empty `IGNORE_BACKEND` directive (vor 6 Tagen) <Dmitriy Novozhilov>
* 726184eda91 - [Test] Add @JvmMultifileClass to coroutine helpers files (vor 6 Tagen) <Dmitriy Novozhilov>
* 9fd28005946 - [Test] Support KOTLIN_CONFIGURATION_FLAGS directive in new tests (vor 6 Tagen) <Dmitriy Novozhilov>
* e0cd830a0ef - [Test] Drop codegen tests for experimental coroutines (vor 6 Tagen) <Dmitriy Novozhilov>
* d547ce7c42b - [Test] Save TargetBackend instead of BackendKind in TestModule (vor 6 Tagen) <Dmitriy Novozhilov>
* 3c2079c926e - [Test] Compute target backend in test generator automatically using reflection (vor 6 Tagen) <Dmitriy Novozhilov>
* 9378d1ff31d - [Test] Add nullability annotations on InTextDirectivesUtils methods (vor 6 Tagen) <Dmitriy Novozhilov>
* 49f2ac35450 - (tag: build-1.5.0-dev-1404) KT-43818：NPM Dependencies already resolved and installed in Android Studio resolve (vor 6 Tagen) <fjjohnchen>
* 5382e681801 - (tag: build-1.5.0-dev-1402) [Test] Properly delete temporary directories after test run (vor 6 Tagen) <Dmitriy Novozhilov>
* ce44a2a7e47 - [Test] Inject info about test (class and method names, tags) to TestServices (vor 6 Tagen) <Dmitriy Novozhilov>
* 84eb74e1947 - [Test] Fix bug with FirCfgDumpHandler which didn't start at all (vor 6 Tagen) <Dmitriy Novozhilov>
* 13f6b37ae74 - [Test] Drop duplicating `Constructor` typealias (vor 6 Tagen) <Dmitriy Novozhilov>
* af94bcebeac - (tag: build-1.5.0-dev-1401) [IDE] Propagate KotlinFacetSettings version and completely drop isReleaseCoroutines flag (vor 6 Tagen) <Dmitriy Novozhilov>
* e991c9d476c - [CLI] Drop `CommonCompilerArguments.coroutinesState` (vor 6 Tagen) <Dmitriy Novozhilov>
* df3b12e13bc - [FE] Drop `coroutinesState` from build configurations plugins (vor 6 Tagen) <Dmitriy Novozhilov>
* 7f4a925b857 - [FE] Drop `isReleaseCoroutines` flag from LanguageSettingsProvider (vor 6 Tagen) <Dmitriy Novozhilov>
* a8b65bc6736 - [IDE] Drop coroutines KotlinFacetSettings.coroutineSupport (vor 6 Tagen) <Dmitriy Novozhilov>
* 69e1d60b088 - [IDE] Drop coroutines combo box from compiler configuration tab (vor 6 Tagen) <Dmitriy Novozhilov>
* 0fef890d1a4 - Minor refactoring in CompileEnvironmentUtil (vor 6 Tagen) <Alexander Udalov>
* 4374438ff1a - Kotlinc: Exclude module-info.class from resulting jar when "-include-runtime" is specified (vor 6 Tagen) <scaventz>
* 742fef90421 - (tag: build-1.5.0-dev-1398) Rewrite generator for OperationsMapGenerated (vor 6 Tagen) <Alexander Udalov>
* df75cddcb88 - (tag: build-1.5.0-dev-1395) [Gradle, JS] Add possibility to set jvmArgs for dce process (vor 6 Tagen) <Ilya Goncharov>
* ab753625fef - (tag: build-1.5.0-dev-1394) [JS Legacy] Fix returning Char from suspend functions (KT-44221) (vor 6 Tagen) <Svyatoslav Kuzmich>
* 2d88ff6fb29 - [JS IR] Fix unsgined integer default arguemtns (KT-44180) (vor 6 Tagen) <Svyatoslav Kuzmich>
* 0110b4e4b4d - (tag: build-1.5.0-dev-1390) Ant: Add support for fork-mode (vor 6 Tagen) <scaventz>
* ee952db1a22 - (tag: build-1.5.0-dev-1389) Added samples for String.replace() function (vor 6 Tagen) <Kris Hall>
* 77180a5b133 - (tag: build-1.5.0-dev-1388) [JVM IR] Make file classes with all private members package-private (vor 6 Tagen) <Iaroslav Postovalov>
* 032c64669cd - (tag: build-1.5.0-dev-1386) Show pre-released 1.5 version in configuration preferences (vor 6 Tagen) <Mikhail Zarechenskiy>
* d53354057a5 - (tag: build-1.5.0-dev-1377, origin/push/mg-google-prs) FIR: build functional type for SAM with receiver properly (vor 6 Tagen) <Jinseong Jeon>
* f6187632505 - FIR: implement -Xfriend-paths (vor 6 Tagen) <pyos>
* bd708da82ca - (tag: build-1.5.0-dev-1361, origin/rr/ic/fixes2) Do not check script discovery file extension (vor 6 Tagen) <Ilya Chernikov>
* 0e3aaceb16d - (tag: build-1.5.0-dev-1356) Fix ultra light structure for @JvmRecord classes (vor 6 Tagen) <Denis.Zharkov>
* 43b61a618d4 - (tag: build-1.5.0-dev-1355) [IR+Tests] Improve Local Function Debugging Experience (vor 6 Tagen) <Kristoffer Andersen>
* c2d7b69e5fd - (tag: build-1.5.0-dev-1349) Remove bytecode text test kt15806.kt (vor 7 Tagen) <Alexander Udalov>
* 92f3b759c0a - (tag: build-1.5.0-dev-1347) Fix codegen test data for genericTypeWithNothing.kt (vor 7 Tagen) <Alexander Udalov>
* 0c0dbd6245a - (tag: build-1.5.0-dev-1338) [FIR] Perform more accurate pre-check of candidate receiver type (vor 7 Tagen) <Mikhail Glukhikh>
* 4e4293b6090 - [FIR] Introduce separate getTopLevelFunction/PropertySymbols (vor 7 Tagen) <Mikhail Glukhikh>
* fd99f2b2cf1 - FirDefaultStarImportingScope: improve measurements (vor 7 Tagen) <Mikhail Glukhikh>
* 33037fd885c - FirAbstractImportingScope: minor simplification (vor 7 Tagen) <Mikhail Glukhikh>
* 3f5e515bd65 - Fix broken ABI in DiagnosticFactory #KT-44145 Fixed (vor 7 Tagen) <Mikhail Glukhikh>
* b02a9846d04 - (tag: build-1.5.0-dev-1335) IR KT-44233 support flexible nullability in IrTypeSystemContext (vor 7 Tagen) <Dmitry Petrov>
* 093f62caac7 - (tag: build-1.5.0-dev-1330) FIR2IR: check non-parameter Unit type for adapted callable references (vor 7 Tagen) <Jinseong Jeon>
* 4d3ec301c0a - (tag: build-1.5.0-dev-1328) Misprint: "val or val" instead of "val or var" (vor 7 Tagen) <Mikhail Galanin>
* 12078666c27 - (tag: build-1.5.0-dev-1326) Add warning if both -Xuse-ir and -Xuse-old-backend are passed (vor 7 Tagen) <Alexander Udalov>
* cb3191769d1 - Enable JVM IR by default if language version is >= 1.5 (vor 7 Tagen) <Alexander Udalov>
* 22d0e5eb659 - Rename -Xno-use-ir -> -Xuse-old-backend, add Gradle option (vor 7 Tagen) <Alexander Udalov>
* b8fb1ce83cf - (tag: build-1.5.0-dev-1325) Fix Java 9 module tests for many JDKs (vor 7 Tagen) <Alexander Udalov>
* b8d7b39e2c1 - Extract Java 9 module test about irrelevant jars in JDK home (vor 7 Tagen) <Alexander Udalov>
* 9fd250b2b11 - Exclude libraries/stdlib/wasm/build in CodeConformanceTest (vor 7 Tagen) <Alexander Udalov>
* 1e677021284 - (tag: build-1.5.0-dev-1323) [Test] Introduce opt in @ObsoleteTestInfrastructure for migrating tests to new infrastructure (vor 7 Tagen) <Dmitriy Novozhilov>
* dfc86feecd8 - (tag: build-1.5.0-dev-1321, origin/push/pr3982) [IR] Extend test coverage for smart cast handling. (vor 7 Tagen) <Mads Ager>
* 6fc0de39c25 - [PSI2IR] Propagate smart cast information for variable loads. (vor 7 Tagen) <Mads Ager>