### PR TITLE
Make incompleteTypes test more robust

### DIFF
--- a/backend.native/tests/interop/incomplete_types/library.cpp
+++ b/backend.native/tests/interop/incomplete_types/library.cpp
@@ -1,21 +1,24 @@
+#include <string>
 #include "library.h"
 
 extern "C" {
 
 struct S {
-    const char* name;
+    std::string name;
 };
 
-struct S s = {
+S s = {
     .name = "initial"
 };
 
 void setContent(struct S* s, const char* name) {
+    // Note that copy here is intentional: we use it as a workaround
+    // for short lifetime of copy of the passed Kotlin string.
     s->name = name;
 }
 
 const char* getContent(struct S* s) {
-    return s->name;
+    return s->name.c_str();
 }
 
 union U {

--- a/backend.native/tests/interop/incomplete_types/main.kt
+++ b/backend.native/tests/interop/incomplete_types/main.kt
@@ -9,7 +9,8 @@ fun main() {
 
     assertEquals("initial", getContent(s.ptr)?.toKString())
     setContent(s.ptr, "yo")
-    assertEquals("yo", getContent(s.ptr)?.toKString())
+    val ptr = getContent(s.ptr)
+    assertEquals("yo", ptr?.toKString())
 
     assertEquals(0.0, getDouble(u.ptr))
     setDouble(u.ptr, Double.MIN_VALUE)


### PR DESCRIPTION
Currently, Kotlin strings that are passed to C functions are copied under the hood on the callsite. These copies have a short lifetime which might cause problems if it should outlive current call.