### PR TITLE
Update runtimeDefinitions after toolchain upgrade

### DIFF
--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -510,7 +510,8 @@ abiSpecificLibraries.linux_arm32_hfp = lib usr/lib
 # targetSysRoot relative
 crtFilesLocation.linux_arm32_hfp = usr/lib
 runtimeDefinitions.linux_arm32_hfp = USE_GCC_UNWIND=1 KONAN_LINUX=1 \
-  KONAN_ARM32=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_UNALIGNED_ACCESS=1
+  KONAN_ARM32=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_UNALIGNED_ACCESS=1 \
+  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
 
 # Linux arm64
 gccToolchain.linux_arm64 = aarch64-unknown-linux-gnu-gcc-8.3.0-glibc-2.25-kernel-4.9
@@ -562,7 +563,7 @@ abiSpecificLibraries.linux_arm64 = lib usr/lib
 # targetSysRoot relative
 crtFilesLocation.linux_arm64 = usr/lib
 runtimeDefinitions.linux_arm64 = USE_GCC_UNWIND=1 KONAN_LINUX=1 KONAN_ARM64=1 \
-  USE_ELF_SYMBOLS=1 ELFSIZE=64
+  USE_ELF_SYMBOLS=1 ELFSIZE=64 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
 
 # MIPS
 gccToolchain.linux_mips32 = mips-unknown-linux-gnu-gcc-8.3.0-glibc-2.19-kernel-4.9
@@ -604,7 +605,8 @@ abiSpecificLibraries.linux_mips32 = lib usr/lib
 crtFilesLocation.linux_mips32 = usr/lib
 # TODO: reconsider KONAN_NO_64BIT_ATOMIC, once target MIPS can do proper 64-bit load/store/CAS.
 runtimeDefinitions.linux_mips32 = USE_GCC_UNWIND=1 KONAN_LINUX=1 KONAN_MIPS32=1 \
-  USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1
+  USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1 \
+  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
 
 # MIPSel
 gccToolchain.linux_mipsel32 = mipsel-unknown-linux-gnu-gcc-8.3.0-glibc-2.19-kernel-4.9
@@ -643,7 +645,8 @@ abiSpecificLibraries.linux_mipsel32 = lib usr/lib
 crtFilesLocation.linux_mipsel32 = usr/lib
 # TODO: reconsider KONAN_NO_64BIT_ATOMIC, once target MIPS can do proper 64-bit load/store/CAS.
 runtimeDefinitions.linux_mipsel32 = USE_GCC_UNWIND=1 KONAN_LINUX=1 \
-  KONAN_MIPSEL32=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1
+  KONAN_MIPSEL32=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1 \
+  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
 
 # Android ARM32, based on NDK for android-21.
 targetToolchain.macos_x64-android_arm32 = target-toolchain-2-osx-android_ndk
@@ -672,7 +675,7 @@ clangNooptFlags.android_arm32 = -O1
 targetSysRoot.android_arm32 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_arm32 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 runtimeDefinitions.android_arm32 = __ANDROID__ USE_GCC_UNWIND=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 \
-  KONAN_ANDROID=1 KONAN_ARM32=1 KONAN_NO_UNALIGNED_ACCESS=1
+  KONAN_ANDROID=1 KONAN_ARM32=1 KONAN_NO_UNALIGNED_ACCESS=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
 
 # Android ARM64, based on NDK.
 targetToolchain.macos_x64-android_arm64 = target-toolchain-2-osx-android_ndk

--- a/konan/konan.properties
+++ b/konan/konan.properties
@@ -98,7 +98,7 @@ osVersionMinFlagLd.macos_x64 = -macosx_version_min
 osVersionMinFlagClang.macos_x64 = -mmacosx-version-min
 osVersionMin.macos_x64 = 10.11
 runtimeDefinitions.macos_x64 = KONAN_OSX=1 KONAN_MACOSX=1 KONAN_X64=1 KONAN_OBJC_INTEROP=1 \
-  KONAN_CORE_SYMBOLICATION=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_CORE_SYMBOLICATION=1
 dependencies.macos_x64 = \
     libffi-3.2.1-3-darwin-macos \
     lldb-3-macos
@@ -135,7 +135,7 @@ osVersionMinFlagLd.macos_arm64 = -macosx_version_min
 osVersionMinFlagClang.macos_arm64 = -mmacosx-version-min
 osVersionMin.macos_arm64 = 11.0
 runtimeDefinitions.macos_arm64 = KONAN_OSX=1 KONAN_MACOSX=1 KONAN_ARM64=1 KONAN_OBJC_INTEROP=1 \
-  KONAN_CORE_SYMBOLICATION=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_CORE_SYMBOLICATION=1
 dependencies.macos_x64-macos_arm64 = \
     libffi-3.2.1-3-darwin-macos
 
@@ -172,7 +172,7 @@ osVersionMin.ios_arm32 = 9.0
 # https://developer.apple.com/library/archive/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARMv6FunctionCallingConventions.html#//apple_ref/doc/uid/TP40009021-SW1
 # See https://github.com/ktorio/ktor/issues/941 for the context.
 runtimeDefinitions.ios_arm32 = KONAN_OBJC_INTEROP=1 KONAN_IOS KONAN_ARM32=1 \
-  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1 KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 MACHSIZE=32 \
+  KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 MACHSIZE=32 \
   KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1
 
 # Apple's 64-bit iOS.
@@ -203,7 +203,7 @@ osVersionMinFlagLd.ios_arm64 = -iphoneos_version_min
 osVersionMinFlagClang.ios_arm64 = -miphoneos-version-min
 osVersionMin.ios_arm64 = 9.0
 runtimeDefinitions.ios_arm64 = KONAN_OBJC_INTEROP=1 KONAN_IOS=1 KONAN_ARM64=1 \
-  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1 KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 MACHSIZE=64
+  KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 MACHSIZE=64
 additionalCacheFlags.ios_arm64 = -Xembed-bitcode-marker
 
 #  Apple's iOS simulator.
@@ -231,7 +231,7 @@ osVersionMinFlagLd.ios_x64 = -ios_simulator_version_min
 osVersionMinFlagClang.ios_x64 = -mios-simulator-version-min
 osVersionMin.ios_x64 = 9.0
 runtimeDefinitions.ios_x64 = KONAN_OBJC_INTEROP=1 KONAN_IOS=1 KONAN_X64=1 \
-  KONAN_CORE_SYMBOLICATION=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_CORE_SYMBOLICATION=1
 
 #  Apple's tvOS simulator.
 targetToolchain.macos_x64-tvos_x64 = target-toolchain-xcode_12_2-macos_x64
@@ -258,7 +258,7 @@ osVersionMinFlagLd.tvos_x64 = -tvos_simulator_version_min
 osVersionMinFlagClang.tvos_x64 = -mtvos-simulator-version-min
 osVersionMin.tvos_x64 = 9.0
 runtimeDefinitions.tvos_x64 = KONAN_OBJC_INTEROP=1 KONAN_TVOS=1 KONAN_X64=1 \
-  KONAN_CORE_SYMBOLICATION=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_CORE_SYMBOLICATION=1
 
 # Apple's 64-bit tvOS.
 targetToolchain.macos_x64-tvos_arm64 = target-toolchain-xcode_12_2-macos_x64
@@ -285,7 +285,7 @@ osVersionMinFlagLd.tvos_arm64 = -tvos_version_min
 osVersionMinFlagClang.tvos_arm64 = -mtvos-version-min
 osVersionMin.tvos_arm64 = 9.0
 runtimeDefinitions.tvos_arm64 = KONAN_OBJC_INTEROP=1 KONAN_TVOS=1 KONAN_ARM64=1 \
-  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1 KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 MACHSIZE=64
+  KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 MACHSIZE=64
 
 # watchOS armv7k
 targetToolchain.macos_x64-watchos_arm32 = target-toolchain-xcode_12_2-macos_x64
@@ -313,7 +313,7 @@ osVersionMinFlagClang.watchos_arm32 = -mwatchos-version-min
 osVersionMin.watchos_arm32 = 5.0
 # Regarding KONAN_NO_64BIT_ATOMIC=1: see explanation for ios_arm32 above.
 runtimeDefinitions.watchos_arm32 = KONAN_OBJC_INTEROP=1 KONAN_WATCHOS KONAN_ARM32=1 \
-  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1 KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 \
+  KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 \
   MACHSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1
 
 # watchOS arm64_32
@@ -343,7 +343,7 @@ osVersionMinFlagClang.watchos_arm64 = -mwatchos-version-min
 osVersionMin.watchos_arm64 = 5.0
 # Regarding KONAN_NO_64BIT_ATOMIC=1: see explanation for ios_arm32 above.
 runtimeDefinitions.watchos_arm64 = KONAN_OBJC_INTEROP=1 KONAN_WATCHOS KONAN_ARM32=1 \
-  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1 KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 \
+  KONAN_REPORT_BACKTRACE_TO_IOS_CRASH_LOG=1 \
   MACHSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1
 
 #  Apple's watchOS i386 simulator.
@@ -375,7 +375,7 @@ osVersionMinFlagLd.watchos_x86 = -watchos_simulator_version_min
 osVersionMinFlagClang.watchos_x86 = -mwatchos-simulator-version-min
 osVersionMin.watchos_x86 = 5.0
 runtimeDefinitions.watchos_x86 = KONAN_OBJC_INTEROP=1 KONAN_WATCHOS=1 KONAN_NO_64BIT_ATOMIC=1 \
-  KONAN_X86=1 KONAN_CORE_SYMBOLICATION=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_X86=1 KONAN_CORE_SYMBOLICATION=1
 
 # watchOS x86_64 simulator.
 targetToolchain.macos_x64-watchos_x64 = target-toolchain-xcode_12_2-macos_x64
@@ -402,7 +402,7 @@ osVersionMinFlagLd.watchos_x64 = -watchos_simulator_version_min
 osVersionMinFlagClang.watchos_x64 = -mwatchos-simulator-version-min
 osVersionMin.watchos_x64 = 7.0
 runtimeDefinitions.watchos_x64 = KONAN_OBJC_INTEROP=1 KONAN_WATCHOS=1 \
-  KONAN_X64=1 KONAN_CORE_SYMBOLICATION=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_X64=1 KONAN_CORE_SYMBOLICATION=1
 
 # Linux x86-64.
 llvmHome.linux_x64 = $llvm.linux_x64.dev
@@ -456,7 +456,7 @@ abiSpecificLibraries.linux_x64 = lib usr/lib ../lib64 lib64 usr/lib64
 # targetSysRoot relative
 crtFilesLocation.linux_x64 = usr/lib
 runtimeDefinitions.linux_x64 = USE_GCC_UNWIND=1 KONAN_LINUX=1 KONAN_X64=1 \
-  USE_ELF_SYMBOLS=1 ELFSIZE=64 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  USE_ELF_SYMBOLS=1 ELFSIZE=64
 
 # Raspberry Pi
 gccToolchain.linux_arm32_hfp = arm-unknown-linux-gnueabihf-gcc-8.3.0-glibc-2.19-kernel-4.9
@@ -510,8 +510,7 @@ abiSpecificLibraries.linux_arm32_hfp = lib usr/lib
 # targetSysRoot relative
 crtFilesLocation.linux_arm32_hfp = usr/lib
 runtimeDefinitions.linux_arm32_hfp = USE_GCC_UNWIND=1 KONAN_LINUX=1 \
-  KONAN_ARM32=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_UNALIGNED_ACCESS=1 \
-  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_ARM32=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_UNALIGNED_ACCESS=1
 
 # Linux arm64
 gccToolchain.linux_arm64 = aarch64-unknown-linux-gnu-gcc-8.3.0-glibc-2.25-kernel-4.9
@@ -563,7 +562,7 @@ abiSpecificLibraries.linux_arm64 = lib usr/lib
 # targetSysRoot relative
 crtFilesLocation.linux_arm64 = usr/lib
 runtimeDefinitions.linux_arm64 = USE_GCC_UNWIND=1 KONAN_LINUX=1 KONAN_ARM64=1 \
-  USE_ELF_SYMBOLS=1 ELFSIZE=64 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  USE_ELF_SYMBOLS=1 ELFSIZE=64
 
 # MIPS
 gccToolchain.linux_mips32 = mips-unknown-linux-gnu-gcc-8.3.0-glibc-2.19-kernel-4.9
@@ -605,8 +604,7 @@ abiSpecificLibraries.linux_mips32 = lib usr/lib
 crtFilesLocation.linux_mips32 = usr/lib
 # TODO: reconsider KONAN_NO_64BIT_ATOMIC, once target MIPS can do proper 64-bit load/store/CAS.
 runtimeDefinitions.linux_mips32 = USE_GCC_UNWIND=1 KONAN_LINUX=1 KONAN_MIPS32=1 \
-  USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1 \
-  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1
 
 # MIPSel
 gccToolchain.linux_mipsel32 = mipsel-unknown-linux-gnu-gcc-8.3.0-glibc-2.19-kernel-4.9
@@ -645,8 +643,7 @@ abiSpecificLibraries.linux_mipsel32 = lib usr/lib
 crtFilesLocation.linux_mipsel32 = usr/lib
 # TODO: reconsider KONAN_NO_64BIT_ATOMIC, once target MIPS can do proper 64-bit load/store/CAS.
 runtimeDefinitions.linux_mipsel32 = USE_GCC_UNWIND=1 KONAN_LINUX=1 \
-  KONAN_MIPSEL32=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1 \
-  KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_MIPSEL32=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 KONAN_NO_64BIT_ATOMIC=1 KONAN_NO_UNALIGNED_ACCESS=1
 
 # Android ARM32, based on NDK for android-21.
 targetToolchain.macos_x64-android_arm32 = target-toolchain-2-osx-android_ndk
@@ -675,7 +672,7 @@ clangNooptFlags.android_arm32 = -O1
 targetSysRoot.android_arm32 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_arm32 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 runtimeDefinitions.android_arm32 = __ANDROID__ USE_GCC_UNWIND=1 USE_ELF_SYMBOLS=1 ELFSIZE=32 \
-  KONAN_ANDROID=1 KONAN_ARM32=1 KONAN_NO_UNALIGNED_ACCESS=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  KONAN_ANDROID=1 KONAN_ARM32=1 KONAN_NO_UNALIGNED_ACCESS=1
 
 # Android ARM64, based on NDK.
 targetToolchain.macos_x64-android_arm64 = target-toolchain-2-osx-android_ndk
@@ -703,7 +700,7 @@ targetSysRoot.android_arm64 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_arm64 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 linkerNoDebugFlags.android_arm64 = -Wl,-S
 runtimeDefinitions.android_arm64 = __ANDROID__ USE_GCC_UNWIND=1 USE_ELF_SYMBOLS=1 \
-  ELFSIZE=64 KONAN_ANDROID=1 KONAN_ARM64=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  ELFSIZE=64 KONAN_ANDROID=1 KONAN_ARM64=1
 
 # Android X86, based on NDK.
 targetToolchain.macos_x64-android_x86 = target-toolchain-2-osx-android_ndk
@@ -735,7 +732,7 @@ targetSysRoot.android_x86 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_x86 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 linkerNoDebugFlags.android_x86 = -Wl,-S
 runtimeDefinitions.android_x86 = __ANDROID__ USE_GCC_UNWIND=1 USE_ELF_SYMBOLS=1 \
-  ELFSIZE=32 KONAN_ANDROID=1 KONAN_X86=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  ELFSIZE=32 KONAN_ANDROID=1 KONAN_X86=1
 
 # Android X64, based on NDK.
 targetToolchain.macos_x64-android_x64 = target-toolchain-2-osx-android_ndk
@@ -763,7 +760,7 @@ targetSysRoot.android_x64 = target-sysroot-1-android_ndk
 linkerKonanFlags.android_x64 = -lm -lc++_static -lc++abi -landroid -llog -latomic
 linkerNoDebugFlags.android_x64 = -Wl,-S
 runtimeDefinitions.android_x64 = __ANDROID__ USE_GCC_UNWIND=1 USE_ELF_SYMBOLS=1 \
-  ELFSIZE=64 KONAN_ANDROID=1 KONAN_X64=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  ELFSIZE=64 KONAN_ANDROID=1 KONAN_X64=1
 
 # Windows x86-64, based on mingw-w64.
 llvmHome.mingw_x64 = $llvm.mingw_x64.dev
@@ -799,7 +796,7 @@ linkerKonanFlags.mingw_x64 =-static-libgcc -static-libstdc++ \
 linkerOptimizationFlags.mingw_x64 = -Wl,--gc-sections
 mimallocLinkerDependencies.mingw_x64 = -lbcrypt
 runtimeDefinitions.mingw_x64 = USE_GCC_UNWIND=1 USE_PE_COFF_SYMBOLS=1 KONAN_WINDOWS=1 \
-  UNICODE KONAN_X64=1 KONAN_NO_MEMMEM=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  UNICODE KONAN_X64=1 KONAN_NO_MEMMEM=1
 
 # Windows i686, based on mingw-w64.
 targetToolchain.mingw_x64-mingw_x86 = msys2-mingw-w64-i686-clang-llvm-lld-compiler_rt-8.0.1
@@ -837,7 +834,7 @@ linkerKonanFlags.mingw_x86 = -static-libgcc -static-libstdc++ \
 mimallocLinkerDependencies.mingw_x86 = -lbcrypt
 linkerOptimizationFlags.mingw_x86 = -Wl,--gc-sections
 runtimeDefinitions.mingw_x86 = USE_GCC_UNWIND=1 USE_PE_COFF_SYMBOLS=1 KONAN_WINDOWS=1 \
-  UNICODE KONAN_X86=1 KONAN_NO_MEMMEM=1 KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS=1
+  UNICODE KONAN_X86=1 KONAN_NO_MEMMEM=1
 
 # WebAssembly 32-bit.
 targetToolchain.macos_x64-wasm32 = target-toolchain-3-macos-wasm

--- a/runtime/src/main/cpp/Exceptions.cpp
+++ b/runtime/src/main/cpp/Exceptions.cpp
@@ -252,9 +252,7 @@ RUNTIME_NORETURN void TerminateWithUnhandledException(KRef throwable) {
   });
 }
 
-// Some libstdc++-based targets has limited support for std::current_exception and other C++11 functions.
-// This restriction can be lifted later when toolchains will be updated.
-#if KONAN_HAS_CXX11_EXCEPTION_FUNCTIONS
+#if !KONAN_NO_EXCEPTIONS
 
 namespace {
 // Copy, move and assign would be safe, but not much useful, so let's delete all (rule of 5)
@@ -308,13 +306,13 @@ void SetKonanTerminateHandler() {
   TerminateHandler::install();
 }
 
-#else // KONAN_OBJC_INTEROP
+#else // !KONAN_NO_EXCEPTIONS
 
 void SetKonanTerminateHandler() {
   // Nothing to do.
 }
 
-#endif // KONAN_OBJC_INTEROP
+#endif // !KONAN_NO_EXCEPTIONS
 
 void DisallowSourceInfo() {
   disallowSourceInfo = true;


### PR DESCRIPTION
Addressing

```cpp
// Some libstdc++-based targets has limited support for std::current_exception and other C++11 functions.
// This restriction can be lifted later when toolchains will be updated.
```
https://github.com/JetBrains/kotlin-native/blob/ce946a9679087e6c72ad0d2c076dfa1f3cfc062c/runtime/src/main/cpp/Exceptions.cpp#L255