### PR TITLE
[IR][cache] Fix for https://youtrack.jetbrains.com/issue/KT-44764

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LlvmModuleSpecification.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LlvmModuleSpecification.kt
@@ -7,7 +7,9 @@ package org.jetbrains.kotlin.backend.konan
 
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.library.KotlinLibrary
 
 /**
@@ -20,5 +22,6 @@ interface LlvmModuleSpecification {
     fun containsLibrary(library: KotlinLibrary): Boolean
     fun containsModule(module: ModuleDescriptor): Boolean
     fun containsModule(module: IrModuleFragment): Boolean
+    fun containsPackageFragment(packageFragment: IrPackageFragment): Boolean
     fun containsDeclaration(declaration: IrDeclaration): Boolean
 }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LlvmModuleSpecificationImpl.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/LlvmModuleSpecificationImpl.kt
@@ -8,7 +8,9 @@ package org.jetbrains.kotlin.backend.konan
 import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.library.KotlinLibrary
 
 internal abstract class LlvmModuleSpecificationBase(protected val cachedLibraries: CachedLibraries) : LlvmModuleSpecification {
@@ -23,6 +25,9 @@ internal abstract class LlvmModuleSpecificationBase(protected val cachedLibrarie
 
     override fun containsModule(module: ModuleDescriptor): Boolean =
             module.konanLibrary.let { it == null || containsLibrary(it) }
+
+    override fun containsPackageFragment(packageFragment: IrPackageFragment): Boolean =
+            packageFragment.konanLibrary.let { it == null || containsLibrary(it) }
 
     override fun containsDeclaration(declaration: IrDeclaration): Boolean =
             declaration.konanLibrary.let { it == null || containsLibrary(it) }

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/ir/NewIrUtils.kt
@@ -114,6 +114,11 @@ internal fun IrExpression.isBoxOrUnboxCall() =
 val ModuleDescriptor.konanLibrary get() = (this.klibModuleOrigin as? DeserializedKlibModuleOrigin)?.library
 val IrModuleFragment.konanLibrary get() =
     (this as? KonanIrModuleFragmentImpl)?.konanLibrary ?: descriptor.konanLibrary
+val IrPackageFragment.konanLibrary get() =
+        if (this is IrFile)
+            this.konanLibrary
+        else
+            this.packageFragmentDescriptor.containingDeclaration.konanLibrary
 val IrFile.konanLibrary get() =
     (metadata as? KonanFileMetadataSource)?.module?.konanLibrary ?: packageFragmentDescriptor.containingDeclaration.konanLibrary
 val IrDeclaration.konanLibrary: KotlinLibrary? get() {

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeInlineFunctionResolver.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/lower/NativeInlineFunctionResolver.kt
@@ -15,6 +15,9 @@ import org.jetbrains.kotlin.backend.konan.Context
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.util.dump
+import org.jetbrains.kotlin.ir.util.file
+import org.jetbrains.kotlin.ir.util.fileOrNull
+import org.jetbrains.kotlin.ir.util.getPackageFragment
 
 // TODO: This is a bit hacky. Think about adopting persistent IR ideas.
 internal class NativeInlineFunctionResolver(override val context: Context) : DefaultInlineFunctionResolver(context) {
@@ -39,7 +42,7 @@ internal class NativeInlineFunctionResolver(override val context: Context) : Def
 
         LocalClassesInInlineLambdasLowering(context).lower(body, function)
 
-        if (context.llvmModuleSpecification.containsDeclaration(function)) {
+        if (context.llvmModuleSpecification.containsPackageFragment(function.getPackageFragment()!!)) {
             // Do not extract local classes off of inline functions from cached libraries.
             LocalClassesInInlineFunctionsLowering(context).lower(body, function)
             LocalClassesExtractionFromInlineFunctionsLowering(context).lower(body, function)


### PR DESCRIPTION
The .konanLibrary is cached for each declaration for performance purposes, but it is only ok to do it
after IR has been lowered to its final state (or at least when declarations aren't being moved around),
so the fix respects that by only taking .konanLibrary of a IrFile (it is assumed that files stay on their place
during entire backend lowering procedure).