### PR TITLE
Remove .git directory when downloading googletest sources

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -16,6 +16,5 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/runtime/googletest" vcs="Git" />
   </component>
 </project>

--- a/build-tools/src/main/kotlin/org/jetbrains/kotlin/testing/native/GitDownloadTask.kt
+++ b/build-tools/src/main/kotlin/org/jetbrains/kotlin/testing/native/GitDownloadTask.kt
@@ -103,6 +103,9 @@ open class GitDownloadTask @Inject constructor(
 
         // Store info about used revision for the manual up-to-date check.
         upToDateChecker.storeRevisionInfo()
+
+        // Delete the .git directory of the cloned repo to avoid adding it to IDEA's VCS roots.
+        outputDirectory.resolve(".git").deleteRecursively()
     }
 
 


### PR DESCRIPTION
Keeping the .git folder in the googletest directory may cause
changing .idea/vcs.xml during IDEA import. .idea/vcs.xml is under
source control, thus changing it litters a current diff.