### PR TITLE
[kotlin compiler][update] 1.5.20-dev-372

### DIFF
--- a/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/AbiSpecific.kt
+++ b/Interop/StubGenerator/src/main/kotlin/org/jetbrains/kotlin/native/interop/gen/AbiSpecific.kt
@@ -18,7 +18,8 @@ internal fun Type.isStret(target: KonanTarget): Boolean {
     val unwrappedType = this.unwrapTypedefs()
     val abiInfo: ObjCAbiInfo = when (target) {
         KonanTarget.IOS_ARM64,
-        KonanTarget.TVOS_ARM64 -> DarwinArm64AbiInfo()
+        KonanTarget.TVOS_ARM64,
+        KonanTarget.MACOS_ARM64 -> DarwinArm64AbiInfo()
 
         KonanTarget.IOS_X64,
         KonanTarget.MACOS_X64,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BitcodeCompiler.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/BitcodeCompiler.kt
@@ -52,12 +52,18 @@ internal class BitcodeCompiler(val context: Context) {
 
         val profilingFlags = llvmProfilingFlags().map { listOf("-mllvm", it) }.flatten()
 
-        // LLVM we use does not have support for arm64_32.
         // TODO: fix with LLVM update.
         val targetTriple = when (context.config.target) {
+            // LLVM we use does not have support for arm64_32.
             KonanTarget.WATCHOS_ARM64 -> {
                 require(configurables is AppleConfigurables)
                 "arm64_32-apple-watchos${configurables.osVersionMin}"
+            }
+            // Runtime generates bitcode for mythical macos 10.16 because of old Clang.
+            // Let's fix it.
+            KonanTarget.MACOS_ARM64 -> {
+                require(configurables is AppleConfigurables)
+                "arm64-apple-macos${configurables.osVersionMin}"
             }
             else -> context.llvm.targetTriple
         }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlin.backend.konan
 
-import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContextImpl
 import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideChecker
@@ -38,6 +37,7 @@ internal fun Context.psiToIr(
 ) {
     // Translate AST to high level IR.
     val expectActualLinker = config.configuration.get(CommonConfigurationKeys.EXPECT_ACTUAL_LINKER)?:false
+    val messageLogger = config.configuration.get(IrMessageLogger.IR_MESSAGE_LOGGER) ?: IrMessageLogger.None
 
     val translator = Psi2IrTranslator(config.configuration.languageVersionSettings, Psi2IrConfiguration(false))
     val generatorContext = translator.createGeneratorContext(moduleDescriptor, bindingContext, symbolTable)
@@ -89,7 +89,7 @@ internal fun Context.psiToIr(
                 moduleDescriptor,
                 functionIrClassFactory,
                 translationContext,
-                this as LoggingContext,
+                messageLogger,
                 generatorContext.irBuiltIns,
                 symbolTable,
                 forwardDeclarationsModuleDescriptor,
@@ -149,7 +149,8 @@ internal fun Context.psiToIr(
                 generatorContext.symbolTable,
                 generatorContext.typeTranslator,
                 generatorContext.irBuiltIns,
-                linker = irDeserializer
+                linker = irDeserializer,
+                diagnosticReporter = messageLogger
         )
         pluginExtensions.forEach { extension ->
             extension.generate(module, pluginContext)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ToplevelPhases.kt
@@ -169,10 +169,11 @@ internal val copyDefaultValuesToActualPhase = konanUnitPhase(
 internal val serializerPhase = konanUnitPhase(
         op = {
             val expectActualLinker = config.configuration.get(CommonConfigurationKeys.EXPECT_ACTUAL_LINKER) ?: false
+            val messageLogger = config.configuration.get(IrMessageLogger.IR_MESSAGE_LOGGER) ?: IrMessageLogger.None
 
             serializedIr = irModule?.let { ir ->
                 KonanIrModuleSerializer(
-                    this, ir.irBuiltins, expectDescriptorToSymbol, skipExpects = !expectActualLinker
+                    messageLogger, ir.irBuiltins, expectDescriptorToSymbol, skipExpects = !expectActualLinker
                 ).serializedIrModule(ir)
             }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/llvm/objcexport/ObjCExportCodeGenerator.kt
@@ -1671,6 +1671,7 @@ private fun Context.is64BitNSInteger(): Boolean = when (val target = this.config
     KonanTarget.TVOS_ARM64,
     KonanTarget.TVOS_X64,
     KonanTarget.MACOS_X64,
+    KonanTarget.MACOS_ARM64,
     KonanTarget.WATCHOS_X64 -> true
     KonanTarget.WATCHOS_ARM64,
     KonanTarget.WATCHOS_ARM32,
@@ -1702,6 +1703,7 @@ internal fun Context.is64BitLong(): Boolean = when (this.config.target) {
     KonanTarget.MINGW_X64,
     KonanTarget.LINUX_X64,
     KonanTarget.MACOS_X64,
+    KonanTarget.MACOS_ARM64,
     KonanTarget.WATCHOS_X64 -> true
     KonanTarget.WATCHOS_ARM64,
     KonanTarget.WATCHOS_ARM32,

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/objcexport/ObjCExport.kt
@@ -136,8 +136,7 @@ internal class ObjCExport(val context: Context, symbolTable: SymbolTable) {
         modules.child("module.modulemap").writeBytes(moduleMap.toByteArray())
 
         emitInfoPlist(frameworkContents, frameworkName)
-
-        if (target == KonanTarget.MACOS_X64) {
+        if (target.family == Family.OSX) {
             framework.child("Versions/Current").createAsSymlink("A")
             for (child in listOf(frameworkName, "Headers", "Modules", "Resources")) {
                 framework.child(child).createAsSymlink("Versions/Current/$child")
@@ -163,7 +162,7 @@ internal class ObjCExport(val context: Context, symbolTable: SymbolTable) {
             KonanTarget.IOS_X64 -> "iPhoneSimulator"
             KonanTarget.TVOS_ARM64 -> "AppleTVOS"
             KonanTarget.TVOS_X64 -> "AppleTVSimulator"
-            KonanTarget.MACOS_X64 -> "MacOSX"
+            KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64 -> "MacOSX"
             KonanTarget.WATCHOS_ARM32, KonanTarget.WATCHOS_ARM64 -> "WatchOS"
             KonanTarget.WATCHOS_X86, KonanTarget.WATCHOS_X64 -> "WatchSimulator"
             else -> error(target)

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrFileSerializer.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlin.backend.konan.serialization
 
-import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.serialization.DeclarationTable
 import org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer
 import org.jetbrains.kotlin.backend.konan.RuntimeNames
@@ -9,15 +8,16 @@ import org.jetbrains.kotlin.ir.declarations.IrAnnotationContainer
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
+import org.jetbrains.kotlin.ir.util.IrMessageLogger
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 
 class KonanIrFileSerializer(
-    logger: LoggingContext,
+    messageLogger: IrMessageLogger,
     declarationTable: DeclarationTable,
     expectDescriptorToSymbol: MutableMap<DeclarationDescriptor, IrSymbol>,
     skipExpects: Boolean,
     bodiesOnlyForInlines: Boolean = false
-): IrFileSerializer(logger, declarationTable, expectDescriptorToSymbol, skipExpects = skipExpects, bodiesOnlyForInlines = bodiesOnlyForInlines) {
+): IrFileSerializer(messageLogger, declarationTable, expectDescriptorToSymbol, skipExpects = skipExpects, bodiesOnlyForInlines = bodiesOnlyForInlines) {
 
     override fun backendSpecificExplicitRoot(node: IrAnnotationContainer): Boolean {
         val fqn = when (node) {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrModuleSerializer.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlin.backend.konan.serialization
 
-import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.serialization.*
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureSerializer
 import org.jetbrains.kotlin.backend.konan.ir.interop.IrProviderForCEnumAndCStructStubs
@@ -8,13 +7,14 @@ import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
+import org.jetbrains.kotlin.ir.util.IrMessageLogger
 
 class KonanIrModuleSerializer(
-    logger: LoggingContext,
+    messageLogger: IrMessageLogger,
     irBuiltIns: IrBuiltIns,
     private val expectDescriptorToSymbol: MutableMap<DeclarationDescriptor, IrSymbol>,
     val skipExpects: Boolean
-) : IrModuleSerializer<KonanIrFileSerializer>(logger) {
+) : IrModuleSerializer<KonanIrFileSerializer>(messageLogger) {
 
     private val signaturer = IdSignatureSerializer(KonanManglerIr)
     private val globalDeclarationTable = KonanGlobalDeclarationTable(signaturer, irBuiltIns)
@@ -29,5 +29,5 @@ class KonanIrModuleSerializer(
             file.fileEntry.name != IrProviderForCEnumAndCStructStubs.cTypeDefinitionsFileName
 
     override fun createSerializerForFile(file: IrFile): KonanIrFileSerializer =
-            KonanIrFileSerializer(logger, KonanDeclarationTable(globalDeclarationTable), expectDescriptorToSymbol, skipExpects = skipExpects)
+            KonanIrFileSerializer(messageLogger, KonanDeclarationTable(globalDeclarationTable), expectDescriptorToSymbol, skipExpects = skipExpects)
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -16,7 +16,6 @@
 
 package org.jetbrains.kotlin.backend.konan.serialization
 
-import org.jetbrains.kotlin.backend.common.LoggingContext
 import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideBuilder
 import org.jetbrains.kotlin.backend.common.overrides.FakeOverrideClassFilter
 import org.jetbrains.kotlin.backend.common.serialization.*
@@ -71,7 +70,7 @@ internal class KonanIrLinker(
         private val currentModule: ModuleDescriptor,
         override val functionalInterfaceFactory: IrAbstractFunctionFactory,
         override val translationPluginContext: TranslationPluginContext?,
-        logger: LoggingContext,
+        messageLogger: IrMessageLogger,
         builtIns: IrBuiltIns,
         symbolTable: SymbolTable,
         private val forwardModuleDescriptor: ModuleDescriptor?,
@@ -79,7 +78,7 @@ internal class KonanIrLinker(
         private val cenumsProvider: IrProviderForCEnumAndCStructStubs,
         exportedDependencies: List<ModuleDescriptor>,
         private val cachedLibraries: CachedLibraries
-) : KotlinIrLinker(currentModule, logger, builtIns, symbolTable, exportedDependencies) {
+) : KotlinIrLinker(currentModule, messageLogger, builtIns, symbolTable, exportedDependencies) {
 
     companion object {
         private val C_NAMES_NAME = Name.identifier("cnames")

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/FrameworkTest.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/FrameworkTest.kt
@@ -183,7 +183,7 @@ open class FrameworkTest : DefaultTask(), KonanTestExecutable {
             KonanTarget.IOS_ARM32, KonanTarget.IOS_ARM64 -> "iphoneos"
             KonanTarget.TVOS_X64 -> "appletvsimulator"
             KonanTarget.TVOS_ARM64 -> "appletvos"
-            KonanTarget.MACOS_X64 -> "macosx"
+            KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64 -> "macosx"
             KonanTarget.WATCHOS_ARM64 -> "watchos"
             KonanTarget.WATCHOS_X64, KonanTarget.WATCHOS_X86 -> "watchsimulator"
             else -> throw IllegalStateException("Test target $target is not supported")
@@ -213,6 +213,7 @@ open class FrameworkTest : DefaultTask(), KonanTestExecutable {
             KonanTarget.TVOS_X64 -> "SIMCTL_CHILD_DYLD_LIBRARY_PATH"
             else -> "DYLD_LIBRARY_PATH"
         }
+        // TODO: macos_arm64?
         return if (newMacos && target == KonanTarget.MACOS_X64) emptyMap() else mapOf(
                 dyldLibraryPathKey to getSwiftLibsPathForTestTarget()
         )
@@ -253,7 +254,8 @@ open class FrameworkTest : DefaultTask(), KonanTestExecutable {
             KonanTarget.WATCHOS_X64 -> return // bitcode-build-tool doesn't support simulators.
             KonanTarget.IOS_ARM64,
             KonanTarget.IOS_ARM32 -> Xcode.current.iphoneosSdk
-            KonanTarget.MACOS_X64 -> Xcode.current.macosxSdk
+            KonanTarget.MACOS_X64,
+            KonanTarget.MACOS_ARM64 -> Xcode.current.macosxSdk
             KonanTarget.TVOS_ARM64 -> Xcode.current.appletvosSdk
             KonanTarget.WATCHOS_ARM32,
             KonanTarget.WATCHOS_ARM64 -> Xcode.current.watchosSdk

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/Utils.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/Utils.kt
@@ -244,6 +244,7 @@ fun compileSwift(project: Project, target: KonanTarget, sources: List<String>, o
         KonanTarget.TVOS_X64   -> "x86_64-apple-tvos" + configs.osVersionMin
         KonanTarget.TVOS_ARM64 -> "arm64-apple-tvos" + configs.osVersionMin
         KonanTarget.MACOS_X64 -> "x86_64-apple-macosx" + configs.osVersionMin
+        KonanTarget.MACOS_ARM64 -> "arm64-apple-macos" + configs.osVersionMin
         KonanTarget.WATCHOS_X86 -> "i386-apple-watchos" + configs.osVersionMin
         KonanTarget.WATCHOS_X64 -> "x86_64-apple-watchos" + configs.osVersionMin
         else -> throw IllegalStateException("Test target $target is not supported")

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,15 +15,15 @@
 #
 
 # A version of the Kotlin compiler that is used to build Kotlin/Native.
-buildKotlinVersion=1.5.0-dev-2205
-buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.0-dev-2205,branch:default:any,pinned:true/artifacts/content/maven
+buildKotlinVersion=1.5.20-dev-372
+buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-372,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-60,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.20-dev-60
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-60,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.20-dev-60
-kotlinStdlibTestsVersion=1.5.20-dev-60
-testKotlinCompilerVersion=1.5.20-dev-60
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-372,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.20-dev-372
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-372,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.20-dev-372
+kotlinStdlibTestsVersion=1.5.20-dev-372
+testKotlinCompilerVersion=1.5.20-dev-372
 konanVersion=1.5.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -111,6 +111,34 @@ target-toolchain-xcode_12_2-macos_x64.default = \
 xcode-addon-xcode_12_2-macos_x64.default = \
   remote:internal
 
+# macOS Apple Silicon
+targetToolchain.macos_x64-macos_arm64 = target-toolchain-xcode_12_2-macos_x64
+arch.macos_arm64 = arm64
+targetSysRoot.macos_arm64 = target-sysroot-xcode_12_2-macos_x64
+# TODO: Check Clang behaviour.
+targetCpu.macos_arm64 = cyclone
+clangFlags.macos_arm64 = -cc1 -emit-obj -disable-llvm-passes -x ir
+clangNooptFlags.macos_arm64 = -O1
+clangOptFlags.macos_arm64 = -O3
+# See clangDebugFlags.ios_arm64
+# TODO: Is it still necessary?
+clangDebugFlags.macos_arm64 = -O0 -mllvm -fast-isel=false -mllvm -global-isel=false
+
+linkerKonanFlags.macos_arm64 = -lSystem -lc++ -lobjc -framework Foundation -sdk_version 11.0.1
+linkerOptimizationFlags.macos_arm64 = -dead_strip
+linkerNoDebugFlags.macos_arm64 = -S
+linkerDynamicFlags.macos_arm64 = -dylib
+
+osVersionMinFlagLd.macos_arm64 = -macosx_version_min
+osVersionMinFlagClang.macos_arm64 = -mmacosx-version-min
+osVersionMin.macos_arm64 = 11.0
+runtimeDefinitions.macos_arm64 = KONAN_OSX=1 KONAN_MACOSX=1 KONAN_ARM64=1 KONAN_OBJC_INTEROP=1 \
+  KONAN_CORE_SYMBOLICATION=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+dependencies.macos_x64-macos_arm64 = \
+    libffi-3.2.1-3-darwin-macos
+
+target-sysroot-xcode_12_2-macos_arm64.default = \
+  remote:internal
 
 # Apple's 32-bit iOS.
 targetToolchain.macos_x64-ios_arm32 = target-toolchain-xcode_12_2-macos_x64

--- a/platformLibs/src/platform/osx/Hypervisor.def
+++ b/platformLibs/src/platform/osx/Hypervisor.def
@@ -1,4 +1,4 @@
-depends = darwin posix
+depends = darwin osx posix
 language = Objective-C
 package = platform.Hypervisor
 

--- a/platformLibs/src/platform/osx/darwin.def
+++ b/platformLibs/src/platform/osx/darwin.def
@@ -26,6 +26,7 @@ headers = AppleTextureEncoder.h AssertMacros.h Availability.h AvailabilityIntern
     os/activity.h os/availability.h os/base.h os/lock.h \
     os/log.h os/object.h os/overflow.h os/signpost.h os/trace.h \
     simd/simd.h sys/sysctl.h sys/user.h \
+    sys/_types/_os_inline.h \
     net/if_media.h sys/disk.h sys/kernel_types.h
 
 headerFilter = **
@@ -39,5 +40,6 @@ excludedFunctions = __tg_promote KERNEL_AUDIT_TOKEN KERNEL_SECURITY_TOKEN \
                     xpc_debugger_api_misuse_info \
                     vm_stats
 
-compilerOpts = -D_XOPEN_SOURCE -DSHARED_LIBBIND -D_DARWIN_NO_64_BIT_INODE -DSYSCTL_DEF_ENABLED
+compilerOpts.macos_x64 = -D_XOPEN_SOURCE -DSHARED_LIBBIND -D_DARWIN_NO_64_BIT_INODE -DSYSCTL_DEF_ENABLED
+compilerOpts.macos_arm64 = -D_XOPEN_SOURCE -DSHARED_LIBBIND -DSYSCTL_DEF_ENABLED
 linkerOpts = -ldl -lz -lcurses -lbz2 -lcompression -late -lbsm

--- a/platformLibs/src/platform/osx/osx.def
+++ b/platformLibs/src/platform/osx/osx.def
@@ -1,17 +1,18 @@
 depends = darwin posix
 language = Objective-C
 package = platform.osx
+
 headers = NSSystemDirectories.h \
     aliasdb.h bootparams.h bootstrap.h \
     com_err.h \
     crt_externs.h \
     disktab.h dtrace.h \
-    emmintrin.h eti.h expat.h \
+    eti.h expat.h \
     expat_external.h form.h fsproperties.h get_compat.h \
     gssapi.h histedit.h \
     krb5.h launch.h lber.h lber_types.h ldif.h libc.h libcharset.h \
     libproc.h localcharset.h \
-    mmintrin.h monitor.h \
+    monitor.h \
     nc_tparm.h ncurses.h ncurses_dll.h \
     nlist.h \
     panel.h pcap-bpf.h pcap-namedb.h pcap.h printerdb.h \
@@ -20,10 +21,15 @@ headers = NSSystemDirectories.h \
     struct.h term.h \
     term_entry.h termcap.h tic.h timeconv.h tzfile.h \
     unctrl.h vproc.h \
-    xmmintrin.h \
     atm/atm_types.h corpses/task_corpse.h \
     hfs/hfs_format.h hfs/hfs_mount.h hfs/hfs_unistr.h \
     sys/kauth.h
+headers.macos_x64 = \
+    emmintrin.h \
+    mmintrin.h \
+    xmmintrin.h
+headers.macos_arm64 = \
+    arm64/hv/hv_kern_types.h
 
 headerFilter = **
 

--- a/platformLibs/src/platform/osx/posix.def
+++ b/platformLibs/src/platform/osx/posix.def
@@ -13,7 +13,8 @@ headers = alloca.h ar.h assert.h complex.h ctype.h dirent.h dlfcn.h err.h errno.
     sys/queue.h sys/select.h sys/shm.h sys/socket.h sys/stat.h \
     sys/syslimits.h sys/time.h sys/times.h sys/utsname.h sys/wait.h
 
-compilerOpts = -D_XOPEN_SOURCE -DSHARED_LIBBIND -D_DARWIN_NO_64_BIT_INODE -D_DARWIN_C_SOURCE
+compilerOpts.macos_x64 = -D_XOPEN_SOURCE -DSHARED_LIBBIND -D_DARWIN_NO_64_BIT_INODE -D_DARWIN_C_SOURCE
+compilerOpts.macos_arm64 = -D_XOPEN_SOURCE -DSHARED_LIBBIND -D_DARWIN_C_SOURCE
 # -D_ANSI_SOURCE, sigh, breaks user_addr_t
 excludedFunctions = KERNEL_AUDIT_TOKEN KERNEL_SECURITY_TOKEN add_profil             \
                     addrsel_policy_init                                             \

--- a/platformLibs/src/platform/osx/set_depends.sh
+++ b/platformLibs/src/platform/osx/set_depends.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-../../../../dist/bin/run_konan defFileDependencies -target macos_x64 *.def
+../../../../dist/bin/run_konan defFileDependencies -target macos_x64 -target macos_arm64 *.def

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Apple.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/Apple.kt
@@ -33,7 +33,7 @@ class AppleConfigurablesImpl(
 
     override val absoluteTargetSysRoot: String get() = when (val provider = xcodePartsProvider) {
         is XcodePartsProvider.Local -> when (target) {
-            KonanTarget.MACOS_X64 -> provider.xcode.macosxSdk
+            KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64 -> provider.xcode.macosxSdk
             KonanTarget.IOS_ARM32, KonanTarget.IOS_ARM64 -> provider.xcode.iphoneosSdk
             KonanTarget.IOS_X64 -> provider.xcode.iphonesimulatorSdk
             KonanTarget.TVOS_ARM64 -> provider.xcode.appletvosSdk

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ClangArgs.kt
@@ -95,6 +95,14 @@ class ClangArgs(private val configurables: Configurables) : Configurables by con
                 "-mmacosx-version-min=$osVersionMin"
         )
 
+        // Here we workaround Clang 8 limitation: macOS major version should be 10.
+        // So we compile runtime with version 10.16 and then override version in BitcodeCompiler.
+        // TODO: Fix with LLVM Update.
+        KonanTarget.MACOS_ARM64 -> listOf(
+                "-arch", "arm64",
+                "-mmacosx-version-min=10.16"
+        )
+
         KonanTarget.IOS_ARM32 -> listOf(
                 "-stdlib=libc++",
                 "-arch", "armv7",

--- a/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ConfigurablesImpl.kt
+++ b/shared/src/main/kotlin/org/jetbrains/kotlin/konan/target/ConfigurablesImpl.kt
@@ -42,7 +42,7 @@ fun loadConfigurables(target: KonanTarget, properties: Properties, baseDir: Stri
         KonanTarget.LINUX_MIPS32, KonanTarget.LINUX_MIPSEL32 ->
             GccConfigurablesImpl(target, properties, baseDir)
 
-        KonanTarget.MACOS_X64,
+        KonanTarget.MACOS_X64, KonanTarget.MACOS_ARM64,
         KonanTarget.IOS_ARM32, KonanTarget.IOS_ARM64, KonanTarget.IOS_X64,
         KonanTarget.TVOS_ARM64, KonanTarget.TVOS_X64,
         KonanTarget.WATCHOS_ARM64, KonanTarget.WATCHOS_ARM32,


### PR DESCRIPTION
* dcb47d99348 - (tag: build-1.5.20-dev-372) Fix broken compilation after changing kotlin compiler configuration form (2 days ago) <Dmitriy Novozhilov>
* 391f53154ad - (tag: build-1.5.20-dev-355) Fix NPE in Kotlin facets tab (3 days ago) <Vladimir Dolzhenko>
* 250040bab72 - (tag: build-1.5.20-dev-353) Common fix GradleQuickFixTest and GradleUpdateConfigurationQuickFixTest (3 days ago) <Alexander Dudinsky>
* 94e66acd548 - Revert "Fix GradleQuickFixTest" (3 days ago) <Alexander Dudinsky>
* 9f7d7e55daa - (tag: build-1.5.20-dev-341) Consider platform compatibility in library usage index (3 days ago) <Pavel Kirpichenkov>
* 27dcd07a5e7 - (tag: build-1.5.20-dev-336) [Commonizer] Remove filter for simd_ functions (no more relevant) (3 days ago) <Dmitriy Dolovov>
* 4d5ec6e52ab - [Commonizer] Minor. Rename: builders.kt -> entityBuilders.kt (3 days ago) <Dmitriy Dolovov>
* 955f86ef9f9 - [Commonizer] Minor. Rename: buildingVisitor.kt -> metadataBuilder.kt (3 days ago) <Dmitriy Dolovov>
* 33c1ca01f49 - [Commonizer] Simplify creation of SerializedMetadataLibraryProvider (3 days ago) <Dmitriy Dolovov>
* 6c92ea518b7 - [Commonizer] Add ModulesProvider.loadModuleMetadata() to load raw metadata (3 days ago) <Dmitriy Dolovov>
* cb226e74a51 - [Commonizer] Refactor ModulesProvider.loadModuleInfos() function (3 days ago) <Dmitriy Dolovov>
* 08111031ece - (tag: build-1.5.20-dev-332) [KAPT] Keep annotations from kotlin.jvm. in stubs (3 days ago) <Andrey Zinovyev>
* a68837451a7 - (tag: build-1.5.20-dev-322) FirCatchParameterChecker: minor fix (3 days ago) <Mikhail Glukhikh>
* 0d1f493b6c4 - (tag: build-1.5.20-dev-318) Remove unneeded artifacts for Kotlin IDE plugin (3 days ago) <Yan Zhulanow>
* f1ab5d1fbd2 - (tag: build-1.5.20-dev-317) FIR: introduce & use Throwable built-in type (3 days ago) <Mikhail Glukhikh>
* bbd1da7b713 - Use reportOn in FirThrowableSubclassChecker & FirCatchParameterChecker (3 days ago) <Mikhail Glukhikh>
* a564f92eef0 - FIR: introduce ThrowableSubclassChecker (3 days ago) <eugenpolytechnic>
* cd189c0812c - (tag: build-1.5.20-dev-311) JVM_IR. Do not unbox Result in inline lambda (4 days ago) <Ilmir Usmanov>
* fb296b5b95a - (tag: build-1.5.20-dev-310) Do not create Array instance in kotlin-reflect where not necessary (4 days ago) <Alexander Udalov>
* 35ec6b4f5c5 - (tag: build-1.5.20-dev-307) Run IR test on `Test Codegen on different platforms` (4 days ago) <Mikhael Bogdanov>
* d5deccd2e96 - (tag: build-1.5.20-dev-306) Fix GradleQuickFixTest (4 days ago) <Nikolay Krasko>
* dacf012a788 - (tag: build-1.5.20-dev-292) [KAPT] Add newline after each java compiler log (#4087) (4 days ago) <Andrey Zinovyev>
* cdb488149f3 - (tag: build-1.5.20-dev-281) [JS IR] Namer improvements (4 days ago) <Svyatoslav Kuzmich>
* c9cb7bc0fdc - [JS IR] Update tests (4 days ago) <Svyatoslav Kuzmich>
* ae738e9c59b - [JS] Add basic optional logs to test runner (4 days ago) <Svyatoslav Kuzmich>
* c6242ad1672 - [JS] String.isValidES5Identifier (4 days ago) <Svyatoslav Kuzmich>
* 8be7e6064ea - [JS IR] Optimize sanitization (4 days ago) <Svyatoslav Kuzmich>
* 2a424ad2af6 - [IR] Make isExternal mutable and accessible via common interface (4 days ago) <Svyatoslav Kuzmich>
* 924a7b009bf - [JS IR] Fix object getInstance visibility (4 days ago) <Svyatoslav Kuzmich>
* 218c2461111 - [JS] Fix extra js function capturing (4 days ago) <Svyatoslav Kuzmich>
* 95140f35f8d - (tag: build-1.5.20-dev-273) [parcelize] Fix codegen for generic classes (4 days ago) <Andrey Zinovyev>
* ca02573d1eb - (tag: build-1.5.20-dev-266) [Test] Print bytecode if DxCheckerHandler had failed (4 days ago) <Dmitriy Novozhilov>
* 771b1acbc10 - [Test] Ignore multimodule tests in AbstractLightAnalysisModeTest (4 days ago) <Dmitriy Novozhilov>
* 29b96aa15d4 - [Test] Properly merge box against java testdata into codegen/box (4 days ago) <Dmitriy Novozhilov>
* 21c493a8541 - [Test] Support different backends enumeration in DONT_TARGET_EXACT_BACKEND directive (4 days ago) <Dmitriy Novozhilov>
* acd8c4503b1 - (tag: build-1.5.20-dev-244) Do not generate $suspendImpl for JvmDefault functions in interfaces (5 days ago) <Alexander Udalov>
* 5f71cd5476f - (tag: build-1.5.20-dev-242) Minor. Mute test on FIR (5 days ago) <Ilmir Usmanov>
* 02f845636ef - JVM_IR: Box generic Result parameter in suspend lambda (5 days ago) <Ilmir Usmanov>
* a30a961cf51 - Minor. Throw exceptions in test coroutine builders (5 days ago) <Ilmir Usmanov>
* 52e22796e11 - (tag: build-1.5.20-dev-239) [Commonizer] Prettier message about target with no libraries inside (5 days ago) <Dmitriy Dolovov>
* 73113c10410 - [Commonizer] Dump every module to disk immediately when it's ready (5 days ago) <Dmitriy Dolovov>
* 53204661e35 - (tag: build-1.5.20-dev-238) [JS] Update stdlib API test data after dukat update (5 days ago) <Svyatoslav Kuzmich>
* d3b4df7da8a - [JS] Revert paramter names changed by dukat (5 days ago) <Svyatoslav Kuzmich>
* f1682cba13f - KT-40235 Dukat `0.5.8-rc.4` (5 days ago) <Victor Turansky>
* ba0d60853dd - KT-40235 `null` companion for stdlib external union types (5 days ago) <Victor Turansky>
* 7523a5e97f9 - KT-40235 Fix external interface companion support (5 days ago) <Victor Turansky>
* cc55580300e - (tag: build-1.5.20-dev-235) Exclude kotlin-test root project during JPS sync (5 days ago) <Ilya Gorbunov>
* b32db1ac026 - (tag: build-1.5.20-dev-233) Refactoring: change assertion signature, proper source set copying way (5 days ago) <yaroslav.chernyshev>
* b2017a9c9c4 - Introduce importing checkers with implementation for orphan source sets (5 days ago) <yaroslav.chernyshev>
* 87e130e77a5 - (tag: build-1.5.20-dev-228) Remove obsolete diagnostics suppression (5 days ago) <Ilya Gorbunov>
* ebced14db2e - (tag: build-1.5.20-dev-227) [FIR] Implement suppressing diagnostics with @Suppress (5 days ago) <Dmitriy Novozhilov>
* 459a2886a02 - [FIR] Add CheckerContext to DiagnosticReporter and refactor diagnostic reporting (5 days ago) <Dmitriy Novozhilov>
* 923a4427c51 - (tag: build-1.5.20-dev-224) [KAPT]  Fix stub generation for anonymous delegates (5 days ago) <Andrey Zinovyev>
* 60a05dded05 - (tag: build-1.5.20-dev-222) Build: fix default value for kotlin.build.disable.werror (5 days ago) <Alexander Udalov>
* 7942bd0b3bb - (tag: build-1.5.20-dev-220) Minor. Regenerate tests (5 days ago) <Denis.Zharkov>
* 2535e5d5c93 - (tag: build-1.5.20-dev-212) Minor: LAMBDAS directive in old back-end tests (5 days ago) <Dmitry Petrov>
* bd45a6c11d8 - (tag: build-1.5.20-dev-211) Support -Xsuppress-version-warnings to suppress API/language version warnings (5 days ago) <Alexander Udalov>
* d901ceb7344 - (tag: build-1.5.20-dev-210) FIR: Fix loading Java annotations with Class[]-typed methods (5 days ago) <Denis.Zharkov>
* 5a55d56320b - IR: Fix offsets for value parameters for bridges (5 days ago) <Denis.Zharkov>
* 8712772a5f7 - FIR: Add test for type resolution when referenced nested class from supertypes (5 days ago) <Denis.Zharkov>
* c51798d46f7 - Fix warning at VMCounters.kt (5 days ago) <Denis.Zharkov>
* e7669ef9d6f - FIR: Fix builder inference case with independent calls inside lambda (5 days ago) <Denis.Zharkov>
* 29ac4cb9cc5 - Minor. Simplify conditions in shouldRunCompletion (5 days ago) <Denis.Zharkov>
* 173a852273b - FIR: Fix uninitialized lateinit FirSymbol::symbol for supertype of Java class (5 days ago) <Denis.Zharkov>
* 8b2279072fb - Fix compilation in tests-compiler-utils (5 days ago) <Alexander Udalov>
* e0b6d4d9178 - (tag: build-1.5.20-dev-208) Add -Xsuppress-deprecated-jvm-target-warning to modules compiled with 1.6 (5 days ago) <Alexander Udalov>
* 99b5e5a3732 - Deprecate JVM target 1.6 (5 days ago) <Alexander Udalov>
* ab20a8ffffc - (tag: build-1.5.20-dev-205) JVM_IR indy-lambdas: minor updates and fixes (5 days ago) <Dmitry Petrov>
* 088448043aa - JVM_IR indy-lambdas: don't use indy for big arity lambdas (5 days ago) <Dmitry Petrov>
* d94912ed624 - JVM_IR indy-lambdas: initial implementation and tests (5 days ago) <Dmitry Petrov>
* 0bc386cb08b - (tag: build-1.5.20-dev-204) [IR] Fixed bug with reflectionTarget evaluation (5 days ago) <Igor Chevdar>
* bb8bf28b8b8 - [PSI2IR] Set reflectionTarget for all adapted references (5 days ago) <Igor Chevdar>
* 690fb47cbbd - (tag: build-1.5.20-dev-202) KT-44079 [Sealed Interfaces]: move refactoring update (5 days ago) <Andrei Klunnyi>
* de3678a805b - (tag: build-1.5.20-dev-196) [JS IR] Add test with fun interface call inside lambda (5 days ago) <Ilya Goncharov>
* d6e74b9620e - [JS IR] Use local scope for SAM if there are scopes (5 days ago) <Ilya Goncharov>
* ca314c5bb99 - (tag: build-1.5.20-dev-194) FIR checker: add diagnostic CANNOT_WEAKEN_ACCESS_PRIVILEGE (5 days ago) <Jinseong Jeon>
* 3a07ca4c643 - FIR checker: add diagnostic VAR_OVERRIDDEN_BY_VAL (5 days ago) <Jinseong Jeon>
* 80d5a1a1dbe - FIR checker: add diagnostic OVERRIDING_FINAL_MEMBER (5 days ago) <Jinseong Jeon>
* 4ef1e1119fb - FIR LT: introduce positioning strategies for specific modifiers (5 days ago) <Jinseong Jeon>
* 0dd5b945565 - FIR checker: rename override checker (5 days ago) <Jinseong Jeon>
* b48835f3ce0 - FIR checker: fix positions of type mismatch on overrides (5 days ago) <Jinseong Jeon>
* 571c4ce3981 - [Test] Support new configuration directives in old codegen tests (5 days ago) <Dmitriy Novozhilov>
* 8277c969337 - (tag: build-1.5.20-dev-184) FIR: copy nullability when mapping type alias arguments (5 days ago) <pyos>
* bd205317aae - (tag: build-1.5.20-dev-180) CLI: improve behavior of -include-runtime (5 days ago) <scaventz>
* 496d857db14 - Add kotlin.build.disable.werror to disable -Werror locally (5 days ago) <Alexander Udalov>
* 6a959fefd0e - [JVM_IR] Fix accessibility bridges for static protected fields. (5 days ago) <Mads Ager>
* 62897a194bc - (tag: build-1.5.20-dev-175) [Commonizer] Force GC after each serialized target (6 days ago) <Dmitriy Dolovov>
* ff45e585434 - [Commonizer] Minor. Post-review changes, p.2 (6 days ago) <Dmitriy Dolovov>
* c8a938275ca - [Commonizer] Minor. Post-review changes (6 days ago) <Dmitriy Dolovov>
* 318dd22bd1a - [Commonizer] Add tests for CommonizerTarget (6 days ago) <Dmitriy Dolovov>
* 6fe5f85da75 - [Commonizer] Use kotlin/Any as the default supertype for commonized class (6 days ago) <Dmitriy Dolovov>
* 2438265ba8e - [Commonizer] Dump every target to disk immediately when it's ready (6 days ago) <Dmitriy Dolovov>
* 9c4af5070b7 - [Commonizer] Ignore acceptable (minor) metadata mismatches in tests (6 days ago) <Dmitriy Dolovov>
* a4438ad64f5 - [Commonizer] Fix calculation of type parameter IDs for nested classes and their members (6 days ago) <Dmitriy Dolovov>
* 55c37183d91 - [Commonizer] Ignore constructors for enum entries (6 days ago) <Dmitriy Dolovov>
* dfd1a536244 - [Commonizer] Don't serialize kotlin/Any? as the single type parameter upper bound (6 days ago) <Dmitriy Dolovov>
* 1c8cd242bfc - [Commonizer] Don't write IS_EXPECT flag for synthesized expect functions (6 days ago) <Dmitriy Dolovov>
* 9d6c0e56edb - [Commonizer] Fix HAS_ANNOTATIONS flag calculation for serialized classes (6 days ago) <Dmitriy Dolovov>
* b39a2056719 - [Commonizer] Minor. Improved diagnostics message in tests (6 days ago) <Dmitriy Dolovov>
* 80b95a22a4a - [Commonizer] Fix property backing/delegate field annotations serialization (6 days ago) <Dmitriy Dolovov>
* 3b91d1c5e5e - [Commonizer] Don't commonize built-ins (6 days ago) <Dmitriy Dolovov>
* 585cd64b9a8 - [Commonizer] Drop descriptors for commonized declarations (6 days ago) <Dmitriy Dolovov>
* 5ff6b5ef423 - [Commonizer] Rework test infrastructure to compare metadata instead of descriptors (6 days ago) <Dmitriy Dolovov>
* f67a9615b81 - [Commonizer] Pretty target name output in console (6 days ago) <Dmitriy Dolovov>
* e5aa7726392 - [Commonizer] Fix approximation for aliases types (6 days ago) <Dmitriy Dolovov>
* 4c640e3f811 - [Commonizer] Log stats during building metadata (6 days ago) <Dmitriy Dolovov>
* d610837caff - [Commonizer] Integrate metadata builder with the commonizer environment (6 days ago) <Dmitriy Dolovov>
* 2bcaf1fa635 - [Commonizer] Introduce metadata builder (6 days ago) <Dmitriy Dolovov>
* e28c1fd3107 - Metadata: Chunked KlibModuleFragmentWriteStrategy implementation (6 days ago) <Dmitriy Dolovov>
* 9551e0fff20 - [Commonizer] Introduce MetadataDeclarationsComparator for metadata-based comparison of KLIBs (6 days ago) <Dmitriy Dolovov>
* 701374a6464 - [Commonizer] Embed :kotlinx-metadata-klib into the commonizer Jar (6 days ago) <Dmitriy Dolovov>
* 08cc904a713 - [Commonizer] Restore lost nullability for underlying types in TAs (6 days ago) <Dmitriy Dolovov>
* 85f79695b93 - [Commonizer] Avoid leaking non-commonized underlying types in TAs (6 days ago) <Dmitriy Dolovov>
* 4bf6e58f2ba - (tag: build-1.5.20-dev-174) [TD] Fix directive order in codegen testdata (6 days ago) <Dmitriy Novozhilov>
* 3f10914f05b - (tag: build-1.5.20-dev-158) [JS] Replace usages of FileUtil.loadTextAndClose with functions from stdlib to avoid crashes on files larger than 10MiB (6 days ago) <Zalim Bashorov>
* 165533fdb72 - (tag: build-1.5.20-dev-155) JS DCE: use Multimaps to reduce Node fields RAM (6 days ago) <Anton Bannykh>
* f42f2fa743c - JS DCE: disable logging by default (6 days ago) <Anton Bannykh>
* 26ce6b5131f - JS DCE: inline Qualifier class to reduce RAM usage (6 days ago) <Anton Bannykh>
* bbc6d2b9936 - JS DCE: use less LinkedHashSets (6 days ago) <Anton Bannykh>
* 3c0b2263440 - JS DCE: create collections on demand (6 days ago) <Anton Bannykh>
* 0ebb39a26ea - (tag: build-1.5.20-dev-153) [Test] Exclude multimodule tests from codegen tests on android (6 days ago) <Dmitriy Novozhilov>
* 17d59e0daac - [Test] Support skip of android codegen tests with new ASSERTION_MODE directive (6 days ago) <Dmitriy Novozhilov>
* 81ba7aa8335 - [Test] Use javac for compilation test java files from runtime by default (6 days ago) <Dmitriy Novozhilov>
* e9cb30b4f3b - [Test] Add ability to use custom CompilerConfigurationProvider (6 days ago) <Dmitriy Novozhilov>
* c432efc3648 - [Build] Extract configuration of JUnit5 dependencies to common helper in buildSrc (6 days ago) <Dmitriy Novozhilov>
* dea3c954f12 - [Test] Add ability to stop test pipeline if there was an exception in handler (6 days ago) <Dmitriy Novozhilov>
* 2ae35b0b085 - [Test] Move fir backend tests back to :compiler:fir2ir module (6 days ago) <Dmitriy Novozhilov>
* e79d02f482d - [Test] Don't generate extends clause for nested classes in generated tests for JUnit5 (6 days ago) <Dmitriy Novozhilov>
* a4e9ab90a0d - [Test] Migrate :tests-different-jdk on runners which are using JUnit5 (6 days ago) <Dmitriy Novozhilov>
* c969a346441 - [Test] Set static field with application to null after tests are completed (6 days ago) <Dmitriy Novozhilov>
* 53e5aa43643 - [Test] Don't use PSI based class reading in codegen BB tests (6 days ago) <Dmitriy Novozhilov>
* 09ec3f6eaf0 - [Test] Support various jdk targets in test infrastructure (6 days ago) <Dmitriy Novozhilov>
* 93741ced5ce - [Test] Read default target version from sys property in new test infra (6 days ago) <Dmitriy Novozhilov>
* a3ad626f99a - [Test] Support invoking `box` method in BB tests in separate process (6 days ago) <Dmitriy Novozhilov>
* b351ca6bd40 - [Test] Regenerate spec tests (6 days ago) <Dmitriy Novozhilov>
* 3199ce03a62 - [Test] Merge box against java testdata into codegen black box testsdata (6 days ago) <Dmitriy Novozhilov>
* e62b118351e - [TD] Ignore JS backends in boxAgainstJava tests (6 days ago) <Dmitriy Novozhilov>
* 99cb85ab005 - [Test] Merge box against java tests into codegen black box tests (6 days ago) <Dmitriy Novozhilov>
* 6f3713af5f5 - [Test] Migrate AbstractIrCompileKotlinAgainstKotlinTest to new infrastructure (6 days ago) <Dmitriy Novozhilov>
* 49c2bfe637e - [Test] Enable SMAP dump handler in boxInline tests (6 days ago) <Dmitriy Novozhilov>
* 64a300bfcde - [TD] Update testdata according to previous commit (6 days ago) <Dmitriy Novozhilov>
* 3a0eee64b87 - [Test] Migrate all jvm tests runners for boxInline tests (6 days ago) <Dmitriy Novozhilov>
* 8973e3f362a - [TD] Update fir directives in boxInline tests (6 days ago) <Dmitriy Novozhilov>
* 92e21e76bae - [Test] Implement SMAP dump handler (6 days ago) <Dmitriy Novozhilov>
* e3ab3d6be38 - [Test] Align lines in TestFile with lines in real testdata file (6 days ago) <Dmitriy Novozhilov>
* 60e0831c119 - [Test] Introduce two module structure transformers for codegen test (6 days ago) <Dmitriy Novozhilov>
* 13a778fd9c0 - [Test] Add ability to freely transform module structure which was parsed from directive (6 days ago) <Dmitriy Novozhilov>
* fc83dc17fe8 - [Test] Support USE_OLD_INLINE_CLASSES_MANGLING_SCHEME directive (6 days ago) <Dmitriy Novozhilov>
* 3f758a3fa20 - [Test] Make BytecodeInliningHandler for new infrastructure (6 days ago) <Dmitriy Novozhilov>
* 0768a7089ca - [TD] Fix friend modules (6 days ago) <Dmitriy Novozhilov>
* 5075484c8e5 - [TD] Update directives in kotlinAgainstKotlin testdata (6 days ago) <Dmitriy Novozhilov>
* 9ba41c5b885 - [Test] Improve error reporting if there are too many values passed to directive (6 days ago) <Dmitriy Novozhilov>
* 5c8d555808b - [Test] Move KotlinAgainstKotlin tests under BlackBoxCodegen tests (6 days ago) <Dmitriy Novozhilov>
* 1ea4fa4464d - (tag: build-1.5.20-dev-147) Fix android test with type annotations. Remove obsolete JVM 8 flavors (6 days ago) <Mikhael Bogdanov>
* c13f38f6dfe - Support proper frame maps for enumValues (6 days ago) <Mikhael Bogdanov>
* 1a044e5af47 - Support proper frame maps for enum valueOf (6 days ago) <Mikhael Bogdanov>
* 5b64ceceb30 - JVM_IR. Generate additional checkcast for when/try epressions to avoid frame map problems on reification (6 days ago) <Mikhael Bogdanov>
* 16928d6e3fc - Don't remove checkcast for reified values (6 days ago) <Mikhael Bogdanov>
* 0b0ba7d9872 - Don't use warningsAsError in compiler modules if useFIR is ON (6 days ago) <Mikhail Glukhikh>
* d953a038071 - (tag: build-1.5.20-dev-146) Specify type explicitly in KotlinCoreProjectEnvironment.createCoreFileManager to allow overriding this method with different implementation (6 days ago) <Marcin Aman>
* 21000f4174f - [FIR] Support TypeVariableMarker.isReified (6 days ago) <Mikhail Glukhikh>
* 465261e6115 - FIR: don't create intersection override for duplicating symbols (6 days ago) <Mikhail Glukhikh>
* b9c33a0c6ef - [i18n] copy-paste message from RefactoringBundle to fix missing resource in 202 (6 days ago) <Dmitry Gridin>
* 2fce6a4af90 - (tag: build-1.5.20-dev-127) Locate build history when file is outside of root project dir (6 days ago) <Ivan Gavrilovic>
* 5de34b052fa - (tag: build-1.5.20-dev-125) Remove unsupported '!' from DIAGNOSTICS directive (6 days ago) <Nicola Corti>
* e2b7aba0862 - (tag: build-1.5.20-dev-122) Do not report UNNECESSARY_SAFE_CALL on ErrorType (6 days ago) <Nicola Corti>
* 59551eb0371 - [Plugin API] Provide diagnostic API for IR plugins (6 days ago) <Roman Artemev>
* 9fa5feeeea2 - [CLI] Provide `MessageCollector` based logger for IR from CLI (6 days ago) <Roman Artemev>
* daa65a2fffa - [KLIB] Handle linkage error (6 days ago) <Roman Artemev>
* bf67308cc2e - [KLIB] Use `IrMessageLogger` in klib linker to report errors (6 days ago) <Roman Artemev>
* 6891ad0dfc5 - [IR] Add `IrMessageLogger` interface for diagnostic reporting from IR (6 days ago) <Roman Artemev>
* bb66b2fd044 - Drop redundant compile dependency (6 days ago) <Roman Artemev>
* c5068b7d45f - [KLIB] Drop unused logger (6 days ago) <Roman Artemev>
* 484b884d04e - [KLIB] Make `IrModuleDeserializer`'s printable (6 days ago) <Roman Artemev>
* d6bb1f2d4e6 - [KLIB] Make `KotlinLibraryImpl` printable (6 days ago) <Roman Artemev>
* 24d82c63e0d - [JS IR] Commonize CLI error reporting (6 days ago) <Roman Artemev>
* ba5193870e7 - [IR] Drop unused language version settings parameters from DependenciesGenerator (6 days ago) <Roman Artemev>
* 06498c0efdb - (tag: build-1.5.20-dev-121) Support for macos_arm64 target in backend (6 days ago) <Sergey Bogolepov>
* f255f93ad94 - (tag: build-1.5.20-dev-117) [Test] Support skip of android codegen tests with new ASSERTION_MODE directive (6 days ago) <Dmitriy Novozhilov>
* eff13d24dc9 - (tag: build-1.5.20-dev-106) Remove unneeded language feature configuration from fir:tree (7 days ago) <Alexander Udalov>
* e47dfcbe648 - (tag: build-1.5.20-dev-102) Update ReadMe.md (#3877) (7 days ago) <Nwokocha wisdom maduabuchi>
* 18cebe51314 - (origin/yakovlev/fir_incomplete_types) [FIR IDE] Codereview minor refactoring (7 days ago) <Igor Yakovlev>
* e529a7bf9bc - [FIR IDE] Implement isInheritor for FirLightClassForClassOrObjectSymbol (7 days ago) <Igor Yakovlev>
* 56db4bd1acf - [FIR IDE] Implement isInheritor for KtFirBasedFakeLightClass (7 days ago) <Igor Yakovlev>
* 5d4606daaa5 - [FIR IDE] Remove LightClassProvider (7 days ago) <Igor Yakovlev>
* 28120348963 - [FIR IDE] Make KtFakeLightClass independent (7 days ago) <Igor Yakovlev>
* c1cdf273a60 - [FIR IDE] Fix test data fir parameters highlighting test (7 days ago) <Igor Yakovlev>
* 9f282e0ddc6 - [FIR] Do not erase type arguments for unresolved method calls (7 days ago) <Igor Yakovlev>
* 659d2c13b4a - [FIR IDE] Fix annotation value parameter and ctor resolve (7 days ago) <Igor Yakovlev>
* 019635189a8 - [FIR IDE] Fix annotation call reference resolve to ctor (7 days ago) <Igor Yakovlev>
* 65b6a95f642 - [FIR IDE] Fix structure element non analyzable elements recording for analyzable properties (7 days ago) <Igor Yakovlev>
* 5480faf5c59 - (tag: build-1.5.20-dev-98) Add tests for issues fixed in JVM IR and other obsolete issues (7 days ago) <Alexander Udalov>
* 3e59adc7f3f - (tag: build-1.5.20-dev-94) Add change-notes for 1.4.30 release (7 days ago) <Anton Yalyshev>
* 90f9dd5b330 - (tag: build-1.5.20-dev-93) Revert change-notes for 1.4.30 (7 days ago) <Anton Yalyshev>
* 206b38f0ab0 - (tag: build-1.5.20-dev-92) Fix compilation against asm 7.0 (7 days ago) <Mikhael Bogdanov>
* 78c6e0733c8 - Add change-notes for 1.4.30 (7 days ago) <Anton Yalyshev>
* 1f62fee4f94 - (tag: build-1.5.20-dev-89) Fix typo (7 days ago) <Mikhail Glukhikh>
* 593fb8770b3 - [FIR] Fix lookup order for statics in super chains (7 days ago) <Mads Ager>
* 4ec369ac5be - (tag: build-1.5.20-dev-83) JVM_IR fix special bridge generation for inline classes (7 days ago) <Dmitry Petrov>
* 8172ae5d89d - (tag: build-1.5.20-dev-82) Fix codegen test classLiteralWithExpectedType.kt on Android (7 days ago) <Alexander Udalov>
* bd3bc13e752 - (tag: build-1.5.20-dev-81) JVM_IR: give loops somewhat more debuggable labels (7 days ago) <pyos>
* ad53fc931e6 - JVM: optimize temporary `kotlin.jvm.internal.Ref`s as well (7 days ago) <pyos>
* 0f2ca5d84c0 - JVM_IR: support non-local break/continue in the inliner (7 days ago) <pyos>
* 4a172286217 - (tag: build-1.5.20-dev-77) Infer required kotlin-test jvm capability based on used test framework (7 days ago) <Ilya Gorbunov>
* cbeadba15d2 - Disable metadata publishing for legacy common artifacts (7 days ago) <Ilya Gorbunov>
* 573aac7252e - Apply common configuration to custom publications in kotlin-test (7 days ago) <Ilya Gorbunov>
* a16aaa38240 - Setup publications with MPP Gradle metadata for kotlin-test library (7 days ago) <Ilya Gorbunov>
* 913c298be85 - (tag: build-1.5.20-dev-72) Kotlin highlight passes are reworked (7 days ago) <Vladimir Dolzhenko>
* 558338f9970 - Lazy diagnostics API in frontend (7 days ago) <Vladimir Dolzhenko>
* 8f675fe757f - (tag: build-1.5.20-dev-67) Split combined test into two to avoid flaky behaviour (7 days ago) <Pavel Kirpichenkov>
* 9ad88a5a0d7 - (tag: build-1.5.20-dev-66) FIR: introduce parameter type is Throwable check (7 days ago) <eugenpolytechnic>
* 5c0231b727d - FIR: introduce CatchParameterChecker (7 days ago) <eugenpolytechnic>
* d8549d62924 - (tag: build-1.5.20-dev-62) Build: fix inaccurate change to the logic of useIRForLibraries (7 days ago) <Alexander Udalov>
* e9436da858e - Change logic of applying JVM target from AGP options (7 days ago) <Alexander Udalov>
* adfa8c788ca - Light classes: use JVM target from the module (7 days ago) <Alexander Udalov>
* 64e97225b8a - Light classes: map annotation targets depending on JVM target (7 days ago) <Alexander Udalov>
* d022bb0248a - Switch default JVM target to 1.8 (7 days ago) <Alexander Udalov>