### PR TITLE
[kotlin compiler][update] 1.5.20-dev-576

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.ir.linkage.IrDeserializer
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.acceptVoid
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi2ir.Psi2IrConfiguration
 import org.jetbrains.kotlin.psi2ir.Psi2IrTranslator
 import org.jetbrains.kotlin.resolve.BindingContext
@@ -67,6 +68,9 @@ internal fun Context.psiToIr(
 
         object : IrDeserializer {
             override fun getDeclaration(symbol: IrSymbol) = stubGenerator.getDeclaration(symbol)
+            override fun resolveBySignatureInModule(signature: IdSignature, kind: IrDeserializer.TopLevelSymbolKind, moduleName: Name): IrSymbol {
+                error("Should not be called")
+            }
         }
     } else {
         val irProviderForCEnumsAndCStructs =

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.5.20-dev-372
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-372,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-372,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.20-dev-372
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-372,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.20-dev-372
-kotlinStdlibTestsVersion=1.5.20-dev-372
-testKotlinCompilerVersion=1.5.20-dev-372
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-576,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.20-dev-576
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-576,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.20-dev-576
+kotlinStdlibTestsVersion=1.5.20-dev-576
+testKotlinCompilerVersion=1.5.20-dev-576
 konanVersion=1.5.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 6eaf0a95cab - (tag: build-1.5.20-dev-576) [KAPT] Fix expected resolve errors in tests (#4105) (5 days ago) <Andrey Zinovyev>
* af8061a4dd8 - (tag: build-1.5.20-dev-567) Remove kotlin-test-multiplatform special dependency handling (5 days ago) <Ilya Gorbunov>
* 2cd1aefd5ee - (tag: build-1.5.20-dev-561) [FIR-IDE] Add mapping for FirExpression in diagnostics and generate new IDE ones (5 days ago) <Dmitriy Novozhilov>
* 9b1f01ab04c - FIR checker: differentiate unsafe infix/operator calls from UNSAFE_CALL (5 days ago) <Jinseong Jeon>
* 1729eff31b5 - FIR checker: reincarnate FIR source child lookup utils (5 days ago) <Jinseong Jeon>
* 5e150d62eac - FIR checker: differentiate UNSAFE_IMPLICIT_INVOKE_CALL from UNSAFE_CALL (5 days ago) <Jinseong Jeon>
* 0c0c53cc2e5 - (tag: build-1.5.20-dev-557) [FE] Don't analyze members with CLASSIFIERS kind filter in AbstractLazyMemberScope (5 days ago) <Dmitriy Novozhilov>
* 903defdf30d - (tag: build-1.5.20-dev-542) Use IDEA ASM in kapt module (5 days ago) <Mikhael Bogdanov>
* 154a768a3ad - (tag: build-1.5.20-dev-540) [Commonizer] Minor. Remove unused import (5 days ago) <Dmitriy Dolovov>
* ac966ad1d27 - [Commonizer] Add getParentEntityId() method to CirEntityId (5 days ago) <Dmitriy Dolovov>
* 4bab505c3a1 - [Commonizer] Introduce CIR entities for representing various flavors of names (5 days ago) <Dmitriy Dolovov>
* f8c5244a39e - [Commonizer] Use CirConstantValue class to represent constant values (5 days ago) <Dmitriy Dolovov>
* 25df25ccc65 - [Commonizer] Minor. Extract common module names from CommonizerParameters (5 days ago) <Dmitriy Dolovov>
* 97000b12853 - [Commonizer] Drop CirContainingClassdetails in favor of CirClass entity (5 days ago) <Dmitriy Dolovov>
* 054b59198be - [Commonizer] Don't keep fqName inside of CirPackageNode (5 days ago) <Dmitriy Dolovov>
* 5d19ac16d5c - [Commonizer] Drop useless CirPackageNode.moduleName property (5 days ago) <Dmitriy Dolovov>
* c6756762e57 - [Commonizer] Refactoring: Clean-up in CirTreeMerger (5 days ago) <Dmitriy Dolovov>
* 671ebc68194 - [FIR] Fix detecting that `if` in `then` branch of outer `if` used as expression (5 days ago) <Dmitriy Novozhilov>
* e6588ee8a49 - (tag: build-1.5.20-dev-539) CLI: include META-INF/services/ from kotlin-reflect with -include-runtime (5 days ago) <Alexander Udalov>
* 3dfd2a95fa7 - Minor, do not output "Not changed" for generated FIR checkers on each build (5 days ago) <Alexander Udalov>
* 1216b335935 - (tag: build-1.5.20-dev-536) [Test] Move extracting JVM_TARGET to provideConfigurationKeys (5 days ago) <Dmitriy Novozhilov>
* 606ae45f5f6 - [Test] Replace remaining `KOTLIN_CONFIGURATION_FLAGS` directives with specific ones (5 days ago) <Dmitriy Novozhilov>
* 3ee5665746b - Parse compiler configuration for android tests using new test infrastructure (5 days ago) <Dmitriy Novozhilov>
* a0007bf244f - Add analysisFlags of LanguageVersionSettings to `toString()` method (5 days ago) <Dmitriy Novozhilov>
* 7e59e083d3b - [Test] Make some functions of environment configurators public (5 days ago) <Dmitriy Novozhilov>
* 24d6853ead2 - [Test] Cleanup JvmEnvironmentConfigurator (5 days ago) <Dmitriy Novozhilov>
* a932f69b8a0 - [Test] Don't pass MockProject to environment configurators (5 days ago) <Dmitriy Novozhilov>
* bd37badf297 - (tag: build-1.5.20-dev-531) FIR checker: add diagnostics for backing fields (5 days ago) <Jinseong Jeon>
* a88b82d8ff2 - Rewrite nasty code with if without else in elvis RHS (5 days ago) <Mikhail Glukhikh>
* 7a9315e6b65 - (tag: build-1.5.20-dev-525) Fix KaptWithoutKotlincTask task tries to get wrong properties. (5 days ago) <Yahor Berdnikau>
* 48ec227aafc - (tag: build-1.5.20-dev-519) [KAPT] Suppress resolve error in annotation procssing (5 days ago) <Andrey Zinovyev>
* d64f7dd8c7d - (tag: build-1.5.20-dev-518) Revert "Add :kotlin-scripting-compiler.test to modules with disabled -Werror flag" (5 days ago) <Ilya Chernikov>
* 79b4b18e25a - [minor] fix warnings in the script compiler and tests (5 days ago) <Ilya Chernikov>
* d0f26abd18f - (tag: build-1.5.20-dev-512) JVM_IR KT-44798 don't generate multiple stubs with same signature (5 days ago) <Dmitry Petrov>
* 9afe8a0a39b - (tag: build-1.5.20-dev-504) Make checker tests independent of plugin version (5 days ago) <Vladimir Dolzhenko>
* 09ea4116e4c - (tag: build-1.5.20-dev-500) Implement forced script configuration reloading API for plugins (5 days ago) <Ilya Chernikov>
* 2673261b109 - (tag: build-1.5.20-dev-497) Use proper `jvmArgs` syntax, remove `-FailOverToOldVerifier` from last configurations (6 days ago) <Mikhael Bogdanov>
* c54354f3480 - (tag: build-1.5.20-dev-491) FIR: fix memory leak from ConeIntegerLiteralTypeImpl via static NUMBER_TYPE (6 days ago) <Ilya Kirillov>
* ede5fef39c7 - FIR IDE: fix memory leak in symbols by firBuilder (6 days ago) <Ilya Kirillov>
* cf3defbc9c5 - FIR IDE: add more KDoc to HLApplicator stuff (6 days ago) <Ilya Kirillov>
* 2554065ae9a - FIR IDE: forbid resolve in HLApplicator/HLApplicabilityRange/HLPresentation (6 days ago) <Ilya Kirillov>
* 7ab9583102b - FIR IDE: add KDoc for HLApplicabilityRange (6 days ago) <Ilya Kirillov>
* 91e135888de - FIR IDE: introduce HLSpecifyExplicitTypeForCallableDeclarationIntention and HLRedundantUnitReturnTypeInspection (6 days ago) <Ilya Kirillov>
* a6f76399e24 - FIR IDE: introduce infrastructure for HL based inspections & intentions (6 days ago) <Ilya Kirillov>
* 5cefad1ab3c - FIR: use GeneratorsFileUtil for checkers-component-generator (6 days ago) <Ilya Kirillov>
* 4cf863e0546 - FIR: simplify PositioningStrategy checkers generator (6 days ago) <Ilya Kirillov>
* 21ac83aba0a - FIR: rename Diagnostic to DiagnosticData in checkers generators to avoid conflict with existing Diagnostic class (6 days ago) <Ilya Kirillov>
* cf56c59ca24 - Fix binary incompatibility of createRemoveModifierFromListOwnerFactory (6 days ago) <Ilya Kirillov>
* 8fc6e50dd10 - FIR IDE: allow specify position to insert directive in IgnoreTests (6 days ago) <Ilya Kirillov>
* b2d51dc4559 - FIR: Update diagnostics list after rebase (6 days ago) <Ilya Kirillov>
* fe9c0e584fb - FIR IDE: update test data (6 days ago) <Ilya Kirillov>
* e269b1d19da - FIR IDE: temporary mute failing tests (6 days ago) <Ilya Kirillov>
* d72a2d39da2 - FIR IDE: ignore not passing quickfixes tests (6 days ago) <Ilya Kirillov>
* 6c81d9848d9 - FIR IDE: introduce ChangeReturnTypeOnOverrideQuickFix (6 days ago) <Ilya Kirillov>
* 93040569018 - FIR IDE: add quick fix tests (6 days ago) <Ilya Kirillov>
* 5d32cb0daf3 - FIR IDE: add remove modifier quick fixes (6 days ago) <Ilya Kirillov>
* c87e6c6a874 - FIR IDE: fix finding containing declaration for constructor param (6 days ago) <Ilya Kirillov>
* f7aec31abf2 - FIR IDE: add KDoc for KtSymbol.psi (6 days ago) <Ilya Kirillov>
* aed728c4d83 - FIR IDE: do not require containing declaration for getting overridden symbols (6 days ago) <Ilya Kirillov>
* 0fbb5c60c95 - FIR IDE: add helper function for getting psi of KtSymbol (6 days ago) <Ilya Kirillov>
* 99a6f247712 - FIR IDE: make KtCallableSymbol to be KtTypedSymbol (6 days ago) <Ilya Kirillov>
* b114a45f23c - FIR IDE: render KtFunctionalType in KtTypeRenderer (6 days ago) <Ilya Kirillov>
* a10f54befae - FIR IDE: introduce KtFunctionalType (6 days ago) <Ilya Kirillov>
* 05518341648 - Extract getText/getFamilyName from ChangeCallableReturnTypeFix to use in FIR IDE (6 days ago) <Ilya Kirillov>
* 79baffb69db - FIR IDE: add PSI type parameter to KtDiagnostic (6 days ago) <Ilya Kirillov>
* e008ad03a21 - FIR: add groups to diagnostics DSL (6 days ago) <Ilya Kirillov>
* aaba5742dcb - FIR IDE: add severity to KtDiagnostic (6 days ago) <Ilya Kirillov>
* f5ec37db95c - FIR IDE: report diagnostics for non-kt elements (6 days ago) <Ilya Kirillov>
* e9a5749cf46 - FIR IDE: introduce KtQuickFixService (6 days ago) <Ilya Kirillov>
* 05fb88d2d90 - Migrate RemoveModifierFix factories to QuickFixesPsiBasedFactory to use in FIR IDE (6 days ago) <Ilya Kirillov>
* 794558ab681 - Introduce QuickFixesPsiBasedFactory for quickfixes which can be created only by PSI (6 days ago) <Ilya Kirillov>
* 6dd2037f857 - Move QuickFixActionBase & KotlinIntentionActionsFactory to frontend-independent module (6 days ago) <Ilya Kirillov>
* 15ff79830fc - FIR: remove existingN diagnostic creation functions (6 days ago) <Ilya Kirillov>
* e41ad2ea062 - FIR IDE: implement generators for IDE diagnostics (6 days ago) <Ilya Kirillov>
* c87684a6efe - FIR IDE: use simple KtDiagnostic wrapper for diagnostics (6 days ago) <Ilya Kirillov>
* b92dce9be4a - FIR: introduce DSL to generate diagnostics list (6 days ago) <Ilya Kirillov>
* 5ff816127aa - FIR: extract ConeDiagnostic -> FirDiagnostic to fun to use in IDE code (6 days ago) <Ilya Kirillov>
* ef4fa3381d6 - (tag: build-1.5.20-dev-485, origin/rr/ic/scripting) Pass provided script configuration to refining code (6 days ago) <Ilya Chernikov>
* 6dd331d7e89 - (tag: build-1.5.20-dev-475) [FIR] Add tests for non exhaustive when as last expression of lambda (6 days ago) <Dmitriy Novozhilov>
* e54f31cc2fc - [IR] Remove useless init block from IrLazyFunction (6 days ago) <Dmitriy Novozhilov>
* 8f0e1035fa7 - [FIR] Rename `KEY` and `VALUE` generics of FirCache to `K` and `V` (6 days ago) <Dmitriy Novozhilov>
* e7fdc18ced4 - [FIR] Fix `[JSP] Fast FIR tests` run configuration (6 days ago) <Dmitriy Novozhilov>
* d7e3e83251d - [FIR] Update testdata of FIR spec tests (6 days ago) <Dmitriy Novozhilov>
* 18bde2c5422 - [FIR] Reimplement when exhaustiveness checker to fir it's logic with FE 1.0 (6 days ago) <Dmitriy Novozhilov>
* 2a1c9283a47 - [FIR] Add useful util extensions for cone type (6 days ago) <Dmitriy Novozhilov>
* ad677046a82 - [FIR] Replace `isExhaustive` flag with `ExhaustivenessStatus` object (6 days ago) <Dmitriy Novozhilov>
* 96038e4b32f - [FIR] Support java sealed class interop (6 days ago) <Dmitriy Novozhilov>
* abd1c8fb30a - [FIR] Move `sealedInheritors` declaration data to :fir:tree module (6 days ago) <Dmitriy Novozhilov>
* 8dd9d981292 - [FIR] Implement checker for exhaustive when's in expression position (6 days ago) <Dmitriy Novozhilov>
* 3f715e671da - [FIR] Fix checking for null exhaustiveness with expression of Nothing? type (6 days ago) <Dmitriy Novozhilov>
* 76f9830b47c - [FIR] Fix checking for boolean exhaustiveness with || in branch (6 days ago) <Dmitriy Novozhilov>
* 6469900b5ee - [FIR] Fix forgotten light source element for if expression (6 days ago) <Dmitriy Novozhilov>
* 11ab37160ee - [FIR] Save info that when was used as expression (6 days ago) <Dmitriy Novozhilov>
* 490ef210ac0 - [FIR] Support sealed class inheritors in multiple files (6 days ago) <Dmitriy Novozhilov>
* c8f9cc33ef4 - [FIR] Pass all FirFiles to FirGlobalResolveProcessor.process (6 days ago) <Dmitriy Novozhilov>
* 38437fb036c - [FIR] Rename `session.firSymbolProvider` to `session.symbolProvider` (6 days ago) <Dmitriy Novozhilov>
* e3c1aa599d4 - (tag: build-1.5.20-dev-474) KT-44487 [Sealed Interfaces]: sealed-inheritors-provider for MPP (6 days ago) <Andrei Klunnyi>
* 6f9bcf249b0 - (tag: build-1.5.20-dev-472) [IR] Supported inlining of adapted references + tests (6 days ago) <Igor Chevdar>
* 9724d81a499 - (tag: build-1.5.20-dev-471) [FIR] Support boolean elvis bound smartcasts (6 days ago) <Dmitriy Novozhilov>
* 2b088f11475 - [FIR] Fix generating data class if there is non-property in primary constructor (6 days ago) <Dmitriy Novozhilov>
* 30b5bfe767e - (tag: build-1.5.20-dev-466) Disable D8 checks for `-jvm-target 15` tests (6 days ago) <Mikhael Bogdanov>
* 3dff225b983 - Aligh test data with JDK 15 reflection output (6 days ago) <Mikhael Bogdanov>
* 21e9f67322e - Add JvmTargetXOnJvm15 test suites (6 days ago) <Mikhael Bogdanov>
* 5c5fb0ae39f - Add JvmTarget6OnJvm8 test suite (6 days ago) <Mikhael Bogdanov>
* 8af9ce1e0b6 - (tag: build-1.5.20-dev-465) Minor. Ignore test on WASM (6 days ago) <Ilmir Usmanov>
* 275fef94fe6 - JVM_IR. Do not mangle callable reference constructor call (6 days ago) <Ilmir Usmanov>
* 10cc86c9756 - (tag: build-1.5.20-dev-458) [KAPT] Warn about usage of types from default package (6 days ago) <Andrey Zinovyev>
* 58d903c6386 - (tag: build-1.5.20-dev-455) [FIR IDE] Make KtSmartcastProvider report resolved smartcast type (6 days ago) <Tianyu Geng>
* d97a2b13c06 - (tag: build-1.5.20-dev-448) [Plugin API] Add API to load top level declaration by its signature (6 days ago) <Roman Artemev>
* ca6e1b8f1b5 - (tag: build-1.5.20-dev-447) Add box test for #KT-43831 (6 days ago) <Roman Artemev>
* 79f986bb75f - [IR] Fix IrType equality in case of complex variance (6 days ago) <Roman Artemev>
* 4ed93d3dee2 - [IR] Add IrCapturedType into IR type system (6 days ago) <Roman Artemev>
* 9b6f95faa25 - (tag: build-1.5.20-dev-445) FIR: report lowering time in FullPipelineModularizedTest (6 days ago) <Georgy Bronnikov>
* 1664eec7e43 - FIR: report lowering time from JvmIrCodegenFactory (6 days ago) <Georgy Bronnikov>
* 75954dd1a45 - (tag: build-1.5.20-dev-427) Minor: refactor extended compiler checks (7 days ago) <Pavel Kirpichenkov>
* 2a46da906cc - Provide additional information about missing supertypes (7 days ago) <Pavel Kirpichenkov>
* 4a381d4b836 - (tag: build-1.5.20-dev-426) FIR DFA: update receivers properly in case of single flow in merge point (7 days ago) <Mikhail Glukhikh>
* d96921e2873 - FIR2IR: collect annotations when expanding type aliases (7 days ago) <pyos>
* 872effc21ef - (tag: build-1.5.20-dev-422) Check declaration modifier for actual method to avoid freeze (7 days ago) <Vladimir Dolzhenko>
* 3e17317f316 - (tag: build-1.5.20-dev-416) Update steps to install JDK 6 on Mac OS (#4052) (7 days ago) <Muhammad Hakim Asy'ari>
* d4b0688690b - (tag: build-1.5.20-dev-404) FIR: introduce delegate field initializers (7 days ago) <Mikhail Glukhikh>
* 2cbdad0bb17 - FIR2IR: insert implicit cast of receiver to Any for interface Any calls (7 days ago) <Mikhail Glukhikh>
* 1c210c23862 - FIR: fix of super.methodOfAny resolve in case of one supertype (7 days ago) <Mikhail Glukhikh>
* 694d69fbfa7 - FIR2IR: select return target inside accessor properly (7 days ago) <Mikhail Glukhikh>
* 19bffc694be - (tag: build-1.5.20-dev-402) [JS IR] Add test with chain export--not-export--export (7 days ago) <Ilya Goncharov>
* 76b124a9c06 - [JS IR] Method of any is exported (7 days ago) <Ilya Goncharov>
* 7b4624aac46 - [JS IR] Add exported method into exportNestedClass.kt (7 days ago) <Ilya Goncharov>
* 6c051b2be4d - [JS IR] Override method are not exported (7 days ago) <Ilya Goncharov>
* a9322a01ce5 - (tag: build-1.5.20-dev-400) FIR checker: avoid redundant casting to resolved type ref (7 days ago) <Jinseong Jeon>
* 37a702b9627 - FIR: coerce to Unit when a lambda has early returns (7 days ago) <Jinseong Jeon>
* 83e32016775 - FIR DFA: correct exit node retrieval when a safe call is the last expression (7 days ago) <Jinseong Jeon>
* 266432a4820 - FIR checker: fix condition for property type mismatch on override (7 days ago) <Jinseong Jeon>
* 065d0c66ab0 - FIR checker: reproduce a false alarm on type mismatch of overridden property (7 days ago) <Jinseong Jeon>
* 64c5608f318 - FIR: expect nullable type for elvis LHS (7 days ago) <pyos>
* 0e8f4294f09 - (tag: build-1.5.20-dev-397) Add changelog for 1.4.30 (7 days ago) <Margarita Bobova>
* 04017b00a14 - (tag: build-1.5.20-dev-395) [FIR IDE] Fix TypeRef resolve to error type caused by invalid number of arguments (7 days ago) <Igor Yakovlev>
* f9e5584a3e7 - (tag: build-1.5.20-dev-390) Report error about uninferred type parameter for all `CallForImplicitInvoke` psi calls (7 days ago) <Victor Petukhov>
* c75d2c05f01 - (tag: build-1.5.20-dev-388) [KAPT] Correct type for property with accessor (7 days ago) <Andrey Zinovyev>