### PR TITLE
[kotlin compiler][update] 1.5.20-dev-1166 

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/KonanBackendContext.kt
@@ -65,8 +65,6 @@ internal abstract class KonanBackendContext(val config: KonanConfig) : CommonBac
 
     override val mapping: Mapping = DefaultMapping()
 
-    override val extractedLocalClasses: MutableSet<IrClass> = mutableSetOf()
-
     override val irFactory: IrFactory = IrFactoryImpl
 }
 

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -113,7 +113,7 @@ internal class KonanIrLinker(
             moduleDescriptor: ModuleDescriptor,
             klib: IrLibrary,
             strategy: DeserializationStrategy
-    ): KotlinIrLinker.BasicIrModuleDeserializer(moduleDescriptor, klib, strategy) {
+    ): BasicIrModuleDeserializer(this@KonanIrLinker, moduleDescriptor, klib, strategy){
         override val moduleFragment: IrModuleFragment = KonanIrModuleFragmentImpl(moduleDescriptor, builtIns, emptyList())
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.5.20-dev-372
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-372,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-576,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.20-dev-576
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-576,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.20-dev-576
-kotlinStdlibTestsVersion=1.5.20-dev-576
-testKotlinCompilerVersion=1.5.20-dev-576
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-1166,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.20-dev-1166
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-1166,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.20-dev-1166
+kotlinStdlibTestsVersion=1.5.20-dev-1166
+testKotlinCompilerVersion=1.5.20-dev-1166
 konanVersion=1.5.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
* 073a5003704 - (HEAD -> master, tag: build-1.5.20-dev-1166, origin/master, origin/HEAD) Change order of WITH_RUNTIME and FILE. Wrong order brakes module pattern. (22 hours ago) <Pavel Punegov>
* 95a8c60a9ce - Ignore test in Native backend. Test overrides kotlin.Result (22 hours ago) <Pavel Punegov>
* 4643f12a5f1 - Ignore JVM test in Native backend (22 hours ago) <Pavel Punegov>
* d9be59ea97c - (tag: build-1.5.20-dev-1156) [JS IR] JS code in init block only for js ir backend test (2 days ago) <Ilya Goncharov>
* 13dfa5a8867 - (tag: build-1.5.20-dev-1153) [FIR2IR] Add handling exceptions from Fir2Ir and reporting declaration where converter failed (2 days ago) <Dmitriy Novozhilov>
* ea2783eace4 - [FIR] Fix generating `this` reference in delegated accessors (2 days ago) <Dmitriy Novozhilov>
* 4e5647090e1 - (tag: build-1.5.20-dev-1143) Approximate captured types in contravariant positions properly (2 days ago) <Victor Petukhov>
* 387d84f8260 - (tag: build-1.5.20-dev-1136) JVM_IR indy-SAM: KT-45069 box lambda 'Unit' return type if needed (2 days ago) <Dmitry Petrov>
* 187d4998fa8 - (tag: build-1.5.20-dev-1132) [JS IR] Not cast to declaration parent in JsCodeOutlineLowering, use parent otherwise (2 days ago) <Ilya Goncharov>
* bd2601f289d - (tag: build-1.5.20-dev-1128) [JS IR] Extract adding of function call to another function (2 days ago) <Ilya Goncharov>
* 5568ceef689 - (tag: build-1.5.20-dev-1125) Add test for KT-37056 (already fixed) (2 days ago) <Mikhail Glukhikh>
* 6e46b0a1c4b - Add test for KT-41917 (already fixed) (2 days ago) <Mikhail Glukhikh>
* 1fe0a1f1609 - FIR: Fix interface delegation case via type alias (2 days ago) <Denis.Zharkov>
* e4c851e3ceb - FIR2IR: Fix case of @JvmOverloads with subclass (2 days ago) <Denis.Zharkov>
* 377a0aa237b - FIR2IR: Adjust test data for updated overridden structure (2 days ago) <Denis.Zharkov>
* a750d9466ec - FIR2IR: Rework resulted overridden-relation structure (2 days ago) <Denis.Zharkov>
* fd146e3eed9 - FIR2IR: Copy annotations from original declarations to fake overrides (2 days ago) <Denis.Zharkov>
* a883833941a - FIR2IR: Use IrDeclarationOrigin.FAKE_OVERRIDE for non-source classes (2 days ago) <Denis.Zharkov>
* d339096ac33 - FIR2IR: Introduce and use declarationStorage.getOrCreateIrConstructor (2 days ago) <Denis.Zharkov>
* fb8314f6e76 - FIR: Fix enhancement of property overrides accessors in Java (2 days ago) <Denis.Zharkov>
* 45018ea4685 - FIR: Rework loading overrides of special built-in methods from Java (2 days ago) <Denis.Zharkov>
* 4b0aeb71057 - FIR2IR: Support initialSignatureDescriptor (2 days ago) <Denis.Zharkov>
* 23705a269ff - FIR: Fix supertype scopes for local classes (2 days ago) <Denis.Zharkov>
* 3e420ca4e32 - FIR: Introduce FirDeclarationOrigin.BuiltIns (2 days ago) <Denis.Zharkov>
* 893b1045ba4 - Move some common parts from BuiltinMethodsWithDifferentJvmName to SpecialGenericSignatures (2 days ago) <Denis.Zharkov>
* 5d5228cfc59 - FIR: Require FirJavaClass in JavaScopeProvider (2 days ago) <Denis.Zharkov>
* 04f53d6a23f - FIR: Simplify JavaScopeProvider (2 days ago) <Denis.Zharkov>
* 6766c8fe47f - FIR: Simplify supertypes scopes computation (2 days ago) <Denis.Zharkov>
* 31b9be2d01b - FIR: Extract ConeKotlinType::scopeForSupertype (2 days ago) <Denis.Zharkov>
* 1a0be3ee405 - (tag: build-1.5.20-dev-1124) Fix FirAnnotationArgumentChecker (String + ... case) #KT-44995 Fixed (2 days ago) <Mikhail Glukhikh>
* cd8f597e2f6 - (tag: build-1.5.20-dev-1123) [FIR] Fix building callable reference adaptation against flexible types (2 days ago) <Dmitriy Novozhilov>
* 469252f6b40 - [FIR] Don't create smartcast node if smartcasted type is equal to original type (2 days ago) <Dmitriy Novozhilov>
* 1c0d862e406 - [FIR] Don't smartcast variables to invisible types (2 days ago) <Dmitriy Novozhilov>
* 026efca49fa - [Test] Add helpers file with functions for inference testing (2 days ago) <Dmitriy Novozhilov>
* d0eeb0535de - (tag: build-1.5.20-dev-1110) Add synchronization to MultiClassFiles maps (2 days ago) <Aleksei.Cherepanov>
* aa683d3b2ac - JPS: Fix JvmMultifileClass processing for IR backend (2 days ago) <Aleksei.Cherepanov>
* ca4ec997ee8 - (tag: build-1.5.20-dev-1106) FIR IDE: split KtAnalysisSession into mixins (3 days ago) <Ilya Kirillov>
* 141b6b0e550 - (tag: build-1.5.20-dev-1098) FIR IDE: use different .after testdata for AbstractHLIntentionTest.kt (3 days ago) <Ilya Kirillov>
* 42103b7363b - FIR IDE: use correct denotable type approximator (3 days ago) <Ilya Kirillov>
* af4d3006868 - Use nullability from approximated local type in AbstractTypeApproximator (3 days ago) <Ilya Kirillov>
* 3571074da40 - (tag: build-1.5.20-dev-1096) Update FIR-IDE diagnostic components (3 days ago) <Mikhail Glukhikh>
* 7c080395f2e - FIR: minor test data fixes (3 days ago) <Mikhail Glukhikh>
* 7fdc1c7b217 - Fix RawFirBuilderTotalKotlinTestCase.testPsiConsistency (3 days ago) <Mikhail Glukhikh>
* 54139b83cee - FIR: fix EXPRESSION_REQUIRED positioning (3 days ago) <Mikhail Glukhikh>
* 588b1354f60 - FIR IDE: fix reference shortening regarding new qualified sources (3 days ago) <Mikhail Glukhikh>
* 5066a90f6f3 - FIR2IR: fix offsets for qualified expressions (3 days ago) <Mikhail Glukhikh>
* 239a44b30c7 - FIR: forbid reporting inapplicable-likes on implicit constructors (3 days ago) <Mikhail Glukhikh>
* 34c90aab3b8 - FIR: introduce & use REFERENCE_BY_QUALIFIER positioning strategy (3 days ago) <Mikhail Glukhikh>
* 0accaf0f301 - FIR: report resolve-time errors on qualified access instead of reference (3 days ago) <Mikhail Glukhikh>
* 5ffa72f1fac - FIR: change DOT_BY_SELECTOR to DOT_BY_QUALIFIED strategy (3 days ago) <Mikhail Glukhikh>
* 04caa5c6127 - Fix DEBUG_INFO_CALL positioning in FIR (3 days ago) <Mikhail Glukhikh>
* 5ca3ce9e371 - FIR: introduce & use SELECTOR_BY_QUALIFIED positioning strategy (3 days ago) <Mikhail Glukhikh>
* 5892646a275 - Change FirQualifiedAccess source to KtQualifiedExpression (if any) (3 days ago) <Mikhail Glukhikh>
* 742f1e00693 - FIR: add replaceSource to all FIR tree nodes (3 days ago) <Mikhail Glukhikh>
* b8d1bbdd0d7 - (tag: build-1.5.20-dev-1095) Do not swallow PCE (3 days ago) <Vladimir Dolzhenko>
* d40777c28f1 - (tag: build-1.5.20-dev-1085) [FIR] Fix calculating arguments of bare type with intersection type as base (3 days ago) <Dmitriy Novozhilov>
* 56f9e3360ff - JVM IR: do not generate invokeinterface hashCode if smart cast is present (3 days ago) <Alexander Udalov>
* 56854a8b1a5 - (tag: build-1.5.20-dev-1078) FIR IDE: register quickfix for the following (3 days ago) <Tianyu Geng>
* 88c43e7f7bb - (tag: build-1.5.20-dev-1072) [FE] Assume that effective visibility of sealed class constructor is internal (3 days ago) <Dmitriy Novozhilov>
* b08eb6cf4c7 - (tag: build-1.5.20-dev-1069) FIR IDE: specify behaviour of HL API getOverriddenSymbols (3 days ago) <Ilya Kirillov>
* 804df1aec2c - FIR IDE: introduce base class for multifile tests (3 days ago) <Ilya Kirillov>
* 3626008ed26 - (tag: build-1.5.20-dev-1065) [Inference] Add ability to approximate local types in AbstractTypeApproximator (3 days ago) <Dmitriy Novozhilov>
* 73616107b47 - (tag: build-1.5.20-dev-1060) Unmute passing FIR BB test (3 days ago) <Mikhail Glukhikh>
* c629ba5a3cb - (tag: build-1.5.20-dev-1058) JVM_IR indy-SAM: function reference to Java interface (3 days ago) <Dmitry Petrov>
* 357a7907a34 - (tag: build-1.5.20-dev-1051) FIR: fix type approximation by visibility (3 days ago) <Mikhail Glukhikh>
* 74bdb2398ef - (tag: build-1.5.20-dev-1048) FIR: Get rid of PSI dependency in the `:fir:resolve` module (3 days ago) <Roman Golyshev>
* 6b453d9b233 - FIR: implement checker for open members (3 days ago) <Tianyu Geng>
* 3e9ff3ecda8 - FIR: report SUPERTYPE_NOT_A_CLASS_OR_INTERFACE on type parameters (3 days ago) <Mikhail Glukhikh>
* e67eb0c1237 - FIR checker: typed declaration's return type should be resolved (3 days ago) <Jinseong Jeon>
* 5f9357eb41c - FIR: transform implicit type ref in anonymous function arguments & body (3 days ago) <Jinseong Jeon>
* a841a0bbca0 - FIR: transform other parts of function call even though callee is an error (3 days ago) <Jinseong Jeon>
* 27c942a0fff - FIR: enforce the return type of function literals without body (3 days ago) <Jinseong Jeon>
* 9aaa952b39b - FIR: regard implicit type for value parameter after body resolve as an error type (3 days ago) <Jinseong Jeon>
* fbb19e3b50d - FIR: ensure type ref transformed by type resolve transformer is resolved (3 days ago) <Jinseong Jeon>
* 52ea7fdb72b - FIR: ensure type ref after supertype resolve transformer is resolved (3 days ago) <Jinseong Jeon>
* 8783ebc3524 - (tag: build-1.5.20-dev-1042) Report highlight errors to WolfTheProblemSolver (3 days ago) <Vladimir Dolzhenko>
* afe71f5d59b - (tag: build-1.5.20-dev-1036) FIR: Add runConfig to generate FIR boilerplate (#4130) (3 days ago) <tgeng>
* 51da54ce669 - (tag: build-1.5.20-dev-1030) FIR IDE: Simplify registerPsiQuickFixes (4 days ago) <Tianyu Geng>
* cacd84390e5 - (tag: build-1.5.20-dev-1027) Use erased upper bound instead of checking for inline type (4 days ago) <Ilmir Usmanov>
* 741c1a864f2 - JVM_IR: IC: Unbox inline class argument of callable reference (4 days ago) <Ilmir Usmanov>
* 744a0fcd250 - PSI2IR KT-45022 object in LHS of compound assignment (4 days ago) <Dmitry Petrov>
* 05447ce0c8b - (tag: build-1.5.20-dev-1023) [Commonizer] Print true time for resolving of libraries to be commonized (4 days ago) <Dmitriy Dolovov>
* 0b26a281dee - [Commonizer] Print pretty target name in console output (4 days ago) <Dmitriy Dolovov>
* fb51105a5d2 - [Commonizer] Log time in commonizer result consumers (4 days ago) <Dmitriy Dolovov>
* 496aad3c4ac - [Commonizer] Log commonization only for really present targets (4 days ago) <Dmitriy Dolovov>
* 3ad7b607478 - [Commonizer] Prefer using CommonizerTarget instead of KonanTarget (4 days ago) <Dmitriy Dolovov>
* 1895c230efb - [Commonizer] K/N dist: Process targets in alphabetical order (4 days ago) <Dmitriy Dolovov>
* f473b88e478 - [Commonizer] Nicer API for CirProvidedClassifiers (4 days ago) <Dmitriy Dolovov>
* 84ce9c612c9 - [Commonizer] Keep only "common" dependencies in CirKnownClassifiers (4 days ago) <Dmitriy Dolovov>
* 2581b67cdaa - [Commonizer] Rename: CirCommonizedClassifiers -> CirCommonizedClassifierNodes (4 days ago) <Dmitriy Dolovov>
* 43ad0ed9071 - [Commonizer] Optimized implementation of CirProvidedClassifiers (4 days ago) <Dmitriy Dolovov>
* 79e3ce022f0 - [Commonizer] Fix: Keep fwd declarations under real names in CirForwardDeclarations cache (4 days ago) <Dmitriy Dolovov>
* bc9a7918090 - (tag: build-1.5.20-dev-1021) Refactor klib serializer/deserializer (4 days ago) <Anton Bannykh>
* ad9fd7ecf3c - (tag: build-1.5.20-dev-1015) KotlinBinaryClassCache: clean-up request caches for all threads (4 days ago) <Victor Petukhov>
* 5cbbbc3b832 - (tag: build-1.5.20-dev-1013) Fix artifacts needed for the kotlin-gradle-plugin (4 days ago) <Alexander Dudinsky>
* 33313ae4b40 - Fix artifacts needed for the kotlin-gradle-plugin (4 days ago) <Alexander Dudinsky>
* 8c20c655feb - (tag: build-1.5.20-dev-1003) Updated bytecode of serialization for IR (4 days ago) <Sergey Shanshin>
* 7b7b8fbea74 - (tag: build-1.5.20-dev-998) [Test] Filter dependent modules by source kind in creating FirModuleInfo (4 days ago) <Dmitriy Novozhilov>
* 8c95b783463 - Update JVM metadata version to 1.5.0 (4 days ago) <Alexander Udalov>
* dbadd5846a4 - Add test for script flag in kotlin.Metadata (4 days ago) <Alexander Udalov>
* 1d6b1989151 - Build: suppress version and JVM target warnings (4 days ago) <Alexander Udalov>
* 49fc1b9e3e6 - Build: enable -Werror for several modules (4 days ago) <Alexander Udalov>
* 82ac4821433 - (tag: build-1.5.20-dev-989, origin/jupiter/master) Fix typo (#4051) (4 days ago) <Hyojae Kim>
* a3fa6c6d136 - (tag: build-1.5.20-dev-985) Publish artifacts needed for the kotlin-gradle-plugin in kotlin-ide repository (4 days ago) <Alexander Dudinsky>
* 9b4949a3c58 - (tag: build-1.5.20-dev-978) [FIR] Fix taking symbol of expression with smartcast inside DFA (4 days ago) <Dmitriy Novozhilov>
* adb05ab076d - (tag: build-1.5.20-dev-972) JVM IR: write inherited multifile parts flag to kotlin.Metadata (4 days ago) <Alexander Udalov>
* 35008df9697 - (tag: build-1.5.20-dev-969) [Commonizer] Rename NativeDistributionCommonizer to LibraryCommonizer (4 days ago) <sebastian.sellmair>
* 4500b6ce74c - [Commonizer] Implement :native:kotlin-klib-commonizer:api with support for library commonization (4 days ago) <sebastian.sellmair>
* 6d019d9544b - (tag: build-1.5.20-dev-968) JVM_IR indy-SAM on functional expression (4 days ago) <Dmitry Petrov>
* 134fda8bad8 - (tag: build-1.5.20-dev-967) Support Unit/V types in string-concat indy calls (5 days ago) <Mikhael Bogdanov>
* e3e7e6b740d - Make `indy-with-constants` default for -jvm-target 9+ (5 days ago) <Mikhael Bogdanov>
* 3d8e8dd3ba9 - Fail on compilation errors in AbstractBytecodeTextTest (5 days ago) <Mikhael Bogdanov>
* 61fce74b76b - Support new targets in KotlinBytecodeToolWindow (5 days ago) <Mikhael Bogdanov>
* 91f1cb88c16 - (tag: build-1.5.20-dev-966) Support serialization of java enum classes in IR (5 days ago) <Sergey Shanshin>
* 652207dcac2 - (tag: build-1.5.20-dev-965) FIR IDE: add AddModifierFix (5 days ago) <Tianyu Geng>
* 5793f77ece2 - FIR IDE: AddModifierFix -> AddModifierFixMpp (5 days ago) <Tianyu Geng>
* de06a69b128 - (tag: build-1.5.20-dev-964) Added external serializers in serialization plugin for IR backend (5 days ago) <Sergey Shanshin>
* 66f00a2eb5d - FIR IDE: move AddFunctionBodyFix to fe-independent (5 days ago) <Tianyu Geng>
* 67e91b7ebdc - (tag: build-1.5.20-dev-959) Minor, add workaround for KT-45008 (5 days ago) <Alexander Udalov>
* 4d9cffccf23 - (tag: build-1.5.20-dev-946) Support structural equals/hashCode for type constructors of type parameters (5 days ago) <Alexander Udalov>
* aaecb87d1ba - Tests: compute runtime classpath for JVM box tests manually (5 days ago) <Alexander Udalov>
* df428688741 - [Inference] Fix subtyping on classes with same FQN but with different number of arguments (5 days ago) <Dmitriy Novozhilov>
* 0b22c30ab1a - [FIR] Fix dispatch receiver type for members of builtin functional types (5 days ago) <Dmitriy Novozhilov>
* e5ab6841272 - [FIR] Support methods of cone type contexts with annotation markers (5 days ago) <Dmitriy Novozhilov>
* 57d29009eef - [FIR] Fix TODOs and cleanup ConeTypeContext and ConeInferenceContext (5 days ago) <Dmitriy Novozhilov>
* 373bc578fb3 - [FIR] Implement capturing of cone types same as for kotlin types (5 days ago) <Dmitriy Novozhilov>
* 5ce36a528ec - [FE] Prohibit sealed fun interfaces (5 days ago) <Dmitriy Novozhilov>
* cdf7de5524a - [FE] Change message for sealed interfaces with language target < 1.5 (5 days ago) <Dmitriy Novozhilov>
* 8521d844e24 - (tag: build-1.5.20-dev-935, tag: build-1.5.20-dev-913) Advance bootstrap to 1.5.20-dev-814 (5 days ago) <Dmitriy Novozhilov>
* 83343f3a7a2 - (tag: build-1.5.20-dev-907, tag: build-1.5.20-dev-901) IR: get rid of some type checks in JvmBackendContext (5 days ago) <Georgy Bronnikov>
* 68cabba6987 - IR: preserve signatures when copying IrFiles in performByIrFile (5 days ago) <Georgy Bronnikov>
* db18ffc7640 - IR: only worry about threads in JvmIrSignatureDescriptor (5 days ago) <Georgy Bronnikov>
* cacfe530650 - IR: move performByIrFile to a separate .kt (5 days ago) <Georgy Bronnikov>
* 4c701cf44c1 - IR: make extractedLocalClasses a JS-only field (5 days ago) <Georgy Bronnikov>
* 445f6eac3dc - IR: IrBasedDescriptor fix (5 days ago) <Georgy Bronnikov>
* c081bc8d7e2 - Fir concurrent maps (5 days ago) <Georgy Bronnikov>
* 9cdad272de0 - Fir threadLocal (5 days ago) <Georgy Bronnikov>
* ec2dc9c0fa7 - IR: synchronize on SymbolTable operations (5 days ago) <Georgy Bronnikov>
* c9d0448fd15 - IR: use threadLocal (5 days ago) <Georgy Bronnikov>
* 56a26113cdd - IR: threadLocal (5 days ago) <Georgy Bronnikov>
* 57167922e22 - IR: make lazyVar synchronized (5 days ago) <Georgy Bronnikov>
* 4e9bedc2fc8 - JVM_IR: use ConcurrentHashMap (5 days ago) <Georgy Bronnikov>
* 23da2bde679 - IR: fixes for IR by-file copying (5 days ago) <Georgy Bronnikov>
* 54a76977dbe - IR: fix fake override computation (5 days ago) <Georgy Bronnikov>
* d154c8d8e67 - IR: copy each file before lowering. (5 days ago) <Georgy Bronnikov>
* 103f82c95c3 - IR: an option to automatically select the number of lowering threads (5 days ago) <Georgy Bronnikov>
* 52b3cb362bb - IR: thread pool in PerformByIrFilePhase (5 days ago) <Georgy Bronnikov>
* eae416d7394 - IR: Handle exceptions from by-file lowering thread (5 days ago) <Georgy Bronnikov>
* bea5d955d4d - JVM_IR: perform file lowerings in parallel (5 days ago) <Georgy Bronnikov>
* c06b345f3c2 - (tag: build-1.5.20-dev-898) Hide `stageController` into the IrFactory (5 days ago) <Anton Bannykh>
* 97080c49fcb - Persistent IR generator (5 days ago) <Anton Bannykh>
* 8a0ce20d439 - PIR: minor restructuring (5 days ago) <Anton Bannykh>
* 1310a65f0cc - (tag: build-1.5.20-dev-894) JVM: rename this$0 when regenerating nested objects too (5 days ago) <pyos>
* ec89cb23135 - (tag: build-1.5.20-dev-883, origin/push/nk/all) Ignore hanging KotlinAndroid36GradleIT.testAndroidMppSourceSets() (5 days ago) <Nikolay Krasko>
* ec569a4c893 - (tag: build-1.5.20-dev-875) Minor. Suppress errors in tests (5 days ago) <Ilmir Usmanov>
* bad197e0759 - Raise RESERVED_VAR_PROPERTY_OF_VALUE_CLASS to error (5 days ago) <Ilmir Usmanov>
* 56a104dda91 - (tag: build-1.5.20-dev-867) JVM_IR KT-44974 fix SAM-converted capturing extension lambda (6 days ago) <Dmitry Petrov>
* 83ed67546b6 - (tag: build-1.5.20-dev-857) [Test] Support WITH_STDLIB directive in js box tests (6 days ago) <Dmitriy Novozhilov>
* dfcff132fde - [FIR] Fix false-positive smartcast on receiver in rhs of elvis (6 days ago) <Dmitriy Novozhilov>
* 2b392826822 - [FIR] Render original type before smartcasted type in DEBUG_INFO_EXPRESSION_TYPE (6 days ago) <Dmitriy Novozhilov>
* d4c26cca52a - [FIR] Use type without smartcast for local variable with smartcasted initializer (6 days ago) <Dmitriy Novozhilov>
* 40e286b3546 - [FIR] Increase level of sequential when branches (6 days ago) <Dmitriy Novozhilov>
* 92271527cb8 - [Test] Add CFG and IR dump handlers to FirBlackBoxTests (6 days ago) <Dmitriy Novozhilov>
* b5619dbf370 - [FIR] Add ability to render node levels in CFG graph dumper (6 days ago) <Dmitriy Novozhilov>
* 3e220116266 - Fix compilation of HLRedundantVisibilityModifierInspection (6 days ago) <Ilya Kirillov>
* e8f3ebdd199 - (tag: build-1.5.20-dev-855) FIR IDE: introduce HLRedundantVisibilityModifierInspection by extended checker (6 days ago) <Ilya Kirillov>
* 6d97841f388 - FIR IDE: introduce HLLocalInspectionTest (6 days ago) <Ilya Kirillov>
* 7fb6c228895 - FIR IDE: allow creating inspections by extended checkers (6 days ago) <Ilya Kirillov>
* b9a4613e44e - FIR IDE: remove getMessage from HLPresentation as it duplicates HLApplicator.getActionName (6 days ago) <Ilya Kirillov>
* c13889c2ea2 - FIR: add ability to specify checkers list for checker components (6 days ago) <Ilya Kirillov>
* ca4a07f73f3 - Unify message bundles used in IDEA FIR into KotlinBundle (6 days ago) <Ilya Kirillov>
* 6352814d452 - Fix NPE (6 days ago) <Vladimir Dolzhenko>
* 98ba379e075 - Fixed NPE on StandaloneScriptRootsCache instantiation (6 days ago) <Vladimir Dolzhenko>
* 45b17120ad4 - [Commonizer] Minor. Rename: 'dependee' -> 'dependency' (6 days ago) <Dmitriy Dolovov>
* ec7e411d806 - [Commonizer] Remove classifierId from CIR class/TA nodes (6 days ago) <Dmitriy Dolovov>
* ef931d55611 - [Commonizer] Don't keep kotlin/Any as the single supertype in CirClass (6 days ago) <Dmitriy Dolovov>
* baeee8988ea - [all-open] Don't affect private declarations to change their modality to open (6 days ago) <Victor Petukhov>
* ec41775d7e4 - [all-open] Fix formatting (6 days ago) <Victor Petukhov>
* 05ff2b12923 - (tag: build-1.5.20-dev-842) [JVM_IR] Extend when to switch translation to deal with nested ors. (6 days ago) <Mads Ager>
* 91581d6c1ad - Move KotlinBundle to frontend-independent module (6 days ago) <Ilya Kirillov>
* a8c23e1c3a0 - (tag: build-1.5.20-dev-830) FirDefaultStarImportingScope: filter INVISIBLE_CLASSES properly (6 days ago) <Mikhail Glukhikh>
* 940588a9bba - FE: commonize throw-related annotation FQ names (6 days ago) <Mikhail Glukhikh>
* 2dc0404751c - FIR: prioritize visible imported classes during type resolution (6 days ago) <pyos>
* 291ed4a38a5 - FIR: handle typealiases during conflict resolution (6 days ago) <pyos>
* 592c285198b - (tag: build-1.5.20-dev-826) Kapt: Don't create KDocCommentKeeper when not needed (6 days ago) <Hung Nguyen>
* 0a72e164510 - (tag: build-1.5.20-dev-814) FIR: transform DiagnosticBuilder DSL to an object (6 days ago) <Ilya Kirillov>
* 15aaf3a0789 - (tag: build-1.5.20-dev-813) Copy typeParameters from original declaration to the exportedDefaultStubFun before substitution of type parameters (6 days ago) <SokolovaMaria>
* 706d3e5aa87 - (tag: build-1.5.20-dev-812) FIR IDE: Add quickfix for VAR_ANNOTATION_PARAMETER. (6 days ago) <Mark Punzalan>
* 2f450549ab4 - (tag: build-1.5.20-dev-806) FIR IDE: Update FIR diagnostic test data for INAPPLICABLE_LATEINIT_MODIFIER. (7 days ago) <Mark Punzalan>
* 4e44804c775 - FIR IDE: Add quickfix for INAPPLICABLE_LATEINIT_MODIFIER. (7 days ago) <Mark Punzalan>
* b1ab64e854e - (tag: build-1.5.20-dev-804) JVM_IR KT-44483 argument adaptation is already done in PSI2IR (7 days ago) <Dmitry Petrov>
* f1b0e893ae8 - (tag: build-1.5.20-dev-797) Remove kotlin-annotations-android (7 days ago) <Alexander Udalov>
* 899f75466d4 - Remove tests on kotlin-annotations-android (7 days ago) <Alexander Udalov>
* 3432f581cb2 - Remove compiler support for kotlin-annotations-android (7 days ago) <Alexander Udalov>
* a8845551712 - FIR: bail out early for override check if base candidate is private (7 days ago) <Jinseong Jeon>
* 09640d9d63a - FIR checker: apply override checker to anonymous objects (7 days ago) <Jinseong Jeon>
* 9370f918e9d - FIR: use override checker when populating directOverriddenProperties (7 days ago) <Jinseong Jeon>
* fa1507fb91a - (tag: build-1.5.20-dev-795) Fix FIR test `lambdaParameterTypeInElvis` (7 days ago) <Victor Petukhov>
* 83836037f8e - (tag: build-1.5.20-dev-793) Add documentation on type checker context / type system context (7 days ago) <Simon Ogorodnik>
* 3909e3c54ca - Decouple TypeCheckerContext and TypeSystemContext (7 days ago) <Simon Ogorodnik>
* 53a7dc1126a - KT-44839 [Sealed interfaces]: restore move-tests for lang-version < 15 (7 days ago) <Andrei Klunnyi>
* eb0c73fd5e9 - KT-44839 [Sealed interfaces]: ability to specify compiler options in tests (7 days ago) <Andrei Klunnyi>
* c63a9afa56f - KT-44839 [Sealed interfaces]: move refactoring for language level < 1.5 (7 days ago) <Andrei Klunnyi>
* 5c7aadece92 - (tag: build-1.5.20-dev-790) Fix test founds more lines then expected. (7 days ago) <Yahor Berdnikau>
* 224aea09530 - Ignore test due to the bug in AGP on Gradle 6.8+. (7 days ago) <Yahor Berdnikau>
* 9d9df0c4ffc - Expect new attributes compatibility error. (7 days ago) <Yahor Berdnikau>
* 6c0ee2f9eaa - Update test to use new test xml output format. (7 days ago) <Yahor Berdnikau>
* 6d2465d00cd - Update Gradle version for tests to 6.8.1. (7 days ago) <Yahor Berdnikau>
* b262d09a81b - (tag: build-1.5.20-dev-787) JVM_IR KT-44627 fix bridge signature for parameter with primitive bound (7 days ago) <Dmitry Petrov>
* fa0f967c833 - (tag: build-1.5.20-dev-785) FIR2IR: support adapted references for constructors (7 days ago) <Mikhail Glukhikh>
* 8bab2083227 - FIR2IR: use information about callable reference adaptation from resolve (7 days ago) <Mikhail Glukhikh>
* dcad9c84fc6 - (tag: build-1.5.20-dev-771) Don't fix type variables into Nothing in priority way (7 days ago) <Victor Petukhov>
* 440fc8c4e40 - (tag: build-1.5.20-dev-764) Deprecated 'kotlin.useCompilerFallbackSearch' property. (7 days ago) <Yahor Berdnikau>
* 069941cdaf6 - Provide compiler classpath as task input. (7 days ago) <Yahor Berdnikau>
* 0eaea655d0d - (tag: build-1.5.20-dev-754) [Commonization] Improvements in approx. keys (7 days ago) <Dmitriy Dolovov>
* 3c6eb8f8f4f - Minor. Formatted (7 days ago) <Dmitriy Dolovov>
* 0af31abb048 - [Commonizer] Add tests for overloading purely by different upper bounds (7 days ago) <Dmitriy Dolovov>
* 90cdb9203fb - [Commonizer] Fix integration tests: wrong mismatches filter (7 days ago) <Dmitriy Dolovov>
* 8a17de38d0e - [Commonizer] Fix integration tests: serialize only own module contents (7 days ago) <Dmitriy Dolovov>
* 7f8f1dc4f82 - [Commonizer] Calculate hash code by pure name in approximation keys (7 days ago) <Dmitriy Dolovov>
* 6ff5704ef96 - Delete obsolete test (7 days ago) <Mikhael Bogdanov>
* f4937665630 - Add IR tests to Android codegen test (7 days ago) <Mikhael Bogdanov>
* c0759f96e93 - (tag: build-1.5.20-dev-751) Fix FIR test `lambdaParameterTypeInElvis` (7 days ago) <Victor Petukhov>
* 8acf3b1d765 - (tag: build-1.5.20-dev-747) [Cocoapods] Fail import if project's version wasn't specified (7 days ago) <Yaroslav Chernyshev>
* c158c64ee00 - (tag: build-1.5.20-dev-744) Reformat TypeWithEnhancement.kt (7 days ago) <Victor Petukhov>
* 0d40022d6de - Add reporting of the warnings based on Java annotations for expanded type aliases (7 days ago) <Victor Petukhov>
* d783d99443e - Use upper bound checker for typealias expansion (7 days ago) <Victor Petukhov>
* edb8007d52b - Add test for errors reporting of UPPER_BOUND_VIOLATED (7 days ago) <Victor Petukhov>
* befe8599c42 - Report warnings or errors for violated type parameter's upper bounds from Java annotated with nullability annotations (7 days ago) <Victor Petukhov>
* cf4e61bebb2 - (tag: build-1.5.20-dev-741) [FIR] Add spec diagnostic tests to `[JPS] Fast FIR tests` run configuration (7 days ago) <Dmitriy Novozhilov>
* 5711a8d6100 - [FIR] Support PreliminaryLoopVisitor in FIR DFA (7 days ago) <Dmitriy Novozhilov>
* 0e46a961a3e - [FIR] Implement util Multimap classes (7 days ago) <Dmitriy Novozhilov>
* 67ad4249c8b - [Test] Add FirDumpHandler to AbstractFirBlackBoxCodegenTest (7 days ago) <Dmitriy Novozhilov>
* a94086224d5 - (tag: build-1.5.20-dev-739) Clear request cache properly during disposing component (7 days ago) <Victor Petukhov>
* 6f64fd2fecf - Propagate inference session into declaration analyzers (7 days ago) <Victor Petukhov>
* dae1f4c05d2 - Remove redundant extension receiver substitution during lambda's completion (7 days ago) <Victor Petukhov>
* b463a0fa588 - (tag: build-1.5.20-dev-736) [Gradle] Use property provider for configuration time only if available (7 days ago) <Alexander Likhachev>
* 683bd0ed384 - (tag: build-1.5.20-dev-735) [Gradle, JVM] Don't create deprecated compile/runtime configurations (7 days ago) <Alexander Likhachev>
* ef458b20e13 - (tag: build-1.5.20-dev-734) [Gradle] Replace deprecated dependencies configurations in buildscript (7 days ago) <Alexander Likhachev>
* c7427a751a9 - [Gradle, K/N] Add integration tests for framework artifacts (7 days ago) <Alexander Likhachev>
* 383b9834a16 - [Gradle, K/N] Make BitcodeEmbeddingMode move backward compatible (7 days ago) <Alexander Likhachev>
* cbeb0310994 - [Gradle, K/N] Move NativeBinaryTypes from kotlin-gradle-plugin to kotlin-gradle-plugin-api (7 days ago) <Alexander Likhachev>
* a6cdfeafede - [Gradle, K/N] Consumable frameworks review fixes (7 days ago) <Alexander Likhachev>
* 604dda839a8 - [Gradle, K/N] Generate fat framework tasks and consumable configurations (7 days ago) <Alexander Likhachev>
* d844296629a - [Gradle, K/N] Add user-defined variant attributes to framework artifact (7 days ago) <Alexander Likhachev>
* cbdcd8f2bcc - [Gradle, K/N] Add consumable configuration with K/N frameworks (7 days ago) <Alexander Likhachev>
* ba969410c24 - [Gradle, JS] Make MultiplePluginDeclarationDetector compatible w/ conf cache (7 days ago) <Alexander Likhachev>
* 1cceec36427 - [Gradle, JS] Postpone TeamCity project property read using 'by lazy' (7 days ago) <Alexander Likhachev>
* 240fdfa7a85 - [Gradle] Support multiple failures in KotlinTestReport back again (7 days ago) <Alexander Likhachev>
* 2b0ad702421 - [Gradle, JS] Add integration test for js plugin configuration cache (7 days ago) <Alexander Likhachev>
* a6bf9bf51b5 - [Gradle, JS] Remove workaround for configuration cache enabled builds (7 days ago) <Alexander Likhachev>
* 432c6486d55 - [Gradle] Make KotlinTest, KotlinTestReport partially cc-compatible (7 days ago) <Alexander Likhachev>
* c7421e2bea2 - [Gradle, JS] Use FileSystemOperations only when it's available (7 days ago) <Alexander Likhachev>
* 0e29a9df6c7 - [Gradle, JS] Use target disambiguation classifier for compilation name (7 days ago) <Alexander Likhachev>
* 6eac5e1907f - [Gradle, JS] Tasks that uses ArchiveOperations compatible w/ Gradle < 6.6 (7 days ago) <Alexander Likhachev>
* 15f6bb9506c - [Gradle, JS] Make NodeJsSetup cc-compatible (7 days ago) <Alexander Likhachev>
* daa9c81bcb1 - [Gradle, JS] Make KotlinJsDce, Dukat, KotlinPackageJson cc-compatible (7 days ago) <Alexander Likhachev>
* da80d53796b - [Gradle, JS] Make KotlinWebpack cc-compatible (7 days ago) <Alexander Likhachev>
* 65faf204722 - [Gradle, JS] Make PublicPackageJsonTask cc-compatible (7 days ago) <Alexander Likhachev>
* 521b722c098 - [Gradle, JS] Compilation to compilationName (7 days ago) <Ilya Goncharov>
* 4566b7c6e5c - [Gradle, JS] rootPackageJson and kotlinNpmInstall cache-friendly (7 days ago) <Ilya Goncharov>
* 8c79baa9985 - [Gradle, JS] Partially rootPackageJson and kotlinNpmInstall with conf cache (7 days ago) <Ilya Goncharov>
* a41d3e5b043 - [Gradle, JS] Webpack task with conf cache (w/o install of dependencies) (7 days ago) <Ilya Goncharov>
* e6bfe9a7024 - [Gradle, JS] Npm dependencies as transient, and store only declarations (7 days ago) <Ilya Goncharov>
* b9aa577f84f - [Gradle, JS] KotlinPackageJson configuration cache works (7 days ago) <Ilya Goncharov>
* cd0dfd6fa9c - [Gradle, JS] Use transient for compilation npm resolver (7 days ago) <Ilya Goncharov>
* 60da9281a2c - [Gradle, JS] Next step of configurstion cache (7 days ago) <Ilya Goncharov>
* 19e59fe7707 - [Gradle, JS] Experimenting with making everything transient in npm (7 days ago) <Ilya Goncharov>
* cc51869a2ab - (tag: build-1.5.20-dev-728) [KAPT] Take function argument names from original descriptor (8 days ago) <Andrey Zinovyev>
* 4a0437a5071 - (tag: build-1.5.20-dev-727) [KAPT] Fix field type correction for delegates (#4107) (8 days ago) <Andrey Zinovyev>
* bf9fa4c9da5 - (tag: build-1.5.20-dev-721) Lightweight hashCode calc for LibraryInfo (8 days ago) <Vladimir Dolzhenko>
* 6882cf820ec - (tag: build-1.5.20-dev-708) FIR IDE: move RemoveModifierFix to ... (10 days ago) <Tianyu Geng>
* 75f6780b908 - (tag: build-1.5.20-dev-701) AndroidDependencyResolver: Don't load android-related classes on class load (10 days ago) <Vyacheslav Karpukhin>
* d42cc219bfd - (tag: build-1.5.20-dev-700) FIR IDE: fix collecting diagnostics for raanalysable non-toplevel declarations (10 days ago) <Ilya Kirillov>
* 6ba57abb8f4 - JVM don't use indy by default for SAM conversions (wait for KT-44844) (10 days ago) <Dmitry Petrov>
* 5013344bc4e - JVM_IR nullability assertions test for indy lambdas (10 days ago) <Dmitry Petrov>
* 4ab242ed51a - JVM_IR indy: minor: use toLowerCaseAsciiOnly for options (10 days ago) <Dmitry Petrov>
* afeb7e18cd5 - JVM_IR indy: fix non-null assertions on indy lambda parameters (10 days ago) <Dmitry Petrov>
* 43b1711010d - JVM_IR indy: extract LambdaMetafactoryArguments code to separate file (10 days ago) <Dmitry Petrov>
* 3438d19c223 - JVM_IR indy: use 'CLASS' mode in SAM bytecode listing tests (10 days ago) <Dmitry Petrov>
* 7564c9bb8c3 - JVM SamWrapperClassesAreSynthetic language feature (10 days ago) <Dmitry Petrov>
* 052f6929c9f - JVM_IR indy SAM conversions: update tests (10 days ago) <Dmitry Petrov>
* 3ebeca58522 - JVM_IR: use indy SAM conversions in jvmTarget 1.8+, fix bridges (10 days ago) <Dmitry Petrov>
* 6c6d43c29ae - JS: add missing reachable nodes data (10 days ago) <Anton Bannykh>
* a719656118d - Fix extracted metadata for IDE erased when scopes conflict, KT-44845 (10 days ago) <Sergey Igushkin>
* 54636f1af72 - (tag: build-1.5.20-dev-693) Enable -Werror in `:compiler:frontend` module (10 days ago) <Dmitriy Novozhilov>
* 0c4bca4bde2 - [FIR] Fix warnings in FIR modules and enable -Werror in them (10 days ago) <Dmitriy Novozhilov>
* 0e31551797c - [FIR] Generate `_` instead of `value` for unused setters in FIR builders (10 days ago) <Dmitriy Novozhilov>
* d696a488b51 - [FIR] Report list of conflicting symbols in REDECLARATION and CONFLICTING_OVERLOADS (10 days ago) <Dmitriy Novozhilov>
* 7a4625b70b2 - (tag: build-1.5.20-dev-689) FIR IDE: Enable passing completion test (10 days ago) <Roman Golyshev>
* d615b6b6827 - (tag: build-1.5.20-dev-683) FIR IDE: `firSymbolProvider` -> `symbolProvider` fix (10 days ago) <Roman Golyshev>
* bc262303923 - FIR IDE: Visit only the smallest acceptable declaration if possible (10 days ago) <Roman Golyshev>
* c3831baba2c - FIR IDE: Refactor `ElementsToShortenCollector` to be more value-oriented (10 days ago) <Roman Golyshev>
* dee4f4345b2 - FIR IDE: Add `ElementToShorten` sealed classes (10 days ago) <Roman Golyshev>
* d202b0feb2c - FIR IDE: Refactor `addElementToShorten` functions (10 days ago) <Roman Golyshev>
* 09ba927680b - FIR IDE: Decouple `ElementsToShortenCollector` from `KtFirReferenceShortener` (10 days ago) <Roman Golyshev>
* c89380fc369 - FIR IDE: Refactor `ElementsToShortenCollector` (10 days ago) <Roman Golyshev>
* 9a464ae9c40 - FIR IDE: Merge all collectors visitors to a single visitor (10 days ago) <Roman Golyshev>
* 7478b8d1896 - FIR IDE: Use single `TextRange` as selection instead of two ints (10 days ago) <Roman Golyshev>
* 798c4d24850 - FIR IDE: Create `FirResolvedImport`s without fake PSI (10 days ago) <Roman Golyshev>
* c0a4301179b - FIR IDE: Enhance check messages in `KtFirReferenceShortener` (10 days ago) <Roman Golyshev>
* 8020424b932 - FIR IDE: Remove fake root prefix even when the element is not shortened (10 days ago) <Roman Golyshev>
* ee98a76600a - FIR IDE: Implement simple importing of the functions (10 days ago) <Roman Golyshev>
* 88e7d1e5eed - FIR: Attach candidate symbol to the `ErrorNamedReference` (10 days ago) <Roman Golyshev>
* 51c59e56343 - FIR IDE: Check function call before trying to drop the receiver (10 days ago) <Roman Golyshev>
* d88fd5bd73a - FIR IDE: More strictly navigate to parent `KtDotQualifiedExpression` (10 days ago) <Roman Golyshev>
* e265a78a33d - FIR IDE: Implement shortening and import for type qualifiers (10 days ago) <Roman Golyshev>
* 0e271b72c78 - FIR IDE: Do not try to shorten type without qualifier (10 days ago) <Roman Golyshev>
* 534f4a66ad6 - FIR IDE: Add simple shortening for qualified calls and properties (10 days ago) <Roman Golyshev>
* f03ca5ea57e - FIR IDE: Add import in case when conflicting class comes from `*` import (10 days ago) <Roman Golyshev>
* 0b48416a1ee - FIR IDE: Unwrap nullable types (10 days ago) <Roman Golyshev>
* 08e271411f0 - FIR IDE: Create fake scopes to avoid import duplicates (10 days ago) <Roman Golyshev>
* e34370554d2 - FIR IDE: Add simple types importing (10 days ago) <Roman Golyshev>
* 0609aa1e2e0 - FIR IDE: Refactor `KtFirReferenceShortener` (10 days ago) <Roman Golyshev>
* 8575ce32d4d - FIR IDE: Add more tests for type conflicts (10 days ago) <Roman Golyshev>
* e744084c15b - FIR IDE: Enable types shortening for nested classes and nested types (10 days ago) <Roman Golyshev>
* b9d074051fa - FIR IDE: Add separate tests for FIR reference shortening (10 days ago) <Roman Golyshev>
* c1130f20106 - FIR IDE: Add reference shortening service which works over FIR (10 days ago) <Roman Golyshev>
* 108395fcfee - FIR: Fix bug with incorrect source element for qualifiers (10 days ago) <Roman Golyshev>
* 1479388bd59 - FIR IDE: Refactor `AbstractFirShortenRefsTest` (10 days ago) <Roman Golyshev>
* 68b5f2736e9 - FIR: Add fake root prefix for IDE resolution (10 days ago) <Roman Golyshev>
* 0de251e50d8 - Add `runTestInWriteCommand` flag to `AbstractImportTest` (10 days ago) <Roman Golyshev>
* 2d5b6855358 - (tag: build-1.5.20-dev-680) [FIR] Fix processing constructors of sealed classes (10 days ago) <Dmitriy Novozhilov>
* 7c61ddc72b7 - [FE] Allow declaring protected constructors in sealed classes (10 days ago) <Dmitriy Novozhilov>
* f3a8fcaea6e - [FE] Make constructors of sealed classes `protected` instead of `internal` (10 days ago) <Dmitriy Novozhilov>
* e795c2c4079 - (tag: build-1.5.20-dev-676) Generate proper hashCode for fun interface wrappers (10 days ago) <Mikhael Bogdanov>
* f33cad54c5f - (tag: build-1.5.20-dev-653) AndroidDependencyResolver: fixed AAR import on modern AGP plugins (10 days ago) <Vyacheslav Karpukhin>
* 7eb5fc77785 - AndroidDependencyResolver: fixed NPE (10 days ago) <Vyacheslav Karpukhin>
* abc44fa6588 - (tag: build-1.5.20-dev-651, origin/rr/abannykh/fix-ant-tests) Increase -Xmx for Ant tests (11 days ago) <Anton Bannykh>
* 20f9787c700 - (tag: build-1.5.20-dev-642) FIR checker: report errors in contract description (11 days ago) <Jinseong Jeon>
* 3d635b6a941 - FIR: unwrap smartcast expression when extracting effects of contract (11 days ago) <Jinseong Jeon>
* 70f462781a9 - FIR-IDE: add mappings for backing field diagnostics (11 days ago) <Jinseong Jeon>
* 510b9e6f2ad - (tag: build-1.5.20-dev-639) Move around some codegen box tests (11 days ago) <Alexander Udalov>
* 2d60fa787dc - Remove codegen tests on old language and API versions (11 days ago) <Alexander Udalov>
* 401f0ac583e - Use TARGET_BACKEND instead of DONT_TARGET_EXACT_BACKEND in box against Java tests (11 days ago) <Alexander Udalov>
* f797ee78035 - (tag: build-1.5.20-dev-631) Substitute captured types with inner intersection one (NewTypeSubstitutor) (11 days ago) <Victor Petukhov>
* 80daf120e6a - (tag: build-1.5.20-dev-630) Apply illegal-access=permit workaround for JDK 16+ (11 days ago) <Alexander Udalov>
* 4b62b2de0c0 - (tag: build-1.5.20-dev-628) Use IDEA ASM in `kotlin-gradle-plugin-integration-tests` module (11 days ago) <Yaroslav Chernyshev>
* c3c8991ab63 - (tag: build-1.5.20-dev-622) FIR IDE: Re-organize MainKtQuickFixRegistrar. (11 days ago) <Mark Punzalan>
* a9f19c4a454 - FIR IDE: Move ChangeVariableMutabilityFix to idea-frontend-independent. (11 days ago) <Mark Punzalan>
* 79622248045 - FIR IDE: Add quickfix for VAR_OVERRIDDEN_BY_VAL. (11 days ago) <Mark Punzalan>
* 57e06992c91 - (tag: build-1.5.20-dev-621) Skip JDK 6 in failing BB test (java.util.function in use) (11 days ago) <Mikhail Glukhikh>
* cd483ad2318 - (tag: build-1.5.20-dev-617) FIR2IR: fix raw SAM conversion (avoid * in type arguments) (11 days ago) <Mikhail Glukhikh>
* 5f3102bf2fa - FIR2IR: expand type before getting nullability #KT-44803 Fixed (11 days ago) <Mikhail Glukhikh>
* 791f5891274 - SymbolTable: Rewrite nasty code with if without else in elvis RHS (11 days ago) <Mikhail Glukhikh>
* 4bc630d82cb - FIR2IR: enhance approximation of captured types (11 days ago) <Mikhail Glukhikh>
* 346ffb3acf9 - FIR2IR: support substitution for SAM types (11 days ago) <Mikhail Glukhikh>
* 7050af9b790 - FIR2IR: use invariant projections for SAM_CONVERSION types (11 days ago) <Mikhail Glukhikh>
* 67671afab4d - (tag: build-1.5.20-dev-616) [Plugin API] Fix missed call in `resolveBySignatureInModule` (11 days ago) <Roman Artemev>
* 2c4a6fdb982 - (tag: build-1.5.20-dev-599) Revert "Use IDEA ASM in kapt module" (11 days ago) <Nikolay Krasko>
* 73aa465ee97 - (tag: build-1.5.20-dev-592) Add tests for issues fixed in JVM IR (11 days ago) <Alexander Udalov>
* 17fc10a8afe - (tag: build-1.5.20-dev-585) Mark obsolete Gradle JVM options as Deprecated with Error (12 days ago) <Yaroslav Chernyshev>