### PR TITLE
[kotlin compiler][update] 1.5.20-dev-1393

### DIFF
--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
@@ -7,11 +7,10 @@ import org.jetbrains.kotlin.backend.common.serialization.mangle.ManglerChecker
 import org.jetbrains.kotlin.backend.common.serialization.mangle.descriptor.Ir2DescriptorManglerAdapter
 import org.jetbrains.kotlin.backend.konan.descriptors.isForwardDeclarationModule
 import org.jetbrains.kotlin.backend.konan.descriptors.isFromInteropLibrary
-import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.backend.konan.ir.KonanSymbols
 import org.jetbrains.kotlin.backend.konan.ir.interop.IrProviderForCEnumAndCStructStubs
+import org.jetbrains.kotlin.backend.konan.ir.konanLibrary
 import org.jetbrains.kotlin.backend.konan.serialization.*
-import org.jetbrains.kotlin.backend.konan.serialization.KonanIrLinker
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -79,8 +78,6 @@ internal fun Context.psiToIr(
         val translationContext = object : TranslationPluginContext {
             override val moduleDescriptor: ModuleDescriptor
                 get() = generatorContext.moduleDescriptor
-            override val bindingContext: BindingContext
-                get() = generatorContext.bindingContext
             override val symbolTable: ReferenceSymbolTable
                 get() = symbolTable
             override val typeTranslator: TypeTranslator

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/PsiToIr.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.ir.visitors.acceptVoid
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi2ir.Psi2IrConfiguration
 import org.jetbrains.kotlin.psi2ir.Psi2IrTranslator
+import org.jetbrains.kotlin.psi2ir.generators.DeclarationStubGeneratorImpl
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.CleanableBindingContext
 import org.jetbrains.kotlin.utils.DFS
@@ -55,7 +56,7 @@ internal fun Context.psiToIr(
     val functionIrClassFactory = BuiltInFictitiousFunctionIrClassFactory(
             symbolTable, generatorContext.irBuiltIns, reflectionTypes)
     generatorContext.irBuiltIns.functionFactory = functionIrClassFactory
-    val stubGenerator = DeclarationStubGenerator(
+    val stubGenerator = DeclarationStubGeneratorImpl(
             moduleDescriptor, symbolTable,
             config.configuration.languageVersionSettings
     )

--- a/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
+++ b/backend.native/compiler/ir/backend.native/src/org/jetbrains/kotlin/backend/konan/serialization/KonanIrlinker.kt
@@ -46,7 +46,6 @@ import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
 object KonanFakeOverrideClassFilter : FakeOverrideClassFilter {
@@ -227,7 +226,6 @@ internal class KonanIrLinker(
         }
     class KonanPluginContext(
             override val moduleDescriptor: ModuleDescriptor,
-            override val bindingContext: BindingContext,
             override val symbolTable: ReferenceSymbolTable,
             override val typeTranslator: TypeTranslator,
             override val irBuiltIns: IrBuiltIns

--- a/build.gradle
+++ b/build.gradle
@@ -341,7 +341,7 @@ task detectJarCollision(type: CollisionDetector) {
                                                     "metadata.jvm", "descriptors", "descriptors.jvm", "descriptors.runtime",
                                                     "deserialization", "util.runtime", "compiler.common", "type-system", "cones", "resolve",
                                                     "tree", "psi2fir", "fir2ir", "java", "kotlin-build-common", "lightTree",
-                                                    "jvm", "checkers", "raw-fir.common", "light-tree2fir", 
+                                                    "jvm", "checkers", "raw-fir.common", "light-tree2fir", "cfg",
                                                     "fir-serialization", "fir-deserialization", "entrypoint", "wasm.ir"])
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,12 @@
 buildKotlinVersion=1.5.20-dev-372
 buildKotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-372,branch:default:any,pinned:true/artifacts/content/maven
 remoteRoot=konan_tests
-kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-1166,branch:default:any,pinned:true/artifacts/content/maven
-kotlinVersion=1.5.20-dev-1166
-kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-1166,branch:default:any,pinned:true/artifacts/content/maven
-kotlinStdlibVersion=1.5.20-dev-1166
-kotlinStdlibTestsVersion=1.5.20-dev-1166
-testKotlinCompilerVersion=1.5.20-dev-1166
+kotlinCompilerRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-1393,branch:default:any,pinned:true/artifacts/content/maven
+kotlinVersion=1.5.20-dev-1393
+kotlinStdlibRepo=https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.5.20-dev-1393,branch:default:any,pinned:true/artifacts/content/maven
+kotlinStdlibVersion=1.5.20-dev-1393
+kotlinStdlibTestsVersion=1.5.20-dev-1393
+testKotlinCompilerVersion=1.5.20-dev-1393
 konanVersion=1.5.20
 
 # A version of Xcode required to build the Kotlin/Native compiler.


### PR DESCRIPTION
commit 55b4c8c738d8dbf878cacba4f76001775803bd6e
Author: Vasily Levchenko <vasily.v.levchenko@gmail.com>
Date:   Mon Mar 1 08:46:32 2021 +0100

    [kotlin compiler][update] 1.5.20-dev-1393
    
    * 1bb31bb36f9 - (tag: build-1.5.20-dev-1393) Update libraries and wrappers versions for 1.5.0 (3 days ago) <anastasiia.spaseeva>
    * d2c9116b512 - (tag: build-1.5.20-dev-1385) [fir][test] ignore native tree (3 days ago) <Vasily Levchenko>
    * dbce28053c3 - IR: move frontend-dependent code into implementations in psi2ir (3 days ago) <Alexander Udalov>
    * 2566aa9db27 - IR: remove TranslationPluginContext.bindingContext (3 days ago) <Alexander Udalov>
    * e00660a7890 - Extract control flow analysis to separate module (3 days ago) <Alexander Udalov>
    | * b05e7422388 - [commonizer-api] workaround for old k/n artifacts (3 days ago) <Vasily Levchenko>
    | * e123127a4a2 - (!fixup)[build] cache repository fix (3 days ago) <Vasily Levchenko>
    | * 417eb60ed3c - Revert "Change order of WITH_RUNTIME and FILE. Wrong order brakes module pattern." (3 days ago) <Alexander Udalov>
    | * f87132fff4e - [performance] don't override user defined properties with fixed values (3 days ago) <Vasily Levchenko>
    | * be08e29cb3b - [.idea][artifacts] added kotlinx_cli_jvm (3 days ago) <Vasily Levchenko>
    | * c9e0928038a - [performance] enable project performance (3 days ago) <Vasily Levchenko>
    | * f2524dbb8df - [gradle][properties] default kotlin.native.home (3 days ago) <Vasily Levchenko>
    | * ed749f9b4a7 - [.gitignore] add kotlin-native output folders (3 days ago) <Vasily Levchenko>
    | * 8eff15c8c2d - [.idea][misc.xml] update after kotlin-native folder appear (3 days ago) <Vasily Levchenko>
    | * fe896619d95 - [editorconfig] added for k/n (3 days ago) <Vasily Levchenko>
    | * 710a6fb7f38 - [JPS] Fix import for Kotlin Native (3 days ago) <Aleksei.Cherepanov>
    | * f051119c4bb - [tests][kotlin-gradle-plugin] workaround for old k/n artifacts (3 days ago) <Vasily Levchenko>
    | * 5c80dbfd4b5 - [kotlin-gradle-plugin] workaround for old k/n artifacts (3 days ago) <Vasily Levchenko>
    | * 7ad656ea7ff - Fix cyclic dependency in run task configuration. (3 days ago) <Pavel Punegov>
    | * c4178daf48d - Remove Bintray kotlin-dev usage from kotlin-native (3 days ago) <Nikolay Krasko>
    | * 29e1390720d - Remove Bintray ktor usage from kotlin-native (3 days ago) <Nikolay Krasko>
    | * f1aa75ffed8 - Remove @author tag to conform with the repository policy (3 days ago) <Nikolay Krasko>
    | * 4f3fa9f9ee7 - Ignore kotlin-native during licences check in Kotlin (3 days ago) <Nikolay Krasko>
    | * 905c0c3dd3b - [build] version of kotlin native stored in resouces (3 days ago) <Vasily Levchenko>
    | * bdc87edfd03 - [build] cache repository fix (3 days ago) <Vasily Levchenko>
    | * f27e3b8c267 - [build][conformance][test] ignore kotlin-native/runtime licence check (3 days ago) <Vasily Levchenko>
    | * fe2799273d9 - [build] drop dead repositories (3 days ago) <Vasily Levchenko>
    | * dac76e606d5 - [build][conformance][test] ignore not related to build repositories (3 days ago) <Vasily Levchenko>
    | * 65dd7988188 - [build][native support] intoduced new native support. (5 days ago) <Vasily Levchenko>
    | * e031da6e702 - [build][dependencies] \r -> \n (5 days ago) <Vasily Levchenko>
    | * 7b73917217d - [build][dist] global dist fixed (5 days ago) <Vasily Levchenko>
    | * 3298cd3455c - [build][checkBuild] fix buildSrc (5 days ago) <Vasily Levchenko>
    | * d34203991de - [konan home provider] make more konan home detector more safe (5 days ago) <Vasily Levchenko>
    | * 8bcb5718d9c - [build] make delete more safe (5 days ago) <Vasily Levchenko>
    | * 13d4003e3f7 - [build] speedup tc-dist (5 days ago) <Vasily Levchenko>
    | * fa08b1dc480 - [kotlin-native] change in output of  library_mismatch (5 days ago) <Vasily Levchenko>
    | * 8a4b5efa9e9 - [build][native] don't ever fix dist, take it with API (5 days ago) <Vasily Levchenko>
    | * ebeac62f17a - [build][tests][g/c] fix dependencies on platform and dist (5 days ago) <Vasily Levchenko>
    | * 46f2182ba68 - [build][tests] more utilities functions used (5 days ago) <Vasily Levchenko>
    | * 39fb47892ce - [build][kotlin-native] stable (5 days ago) <Vasily Levchenko>
    | * 4610d9f1714 - Fix file separator in tests for Windows (5 days ago) <Pavel Punegov>
    | * 0324ee508e2 - [testData][compiler] disable tests KT4282{4,5} for native backend (5 days ago) <Vasily Levchenko>
    | * 69723447c40 - [build][native] dependencies :kotlin-native:dependencies:update (5 days ago) <Vasily Levchenko>
    | * 6234bcb4537 - [build][test] enable external compiler tests (5 days ago) <Vasily Levchenko>
    | * d6c147908ec - [build][bundle]upload (5 days ago) <Vasily Levchenko>
    | * 83fc59b0ffb - [klib][platform][osx] 10.11 (5 days ago) <Vasily Levchenko>
    | * e6557787438 - [build][native] conditional build (5 days ago) <Vasily Levchenko>
    | * 3867cf6ef5e - [build] switch to kotlin-build-gradle-plugin:0.0.25 (5 days ago) <Vasily Levchenko>
    | * ec0f6b9eded - [build][kotlin-build-gradle-plugin] bump version 0.0.25 (5 days ago) <Vasily Levchenko>
    | * 326ab1cd022 - [build][tests] disable interop_concurrentRuntime - very unstable (5 days ago) <Vasily Levchenko>
    | * 17fc4a087ba - [build] enable sanity tests (step 3) (5 days ago) <Vasily Levchenko>
    | * a7eaa35317f - [build] java os mac (Big Sur) (5 days ago) <Vasily Levchenko>
    | * 840c1e612cc - [build] joint (step 2) (5 days ago) <Vasily Levchenko>
    | * c85c3ac1235 - [build] joint (step 1) (5 days ago) <Vasily Levchenko>
    * 9d140cacc04 - (tag: build-1.5.20-dev-1381, origin/master-before-native-merge) [Gradle, K/N] Create compiler download temp dir inside target dir (3 days ago) <Alexander Likhachev>
    * 172b5f96211 - [Gradle, K/N] Unpack compiler into temp directory then move to proper place (3 days ago) <Alexander Likhachev>
    * 45d423e78ca - (tag: build-1.5.20-dev-1379) Fix test is failing to run on CI. (3 days ago) <Yahor Berdnikau>
    * 80a0545ac2e - (tag: build-1.5.20-dev-1374) [Gradle, JS] Fix ProcessedFilesCache.kt according to configuration cache (3 days ago) <Ilya Goncharov>
    * b138b166e3d - (tag: build-1.5.20-dev-1372) FIR: use EQUALS & TO_STRING from OperatorNameConventions (3 days ago) <Mikhail Glukhikh>
    * e6cfd5d06fa - FIR: move data class synthetic members' names (3 days ago) <Jinseong Jeon>
    * 856838f82c7 - FIR: refactor delegate unwrapping (3 days ago) <Jinseong Jeon>
    * ef890464d80 - [Gradle] Rework KotlinTestReport to be compatible with configuration cache (3 days ago) <Alexander Likhachev>
    * 3e09bb3d3f0 - [Gradle] Bump gradle-download-task version to 4.1.1 to support configuration cache (3 days ago) <Alexander Likhachev>
    * 67632a495b2 - [Gradle, MPP] Rework build finished listener into build service (3 days ago) <Alexander Likhachev>
    * 42345b9c492 - (tag: build-1.5.20-dev-1365) Minor: use more clear and specific naming for LazyClassContext.typeChecker (relevant for MPP with type refinement) (3 days ago) <Dmitry Savvinov>
    * 168c692a273 - Use overriding util with proper typechecker for overriding in LazyClassMemberScope (3 days ago) <Dmitry Savvinov>
    * 9616eb94fd5 - Add test on KT-44898 (MPP + type refinement + complex inheritance) (3 days ago) <Dmitry Savvinov>
    * e3d4c440b54 - Minor: rename createMemberScope -> createScopesHolderForClass (3 days ago) <Dmitry Savvinov>
    * 2bf3abcb297 - (tag: build-1.5.20-dev-1364) FIR: cache accessor symbols in JavaClassUseSiteMemberScope (3 days ago) <Mikhail Glukhikh>
    * 750a39a0530 - JavaClassUseSiteMemberScope: optimize createOverridePropertyIfExists (3 days ago) <Mikhail Glukhikh>
    * 07d11508a75 - (tag: build-1.5.20-dev-1358) Generate JvmMultifileClass tests for Gradle (3 days ago) <Aleksei.Cherepanov>
    * e6b61ecc224 - (tag: build-1.5.20-dev-1354) Fix incorrectly generated tests (3 days ago) <Denis.Zharkov>
    * 82f1b8159c2 - (tag: build-1.5.20-dev-1346) Remove deprecated "-XX:-FailOverToOldVerifier" as it breaks JDK on TC (3 days ago) <Mikhael Bogdanov>
    * 2484729bd7f - (tag: build-1.5.20-dev-1342) FIR IDE: fix redundant (3 days ago) <Tianyu Geng>
    * acc2256de92 - (tag: build-1.5.20-dev-1340) IR: support smart cast values in RangeContainsLowering (4 days ago) <Alexander Udalov>
    * 820762ca16e - IR: add isUnsignedType/getUnsignedType (4 days ago) <Alexander Udalov>
    * 0ebdf7c3c49 - IR: add getPrimitiveType, optimize some usages of isInt/isByte/... (4 days ago) <Alexander Udalov>
    * 17ee10a0d86 - Minor, fix compilation warning in DurationUnit.kt (4 days ago) <Alexander Udalov>
    * 94e6ec7dfdf - (tag: build-1.5.20-dev-1338) Fix test after 27846f453209213c844823c052f38ca4fb7546d9 (4 days ago) <Victor Petukhov>
    * 6b56b7cca65 - (tag: build-1.5.20-dev-1337) Fix tests are using slightly different test file names from actual. (4 days ago) <Yahor Berdnikau>
    * 4fffe7b9c8d - (tag: build-1.5.20-dev-1331) FIR: Fix VerifyError caused by private delegates (4 days ago) <Denis.Zharkov>
    * ace66b7179c - FIR: Prettify visibility resolution for private constructors (4 days ago) <Denis.Zharkov>
    * 9d7e40ad992 - Minor. Reformat FirStatusResolveTransformer.kt (4 days ago) <Denis.Zharkov>
    * 2523ea1ef4d - (tag: build-1.5.20-dev-1327) Do not add @JvmInline annotation on JS and Native (4 days ago) <Ilmir Usmanov>
    * 2df049fc035 - Minor. Remove outdated test and update maven test (4 days ago) <Ilmir Usmanov>
    * 8c31fcb6152 - Add inline class -> @JvmInline value class intention (4 days ago) <Ilmir Usmanov>
    * d67e4f0c485 - Rename inline class -> @JvmInline value class in stdlib and compiler (4 days ago) <Ilmir Usmanov>
    * 62123d72e23 - IC: Add inline class -> @JvmInline value class warning (4 days ago) <Ilmir Usmanov>
    * b417786fd4f - (tag: build-1.5.20-dev-1313) JVM IR: do not hide constructor with inline class in anonymous object (4 days ago) <Alexander Udalov>
    * b026de768d2 - Do not ever run JVM test handlers after previous errors (4 days ago) <Alexander Udalov>
    * 27846f45320 - (tag: build-1.5.20-dev-1304) Add tests for obsolete issues (KT-42722, KT-39880) (4 days ago) <Victor Petukhov>
    * 9492e75d38c - (tag: build-1.5.20-dev-1301) FIR checker: Split `checkProperty` util function. (4 days ago) <Mark Punzalan>
    * aad86c3892e - Skip directories with lowercase "testdata" in FIR total Kotlin tests. (4 days ago) <Mark Punzalan>
    * 1c94372b6c0 - FIR checker/IDE: Add checker and quickfix for VAL_WITH_SETTER. (4 days ago) <Mark Punzalan>
    * 99c47a04871 - (tag: build-1.5.20-dev-1300) Fix non-exhaustive when in common stdlib (4 days ago) <Dmitriy Novozhilov>
    * 4222bb9af25 - [FE] Make whens on expect sealed classes and enums not exhaustive (4 days ago) <Dmitriy Novozhilov>
    * 1cf73203c76 - (tag: build-1.5.20-dev-1299, origin/rr/FIR/semoro/perf6) [FIR-Test] Disable pre-release check in modularized tests (4 days ago) <Simon Ogorodnik>
    * 2ea0e69a565 - [FIR-Test] Fix incorrect file count (4 days ago) <Simon Ogorodnik>
    * 0086ebe6f2a - [FIR-Test] Increase code cache size (4 days ago) <Simon Ogorodnik>
    * 1e73f7a5b21 - [FIR-Test] Force min heap size (4 days ago) <Simon Ogorodnik>
    * b6fb3c97998 - [FIR] Isolate benchmark thread, add jit log format events for passes (4 days ago) <Simon Ogorodnik>
    * 618de5fa327 - (tag: build-1.5.20-dev-1296) KT-45074 [Sealed Interfaces]: when exhaustiveness after gradle reimport (4 days ago) <Andrei Klunnyi>
    * a9c6c115be4 - (tag: build-1.5.20-dev-1281) [Test] Disable gradle test parallelization if JUnit 5 is enabled (4 days ago) <Dmitriy Novozhilov>
    * 2a7a20dd999 - [Test] Add ability to set maximum of working threads for parallel JUnit 5 tests (4 days ago) <Dmitriy Novozhilov>
    * ca6ce151a25 - (tag: build-1.5.20-dev-1277) Unify test package names in kotlin-stdlib tests (4 days ago) <Ilya Gorbunov>
    * a6d8bf8127a - (tag: build-1.5.20-dev-1268) Fix compilation of idea-fir-low-level-api (5 days ago) <Alexander Udalov>
    * aeb0906f2da - (tag: build-1.5.20-dev-1264) Build: suppress warnings for kotlin-stdlib-wasm (5 days ago) <Alexander Udalov>
    * 9ce4decb732 - (tag: build-1.5.20-dev-1262) FIR IDE: use WhenMissingCase in NoElseInWhen diagnostic (5 days ago) <Ilya Kirillov>
    * f19a9af7b3e - Unify WhenMissingCase from FIR and FE1.0 (5 days ago) <Ilya Kirillov>
    * f4371c670ee - Move WhenMissingCase from fir module to compiler.common to use in IDE (5 days ago) <Ilya Kirillov>
    * 83f8650e801 - Move CallableId from fir module to compiler.common to use in IDE (5 days ago) <Ilya Kirillov>
    * 7e149a3a44e - (tag: build-1.5.20-dev-1257) IR: remove unneeded dependencies on psi2ir (5 days ago) <Alexander Udalov>
    * e69cc183a4e - IR: remove dependency of 'ir.tree' on 'frontend' (5 days ago) <Alexander Udalov>
    * addabae8d2d - IR: move frontend-dependent code into implementations in psi2ir (5 days ago) <Alexander Udalov>
    * d991a3e40ff - IR: simplify initialization cycle of TypeTranslator/ConstantValueGenerator (5 days ago) <Alexander Udalov>
    * 5ea3d32b98b - IR: remove TranslationPluginContext.bindingContext (5 days ago) <Alexander Udalov>
    * 274e0ad1360 - IR: remove unused dependency on BindingContext (5 days ago) <Alexander Udalov>
    * 837eb739ea8 - IR: move CompilationErrorException to frontend.common (5 days ago) <Alexander Udalov>
    * 1ae46b529f1 - IR: move ExpectDeclarationRemover to ir.backend.common (5 days ago) <Alexander Udalov>
    * 26a96a1c19a - Don't throw an exception while loading type use annotations on implicit bounds of a wildcard (5 days ago) <Victor Petukhov>
    * 7669d8ff26d - (tag: build-1.5.20-dev-1256) Add README.md for the kotlin-parcelize plugin (5 days ago) <Pavel Semyonov>
    * 2e2caae05c3 - Extract control flow analysis to separate module (5 days ago) <Alexander Udalov>
    * c7445158321 - Minor, pass CliSealedClassInheritorsProvider explicitly in some places (5 days ago) <Alexander Udalov>
    * ca5a35b4b32 - Move CompilerEnvironment from 'frontend' to 'cli' (5 days ago) <Alexander Udalov>
    * 3efbca85eac - Minor, rename file ControlFlowInformationProvider{ -> Impl}.kt (5 days ago) <Alexander Udalov>
    * 5ad0033d42e - Extract some cfg utilities into separate files (5 days ago) <Alexander Udalov>
    * a9b9cced156 - (tag: build-1.5.20-dev-1251) IrInterpret: remove thread creation / joining (performance fix) (5 days ago) <Mikhail Glukhikh>
    * df62b5e3112 - (tag: build-1.5.20-dev-1247) JS IR: special origins for declaration created during lowerings (5 days ago) <Anton Bannykh>
    * aec498a4ea8 - (tag: build-1.5.20-dev-1245) Add quickfixes for NON_FINAL_MEMBER_IN_FINAL_CLASS (5 days ago) <Tianyu Geng>
    * e1b3cd32f32 - (tag: build-1.5.20-dev-1236) IDEA-253605 jvmClassPathUtil: preserve old behaviour (5 days ago) <Nikita Katkov>
    * 738c6d31194 - IDEA-253605 jvmClassPathUtil: correct collection of parent classloaders (5 days ago) <Nikita Katkov>
    * 81efdab4e48 - (tag: build-1.5.20-dev-1231) Do not swallow any exceptions apart FNFE (5 days ago) <Vladimir Dolzhenko>
    * cf830887ec1 - (tag: build-1.5.20-dev-1229) FIR2IR: optimize override binding for Fir2IrLazySimpleFunction (5 days ago) <Mikhail Glukhikh>
    * 5bdea9652b8 - FIR: fix position and reporting of PRIVATE_SETTER_* (5 days ago) <Tianyu Geng>
    * bdeecfc188c - FIR: check multiple vararg param and forbidden vararg type (5 days ago) <Tianyu Geng>
    * 0e9474342db - Simplify FirMethodOfAnyImplementedInInterfaceChecker (5 days ago) <Jinseong Jeon>
    * 338595703cf - FIR: delegate to abstract override members of Any (5 days ago) <Jinseong Jeon>
    * 0defdc9e708 - FIR checker: fix typos in diagnostics list (5 days ago) <Jinseong Jeon>
    * c4af92a86a6 - FIR: don't raise an internal error for sealed members in intersection scope (5 days ago) <Jinseong Jeon>
    * 4fba5891c7f - FIR2IR: compute class localness before a loop (5 days ago) <Jinseong Jeon>
    * c571c5c441e - (tag: build-1.5.20-dev-1222) Refactor and apply optimization to KaptModelBuilderService logic (5 days ago) <Yaroslav Chernyshev>
    * 7ef136d1422 - Improve performance of import of pure kotlin project: do not force all tasks creation (5 days ago) <Andrey Uskov>
    * 9d8abca1952 - (tag: build-1.5.20-dev-1218) [box-tests] Disabled a test for K/N (5 days ago) <Igor Chevdar>
    * d88ef642883 - (tag: build-1.5.20-dev-1215) Remove references to validateTaskProperties (6 days ago) <Stefan Wolf>
    * 200ef832d2f - Add PathSensitive annotation to all input file properties (6 days ago) <Stefan Wolf>
    * 8b01df67721 - Enable stricker Kotlin Gradle Plugin validation (6 days ago) <Stefan Wolf>
    * 8852323a76e - (tag: build-1.5.20-dev-1211) [PSI2IR] Do not generate property reference setter if inaccessible. (6 days ago) <Mads Ager>
    * d44799fa78f - (tag: build-1.5.20-dev-1207) JVM IR: Use INVOKESPECIAL instead of INVOKEVIRTUAL for default private (6 days ago) <Ilmir Usmanov>
    * 3ee62cb1b2d - JVM IR: Do not generate private suspend functions as synthetic package-private (6 days ago) <Ilmir Usmanov>
    * 48fb085bf6c - (tag: build-1.5.20-dev-1197) Deprecate kotlin.Metadata.bytecodeVersion (6 days ago) <Alexander Udalov>
    * f63ffc51ae6 - Remove JvmBytecodeBinaryVersion from the compiler code (6 days ago) <Alexander Udalov>
    * d300e05be96 - Remove obsolete code in inliner for experimental coroutines (6 days ago) <Alexander Udalov>
    * 448c6c2f0dc - kotlinx-metadata-jvm: deprecate KotlinClassHeader.bytecodeVersion (6 days ago) <Alexander Udalov>
    * c6f5ce68370 - Do not write bytecode version to class file (6 days ago) <Alexander Udalov>
    * 862a9143dae - Do not report errors about bytecode version (6 days ago) <Alexander Udalov>
    * fa2b2c8735b - (tag: build-1.5.20-dev-1187) [Commonizer] Make CirProperty.compileTimeInitializer non-nullable (7 days ago) <Dmitriy Dolovov>
    * b3e68d3704a - [Commonizer] Make CirProperty.[backing|delegate]FieldAnnotations non-nullable (7 days ago) <Dmitriy Dolovov>
    * 215dd8515bd - Minor. Remove compilation warning (7 days ago) <Dmitriy Dolovov>
    * ee406f1622e - (tag: build-1.5.20-dev-1185) Lift assignment out: if last statement is lambda, enclose it in parentheses if necessary (7 days ago) <Toshiaki Kameyama>
    * e6476c39ca2 - (tag: build-1.5.20-dev-1179) JVM IR: fix isMarkedNullable for nullability-flexible types (7 days ago) <Alexander Udalov>
    * 08cf78fafd9 - (tag: build-1.5.20-dev-1178) MI-141 Fix 'Empty Library' entry in module dependencies (7 days ago) <Aleksandr Liublinskii>
    * eec98314c84 - (tag: build-1.5.20-dev-1176) Revert "Change order of WITH_RUNTIME and FILE. Wrong order brakes module pattern." (7 days ago) <Alexander Udalov>

