### PR TITLE
Optimize CPointer.toKStringFromUtf8 on Native

### DIFF
--- a/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt
+++ b/Interop/Runtime/src/jvm/kotlin/kotlinx/cinterop/JvmUtils.kt
@@ -21,8 +21,21 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 
-internal fun decodeFromUtf8(bytes: ByteArray) = String(bytes)
+private fun decodeFromUtf8(bytes: ByteArray) = String(bytes)
 internal fun encodeToUtf8(str: String) = str.toByteArray()
+
+internal fun CPointer<ByteVar>.toKStringFromUtf8Impl(): String {
+    val nativeBytes = this
+
+    var length = 0
+    while (nativeBytes[length] != 0.toByte()) {
+        ++length
+    }
+
+    val bytes = ByteArray(length)
+    nativeMemUtils.getByteArray(nativeBytes.pointed, bytes, length)
+    return decodeFromUtf8(bytes)
+}
 
 fun bitsToFloat(bits: Int): Float = java.lang.Float.intBitsToFloat(bits)
 fun bitsToDouble(bits: Long): Double = java.lang.Double.longBitsToDouble(bits)

--- a/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Utils.kt
+++ b/Interop/Runtime/src/main/kotlin/kotlinx/cinterop/Utils.kt
@@ -507,18 +507,7 @@ public val String.utf32: CValues<IntVar>
 /**
  * @return the [kotlin.String] decoded from given zero-terminated UTF-8-encoded C string.
  */
-public fun CPointer<ByteVar>.toKStringFromUtf8(): String {
-    val nativeBytes = this
-
-    var length = 0
-    while (nativeBytes[length] != 0.toByte()) {
-        ++length
-    }
-
-    val bytes = ByteArray(length)
-    nativeMemUtils.getByteArray(nativeBytes.pointed, bytes, length)
-    return decodeFromUtf8(bytes)
-}
+public fun CPointer<ByteVar>.toKStringFromUtf8(): String = this.toKStringFromUtf8Impl()
 
 /**
  * @return the [kotlin.String] decoded from given zero-terminated UTF-8-encoded C string.

--- a/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeUtils.kt
+++ b/Interop/Runtime/src/native/kotlin/kotlinx/cinterop/NativeUtils.kt
@@ -20,8 +20,10 @@ import kotlin.native.internal.Intrinsic
 import kotlin.native.internal.TypedIntrinsic
 import kotlin.native.internal.IntrinsicType
 
-internal fun decodeFromUtf8(bytes: ByteArray): String = bytes.decodeToString()
 internal fun encodeToUtf8(str: String): ByteArray = str.encodeToByteArray()
+
+@SymbolName("Kotlin_CString_toKStringFromUtf8Impl")
+internal external fun CPointer<ByteVar>.toKStringFromUtf8Impl(): String
 
 @TypedIntrinsic(IntrinsicType.INTEROP_BITS_TO_FLOAT)
 external fun bitsToFloat(bits: Int): Float

--- a/backend.native/tests/build.gradle
+++ b/backend.native/tests/build.gradle
@@ -3805,6 +3805,10 @@ createInterop("cunsupported") {
     it.defFile 'interop/basics/cunsupported.def'
 }
 
+createInterop("ctoKString") {
+    it.defFile 'interop/basics/ctoKString.def'
+}
+
 createInterop("ctypes") {
     it.defFile 'interop/basics/ctypes.def'
 }
@@ -4117,6 +4121,12 @@ interopTest("interop_unsupported") {
     disabled = (project.testTarget == 'wasm32') // No interop for wasm yet.
     source = "interop/basics/unsupported.kt"
     interop = 'cunsupported'
+}
+
+interopTest("interop_toKString") {
+    disabled = (project.testTarget == 'wasm32') // No interop for wasm yet.
+    source = "interop/basics/toKString.kt"
+    interop = 'ctoKString'
 }
 
 interopTest("interop_types") {

--- a/backend.native/tests/interop/basics/ctoKString.def
+++ b/backend.native/tests/interop/basics/ctoKString.def
@@ -1,0 +1,6 @@
+---
+const char* empty() { return ""; }
+const char* foo() { return "foo"; }
+const char* kuku() { return "куку"; }
+const char* invalid_utf8() { return "\x85\xAF"; }
+const char* zero_in_the_middle() { return "before zero\0after zero"; }

--- a/backend.native/tests/interop/basics/toKString.kt
+++ b/backend.native/tests/interop/basics/toKString.kt
@@ -1,0 +1,12 @@
+import ctoKString.*
+import kotlinx.cinterop.*
+import kotlin.native.*
+import kotlin.test.*
+
+fun main() {
+    assertEquals("", empty()!!.toKStringFromUtf8())
+    assertEquals("foo", foo()!!.toKStringFromUtf8())
+    assertEquals("куку", kuku()!!.toKStringFromUtf8())
+    assertEquals("\uFFFD\uFFFD", invalid_utf8()!!.toKStringFromUtf8())
+    assertEquals("before zero", zero_in_the_middle()!!.toKStringFromUtf8())
+}

--- a/runtime/src/main/cpp/Interop.cpp
+++ b/runtime/src/main/cpp/Interop.cpp
@@ -17,8 +17,10 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "Alloc.h"
+#include "KString.h"
 #include "Memory.h"
 #include "MemorySharedRefs.hpp"
 #include "Types.h"
@@ -40,6 +42,10 @@ void Kotlin_Interop_disposeStablePointer(KNativePtr pointer) {
 OBJ_GETTER(Kotlin_Interop_derefStablePointer, KNativePtr pointer) {
   KRefSharedHolder* holder = reinterpret_cast<KRefSharedHolder*>(pointer);
   RETURN_OBJ(holder->ref<ErrorPolicy::kThrow>());
+}
+
+OBJ_GETTER(Kotlin_CString_toKStringFromUtf8Impl, const char* cstring) {
+  RETURN_RESULT_OF(StringFromUtf8Buffer, cstring, strlen(cstring));
 }
 
 }

--- a/runtime/src/main/cpp/KString.cpp
+++ b/runtime/src/main/cpp/KString.cpp
@@ -511,6 +511,13 @@ OBJ_GETTER(Kotlin_ByteArray_unsafeStringFromUtf8, KConstRef thiz, KInt start, KI
   RETURN_RESULT_OF(utf8ToUtf16, rawString, size);
 }
 
+OBJ_GETTER(StringFromUtf8Buffer, const char* start, size_t size) {
+  if (size == 0) {
+    RETURN_RESULT_OF0(TheEmptyString);
+  }
+  RETURN_RESULT_OF(utf8ToUtf16, start, size);
+}
+
 OBJ_GETTER(Kotlin_String_unsafeStringToUtf8, KString thiz, KInt start, KInt size) {
   RETURN_RESULT_OF(unsafeUtf16ToUtf8Impl<utf8::with_replacement::utf16to8>, thiz, start, size);
 }

--- a/runtime/src/main/cpp/KString.h
+++ b/runtime/src/main/cpp/KString.h
@@ -31,6 +31,8 @@ OBJ_GETTER(CreateStringFromUtf8, const char* utf8, uint32_t lengthBytes);
 char* CreateCStringFromString(KConstRef kstring);
 void DisposeCString(char* cstring);
 
+OBJ_GETTER(StringFromUtf8Buffer, const char* start, size_t size);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Use strlen and stop allocating intermediate ByteArray
to make the performance comparable to ByteArray.decodeToString().

Partially fix KT-44357.