### PR TITLE
[tests] Remove explicit NI switching on in tests

### DIFF
--- a/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
+++ b/build-tools/src/main/groovy/org/jetbrains/kotlin/KonanTest.groovy
@@ -215,7 +215,10 @@ class RunExternalTestGroup extends JavaExec implements CompilerRunner {
         def languageSettings = findLinesWithPrefixesRemoved(text, "// !LANGUAGE: ")
         if (languageSettings.size() != 0) {
             languageSettings.forEach { line ->
-                line.split(" ").toList().forEach { flags.add("-XXLanguage:$it") }
+                line.split(" ").toList().forEach {
+                    if (it != "+NewInference") // It is on already by default, but passing it explicitly turns on a special "compatibility mode" in FE which is not desirable.
+                        flags.add("-XXLanguage:$it")
+                }
             }
         }
 


### PR DESCRIPTION
It is on by default anyway, but specifying it explicitly turns on specific 'compatibility' mode in FE
which is not needed in K/N