### PR TITLE
[kotlin compiler][update] 1.5.20-dev-60

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.5.0-dev-2205
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-2205,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-7,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.20-dev-7
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-7,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.20-dev-7
-kotlinStdlibTestsVersion=1.5.20-dev-7
-testKotlinCompilerVersion=1.5.20-dev-7
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-60,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.20-dev-60
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-60,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.20-dev-60
+kotlinStdlibTestsVersion=1.5.20-dev-60
+testKotlinCompilerVersion=1.5.20-dev-60
 konanVersion=1.5.0
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 509ed64917a - (tag: build-1.5.20-dev-60) KT-43686: Make kapt Gradle task cacheable across machines (2 hours ago) <Ivan Gavrilovic>
* 771600077ca - (tag: build-1.5.20-dev-53, origin/push/demiurg906/fir-identical-TC) [Test] Fail if there are changes in generated fir tree files in teamcity build (5 hours ago) <Dmitriy Novozhilov>
* 297288e9848 - [Test] Don't generate new files in GeneratorsFileUtil in teamcity mode (5 hours ago) <Dmitriy Novozhilov>
* 772ca2715c7 - [Test] Don't change testdata in FirIdenticalChecker in teamcity mode (5 hours ago) <Dmitriy Novozhilov>
* 6265ac8c198 - (tag: build-1.5.20-dev-38, origin/rr/gorshenev/klib_evolution_master) Re-enabled disabled test (2 days ago) <Alexander Gorshenev>
* 16b3fedcd4f - Created AbstractKlibBinaryCompatibilityTest and AbstractJsKlibBinaryCompatibilityTest A common test runner for klib binary compatibility tests and its js counterpart (2 days ago) <Alexander Gorshenev>
* e7cf34a2a97 - (tag: build-1.5.20-dev-27) Workaround illegal access problem in daemon for JDK 17-ea (3 days ago) <Alexander Udalov>
* f08733eb753 - CLI: suppress warning on JDK 9+ with illegal access to ResourceBundle (3 days ago) <Alexander Udalov>
* 2ef4ca4e6e7 - CLI: do not pass -noverify to java process starting from JDK 13 (3 days ago) <Alexander Udalov>
* 2bbe3db0411 - Update copyrights in CLI scripts (3 days ago) <Alexander Udalov>
* 9f9c8e3d778 - (tag: build-1.5.20-dev-15) Mute stream api test on Android (3 days ago) <Mikhael Bogdanov>
* 21f022dec29 - (tag: build-1.5.20-dev-13) Add :kotlin-scripting-compiler.test to modules with disabled -Werror flag (3 days ago) <Dmitriy Novozhilov>
* 021a63827d4 - (tag: build-1.5.20-dev-12) Add API version 1.5 to accepted values in MPP language settings (3 days ago) <Sergey Igushkin>
* 6a29097a8ca - Remove obsolete dependency for dx (3 days ago) <Mikhael Bogdanov>
* be9ef8f3c84 - Remove obsolete DxChecker (3 days ago) <Mikhael Bogdanov>