### PR TITLE
[kotlin compiler][update] 1.5.0-dev-1963

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.4.20-dev-2167
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.20-dev-2167,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1616,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.0-dev-1616
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1616,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.0-dev-1616
-kotlinStdlibTestsVersion=1.5.0-dev-1616
-testKotlinCompilerVersion=1.5.0-dev-1616
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1963,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.0-dev-1963
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-1963,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.0-dev-1963
+kotlinStdlibTestsVersion=1.5.0-dev-1963
+testKotlinCompilerVersion=1.5.0-dev-1963
 konanVersion=1.5.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 293f2f99503 - (HEAD -> master, tag: build-1.5.0-dev-1963, origin/push/nk/all, origin/master, origin/HEAD) Build: Replace Bintray with Space for kotlin-dependencies repository (KTI-466) (vor 20 Stunden) <Nikolay Krasko>
* eed0f50c5d0 - (tag: build-1.5.0-dev-1955) Code cleanup: ConeAttributes (vor 2 Tagen) <Mikhail Glukhikh>
* 94e613dd01d - FIR: support custom annotation-based type attributes (vor 2 Tagen) <Mikhail Glukhikh>
* 4cd6266bce8 - FIR: fix suspend type serialization (vor 2 Tagen) <Mikhail Glukhikh>
* afe335e5041 - FIR: serialize ExtensionFunctionType attribute (vor 2 Tagen) <Mikhail Glukhikh>
* 9e5c9efadf3 - FIR2IR: don't generate IrGetObject for anonymous objects (vor 2 Tagen) <Mikhail Glukhikh>
* 06ee768c6ad - FIR: in case of smart cast, use original type for FirThisRcvrExpression (vor 2 Tagen) <Mikhail Glukhikh>
* 4fd4f504d0d - FIR: make componentX functions operator (vor 3 Tagen) <Mikhail Glukhikh>
* 7934853c8ef - Set ABI stability to JVM modules which are built with FIR (vor 3 Tagen) <Mikhail Glukhikh>
* 4a76ea6ecb0 - (tag: build-1.5.0-dev-1927) JVM: regenerate objects if they have been regenerated in parent contexts (vor 3 Tagen) <pyos>
* ef36b81c676 - (tag: build-1.5.0-dev-1924) [JVM_IR] Reduce the amount of `super` suffixes on accesibility bridges. (vor 3 Tagen) <Mads Ager>
* a33877a9b97 - (tag: build-1.5.0-dev-1914) Fix add import quick fix for unresolved conventional invoke operator (vor 3 Tagen) <Mikhail Zarechenskiy>
* d2ce73853da - Report more specific diagnostic for variable + invoke calls (vor 3 Tagen) <Mikhail Zarechenskiy>
* c4237509621 - (tag: build-1.5.0-dev-1913) [TD] Fix incorrect module structure directives in test data file (vor 3 Tagen) <Dmitriy Novozhilov>
* 0d058c7c8ce - [Test] Allow parse FILE and MODULE directives with other strings between them in old tests (vor 3 Tagen) <Dmitriy Novozhilov>
* b9e9620ab59 - [TD] Unmute passing Fir2Ir text test (vor 3 Tagen) <Dmitriy Novozhilov>
* 842ed624a7b - [TD] Remove some outdated dumps in FIR_IDENTICAL tests (vor 3 Tagen) <Dmitriy Novozhilov>
* 77115cea92b - [TD] Union ir dumps of different test files (vor 3 Tagen) <Dmitriy Novozhilov>
* 4752924b131 - [TD] Update FQN's in testdata of IR text tests (vor 3 Tagen) <Dmitriy Novozhilov>
* 8286a160bdb - [TD] Update order of directives (vor 3 Tagen) <Dmitriy Novozhilov>
* bdcb8aecab1 - [Test] Migrate AbstractFir2IrTextTest to new infrastructure (vor 3 Tagen) <Dmitriy Novozhilov>
* aba029237dd - [Test] Add handler for comparing pretty kt ir dumps (vor 3 Tagen) <Dmitriy Novozhilov>
* 87ffbd82063 - [IR] Collect all dependencies of module recursively (vor 3 Tagen) <Dmitriy Novozhilov>
* aaa3fa58452 - [Test] Migrate IrTextTestGenerated to new infrastructure (vor 3 Tagen) <Dmitriy Novozhilov>
* 5ae5f660f66 - [Test] Add ability to explicitly declare default binary kind for test (vor 3 Tagen) <Dmitriy Novozhilov>
* a2ae6181858 - [Test] Introduce IGNORE_ERRORS diagnostic to suppressing backend errors (vor 3 Tagen) <Dmitriy Novozhilov>
* acb6d2e1966 - [Test] Allow facades to return null which indicates that facade can't complete it's job (vor 3 Tagen) <Dmitriy Novozhilov>
* 6a7cd0c8114 - [Test] Add ability to specify applicability of diagnostic to module or file (vor 3 Tagen) <Dmitriy Novozhilov>
* 28cff22cd02 - [Test] Add ability to specify directive for test file (vor 3 Tagen) <Dmitriy Novozhilov>
* e17153fab93 - (tag: build-1896, tag: build-1.5.0-dev-1901) Minor, improve Ant test on includeRuntime (vor 4 Tagen) <Alexander Udalov>
* a13eb4c8e62 - Ant task: do not include runtime by default if destination is a jar (vor 4 Tagen) <scaventz>
* b0b7f39c75e - (tag: build-1893) FIR: Do not use return statement for type of a block expression (vor 4 Tagen) <Denis.Zharkov>
* 4dc2653736e - FIR: Do not complete finally parts of try-finally (vor 4 Tagen) <Denis.Zharkov>
* 7df4f67f7cf - FIR: Minor. Drop unused parameter (vor 4 Tagen) <Denis.Zharkov>
* 9493e685843 - FIR: Do not run completion for lambda's explicit return too early (vor 4 Tagen) <Denis.Zharkov>
* 5afebb4e789 - FIR: Transform synthetic calls children even without incomplete candidate (vor 4 Tagen) <Denis.Zharkov>
* 5f0d00a83f9 - FIR: Use proper tower data contexts for postponed callable references (vor 4 Tagen) <Denis.Zharkov>
* ad30c6c3802 - FIR: Fix callable references resolution when they're being returned from lambdas (vor 4 Tagen) <Denis.Zharkov>
* 0e368cc2372 - FIR: Analyze return statements for implicit lambda with independent context (vor 4 Tagen) <Denis.Zharkov>
* 5e83e10a72d - FIR: Add callable references nodes to CFG (vor 4 Tagen) <Denis.Zharkov>
* 6dc0440cd00 - (tag: build-1.5.0-dev-1889) Remove commented code in previous commit (vor 4 Tagen) <Alexander Dudinsky>
* 71e74497b55 - (tag: build-1.5.0-dev-1888) Use `addTestJdk`&`removeTestJdk` methods instead `addJdk`&`removeJdk` (vor 4 Tagen) <Alexander Dudinsky>
* 20843b68947 - (tag: build-1.5.0-dev-1887) Remove error suppression in KotlinChangeSignatureDialog (vor 4 Tagen) <Mikhail Glukhikh>
* 628d6a9c30a - (tag: build-1.5.0-dev-1880) Don't store logger in instance field (vor 4 Tagen) <Pavel Kirpichenkov>
* 5003738d29c - Fix: use idea caches correctly (vor 4 Tagen) <Pavel Kirpichenkov>
* 87c6b6bffce - (tag: build-1.5.0-dev-1878) Revert "Set canBeConsumed = false on the deprecated configurations like compile" (vor 4 Tagen) <Sergey Igushkin>
* 2e660ef62aa - (tag: build-1.5.0-dev-1875) Raw FIR: use lambda parameter type if available (vor 4 Tagen) <Jinseong Jeon>
* fa0b933bc81 - FIR checker: add diagnostics for missing/ambiguous component calls (vor 4 Tagen) <Jinseong Jeon>
* 83b9c29495b - FIR checker: relocate sealed class ctor call checker (vor 4 Tagen) <Jinseong Jeon>
* 5f0eb8a4012 - FIR checker: minor cleanups (vor 4 Tagen) <Jinseong Jeon>
* be29b6d64d4 - FIR checker: use aliased checker when possible (part 2) (vor 4 Tagen) <Jinseong Jeon>
* de592f4f676 - FIR checker: introduce FunctionChecker alias (vor 4 Tagen) <Jinseong Jeon>
* 40bec30393d - FIR: implement LT positioning in diagnostic tests, fix LT strategies (vor 4 Tagen) <Mikhail Glukhikh>
* f1d8a6e5d1c - FIR checker: introduce DECLARATION_SIGNATURE_OR_DEFAULT positioning strategy (vor 4 Tagen) <Jinseong Jeon>
* 2e4daee1d46 - (tag: build-1.5.0-dev-1874) [FIR] Fix invalid diagnostic fir node sites and improved invalid type parameters count diagnostic report (vor 4 Tagen) <Igor Yakovlev>
* b7d3469819a - [FIR] Remove transform/accept from FirResolvedTypeRef.delegateTypeRef (vor 4 Tagen) <Simon Ogorodnik>
* 243f85a4d69 - [FIR IDE] Add base support for FIR incomplete types resolve (vor 4 Tagen) <Igor Yakovlev>
* 704366e5312 - (tag: build-1.5.0-dev-1869) JVM: Mark suspend lambda receiver as used if callable reference (vor 4 Tagen) <Ilmir Usmanov>
* de00f72fa31 - (tag: build-1.5.0-dev-1863) Generate linenumber for inline call site in case of implicit iterator/hasNext/next calls in for loop (vor 4 Tagen) <Mikhael Bogdanov>
* dfacccf84fd - (tag: build-1.5.0-dev-1862) Set canBeConsumed = false on the deprecated configurations like compile (vor 4 Tagen) <Sergey Igushkin>
* 6e913e16adb - Add integration tests for Kapt + Android Gradle plugin 7.0 (vor 4 Tagen) <Sergey Igushkin>
* 341b87fad0d - Use `implementation` instead of `compile` in GradleIT, fix versions (vor 4 Tagen) <Sergey Igushkin>
* 17b71555e0d - KT-43944: Don't access Android test source sets' API configurations (vor 4 Tagen) <Sergey Igushkin>
* 77ffc318f2c - (tag: build-1.5.0-dev-1860) KT-44250 [Sealed interfaces]: completion fails for 'when' with sealed (vor 4 Tagen) <Andrei Klunnyi>
* 14108011eef - (tag: build-1.5.0-dev-1853) [FIR] Fix inferring arguments of bare types in different situations (vor 4 Tagen) <Dmitriy Novozhilov>
* b99f1a1512c - (tag: build-1.5.0-dev-1847) FIR checker: error messages for function diagnostics (vor 4 Tagen) <Jinseong Jeon>
* 021395ce397 - FIR checker: error message for destructuring declaration diagnostic (vor 4 Tagen) <Jinseong Jeon>
* 35093e0958f - FIR checker: error messages for properties/accessors diagnostics (vor 4 Tagen) <Jinseong Jeon>
* 952576e98f4 - (tag: build-1.5.0-dev-1837) JVM_IR: Do not unbox Result parameter if it not only one inline class (vor 5 Tagen) <Ilmir Usmanov>
* d48f92775bd - JVM_IR: Do not unbox Result parameter in invoke if there is a bridge (vor 5 Tagen) <Ilmir Usmanov>
* 0ddb603eaa4 - (tag: build-1.5.0-dev-1836) [JS IR] Fix of test with method in abstract class calling extension on super type (vor 5 Tagen) <Ilya Goncharov>
* 9c4f8f7e542 - (tag: build-1.5.0-dev-1835) JVM IR: Fix signature mapping for inline classes using new mangling (vor 5 Tagen) <Steven Schäfer>
* 91717cdcdd3 - (tag: build-1.5.0-dev-1822) Perform inline checks in IR tests (vor 5 Tagen) <Mikhael Bogdanov>
* 216b775095a - Remove obsolete code (vor 5 Tagen) <Mikhael Bogdanov>
* 147d60523df - Generate inline function arguments with parameters types (vor 5 Tagen) <Mikhael Bogdanov>
* 50ab9ed0545 - [JS IR] Add test on interface with default method calling extension method on super-interface (vor 5 Tagen) <Ilya Goncharov>
* 5c28762c02d - (tag: build-1.5.0-dev-1765, tag: build-1.5.0-dev-1760) Fix check for local classes in approximating string table (vor 5 Tagen) <Pavel Kirpichenkov>
* b66f5c81801 - Drop type aliases for JS and KLIB string tables (vor 5 Tagen) <Pavel Kirpichenkov>
* 2f3f75b5120 - Fix local anonymous class name error in K2MetadataCompiler (vor 5 Tagen) <Pavel Kirpichenkov>
* b82a44fa63a - Add test for KT-20996 (vor 5 Tagen) <Pavel Kirpichenkov>
* cce9469e6a0 - (tag: build-1.5.0-dev-1753) JVM_IR: Do not unbox Result parameter in Result methods (vor 5 Tagen) <Ilmir Usmanov>
* 10d9259df53 - (tag: build-1.5.0-dev-1738) Returned support for nullable types by not null serializers (vor 6 Tagen) <Sergey Shanshin>
* b476f1cc3e7 - (tag: build-1.5.0-dev-1727) Minor. Change test to use the feature instead of suppressing error (vor 6 Tagen) <Ilmir Usmanov>
* d1ee45b5184 - Add language feature for suspend functions in fun interfaces (vor 6 Tagen) <Ilmir Usmanov>
* 6aa6f82c47c - (tag: build-1.5.0-dev-1723) Fix MultiplatformModelImportingContextImpl#isOrphanSourceSet predicate (vor 6 Tagen) <Yaroslav Chernyshev>
* cf228bebc3f - (tag: build-1.5.0-dev-1722) Use static year range in copyright of generated FIR and tests (vor 6 Tagen) <Svyatoslav Kuzmich>
* ba8223218fa - [Wasm] Add inline property accessors optimization (vor 6 Tagen) <Svyatoslav Kuzmich>
* 2aa3c197a30 - [Wasm] Use non-persistent IR to speed up tests (vor 6 Tagen) <Svyatoslav Kuzmich>
* 11a3126c8ce - (tag: build-1.5.0-dev-1719) FIR: copy class supertypes list on iterating while calculating supertypes (vor 6 Tagen) <Ilya Kirillov>
* a0ad85e20d3 - (tag: build-1.5.0-dev-1716, origin/rr/4u7/wip) Build: Disable caching of test tasks (vor 6 Tagen) <Vyacheslav Gerasimov>
* 284d42fd2b7 - (tag: build-1.5.0-dev-1710) Use camelCase for cacheKind control property (vor 6 Tagen) <Sergey Bogolepov>
* 29f95c7df27 - (tag: build-1.5.0-dev-1690) FIR: improve inference of implicit type arguments in casts (vor 7 Tagen) <pyos>
* acdc1f532b9 - (tag: build-1.5.0-dev-1682) Rewrite CommonizerTask params to fix ^KT-42098 (vor 7 Tagen) <sebastian.sellmair>
* 23332bac139 - (tag: build-1.5.0-dev-1665) More precise message for "this test can be unmuted" (vor 7 Tagen) <Shagen Ogandzhanian>
* 6331a135c8c - (tag: build-1.5.0-dev-1662) Add LightClassUtil.getLightClassMethodsByName to avoid resolving all lightClassMethods and filtration later on (vor 7 Tagen) <Vladimir Dolzhenko>
* 167bfcf6eaa - (tag: build-1.5.0-dev-1658) Minor. Remove accidentally added bunch file (vor 7 Tagen) <Ilmir Usmanov>
* bf5feb1b4a7 - (tag: build-1.5.0-dev-1657) Remove KotlinMetadataTarget's KotlinTargetComponent in favour of KotlinSoftwareComponent.kt ^KT-44322 fixed (vor 7 Tagen) <Sebastian Sellmair>
* 9a5791ad6d8 - (tag: build-1.5.0-dev-1654) FIR: use correct context for enum entry resolve (vor 7 Tagen) <Mikhail Glukhikh>
* f85fc47383b - FIR: introduce separate companion object resolve context (vor 7 Tagen) <Mikhail Glukhikh>
* f282c3e5474 - Cleanup: FirTowerResolveTask (vor 7 Tagen) <Mikhail Glukhikh>
* 9f06c1a500a - FIR cleanup: runResolverForDelegatingConstructor (vor 7 Tagen) <Mikhail Glukhikh>
* 6cee4e968e6 - [FIR] Don't call componentX for anonymous destructuring entry (vor 7 Tagen) <Mikhail Glukhikh>
* 795bd26eaf9 - FIR bootstrap: don't use -Werror in useFIR mode (vor 7 Tagen) <Mikhail Glukhikh>
* 3787018e40b - [FIR] Fix parameter index storage in contract serializer (vor 7 Tagen) <Mikhail Glukhikh>
* 12caf5d7435 - Fix test BE JvmBoxRunner to be able to see FIR BB tests exceptions (vor 7 Tagen) <Mikhail Glukhikh>