### PR TITLE
Update coverage sample documentation.

### DIFF
--- a/samples/coverage/README.md
+++ b/samples/coverage/README.md
@@ -4,9 +4,8 @@ This example shows how to collect coverage information during execution of the t
 Please note that this functionality will be incorporated into Gradle plugin so you won't need to do it by hand in the nearest future. 
 
 ### Prerequisites
-`createCoverageReport` task requires `llvm-profdata` and `llvm-cov` to be added to the `$PATH`. 
-They can be found in the Kotlin/Native dependencies dir. By default it should look like
-`$HOME/.konan/dependencies/clang-llvm-6.0.1-darwin-macos/bin`
-
+`createCoverageReport` task requires `llvm-profdata` and `llvm-cov` to be added to the `$PATH`.  
+In case of macOS, use tools from Xcode (`/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin`).  
+For Windows and Linux, use the ones from Kotlin/Native LLVM distribution (e.g. `$HOME/.konan/dependencies/clang-llvm-8.0.0-linux-x86-64/bin`).
 ### Usage
 Just run `createCoverageReport` task.


### PR DESCRIPTION
We need to invoke `llvm-profdata` tool from the same toolchain as Clang (on macOS we use the one from Xcode).