### PR TITLE
Fix samples/androidNativeActivity build

### DIFF
--- a/samples/androidNativeActivity/build.gradle.kts
+++ b/samples/androidNativeActivity/build.gradle.kts
@@ -64,6 +64,8 @@ kotlin {
         }
     }
 
+    android()
+
     sourceSets {
         val x86Main by getting
         if (!simulatorOnly) {


### PR DESCRIPTION
Starting from 1.4.0, Kotlin expects Gradle projects with android and 
kotlin-multiplatform plugins to have an android target.

See https://github.com/JetBrains/kotlin/commit/ad9d011ed02bc971a0cf406ff1535c2a67bd3374#diff-685880375690dc3db18f7b39b51c257f7100a11c39791d2b3f9f45cefa485e52R133